### PR TITLE
Playground: shareable URL state (lz-string) + autocomplete styling

### DIFF
--- a/plugins/rigor-playground/frontend/index.html
+++ b/plugins/rigor-playground/frontend/index.html
@@ -602,6 +602,7 @@
     import { ruby }                                from "https://esm.sh/@codemirror/legacy-modes@0.20/mode/ruby"
     import { lintGutter, setDiagnostics }          from "https://esm.sh/@codemirror/lint@0.20"
     import { tags as t }                           from "https://esm.sh/@lezer/highlight@1.1.6"
+    import LZString                                from "https://esm.sh/lz-string@1.5.0"
 
     const API = ""
 
@@ -764,9 +765,21 @@ AscDesc.new.ascdesc(:bad)
       }
     }, { hideOn: () => false })
 
+    // ── Shareable URL state ────────────────────────────────────────────────
+    // The source round-trips through ?c=<lz-string>: restored on load,
+    // rewritten (debounced) on edit. history.replaceState updates the address
+    // bar without a navigation or history spam.
+    const QUERY_KEY = "c"
+    function sourceFromUrl() {
+      const c = new URLSearchParams(location.search).get(QUERY_KEY)
+      if (!c) return null
+      try { return LZString.decompressFromEncodedURIComponent(c) || null } catch { return null }
+    }
+    const INITIAL_DOC = sourceFromUrl() ?? SAMPLE
+
     const view = new EditorView({
       state: EditorState.create({
-        doc: SAMPLE,
+        doc: INITIAL_DOC,
         extensions: [
           basicSetup,
           StreamLanguage.define(ruby),
@@ -778,6 +791,7 @@ AscDesc.new.ascdesc(:bad)
             if (!update.docChanged) return
             if (typesVisible) clearAnnotations()
             scheduleCheck()
+            scheduleUrlSync()
           }),
           EditorView.theme({
             "&"                       : { backgroundColor: "var(--bg)",         color: "var(--text)",      height: "100%" },
@@ -851,6 +865,21 @@ AscDesc.new.ascdesc(:bad)
     function scheduleCheck() {
       clearTimeout(debounceTimer)
       debounceTimer = setTimeout(runCheck, 600)
+    }
+
+    // Mirror the current source into ?c=<lz-string> (debounced). Clears the
+    // param when the buffer is the untouched sample, so a plain visit keeps a
+    // clean URL.
+    let urlTimer = null
+    function scheduleUrlSync() {
+      clearTimeout(urlTimer)
+      urlTimer = setTimeout(() => {
+        const src = view.state.doc.toString()
+        const url = src === SAMPLE
+          ? location.pathname
+          : `${location.pathname}?${QUERY_KEY}=${LZString.compressToEncodedURIComponent(src)}`
+        history.replaceState(null, "", url)
+      }, 600)
     }
 
     async function runCheck() {

--- a/plugins/rigor-playground/frontend/index.html
+++ b/plugins/rigor-playground/frontend/index.html
@@ -509,6 +509,37 @@
     .cm-tooltip-lint .cm-diagnostic-info    { border-left-color: var(--c-info); }
     .cm-tooltip-lint .cm-diagnosticSource   { color: var(--muted); }
 
+    /* Autocomplete dropdown — warm theme; selectors out-specify CM's base. */
+    .cm-tooltip.cm-tooltip-autocomplete { padding: 0; overflow: hidden; }
+    .cm-tooltip.cm-tooltip-autocomplete > ul {
+      font-family: var(--rigor-font-mono);
+      font-size: 12.5px;
+      max-height: 16em;
+      background: var(--surface);
+      color: var(--text);
+      margin: 0; padding: 4px;
+    }
+    .cm-tooltip.cm-tooltip-autocomplete > ul > li {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 8px;
+      border-radius: var(--rigor-radius-1);
+      color: var(--text);
+      line-height: 1.5;
+    }
+    .cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected] {
+      background: var(--accent);
+      color: var(--sev-fg);
+    }
+    .cm-tooltip-autocomplete .cm-completionLabel { color: inherit; }
+    .cm-tooltip-autocomplete .cm-completionMatchedText { text-decoration: underline; font-weight: 700; color: inherit; }
+    .cm-tooltip-autocomplete .cm-completionDetail { color: var(--muted); font-style: italic; margin-left: auto; }
+    .cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected] .cm-completionDetail { color: var(--sev-fg); opacity: 0.85; }
+    .cm-tooltip-autocomplete .cm-completionIcon { color: var(--muted); opacity: 0.8; }
+    .cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected] .cm-completionIcon { color: var(--sev-fg); }
+    .cm-completionInfo { background: var(--surface); color: var(--text); border: 1px solid var(--border-strong); border-radius: var(--rigor-radius-2); }
+
     /* High-contrast scrollbars for the diagnostics + editor regions */
     #diagnostics::-webkit-scrollbar,
     .cm-scroller::-webkit-scrollbar { width: 10px; height: 10px; }

--- a/plugins/rigor-playground/wasm/index.html
+++ b/plugins/rigor-playground/wasm/index.html
@@ -131,6 +131,19 @@
     .cm-tooltip-lint .cm-diagnostic-info { border-left-color: var(--c-info); }
     .cm-tooltip-lint .cm-diagnosticSource { color: var(--muted); }
 
+    /* Autocomplete dropdown — warm theme; selectors out-specify CM's base. */
+    .cm-tooltip.cm-tooltip-autocomplete { padding: 0; overflow: hidden; }
+    .cm-tooltip.cm-tooltip-autocomplete > ul { font-family: var(--rigor-font-mono); font-size: 12.5px; max-height: 16em; background: var(--surface); color: var(--text); margin: 0; padding: 4px; }
+    .cm-tooltip.cm-tooltip-autocomplete > ul > li { display: flex; align-items: center; gap: 6px; padding: 4px 8px; border-radius: 3px; color: var(--text); line-height: 1.5; }
+    .cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected] { background: var(--accent); color: var(--sev-fg); }
+    .cm-tooltip-autocomplete .cm-completionLabel { color: inherit; }
+    .cm-tooltip-autocomplete .cm-completionMatchedText { text-decoration: underline; font-weight: 700; color: inherit; }
+    .cm-tooltip-autocomplete .cm-completionDetail { color: var(--muted); font-style: italic; margin-left: auto; }
+    .cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected] .cm-completionDetail { color: var(--sev-fg); opacity: 0.85; }
+    .cm-tooltip-autocomplete .cm-completionIcon { color: var(--muted); opacity: 0.8; }
+    .cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected] .cm-completionIcon { color: var(--sev-fg); }
+    .cm-completionInfo { background: var(--surface); color: var(--text); border: 1px solid var(--border-strong); border-radius: 4px; }
+
     /* Boot overlay — the wasm VM download + first env build can take several
        seconds; surfacing the phase is the key UX difference vs the backend. */
     #boot {

