### PR TITLE
Add view-template lazy-key scanning to rigor-rails-i18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Plugins
+
+- **[rigor-rails-i18n]** View-template lazy keys are now validated. `t('.title')` inside `app/views/setting/index.html.erb` expands to `setting.index.title` (the Rails virtual-path convention — partial `_`-prefixes and `+variant` suffixes are stripped) and is checked for key existence and per-locale coverage against `config/locales/*.yml`. ERB, Haml, and Slim templates under the configurable `view_search_paths` (default `["app/views"]`) are scanned; the results are cached and invalidated when templates change. Interpolation validation is skipped for templates — the hash may come from controller instance variables not visible in the template source. Plugin bumped to `0.3.0`.
+  - Known limitation: the view scan is a project-wide pass surfaced through the per-file diagnostic hook, so under `--workers` each fork-pool worker re-emits the full set (the same once-per-run limitation the `load-error` diagnostics already carry). Default sequential `rigor check` is unaffected.
+
 ### Performance
 
 - **[spec suite]** Targeted profiling pass removes repeated per-example setup in three of the slowest spec groups, cutting roughly 50 seconds off the sequential suite run.

--- a/docs/manual/plugins/rigor-rails-i18n.md
+++ b/docs/manual/plugins/rigor-rails-i18n.md
@@ -88,6 +88,11 @@ view templates containing lazy `t('.key')` calls.
   may come from controller instance variables not visible in the
   template source. Configure `view_search_paths:` to override the
   default `["app/views"]`.
+- **View diagnostics duplicate under `--workers`** — the view
+  scan is a project-wide pass surfaced through the per-file
+  diagnostic hook, so each fork-pool worker re-emits the full set
+  (the same once-per-run limitation the `load-error` diagnostics
+  carry). Default `rigor check` (sequential) is unaffected.
 - **Pluralization is recognised but not validated** — `count:` is
   treated as a reserved option; whether the locale defines
   `:zero` / `:one` / `:other` is not checked.

--- a/docs/manual/plugins/rigor-rails-i18n.md
+++ b/docs/manual/plugins/rigor-rails-i18n.md
@@ -43,9 +43,14 @@ errors_demo.rb:25:1: warning: `t('errors.messages.blank')` is missing from local
 with a literal first argument. **Lazy keys** — `t('.title')` in a
 controller — are expanded to `<controller_scope>.<action>.<key>`
 from the file path and the innermost enclosing `def`, matching
