### PR TITLE
Bump up version to 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,15 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-06-22
+
+v0.2.4 is a targeted compatibility fix. Analysis was crashing on the lower end of the declared `rbs >= 3.0, < 5.0` range due to API divergences in the environment-loading surface; v0.2.4 corrects both crash paths and adds a CI job that exercises the RBS-loading surface against both RBS 3.x and 4.x on every push. Thanks to https://github.com/aki77 for the report (https://github.com/rigortype/rigor/issues/21).
+
 ### Fixed
 
-- **[rigor check]** Fixed crashes under RBS 3.x (e.g. `undefined method 'primary_decl'`, `uninitialized constant RBS::Source`) so the whole supported RBS range (`rbs >= 3.0, < 5.0`) works again, not just RBS 4.x. (Fixes [#21](https://github.com/rigortype/rigor/issues/21), thank you [@aki77](https://github.com/aki77)!)
-  - Rigor now reads a class entry's representative declaration, populates synthesized RBS into the environment, and walks an entry's declarations through accessors that exist on both the RBS 3.x and 4.x environment APIs.
-  - A new CI job exercises the RBS-loading surface against both an RBS 3.x and an RBS 4.x bundle so the supported range stays honest.
+- **[rigor check]** Fixed two crashes on RBS 3.x — `undefined method 'primary_decl'` and `uninitialized constant RBS::Source` — so the full supported range `rbs >= 3.0, < 5.0` works again, not just RBS 4.x.
+  - Rigor now reads a class entry's representative declaration and walks its declarations through accessors present on both the RBS 3.x and 4.x environment APIs.
+  - A new CI job runs the RBS-loading surface against both an RBS 3.x and an RBS 4.x bundle so the supported range stays honest going forward.
 
 ## [0.2.3] - 2026-06-21
 
@@ -174,7 +178,8 @@ v0.2.0 is Rigor's first publicly-announced (general / evaluation) release, gover
 - **[cli]** `rigor explain call.unresolved-toplevel` now resolves — the [ADR-34](docs/adr/34-toplevel-unresolved-self-call-default.md) rule was missing from the catalogue despite being live since v0.1.14 — and a completeness spec now asserts every rule has a catalogue entry.
 - **[packaging]** The Docker build-context ignore file is scoped to the Dockerfile (`Dockerfile.dockerignore`) instead of a repo-wide `.dockerignore`, so external tools embedding the rigor source via BuildKit `--build-context` no longer get an empty context.
 
-[Unreleased]: https://github.com/rigortype/rigor/compare/v0.2.3...HEAD
+[Unreleased]: https://github.com/rigortype/rigor/compare/v0.2.4...HEAD
+[0.2.4]: https://github.com/rigortype/rigor/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/rigortype/rigor/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/rigortype/rigor/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/rigortype/rigor/compare/v0.2.0...v0.2.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rigortype (0.2.3)
+    rigortype (0.2.4)
       language_server-protocol (>= 3.17, < 4.0)
       prism (>= 1.0, < 2.0)
       rbs (>= 3.0, < 5.0)
@@ -144,7 +144,7 @@ CHECKSUMS
   rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25
   rbs-inline (0.14.0) sha256=eaf47b46690d63acddab1f6804c9cc205a4bc78e637cfc421a0b1239874ef51c
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
-  rigortype (0.2.3)
+  rigortype (0.2.4)
   rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836

--- a/lib/rigor/version.rb
+++ b/lib/rigor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rigor
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end


### PR DESCRIPTION
This is a focused release containing only the RBS 3.x compatibility crash fix (https://github.com/rigortype/rigor/issues/21).

## Summary

- Fixed two crashes (`undefined method 'primary_decl'` / `uninitialized constant RBS::Source`), allowing the analysis to work across the full range of `rbs >= 3.0, < 5.0`.
- Added CI jobs targeting both RBS 3.x and 4.x bundles.

## Test plan

- [x] Confirmed that `ci.yml` is green
- [x] Confirmed no unexpected regressions in perf / sweep on `release-gate.yml`