### PR TITLE
Update README status to the published v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,12 +204,15 @@ the reference companions.
 
 ## Status
 
-Current release: **`v0.1.18`** (2026-06-11), with `v0.2.0` — the first
-evaluation release — landing shortly. Rigor analyses real Ruby today:
-the `0.1.x` line has been hardened against Mastodon, Redmine, and
-GitLab FOSS, and the deliberately conservative rule catalogue grows
-only as fast as the zero-false-positive bar allows. Release history:
-[`CHANGELOG.md`](CHANGELOG.md) · forward-looking commitments:
+Current release: **`v0.2.0`** (2026-06-17) — the first
+publicly-announced (general / evaluation) release. It publishes an
+enumerated [compatibility surface](docs/compatibility.md) as a
+minor-non-break trial, rehearsing the contract that hard-freezes at
+`v1.0.0`. Rigor analyses real Ruby today: it has been hardened against
+Mastodon, Redmine, and GitLab FOSS, and the deliberately conservative
+rule catalogue grows only as fast as the zero-false-positive bar
+allows. Release history: [`CHANGELOG.md`](CHANGELOG.md) ·
+forward-looking commitments:
 [Roadmap](https://rigor.typedduck.fail/reference/roadmap/).
 
 ## Contributing


### PR DESCRIPTION
Post-release docs fix. The `## Status` section still named **v0.1.18** as the current release and described v0.2.0 as "landing shortly"; v0.2.0 is now published (the first publicly-announced general / evaluation release).

Updates Status to v0.2.0 (2026-06-17) and frames the release by what it commits to — the enumerated [compatibility surface](docs/compatibility.md) published as a minor-non-break trial toward the v1.0.0 freeze. Docs-only; no code change.

(Separate from the v0.2.0 release PR #15, which had already merged + published when this update was written.)