### PR TITLE
Fix RBS 3.x compatibility in the env-loading surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,72 @@ jobs:
       - name: Run pool-runner spec
         run: make test-ractor-pool
 
-  # ── 2. RuboCop ───────────────────────────────────────────────────
+  # ── 2. RBS compatibility (3.x + 4.x) ────────────────────────────
+  rbs-compat:
+    name: RBS compatibility (RBS ${{ matrix.rbs }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rbs: "3.x"
+            constraint: "~> 3.10"
+            expected_major: "3"
+          - rbs: "4.x"
+            constraint: "~> 4.0"
+            expected_major: "4"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0"
+
+      # The public gemspec supports `rbs >= 3.0, < 5.0`, but RBS 3.x and
+      # 4.x diverge on the env-population API (`add_signature` /
+      # `MultiEntry::D` wrappers vs `add_source` / `RBS::Source` + bare
+      # decls) — a divergence that crashed `rigor check` under RBS 3.x.
+      # This job exercises both lines against the RBS-loading surface so
+      # that range stays honest.
+      #
+      # The normal development bundle cannot take an `rbs` matrix axis:
+      # it includes rbs-inline, whose upstream gem pins `rbs (~> 4.0)`.
+      # So this focused compatibility bundle installs Rigor as a path gem
+      # — only runtime dependencies, rspec, and the requested RBS line
+      # are resolved, with no rbs-inline to constrain it — and never
+      # rewrites the repo's Gemfile.lock.
+      - name: Install RBS compatibility bundle
+        env:
+          RBS_CONSTRAINT: ${{ matrix.constraint }}
+        run: |
+          cat > Gemfile.rbs-compat <<GEMFILE
+          source "https://rubygems.org"
+          ruby ">= 4.0.0", "< 4.1"
+          gem "rigortype", path: "."
+          gem "rspec", ">= 3.13", "< 4.0"
+          gem "rbs", "$RBS_CONSTRAINT"
+          GEMFILE
+          BUNDLE_GEMFILE=Gemfile.rbs-compat bundle install --jobs 4 --retry 3
+
+      - name: Assert selected RBS version
+        env:
+          EXPECTED_RBS_MAJOR: ${{ matrix.expected_major }}
+        run: |
+          BUNDLE_GEMFILE=Gemfile.rbs-compat bundle exec ruby -e '
+            require "rbs"
+            expected = ENV.fetch("EXPECTED_RBS_MAJOR")
+            abort "expected RBS #{expected}.x, got #{RBS::VERSION}" unless RBS::VERSION.start_with?("#{expected}.")
+            puts "RBS #{RBS::VERSION}"
+          '
+
+      - name: Run RBS environment compatibility specs
+        run: BUNDLE_GEMFILE=Gemfile.rbs-compat bundle exec rspec spec/rigor/environment
+
+  # ── 3. RuboCop ───────────────────────────────────────────────────
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -80,7 +145,7 @@ jobs:
       - name: Run lint
         run: make lint
 
-  # ── 3. Rigor self-check (warm + cold) ───────────────────────────
+  # ── 4. Rigor self-check (warm + cold) ───────────────────────────
   # Two matrix variants run in parallel:
   #   warm — restores .rigor/cache from the previous run so Rigor
   #           exercises the cache read/write path and skips slices
@@ -191,7 +256,7 @@ jobs:
         if: matrix.cache == 'cold'
         run: make check-incremental
 
-  # ── 4. Warm-vs-cold diagnostic diff ─────────────────────────────
+  # ── 5. Warm-vs-cold diagnostic diff ─────────────────────────────
   # The two self-check variants must agree on every diagnostic.  Any
   # difference means the cache is altering analysis results — a bug.
   # Runs whenever self-check was not outright cancelled (so the diff
@@ -230,19 +295,20 @@ jobs:
   # gated without touching protection rules.
   required:
     name: CI required
-    needs: [test, lint, self-check, self-check-diff]
+    needs: [test, rbs-compat, lint, self-check, self-check-diff]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: All checks passed
         env:
           TEST_RESULT: ${{ needs.test.result }}
+          RBS_COMPAT_RESULT: ${{ needs.rbs-compat.result }}
           LINT_RESULT: ${{ needs.lint.result }}
           SELF_CHECK_RESULT: ${{ needs.self-check.result }}
           SELF_CHECK_DIFF_RESULT: ${{ needs.self-check-diff.result }}
         run: |
           failed=0
-          for job_result in "$TEST_RESULT" "$LINT_RESULT" "$SELF_CHECK_RESULT" "$SELF_CHECK_DIFF_RESULT"; do
+          for job_result in "$TEST_RESULT" "$RBS_COMPAT_RESULT" "$LINT_RESULT" "$SELF_CHECK_RESULT" "$SELF_CHECK_DIFF_RESULT"; do
             if [[ "$job_result" != "success" ]]; then
               echo "A required job did not succeed (result: $job_result)"
               failed=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ cycles live in dedicated archives:
 
 ## [Unreleased]
 
+### Fixed
+
+- **[rigor check]** Fixed crashes under RBS 3.x (e.g. `undefined method 'primary_decl'`, `uninitialized constant RBS::Source`) so the whole supported RBS range (`rbs >= 3.0, < 5.0`) works again, not just RBS 4.x. (Fixes [#21](https://github.com/rigortype/rigor/issues/21), thank you [@aki77](https://github.com/aki77)!)
+  - Rigor now reads a class entry's representative declaration, populates synthesized RBS into the environment, and walks an entry's declarations through accessors that exist on both the RBS 3.x and 4.x environment APIs.
+  - A new CI job exercises the RBS-loading surface against both an RBS 3.x and an RBS 4.x bundle so the supported range stays honest.
+
 ## [0.2.3] - 2026-06-21
 
 v0.2.3 is a focused `rigor triage` usability fix. On a Rails project the

--- a/lib/rigor/environment/rbs_loader.rb
+++ b/lib/rigor/environment/rbs_loader.rb
@@ -170,7 +170,7 @@ module Rigor
           source = missing.map { |name| "module #{name}\nend\n" }.join
           buffer = ::RBS::Buffer.new(name: SYNTHETIC_NAMESPACE_BUFFER, content: source)
           _, directives, decls = ::RBS::Parser.parse_signature(buffer)
-          env.add_source(::RBS::Source::RBS.new(buffer, directives || [], decls || []))
+          add_parsed_decls(env, buffer, directives, decls)
         rescue ::RBS::BaseError
           # Fail-soft: synthesis is an opportunistic uplift, never a
           # hard requirement. A parse failure here just leaves the env
@@ -232,11 +232,52 @@ module Rigor
           missing.uniq
         end
 
+        # Normalises a `class_decls` entry's representative declaration
+        # across the gemspec's supported RBS range (`rbs >= 3.0, < 5.0`).
+        # RBS 4.x exposes it as `entry.primary_decl` (the AST declaration
+        # directly); RBS 3.x exposes `entry.primary` (a wrapper whose
+        # `#decl` is the AST declaration). Returns the AST declaration, or
+        # nil when neither accessor is present. Without this guard,
+        # `class_decl_paths` crashed under RBS 3.x with
+        # `undefined method 'primary_decl'`.
+        def primary_decl_for(entry)
+          if entry.respond_to?(:primary_decl)
+            entry.primary_decl
+          elsif entry.respond_to?(:primary)
+            primary = entry.primary
+            primary.respond_to?(:decl) ? primary.decl : primary
+          end
+        end
+
+        # Appends freshly-parsed declarations to an `RBS::Environment`
+        # across the gemspec's supported RBS range (`rbs >= 3.0, < 5.0`).
+        # RBS 4.x wraps the declarations in an `RBS::Source::RBS` and
+        # takes them through `env.add_source`; RBS 3.x has neither
+        # `RBS::Source` nor `add_source` and instead registers them with
+        # `env.add_signature(buffer:, directives:, decls:)` (a bare
+        # `env << decl` is NOT enough — it skips the `signatures` table
+        # that `resolve_type_names` rebuilds from, so the synthesized
+        # declarations silently vanish on resolve). Without this guard
+        # the synthesis paths (`synthesize_missing_namespaces`,
+        # `append_stub_declarations`, `add_virtual_rbs`) crashed under
+        # RBS 3.x with `uninitialized constant RBS::Source`.
+        def add_parsed_decls(env, buffer, directives, decls)
+          decls ||= []
+          directives ||= []
+          if env.respond_to?(:add_source)
+            env.add_source(::RBS::Source::RBS.new(buffer, directives, decls))
+          elsif env.respond_to?(:add_signature)
+            env.add_signature(buffer: buffer, directives: directives, decls: decls)
+          else
+            decls.each { |decl| env << decl }
+          end
+        end
+
         # True when a `class_decls` entry was declared in one of the
         # project's own signature files (by declaration location), so
         # the sweep skips the bundled stdlib / vendored universe.
         def project_entry?(entry, project_files)
-          decl = entry.respond_to?(:primary_decl) ? entry.primary_decl : nil
+          decl = primary_decl_for(entry)
           location = decl&.location
           buffer_name = location&.buffer&.name
           return false unless buffer_name
@@ -262,7 +303,7 @@ module Rigor
           end.join
           buffer = ::RBS::Buffer.new(name: SYNTHETIC_STUB_BUFFER, content: source)
           _, directives, decls = ::RBS::Parser.parse_signature(buffer)
-          base_env.add_source(::RBS::Source::RBS.new(buffer, directives || [], decls || []))
+          add_parsed_decls(base_env, buffer, directives, decls)
         rescue ::RBS::BaseError
           nil
         end
@@ -284,8 +325,7 @@ module Rigor
 
             buffer = ::RBS::Buffer.new(name: filename.to_s, content: content.to_s)
             _, directives, decls = ::RBS::Parser.parse_signature(buffer)
-            source = ::RBS::Source::RBS.new(buffer, directives || [], decls || [])
-            env.add_source(source)
+            add_parsed_decls(env, buffer, directives, decls)
           rescue ::RBS::BaseError
             # WD6 fail-soft: a single broken virtual RBS contribution
             # does not pull the whole env down. The plugin layer
@@ -589,7 +629,7 @@ module Rigor
 
         result = {}
         env.class_decls.each do |rbs_name, entry|
-          decl = entry.primary_decl
+          decl = self.class.primary_decl_for(entry)
           next if decl.nil?
 
           location = decl.location
@@ -911,12 +951,17 @@ module Rigor
       end
 
       # Collects the AST declaration nodes behind a `class_decls`
-      # entry. RBS 4's `ModuleEntry` / `ClassEntry` expose `each_decl`;
-      # the older single-`decl` shape is handled defensively so the
-      # loader survives an rbs-gem minor bump.
+      # entry across the supported RBS range (`rbs >= 3.0, < 5.0`).
+      # RBS 4's `ModuleEntry` / `ClassEntry` expose `each_decl` yielding
+      # bare AST declarations; RBS 3.x exposes `decls`, an array of
+      # `MultiEntry::D` wrappers whose `#decl` is the AST declaration.
+      # The single-`decl` shape is handled defensively so the loader
+      # survives an rbs-gem minor bump.
       def entry_declarations(entry)
         if entry.respond_to?(:each_decl)
           [].tap { |acc| entry.each_decl { |decl| acc << decl } }
+        elsif entry.respond_to?(:decls)
+          entry.decls.map { |d| d.respond_to?(:decl) ? d.decl : d }
         elsif entry.respond_to?(:decl)
           [entry.decl]
         else

--- a/spec/rigor/environment/rbs_loader_spec.rb
+++ b/spec/rigor/environment/rbs_loader_spec.rb
@@ -342,6 +342,36 @@ RSpec.describe Rigor::Environment::RbsLoader do
     end
   end
 
+  describe "#class_decl_paths" do
+    # Regression: `class_decl_paths` called `entry.primary_decl`
+    # unguarded, which only exists on RBS 4.x. Under RBS 3.x (allowed
+    # by the gemspec `rbs >= 3.0, < 5.0`, which exposes `entry.primary`
+    # instead) `rigor check` crashed with
+    # `undefined method 'primary_decl'`. The shared `primary_decl_for`
+    # helper normalises both shapes, so this maps every loaded class to
+    # the file its first declaration came from across the whole range.
+    it "maps core classes to the RBS source file of their first declaration" do
+      paths = loader.class_decl_paths
+      expect(paths).not_to be_empty
+      expect(paths).to be_frozen
+      expect(paths["::Integer"]).to be_a(String)
+      expect(paths["::Integer"]).to end_with(".rbs")
+    end
+
+    it "attributes a project signature_paths class to its own sig file" do
+      tmpdir = Dir.mktmpdir("rigor-rbs-loader-decl-paths-spec-")
+      File.write(
+        File.join(tmpdir, "widget.rbs"),
+        "module Acme\n  class Widget\n    def size: () -> Integer\n  end\nend\n"
+      )
+      project_loader = described_class.new(signature_paths: [tmpdir])
+      expect(project_loader.class_decl_paths["::Acme::Widget"])
+        .to eq(File.join(tmpdir, "widget.rbs"))
+    ensure
+      FileUtils.rm_rf(tmpdir) if tmpdir
+    end
+  end
+
   describe "env build failure short-circuit (O7)" do
     # Open item O7 (real-world Rails survey, 2026-05-15):
     # when a `signature_paths:` entry redeclares a constant or


### PR DESCRIPTION
`rigor check` crashed under RBS 3.x because the loader called `entry.primary_decl` (RBS 4.x only) and `RBS::Source::RBS.new` / `env.add_source` (also 4.x-only) unconditionally.

- Add `primary_decl_for(entry)` — falls back to `entry.primary.decl` on RBS 3.x so `class_decl_paths` and `project_entry?` work across the whole `rbs >= 3.0, < 5.0` range.
- Add `add_parsed_decls(env, ...)` — uses `env.add_source` on 4.x, `env.add_signature` on 3.x, and a bare `env << decl` fallback; fixes the three synthesis paths that populate the RBS environment.
- Extend `entry_declarations` to handle RBS 3.x's `MultiEntry::D` wrapper via `entry.decls` before the existing `entry.decl` fallback.
- Add a focused `Gemfile.rbs-compat` CI job that installs Rigor against both `~> 3.10` and `~> 4.0` RBS and runs `spec/rigor/environment` so the supported range stays honest.
- Add two regression specs for `#class_decl_paths` covering both the core-class path and a project signature_paths class.

Fixes https://github.com/rigortype/rigor/issues/21