--- a/plugins/rigor-playground/wasm/index.html
+++ b/plugins/rigor-playground/wasm/index.html
@@ -191,6 +191,7 @@
     import { lintGutter, setDiagnostics }          from "https://esm.sh/@codemirror/lint@0.20"
     import { tags as t }                           from "https://esm.sh/@lezer/highlight@1.1.6"
     import { DefaultRubyVM }                       from "https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.7.1/dist/browser/+esm"
+    import LZString                               from "https://esm.sh/lz-string@1.5.0"
 
     // ADR-29 WD10 — the docs-site sync step injects the R2 URL into the
     // <meta name="rigor-wasm-url"> tag in production; local `rake serve` keeps
@@ -309,14 +310,27 @@ AscDesc.new.ascdesc(:bad)
       { tag: t.invalid, color: "var(--c-error)" },
     ])
 
+    // ── Shareable URL state ────────────────────────────────────────────────
+    // The source round-trips through ?c=<lz-string>: restored on load,
+    // rewritten (debounced) on edit. lz-string keeps even a multi-KB snippet
+    // inside a comfortable URL length; history.replaceState updates the address
+    // bar without a navigation or history spam.
+    const QUERY_KEY = "c"
+    function sourceFromUrl() {
+      const c = new URLSearchParams(location.search).get(QUERY_KEY)
+      if (!c) return null
+      try { return LZString.decompressFromEncodedURIComponent(c) || null } catch { return null }
+    }
+    const INITIAL_DOC = sourceFromUrl() ?? SAMPLE
+
     const view = new EditorView({
       state: EditorState.create({
-        doc: SAMPLE,
+        doc: INITIAL_DOC,
         extensions: [
           basicSetup, StreamLanguage.define(ruby),
           Prec.highest(syntaxHighlighting(rigorHighlight)),
           lintGutter(), annoField,
-          EditorView.updateListener.of(u => { if (!u.docChanged) return; if (typesVisible) clearAnnotations(); scheduleCheck() }),
+          EditorView.updateListener.of(u => { if (!u.docChanged) return; if (typesVisible) clearAnnotations(); scheduleCheck(); scheduleUrlSync() }),
           EditorView.theme({
             "&": { backgroundColor: "var(--bg)", color: "var(--text)", height: "100%" },
             ".cm-content": { caretColor: "var(--accent)", fontFamily: MONO, padding: "8px 0" },
@@ -361,6 +375,21 @@ AscDesc.new.ascdesc(:bad)
     // ── Check ─────────────────────────────────────────────────────────────
 
     function scheduleCheck() { clearTimeout(debounceTimer); debounceTimer = setTimeout(runCheck, 500) }
+
+    // Mirror the current source into ?c=<lz-string> (debounced). Clears the
+    // param when the buffer is the untouched sample, so a plain visit keeps a
+    // clean URL.
+    let urlTimer = null
+    function scheduleUrlSync() {
+      clearTimeout(urlTimer)
+      urlTimer = setTimeout(() => {
+        const src = view.state.doc.toString()
+        const url = src === SAMPLE
+          ? location.pathname
+          : `${location.pathname}?${QUERY_KEY}=${LZString.compressToEncodedURIComponent(src)}`
+        history.replaceState(null, "", url)
+      }, 500)
+    }
 
     function runCheck() {
       if (!vm) return


### PR DESCRIPTION
Two playground frontend changes (no engine/wasm change — deploys via a docs-site submodule bump, no wasm rebuild).

## Shareable URL state (lz-string)
The editor source round-trips through a `?c=<lz-string>` query param — restored on load (falls back to the sample), rewritten on edit via a debounced `history.replaceState`. A link now carries the snippet with no backend.
- Verified the round-trip in Node, incl. multibyte and the `+`-heavy case (266/300 compressed outputs contain `+`; lz-string's `decompressFromEncodedURIComponent` restores the query-string `+`→space conversion itself, so the raw param round-trips — no extra encoding needed).
- Imported as the **default** export (robust across esm.sh's CJS interop vs. named imports).
- The param is cleared when the buffer is the untouched sample.
- Both `wasm/index.html` (deployed) and `frontend/index.html` (Rack backend) updated.

## Autocomplete dropdown styling
Warm-theme styling for CodeMirror's completion popup (mono font, accent-selected, muted detail/icon), matching the editor tokens. CSS only.

## Verification
- lz-string round-trip + URL handling proven in Node.
- Both module scripts pass `node --check` (no syntax errors).
- Reference: the technique follows https://zenn.dev/glassmonkey/articles/ae6cadef80c6c4 (query param + lz-string compress/decompress, URL-only update via History API).

Deploy = merge → bump the site `upstream/rigor` submodule (the wasm at the current commit is unchanged, so the existing R2 object still matches; only `index.html` changes flow through `sync:playground`).