### PR TITLE
Integrate binpacker for test parallelization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,23 +39,23 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
-      # Cache the binpacker timing file between runs so that LPT
-      # scheduling can use measured per-file runtimes to balance
-      # workers. On a cache miss (first run, or after eviction)
-      # binpacker falls back to filesize weighting automatically —
-      # no cold-start breakage. The file is written at the end of
-      # each run and picked up by the next. Key is unique per
-      # run-id so the post-step always saves fresh timing data;
-      # restore-keys prefix-matches the most recent entry.
-      - name: Restore binpacker timing file
+      # Cache the parallel-rspec runtime log between runs so that
+      # `--group-by default` can use measured per-file runtimes to
+      # balance groups. On a cache miss (first run, or after the key
+      # space is evicted) parallel_rspec falls back to filesize
+      # automatically — no cold-start breakage. The log is written at
+      # the end of each successful run and picked up by the next.
+      # Key is unique per run-id so the post-step always saves fresh
+      # timing data; restore-keys prefix-matches the most recent entry.
+      - name: Restore parallel-rspec runtime log
         uses: actions/cache@v5
         with:
-          path: tmp/binpacker.timings
-          key: binpacker-timings-${{ runner.os }}-ruby${{ matrix.ruby }}-${{ github.run_id }}
-          restore-keys: binpacker-timings-${{ runner.os }}-ruby${{ matrix.ruby }}-
+          path: tmp/parallel_runtime.log
+          key: parallel-runtime-${{ runner.os }}-ruby${{ matrix.ruby }}-${{ github.run_id }}
+          restore-keys: parallel-runtime-${{ runner.os }}-ruby${{ matrix.ruby }}-
 
       - name: Run tests
-        run: make test-binpacker
+        run: make test-parallel
 
       # The pool-runner spec is excluded from the default suite (see
       # spec/spec_helper.rb) and runs as its own rspec process. Without
@@ -64,6 +64,46 @@ jobs:
       # weeks (fork-backend default 86ed9129 → fixed 7ebeac08).
       - name: Run pool-runner spec
         run: make test-ractor-pool
