### PR TITLE
Bump up version to 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,19 @@ cycles live in dedicated archives:
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-06-21
+
+v0.2.3 is a focused `rigor triage` usability fix. On a Rails project the
+report was dominated by plugin recognition trace, which buried the genuine
+error/warning signal and ranked the most *working* files as the top hotspots;
+triage now counts only the actionable diagnostics by default
+([ADR-23 WD6](docs/adr/23-diagnostic-triage-command.md)).
+
 ### Changed
 
-- **[cli]** `rigor triage` now counts only **actionable** diagnostics (`error` + `warning`) in its distribution, selectors, and hotspot sections; `info` diagnostics are excluded from these volume views by default. On a Rails project `info` is dominated by plugin *recognition trace* (`plugin.activerecord.model-call`, `plugin.rails-routes.helper`, …) — positive "Rigor resolved this call" records that previously buried the genuine error/warning signal (a field trip read 257 of 267 diagnostics as such trace) and inverted the hotspot ranking toward the files with the most *working* code. The summary line still reports the full `info` count, and the heuristic hints still see every diagnostic — so the useful `gem-without-rbs` notice survives, while the count-based "systemic cluster" / "genuine bugs" hints no longer mistake recognition trace for a problem. Pass `--include-info` to restore the previous behaviour ([ADR-23 WD6](docs/adr/23-diagnostic-triage-command.md)). **This is a behaviour change to the default `triage` text and JSON output** — the volume views no longer sum to `summary.total` by default, and `--format json` carries a new top-level `include_info` boolean.
+- **[rigor triage]** The distribution, selectors, and hotspot sections now count only the actionable diagnostics (`error` + `warning`); `info` is excluded from these volume views by default ([ADR-23 WD6](docs/adr/23-diagnostic-triage-command.md)).
+  - On a Rails project `info` is dominated by plugin recognition trace (`plugin.activerecord.model-call`, `plugin.rails-routes.helper`) — positive "Rigor resolved this call" records that previously buried the genuine error/warning signal and ranked the files with the most *working* code as the top hotspots. The summary line still reports the full `info` count and the heuristic hints still see every diagnostic, so the useful `gem-without-rbs` notice survives.
+  - This is a behaviour change to the default `triage` text and `--format json` output: the volume views no longer sum to `summary.total`, and the JSON gains a top-level `include_info` boolean. Pass `--include-info` to restore the previous behaviour.
 
 ## [0.2.2] - 2026-06-21
 
@@ -177,7 +187,8 @@ v0.2.0 is Rigor's first publicly-announced (general / evaluation) release, gover
 - **[cli]** `rigor explain call.unresolved-toplevel` now resolves — the [ADR-34](docs/adr/34-toplevel-unresolved-self-call-default.md) rule was missing from the catalogue despite being live since v0.1.14 — and a completeness spec now asserts every rule has a catalogue entry.
 - **[packaging]** The Docker build-context ignore file is scoped to the Dockerfile (`Dockerfile.dockerignore`) instead of a repo-wide `.dockerignore`, so external tools embedding the rigor source via BuildKit `--build-context` no longer get an empty context.
 
-[Unreleased]: https://github.com/rigortype/rigor/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/rigortype/rigor/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/rigortype/rigor/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/rigortype/rigor/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/rigortype/rigor/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/rigortype/rigor/compare/v0.1.19...v0.2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rigortype (0.2.2)
+    rigortype (0.2.3)
       language_server-protocol (>= 3.17, < 4.0)
       prism (>= 1.0, < 2.0)
       rbs (>= 3.0, < 5.0)
@@ -144,7 +144,7 @@ CHECKSUMS
   rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25
   rbs-inline (0.14.0) sha256=eaf47b46690d63acddab1f6804c9cc205a4bc78e637cfc421a0b1239874ef51c
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
-  rigortype (0.2.2)
+  rigortype (0.2.3)
   rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836

--- a/lib/rigor/version.rb
+++ b/lib/rigor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rigor
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
Release prep for **v0.2.3** — a focused `rigor triage` usability fix ([ADR-23 WD6](https://github.com/rigortype/rigor/blob/release/0.2.3/docs/adr/23-diagnostic-triage-command.md)).

The triage feature itself landed on `master` already (`34be77c2`); this PR is the version-bump commit only.

## What v0.2.3 changes

`rigor triage`'s distribution / selectors / hotspot sections now count only **actionable** diagnostics (`error` + `warning`); `:info` is excluded from these volume views by default. On a Rails project `:info` is dominated by plugin recognition trace (`plugin.activerecord.model-call`, `plugin.rails-routes.helper`, …) — positive "Rigor resolved this call" records that previously buried the genuine signal and ranked the files with the most *working* code as the top hotspots.

- Summary line keeps the full `:info` count; heuristic hints still see every diagnostic, so the useful `gem-without-rbs` notice survives.
- Count-based H5/H6 hints guard against `:info` so recognition trace never reads as a "systemic cluster" / "genuine bug".
- BC: the volume views no longer sum to `summary.total` by default, and `--format json` gains a top-level `include_info` boolean. `--include-info` restores the previous behaviour.

## Verification

- `make verify` green (6993 examples, 0 failures; rubocop clean; self-check + plugin-check exit 0).
- `gem build rigortype.gemspec` succeeds for 0.2.3.
- Validated before/after on the `conference-app` Rails project: default view now surfaces the 10 actionable diagnostics with a correct hotspot ranking; `--include-info` reproduces the pre-0.2.3 output.