-Rails' convention; lazy keys in non-controller files are skipped
-(the scope can't be determined statically). Calls with a
-non-literal key (`t(some_variable)`) pass through unchecked.
+Rails' convention; lazy keys in non-controller Ruby files (models,
+helpers, mailers) are skipped (the scope can't be determined
+statically at that point). **View template lazy keys** —
+`t('.title')` inside `app/views/setting/index.html.erb` expands
+to `setting.index.title` and is validated for key existence and
+per-locale coverage; ERB, Haml, and Slim templates under
+`view_search_paths` (default `app/views`) are scanned. Calls with
+a non-literal key (`t(some_variable)`) pass through unchecked.
 
 Keys under the prefixes Rails and the `rails-i18n` gem ship
 themselves (`date.` / `time.` / `datetime.` / `number.` /
@@ -62,11 +67,14 @@ plugins:
     config:
       locale_search_paths: ["config/locales"]   # default
       configured_locales: ["en"]                # default
+      view_search_paths: ["app/views"]          # default
 ```
 
 `configured_locales` is the set of locales the project ships;
 setting it to `["en", "ja"]` turns on `missing-locale` warnings
 whenever a key resolves in one but not the other.
+`view_search_paths` controls which directories are scanned for
+view templates containing lazy `t('.key')` calls.
 
 ## Limitations
 
@@ -74,6 +82,12 @@ whenever a key resolves in one but not the other.
 - **Lazy keys outside controllers are skipped** — the
   controller/action scope `t('.x')` depends on isn't derivable in
   a model / helper / mailer.
+- **View template lazy keys** (`t('.key')` inside ERB / Haml /
+  Slim) are validated for key existence and per-locale coverage.
+  Interpolation validation is skipped for templates — the hash
+  may come from controller instance variables not visible in the
+  template source. Configure `view_search_paths:` to override the
+  default `["app/views"]`.
 - **Pluralization is recognised but not validated** — `count:` is
   treated as a reserved option; whether the locale defines
   `:zero` / `:one` / `:other` is not checked.

--- a/plugins/rigor-rails-i18n/README.md
+++ b/plugins/rigor-rails-i18n/README.md
@@ -28,7 +28,7 @@ plugins/rigor-rails-i18n/
 │       └── rails_i18n/
 │           ├── locale_index.rb     ← frozen `dotted_key => Entry` value object
 │           ├── locale_loader.rb    ← walks config/locales, parses YAML, builds the index
-│           └── analyzer.rb         ← per-call validation
+│           └── analyzer.rb         ← per-call validation + view template lazy-key scanning
 └── demo/
     ├── .rigor.yml
     ├── .gitignore
@@ -52,9 +52,10 @@ nix --extra-experimental-features 'nix-command flakes' develop --command \
 
 | Surface | Used for |
 | --- | --- |
-| `manifest(... config_schema:)` | `locale_search_paths` / `configured_locales` knobs (ADR-40 declared defaults). |
+| `manifest(... config_schema:)` | `locale_search_paths` / `configured_locales` / `view_search_paths` knobs (ADR-40 declared defaults). |
 | `Plugin::Base.producer :locale_index` | Caches the discovered locale index across runs (cache invalidates via `producer watch:`). |
-| `Plugin::Base#io_boundary` (`read_file`) | Reads each `.yml` / `.yaml` under `locale_search_paths` through the trusted scope. |
+| `Plugin::Base.producer :view_diagnostics` | Scans view templates under `view_search_paths` for lazy `t('.key')` calls; caches across runs. |
+| `Plugin::Base#io_boundary` (`read_file`) | Reads each `.yml` / `.yaml` under `locale_search_paths` and each `.erb` / `.haml` / `.slim` under `view_search_paths` through the trusted scope. |
 | `node_rule` + `NodeContext` (ADR-37) | Per-call validation over the engine-owned walk; the lexical ancestor chain resolves a lazy `t('.key')` to its enclosing controller action. |
 
 ## Future direction
@@ -65,6 +66,10 @@ nix --extra-experimental-features 'nix-command flakes' develop --command \
 - **Pluralization branches**: enrich the index with
   `:zero` / `:one` / `:other` keys and validate
   `t(..., count: …)` against them.
+- **View interpolation validation**: once the engine can walk
+  ERB templates as Ruby ASTs (via the `node_rule` walk),
+  validate `t('.key', name: @user.name)` interpolation hashes
+  inside view templates.
 
 ## License
 

--- a/plugins/rigor-rails-i18n/README.md
+++ b/plugins/rigor-rails-i18n/README.md
@@ -66,10 +66,12 @@ nix --extra-experimental-features 'nix-command flakes' develop --command \
 - **Pluralization branches**: enrich the index with
   `:zero` / `:one` / `:other` keys and validate
   `t(..., count: …)` against them.
-- **View interpolation validation**: once the engine can walk
-  ERB templates as Ruby ASTs (via the `node_rule` walk),
-  validate `t('.key', name: @user.name)` interpolation hashes
-  inside view templates.
+- **View interpolation validation**: the current scanner uses a
+  regex to extract `t('.key')` calls, so interpolation hashes
+  inside templates (e.g. `t('.greeting', name: @user.name)`) are
+  not parsed. A Prism-AST-based ERB walker would let the plugin
+  validate `t('.key', **opts)` interpolation variables in views
+  the same way it validates controller calls.
 
 ## License
 

--- a/plugins/rigor-rails-i18n/README.md
+++ b/plugins/rigor-rails-i18n/README.md
@@ -72,6 +72,12 @@ nix --extra-experimental-features 'nix-command flakes' develop --command \
   not parsed. A Prism-AST-based ERB walker would let the plugin
   validate `t('.key', **opts)` interpolation variables in views
   the same way it validates controller calls.
+- **Once-per-run diagnostic channel**: the view scan is a
+  project-wide pass emitted through the per-file diagnostic hook,
+  so under `--workers` each fork-pool worker re-emits the full set
+  (the same limitation the `load-error` path carries). A deduped
+  once-per-run plugin project-diagnostic channel would let both
+  surface exactly once regardless of the worker count.
 
 ## License
 

--- a/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n.rb
+++ b/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n.rb
@@ -62,6 +62,11 @@ module Rigor
     #   coverage. Interpolation variable validation is skipped
     #   for view templates (the hash may come from controller
     #   instance variables not visible in the template).
+    #   The view scan is a project-wide pass surfaced through the
+    #   per-file diagnostic hook, so under `--workers` each
+    #   fork-pool worker re-emits the full set (the same
+    #   once-per-run limitation the `load-error` path carries);
+    #   sequential `rigor check` is unaffected.
     # - Pluralization (`t('errors.messages.too_short',
     #   count: n)`) is recognised at the call site but the
     #   `count` key is not used to validate the locale's
@@ -175,15 +180,16 @@ module Rigor
         content = read_view_template(view_path) or return []
         scope = Analyzer.view_scope_from_path(view_path) or return []
 
+        display_path = relative_view_path(view_path)
         Analyzer.extract_lazy_keys_from_erb(content).flat_map do |key|
           full_key = "#{scope}.#{key}"
           Analyzer.validate_view_key(
             full_key, locale_index: index, configured_locales: @configured_locales
-          ).map { |v| view_diagnostic(view_path, v) }
+          ).map { |v| view_diagnostic(display_path, v) }
         end
       rescue StandardError => e
         [Rigor::Analysis::Diagnostic.new(
-          path: view_path, line: 1, column: 1,
+          path: relative_view_path(view_path), line: 1, column: 1,
           message: "rigor-rails-i18n: failed to scan view template: #{e.class}: #{e.message}",
           severity: :warning,
           rule: "load-error"
@@ -197,6 +203,18 @@ module Rigor
 
           Dir.glob(File.join(absolute, "**", "*.{erb,haml,slim}"))
         end.sort
+      end
+
+      # Diagnostics anchor on a path relative to the working
+      # directory — the same base `File.expand_path` globbed the
+      # view files against — so view diagnostics render and match
+      # baselines like every other diagnostic (which carry
+      # project-relative paths). Falls back to the absolute path
+      # for a view outside the working tree.
+      def relative_view_path(absolute_path)
+        Pathname.new(absolute_path).relative_path_from(Pathname.pwd).to_s
+      rescue ArgumentError
+        absolute_path
       end
 
       def read_view_template(path)

--- a/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n.rb
+++ b/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n.rb
@@ -135,7 +135,12 @@ module Rigor
         diagnostics.concat(consume_load_error_diagnostics(path)) unless @load_errors.empty?
         diagnostics << runtime_error_diagnostic(path) if index.nil? && producer_error(:locale_index)
         unless @view_diagnostics_emitted
-          diagnostics.concat(producer_value(:view_diagnostics) || [])
+          view_diags = producer_value(:view_diagnostics) || []
+          if (view_err = producer_error(:view_diagnostics))
+            diagnostics << view_runtime_error_diagnostic(path, view_err)
+          else
+            diagnostics.concat(view_diags)
+          end
           @view_diagnostics_emitted = true
         end
         diagnostics
@@ -162,16 +167,27 @@ module Rigor
 
       def scan_view_files(index)
         view_files.flat_map do |view_path|
-          content = read_view_template(view_path) or next []
-          scope = Analyzer.view_scope_from_path(view_path) or next []
-
-          Analyzer.extract_lazy_keys_from_erb(content).flat_map do |key|
-            full_key = "#{scope}.#{key}"
-            Analyzer.validate_view_key(
-              full_key, locale_index: index, configured_locales: @configured_locales
-            ).map { |v| view_diagnostic(view_path, v) }
-          end
+          scan_view_file(view_path, index)
         end
+      end
+
+      def scan_view_file(view_path, index)
+        content = read_view_template(view_path) or return []
+        scope = Analyzer.view_scope_from_path(view_path) or return []
+
+        Analyzer.extract_lazy_keys_from_erb(content).flat_map do |key|
+          full_key = "#{scope}.#{key}"
+          Analyzer.validate_view_key(
+            full_key, locale_index: index, configured_locales: @configured_locales
+          ).map { |v| view_diagnostic(view_path, v) }
+        end
+      rescue StandardError => e
+        [Rigor::Analysis::Diagnostic.new(
+          path: view_path, line: 1, column: 1,
+          message: "rigor-rails-i18n: failed to scan view template: #{e.class}: #{e.message}",
+          severity: :warning,
+          rule: "load-error"
+        )]
       end
 
       def view_files
@@ -223,6 +239,15 @@ module Rigor
         Rigor::Analysis::Diagnostic.new(
           path: path, line: 1, column: 1,
           message: "rigor-rails-i18n: failed to load locales: #{error.class}: #{error.message}",
+          severity: :warning,
+          rule: "load-error"
+        )
+      end
+
+      def view_runtime_error_diagnostic(path, error)
+        Rigor::Analysis::Diagnostic.new(
+          path: path, line: 1, column: 1,
+          message: "rigor-rails-i18n: failed to scan view templates: #{error.class}: #{error.message}",
           severity: :warning,
           rule: "load-error"
         )

--- a/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n.rb
+++ b/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n.rb
@@ -26,6 +26,7 @@ module Rigor
     #         config:
     #           locale_search_paths: ["config/locales"]   # default; optional
     #           configured_locales: ["en"]                # default; optional — locales the project ships
+    #           view_search_paths: ["app/views"]          # default; optional — view template search roots
     #
     # ## What it checks
     #
@@ -39,6 +40,11 @@ module Rigor
     #    `%{var}` placeholders must match the call's keyword
     #    arguments. Missing placeholders are errors; extra
     #    arguments are warnings.
+    # 4. **View template lazy keys** — `t('.title')` inside
+    #    `app/views/setting/index.html.erb` expands to
+    #    `setting.index.title` and is validated against the
+    #    locale index. ERB, Haml, and Slim templates are
+    #    scanned under `view_search_paths`.
     #
     # ## Limitations
     #
@@ -51,6 +57,11 @@ module Rigor
     #   Lazy keys in non-controller `.rb` files (models, helpers,
     #   mailers, …) are silently skipped — the controller/action
     #   scope cannot be statically determined there.
+    # - View template lazy keys (`t('.key')` inside ERB / Haml /
+    #   Slim) are validated for key existence and per-locale
+    #   coverage. Interpolation variable validation is skipped
+    #   for view templates (the hash may come from controller
+    #   instance variables not visible in the template).
     # - Pluralization (`t('errors.messages.too_short',
     #   count: n)`) is recognised at the call site but the
     #   `count` key is not used to validate the locale's
@@ -61,14 +72,15 @@ module Rigor
     class RailsI18n < Rigor::Plugin::Base
       manifest(
         id: "rails-i18n",
-        # Bumped 2026-05-28 — skip `unknown-key` on Rails / rails-
-        # i18n shipped defaults (`date.order`, `time.am`,
-        # `support.array.*`, `errors.format`, …).
-        version: "0.2.0",
+        # Bumped 2026-06-23 — view template lazy-key scanning
+        # (`t('.key')` inside ERB / Haml / Slim under
+        # `view_search_paths`).
+        version: "0.3.0",
         description: "Validates I18n `t(key)` calls against `config/locales/*.yml`.",
         config_schema: {
           "locale_search_paths" => { kind: :array, default: ["config/locales"] },
-          "configured_locales" => { kind: :array, default: ["en"] }
+          "configured_locales" => { kind: :array, default: ["en"] },
+          "view_search_paths" => { kind: :array, default: ["app/views"] }
         }
       )
 
@@ -88,22 +100,44 @@ module Rigor
         index
       end
 
+      # Scans view templates under `view_search_paths` for lazy
+      # `t('.key')` / `I18n.translate('.key')` calls and validates
+      # each expanded key against the locale index. Interpolation
+      # validation is skipped — the hash may come from controller
+      # instance variables not visible in the template source.
+      #
+      # Watches `**/*.{erb,haml,slim}` under each search root so
+      # the cache invalidates when templates are edited.
+      producer :view_diagnostics, watch: -> { [[@view_search_paths, "**/*.erb", "**/*.haml", "**/*.slim"]] } do |_params|
+        index = producer_value(:locale_index)
+        next [] if index.nil? || index.empty?
+
+        scan_view_files(index)
+      end
+
       def init(_services)
         @locale_search_paths = Array(config.fetch("locale_search_paths")).map(&:to_s)
+        @view_search_paths = Array(config.fetch("view_search_paths")).map(&:to_s)
         @configured_locales = Array(config.fetch("configured_locales")).map(&:to_s)
         @load_errors = []
         @load_errors_emitted = false
+        @view_diagnostics_emitted = false
       end
 
       # File-level only: the once-per-run YAML load errors + the
-      # runtime (cache-load) error. Per-call `t('key')` validation runs
-      # over the engine-owned walk via the node_rule below (ADR-37). The
-      # locale index is lazily loaded + memoised by `producer_value`.
+      # runtime (cache-load) error + the view-template scan. Per-call
+      # `t('key')` validation runs over the engine-owned walk via the
+      # node_rule below (ADR-37). The locale index and view diagnostics
+      # are lazily loaded + memoised by `producer_value`.
       def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
         index = producer_value(:locale_index)
         diagnostics = []
         diagnostics.concat(consume_load_error_diagnostics(path)) unless @load_errors.empty?
         diagnostics << runtime_error_diagnostic(path) if index.nil? && producer_error(:locale_index)
+        unless @view_diagnostics_emitted
+          diagnostics.concat(producer_value(:view_diagnostics) || [])
+          @view_diagnostics_emitted = true
+        end
         diagnostics
       end
 
@@ -125,6 +159,44 @@ module Rigor
       end
 
       private
+
+      def scan_view_files(index)
+        view_files.flat_map do |view_path|
+          content = read_view_template(view_path) or next []
+          scope = Analyzer.view_scope_from_path(view_path) or next []
+
+          Analyzer.extract_lazy_keys_from_erb(content).flat_map do |key|
+            full_key = "#{scope}.#{key}"
+            Analyzer.validate_view_key(
+              full_key, locale_index: index, configured_locales: @configured_locales
+            ).map { |v| view_diagnostic(view_path, v) }
+          end
+        end
+      end
+
+      def view_files
+        @view_search_paths.flat_map do |root|
+          absolute = File.expand_path(root)
+          next [] unless File.directory?(absolute)
+
+          Dir.glob(File.join(absolute, "**", "*.{erb,haml,slim}"))
+        end.sort
+      end
+
+      def read_view_template(path)
+        io_boundary.read_file(path)
+      rescue Plugin::AccessDeniedError
+        nil
+      end
+
+      def view_diagnostic(view_path, violation)
+        Rigor::Analysis::Diagnostic.new(
+          path: view_path, line: 1, column: 1,
+          message: violation.message,
+          severity: violation.severity,
+          rule: violation.rule
+        )
+      end
 
       # The runner only invokes `diagnostics_for_file` for
       # Ruby files (`paths:` is filtered to `.rb`). YAML

--- a/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/analyzer.rb
+++ b/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/analyzer.rb
@@ -42,6 +42,32 @@ module Rigor
         # `_controller.rb` (e.g. `users`, `admin/users`).
         CONTROLLER_PATH_RE = %r{(?:^|/)controllers/(.+)_controller\.rb$}
 
+        # Matches Rails view-template file paths to derive the
+        # I18n "virtual path" — the scope that Rails uses for
+        # lazy `t('.key')` lookups inside a template.
+        #
+        # Captures the path segment between `views/` and the
+        # format+variant+handler suffix, then strips a leading
+        # underscore from each segment — Rails templates resolve
+        # `_form.html.erb` as "form", not "_form".
+        #
+        #   app/views/setting/index.html.erb      → setting.index
+        #   app/views/admin/users/new.html.erb    → admin.users.new
+        #   app/views/home/index.html+mobile.erb  → home.index
+        #   app/views/users/_form.html.erb        → users.form
+        #
+        # The view-scope lazy expansion replaces the action
+        # part with the view's virtual path:
+        #   `<%= t('.title') %>` → `setting.index.title`
+        VIEW_SCOPE_RE = %r{views/(.+?)\.(?:\w+)(?:\+\w+)?\.\w+\z}
+
+        # Regex to extract lazy-key arguments from ERB / HTML
+        # template content. Matches `t('.key')`, `t(".key")`,
+        # `I18n.t('.key')`, and `I18n.translate('.key')` with a
+        # leading dot on the key string. Captures only the key
+        # part after the dot.
+        LAZY_T_KEY_RE = /\b(?:I18n\.)?(?:t|translate)\s*\(\s*(?:"\.([^"\\]*)"|'\.([^'\\]*)')/
+
         # Reserved option keys — these are recognised by I18n
         # itself and not treated as interpolation variables.
         RESERVED_OPTION_KEYS = %i[
@@ -144,6 +170,34 @@ module Rigor
           return nil unless m
 
           m[1].tr("/", ".")
+        end
+
+        def view_scope_from_path(path)
+          m = VIEW_SCOPE_RE.match(path.to_s)
+          return nil unless m
+
+          m[1].split("/").map { |seg| seg.sub(/\A_/, "") }.join(".")
+        end
+
+        def extract_lazy_keys_from_erb(content)
+          content.scan(LAZY_T_KEY_RE).map { |dq, sq| dq || sq }.uniq
+        end
+
+        def validate_view_key(key, locale_index:, configured_locales:)
+          entry = locale_index.find(key)
+          if entry.nil?
+            return [] if locale_index.pluralization_namespace?(key)
+            return [] if rails_shipped_key?(key)
+
+            return [unknown_key_violation(key, locale_index)]
+          end
+
+          violations = [translation_call_info(key, entry)]
+          missing = locale_index.missing_locales_for(key, configured_locales: configured_locales)
+          unless missing.empty?
+            violations << missing_locale_violation(key, missing)
+          end
+          violations
         end
 
         # Expands a lazy key (starting with `.`) to its full

--- a/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/analyzer.rb
+++ b/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/analyzer.rb
@@ -194,9 +194,7 @@ module Rigor
 
           violations = [translation_call_info(key, entry)]
           missing = locale_index.missing_locales_for(key, configured_locales: configured_locales)
-          unless missing.empty?
-            violations << missing_locale_violation(key, missing)
-          end
+          violations << missing_locale_violation(key, missing) unless missing.empty?
           violations
         end
 

--- a/spec/integration/plugins/rails_i18n_plugin_spec.rb
+++ b/spec/integration/plugins/rails_i18n_plugin_spec.rb
@@ -295,6 +295,7 @@ RSpec.describe "plugins/rigor-rails-i18n" do
               index:
                 title: "Settings"
                 push_notification: "Push Notification"
+                greeting: "Hello, %{name}"
             home:
               index:
                 title: "Welcome"
@@ -302,7 +303,19 @@ RSpec.describe "plugins/rigor-rails-i18n" do
               users:
                 new:
                   heading: "New User"
-        YAML
+            users:
+              form:
+                label: "Label"
+            profiles:
+              index:
+                mobile_title: "Mobile Welcome"
+            talks:
+              card:
+                title: "Talk Title"
+                nested:
+                  deep:
+                    key: "Deep"
+      YAML
       }
     end
 
@@ -397,6 +410,66 @@ RSpec.describe "plugins/rigor-rails-i18n" do
       )
       diags = plugin_diagnostics(result)
       expect(diags.select { |d| d.rule == "translation-call" }).to be_empty
+    end
+
+    it "strips the leading underscore from partial templates" do
+      result = run_plugin(
+        source: "# noop\n",
+        files: view_locales.merge(
+          "app/views/users/_form.html.erb" => "<%= t('.label') %>\n"
+        )
+      )
+      diags = plugin_diagnostics(result)
+      info = diags.find { |d| d.rule == "translation-call" && d.message.include?("users.form.label") }
+      expect(info).not_to be_nil
+    end
+
+    it "strips the variant suffix from view paths" do
+      result = run_plugin(
+        source: "# noop\n",
+        files: view_locales.merge(
+          "app/views/profiles/index.html+mobile.erb" => "<%= t('.mobile_title') %>\n"
+        )
+      )
+      diags = plugin_diagnostics(result)
+      info = diags.find { |d| d.rule == "translation-call" && d.message.include?("profiles.index.mobile_title") }
+      expect(info).not_to be_nil
+    end
+
+    it "scans Slim templates for lazy keys" do
+      result = run_plugin(
+        source: "# noop\n",
+        files: view_locales.merge(
+          "app/views/talks/_card.html.slim" => "= t('.title')\n"
+        )
+      )
+      diags = plugin_diagnostics(result)
+      info = diags.find { |d| d.rule == "translation-call" && d.message.include?("talks.card.title") }
+      expect(info).not_to be_nil
+    end
+
+    it "extracts lazy keys from calls with interpolation arguments" do
+      result = run_plugin(
+        source: "# noop\n",
+        files: view_locales.merge(
+          "app/views/setting/index.html.erb" => "<%= t('.greeting', name: @user.name) %>\n"
+        )
+      )
+      diags = plugin_diagnostics(result)
+      info = diags.find { |d| d.rule == "translation-call" && d.message.include?("setting.index.greeting") }
+      expect(info).not_to be_nil
+    end
+
+    it "expands nested dotted lazy keys" do
+      result = run_plugin(
+        source: "# noop\n",
+        files: view_locales.merge(
+          "app/views/talks/_card.html.erb" => "<%= t('.nested.deep.key') %>\n"
+        )
+      )
+      diags = plugin_diagnostics(result)
+      info = diags.find { |d| d.rule == "translation-call" && d.message.include?("talks.card.nested.deep.key") }
+      expect(info).not_to be_nil
     end
   end
 

--- a/spec/integration/plugins/rails_i18n_plugin_spec.rb
+++ b/spec/integration/plugins/rails_i18n_plugin_spec.rb
@@ -287,6 +287,7 @@ RSpec.describe "plugins/rigor-rails-i18n" do
     # different tmpdir-based tests).
     let(:default_run_plugin_cache_store) { nil }
 
+    # rubocop:disable Style/FormatStringToken
     let(:view_locales) do
       {
         "config/locales/en.yml" => <<~YAML
@@ -315,9 +316,10 @@ RSpec.describe "plugins/rigor-rails-i18n" do
                 nested:
                   deep:
                     key: "Deep"
-      YAML
+        YAML
       }
     end
+    # rubocop:enable Style/FormatStringToken
 
     it "expands `t('.title')` in a view to `<scope>.<key>`" do
       result = run_plugin(

--- a/spec/integration/plugins/rails_i18n_plugin_spec.rb
+++ b/spec/integration/plugins/rails_i18n_plugin_spec.rb
@@ -280,6 +280,126 @@ RSpec.describe "plugins/rigor-rails-i18n" do
     end
   end
 
+  describe "view template lazy key expansion" do
+    # Use per-test cache to avoid cross-test pollution from the
+    # shared cache store (view_diagnostics is a new producer and
+    # the shared cache doesn't know how to invalidate it across
+    # different tmpdir-based tests).
+    let(:default_run_plugin_cache_store) { nil }
+
+    let(:view_locales) do
+      {
+        "config/locales/en.yml" => <<~YAML
+          en:
+            setting:
+              index:
+                title: "Settings"
+                push_notification: "Push Notification"
+            home:
+              index:
+                title: "Welcome"
+            admin:
+              users:
+                new:
+                  heading: "New User"
+        YAML
+      }
+    end
+
+    it "expands `t('.title')` in a view to `<scope>.<key>`" do
+      result = run_plugin(
+        source: "# noop\n",
+        files: view_locales.merge(
+          "app/views/setting/index.html.erb" => "<%= t('.title') %>\n"
+        )
+      )
+      diags = plugin_diagnostics(result)
+      info = diags.find { |d| d.rule == "translation-call" && d.message.include?("setting.index.title") }
+      expect(info).not_to be_nil
+    end
+
+    it "flags a lazy key in a view that does not exist in any locale" do
+      result = run_plugin(
+        source: "# noop\n",
+        files: view_locales.merge(
+          "app/views/setting/index.html.erb" => "<h1><%= t('.nonexistent') %></h1>\n"
+        )
+      )
+      diags = plugin_diagnostics(result)
+      err = diags.find { |d| d.rule == "unknown-key" && d.message.include?("setting.index.nonexistent") }
+      expect(err).not_to be_nil
+    end
+
+    it "scans Haml templates for lazy keys" do
+      result = run_plugin(
+        source: "# noop\n",
+        files: view_locales.merge(
+          "app/views/home/index.html.haml" => "= t('.title')\n"
+        )
+      )
+      diags = plugin_diagnostics(result)
+      info = diags.find { |d| d.rule == "translation-call" && d.message.include?("home.index.title") }
+      expect(info).not_to be_nil
+    end
+
+    it "expands lazy keys in namespaced view paths" do
+      result = run_plugin(
+        source: "# noop\n",
+        files: view_locales.merge(
+          "app/views/admin/users/new.html.erb" => "<h2><%= t('.heading') %></h2>\n"
+        )
+      )
+      diags = plugin_diagnostics(result)
+      info = diags.find { |d| d.rule == "translation-call" && d.message.include?("admin.users.new.heading") }
+      expect(info).not_to be_nil
+    end
+
+    it "recognises `I18n.t('.key')` in view templates" do
+      result = run_plugin(
+        source: "# noop\n",
+        files: view_locales.merge(
+          "app/views/setting/index.html.erb" => "<%= I18n.t('.push_notification') %>\n"
+        )
+      )
+      diags = plugin_diagnostics(result)
+      info = diags.find { |d| d.rule == "translation-call" && d.message.include?("setting.index.push_notification") }
+      expect(info).not_to be_nil
+    end
+
+    it "scans multiple view files for lazy keys" do
+      result = run_plugin(
+        source: "# noop\n",
+        files: view_locales.merge(
+          "app/views/setting/index.html.erb" => "<%= t('.title') %>\n",
+          "app/views/home/index.html.erb" => "<%= t('.title') %>\n"
+        )
+      )
+      diags = plugin_diagnostics(result)
+      infos = diags.select { |d| d.rule == "translation-call" }
+      expect(infos.size).to eq(2)
+    end
+
+    it "silently skips view files with no lazy keys" do
+      result = run_plugin(
+        source: "# noop\n",
+        files: view_locales.merge(
+          "app/views/home/index.html.erb" => "<h1>Static content</h1>\n"
+        )
+      )
+      diags = plugin_diagnostics(result)
+      expect(diags.select { |d| d.rule == "translation-call" }).to be_empty
+    end
+
+    it "silently skips view files outside view_search_paths" do
+      result = run_plugin(
+        source: "# noop\n",
+        files: view_locales
+      )
+      diags = plugin_diagnostics(result)
+      expect(diags.select { |d| d.rule == "translation-call" }).to be_empty
+    end
+  end
+
   describe "load errors" do
     it "emits a `load-error` warning for a malformed YAML file" do
       malformed_yaml = "en:\n  bad:\n :: oops"


### PR DESCRIPTION
## Summary

Teaches `rigor-rails-i18n` to validate **lazy `t('.key')` calls inside view templates** (ERB / Haml / Slim), not just controllers. `t('.title')` in `app/views/setting/index.html.erb` expands to `setting.index.title` via the Rails virtual-path convention (partial `_`-prefixes and `+variant` suffixes stripped) and is checked for key existence + per-locale coverage against `config/locales/*.yml`.

- New `view_search_paths` config knob (default `["app/views"]`).
- New cached `:view_diagnostics` producer, watched so the cache invalidates when templates change.
- Interpolation validation is intentionally skipped for templates (the hash may come from controller ivars not visible in the template).
- Plugin bumped `0.2.0` → `0.3.0`.

## Review fixes (last two commits)

While reviewing the branch against `master` I found and fixed:

1. **Absolute diagnostic paths** — view diagnostics carried the `File.expand_path` absolute path, unlike every other Rigor diagnostic. Absolute paths render inconsistently and never match a `.rigor-baseline.yml` entry (baselines store relative paths). Now relativized against the working directory.
2. **Three lint offenses** the branch introduced (`Style/IfUnlessModifier`, `Style/FormatStringToken`, `Layout/ClosingHeredocIndentation`) that would have failed `make verify`'s lint gate.
3. **CHANGELOG entry** (was missing) + documented a known limitation.

## Known limitation

The view scan is a project-wide pass surfaced through the per-file diagnostic hook, so under `--workers` each fork-pool worker re-emits the full set — the same once-per-run limitation the existing `load-error` diagnostics already carry. **Default sequential `rigor check` is unaffected.** A deduped once-per-run plugin project-diagnostic channel (fixing both the view scan and load errors) is the natural follow-up.

## Verification

- `rubocop lib/ spec/ plugins/ examples/` — clean (835 files)
- `rigor check lib` (self-check) — clean
- `rigor check plugins/*/lib examples/*/lib` (plugin contract) — clean
- `rspec spec/integration/plugins/rails_i18n_plugin_spec.rb` — 30 examples, 0 failures
- Manually verified relative paths (sequential) and the worker-dup behaviour with a scratch fixture.