+
+  # ── 1b. binpacker parallel suite (trial, not required) ──────────
+  # Runs the spec suite via binpacker alongside the parallel_tests job
+  # to validate correctness and measure scheduling quality during the
+  # trial period. Intentionally excluded from the `required` fan-in
+  # so a binpacker regression never blocks a merge while it is still
+  # under observation. Promote to `required` once the trial passes.
+  test-binpacker:
+    name: Tests via binpacker (Ruby ${{ matrix.ruby }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - "4.0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      # Cache the binpacker timing file between runs so that LPT
+      # scheduling can use measured per-file runtimes to balance
+      # workers. On a cache miss binpacker falls back to filesize
+      # weighting automatically — no cold-start breakage.
+      - name: Restore binpacker timing file
+        uses: actions/cache@v5
+        with:
+          path: tmp/binpacker.timings
+          key: binpacker-timings-${{ runner.os }}-ruby${{ matrix.ruby }}-${{ github.run_id }}
+          restore-keys: binpacker-timings-${{ runner.os }}-ruby${{ matrix.ruby }}-
+
+      - name: Run tests via binpacker
+        run: make test-binpacker
 
   # ── 2. RBS compatibility (3.x + 4.x) ────────────────────────────
   rbs-compat:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,23 +39,23 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
-      # Cache the parallel-rspec runtime log between runs so that
-      # `--group-by default` can use measured per-file runtimes to
-      # balance groups. On a cache miss (first run, or after the key
-      # space is evicted) parallel_rspec falls back to filesize
-      # automatically — no cold-start breakage. The log is written at
-      # the end of each successful run and picked up by the next.
-      # Key is unique per run-id so the post-step always saves fresh
-      # timing data; restore-keys prefix-matches the most recent entry.
-      - name: Restore parallel-rspec runtime log
+      # Cache the binpacker timing file between runs so that LPT
+      # scheduling can use measured per-file runtimes to balance
+      # workers. On a cache miss (first run, or after eviction)
+      # binpacker falls back to filesize weighting automatically —
+      # no cold-start breakage. The file is written at the end of
+      # each run and picked up by the next. Key is unique per
+      # run-id so the post-step always saves fresh timing data;
+      # restore-keys prefix-matches the most recent entry.
+      - name: Restore binpacker timing file
         uses: actions/cache@v5
         with:
-          path: tmp/parallel_runtime.log
-          key: parallel-runtime-${{ runner.os }}-ruby${{ matrix.ruby }}-${{ github.run_id }}
-          restore-keys: parallel-runtime-${{ runner.os }}-ruby${{ matrix.ruby }}-
+          path: tmp/binpacker.timings
+          key: binpacker-timings-${{ runner.os }}-ruby${{ matrix.ruby }}-${{ github.run_id }}
+          restore-keys: binpacker-timings-${{ runner.os }}-ruby${{ matrix.ruby }}-
 
       - name: Run tests
-        run: make test-parallel
+        run: make test-binpacker
 
       # The pool-runner spec is excluded from the default suite (see
       # spec/spec_helper.rb) and runs as its own rspec process. Without

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,13 +196,19 @@ jobs:
       # analysis result; a partial match restores the closest ancestor
       # cache and Rigor fills any missing slices on the fly.
       # Skipped entirely for the cold variant — no restore, no save.
+      #
+      # The restore-keys are scoped to the current Gemfile.lock hash so
+      # that a lockfile change (e.g. adding a gem) never restores a cache
+      # built under the old lockfile.  A stale-lockfile restore would make
+      # the gem-without-rbs count diverge between warm and cold, failing
+      # the warm==cold diff gate even when the analysis is correct.
       - name: Restore Rigor analysis cache
         if: matrix.cache == 'warm'
         uses: actions/cache@v5
         with:
           path: .rigor/cache
-          key: rigor-cache-${{ runner.os }}-${{ hashFiles('lib/**/*.rb', 'sig/**/*.rbs', 'data/builtins/**/*.yml', 'Gemfile.lock') }}
-          restore-keys: rigor-cache-${{ runner.os }}-
+          key: rigor-cache-${{ runner.os }}-${{ hashFiles('Gemfile.lock') }}-${{ hashFiles('lib/**/*.rb', 'sig/**/*.rbs', 'data/builtins/**/*.yml') }}
+          restore-keys: rigor-cache-${{ runner.os }}-${{ hashFiles('Gemfile.lock') }}-
 
       # Run once with --format json so we get both structured output for
       # the warm-vs-cold diff and a human-readable summary in the CI log.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
+    binpacker (0.0.3)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     diff-lcs (1.6.2)
@@ -107,6 +108,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (>= 7.0, < 9.0)
+  binpacker (>= 0.0.1, < 1.0)
   parallel_tests (>= 4.0, < 6.0)
   rack (>= 2.0, < 4.0)
   rake (>= 13.0, < 15.0)
@@ -122,6 +124,7 @@ CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  binpacker (0.0.3) sha256=2452a9dd0794ed191e53bbb1aa908e0fcb22c810e6bb0262822362a11ab3638d
   bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,10 +105,11 @@ GEM
 PLATFORMS
   arm64-darwin-25
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   activesupport (>= 7.0, < 9.0)
-  binpacker (>= 0.0.1, < 1.0)
+  binpacker (>= 0.0.3, < 1.0)
   parallel_tests (>= 4.0, < 6.0)
   rack (>= 2.0, < 4.0)
   rake (>= 13.0, < 15.0)

--- a/Makefile
+++ b/Makefile
@@ -174,16 +174,16 @@ bench-perf:
 # `verify` chains the spec suite, the gated pool-runner spec (its
 # own rspec process — see `test-ractor-pool`), rubocop, `rigor check
 # lib`, and the plugin-tree contract check. The spec phase runs in
-# parallel by default via binpacker (3-4× faster on multi-core hosts
-# than the sequential rspec invocation). `lint` is already
-# process-parallel via rubocop's built-in worker pool; `check` /
-# `check-plugins` are short rigor invocations.
+# parallel by default (3-4× faster on multi-core hosts than the
+# sequential rspec invocation). `lint` is already process-parallel
+# via rubocop's built-in worker pool; `check` / `check-plugins` are
+# short rigor invocations.
 #
 # Total wall time on a 12-core laptop: ~60s (vs ~200s for the
 # sequential variant below). Use `verify-sequential` when chasing
 # parallel-only flakes — the worker isolation hides certain
 # ordering bugs that surface only in a single-process run.
-verify: test-binpacker test-ractor-pool lint check check-plugins
+verify: test-parallel test-ractor-pool lint check check-plugins
 
 # Sequential variant. Identical phases as `verify` but `test`
 # runs single-process. Slower but bit-for-bit reproducible

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install init-git-config init-submodules pull-submodules doctor-submodules test test-parallel test-ractor-pool lint check check-plugins check-incremental docs-check verify verify-parallel check-json extract-builtin-catalogs catalog-diff steep-install steep-check steep cache-clean
+.PHONY: setup install init-git-config init-submodules pull-submodules doctor-submodules test test-parallel test-binpacker test-ractor-pool lint check check-plugins check-incremental docs-check verify verify-parallel check-json extract-builtin-catalogs catalog-diff steep-install steep-check steep cache-clean
 
 REFERENCE_SUBMODULES := \
 	references/rbs \
@@ -96,6 +96,16 @@ test-ractor-pool:
 test-parallel:
 	bundle exec rake spec_parallel
 
+# Spec suite via `binpacker`, distributing files across worker
+# processes using LPT scheduling driven by measured per-file
+# runtimes (tmp/binpacker.timings). On a cold start (no timings
+# file) binpacker falls back to filesize weighting automatically.
+# `PARALLEL_TEST_PROCESSORS=N` is honoured by parallel_tests;
+# binpacker uses `workers: auto` from binpacker.yml (CPU count)
+# or override via the config profile.
+test-binpacker:
+	bundle exec binpacker run
+
 lint:
 	bundle exec rubocop lib/ spec/ plugins/ examples/
 
@@ -164,16 +174,16 @@ bench-perf:
 # `verify` chains the spec suite, the gated pool-runner spec (its
 # own rspec process — see `test-ractor-pool`), rubocop, `rigor check
 # lib`, and the plugin-tree contract check. The spec phase runs in
-# parallel by default (3-4× faster on multi-core hosts than the
-# sequential rspec invocation). `lint` is already process-parallel
-# via rubocop's built-in worker pool; `check` / `check-plugins` are
-# short rigor invocations.
+# parallel by default via binpacker (3-4× faster on multi-core hosts
+# than the sequential rspec invocation). `lint` is already
+# process-parallel via rubocop's built-in worker pool; `check` /
+# `check-plugins` are short rigor invocations.
 #
 # Total wall time on a 12-core laptop: ~60s (vs ~200s for the
 # sequential variant below). Use `verify-sequential` when chasing
 # parallel-only flakes — the worker isolation hides certain
 # ordering bugs that surface only in a single-process run.
-verify: test-parallel test-ractor-pool lint check check-plugins
+verify: test-binpacker test-ractor-pool lint check check-plugins
 
 # Sequential variant. Identical phases as `verify` but `test`
 # runs single-process. Slower but bit-for-bit reproducible

--- a/binpacker.yml
+++ b/binpacker.yml
@@ -1,0 +1,14 @@
+profiles:
+  default:
+    test_runner: rspec
+    workers: auto
+    timing_file: tmp/binpacker.timings
+    test_pattern: spec/**/*_spec.rb
+    test_exclude:
+      - spec/rigor/analysis/runner_pool_spec.rb
+    scheduler:
+      strategy: static
+      algorithm: lpt
+
+  ci:
+    extends: default

--- a/rigortype.gemspec
+++ b/rigortype.gemspec
@@ -65,6 +65,7 @@ Gem::Specification.new do |spec|
   # exercises the real catalogue; the production dep belongs on the
   # plugin gem (rspec-rails apps already pull rack via actionpack).
   spec.add_development_dependency "rack", ">= 2.0", "< 4.0"
+  spec.add_development_dependency "binpacker", ">= 0.0.3", "< 1.0"
   spec.add_development_dependency "parallel_tests", ">= 4.0", "< 6.0"
   spec.add_development_dependency "rake", ">= 13.0", "< 15.0"
   # ADR-32 — the `rigor-rbs-inline` plugin under `plugins/`


### PR DESCRIPTION
## Summary

- Replaces `parallel_tests` with binpacker as the primary parallel test runner
- `binpacker.yml` configures the rspec runner, auto worker count (CPU count), LPT scheduling, and excludes `runner_pool_spec.rb` (which runs separately via `make test-ractor-pool`)
- `tmp/binpacker.timings` is cached between CI runs for optimal LPT scheduling; falls back to filesize weighting on cold start
- `make test-binpacker` added; `make verify` wired to it instead of `test-parallel` (`test-parallel` kept as a named alternative)

The git source pins to the revision containing two UTF-8 fixes (pipe/file I/O encoding) that are not yet in the 0.0.1 rubygems release. Once a new release ships the source ref can be dropped to a plain version constraint.

## Test plan

- [ ] CI `test` job passes with `make test-binpacker`
- [ ] `make test-ractor-pool` still runs separately (unchanged)
- [ ] CI caches `tmp/binpacker.timings` and uses it on the next run