### PR TITLE
Bump up version to 0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,17 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
-### Plugins
+## [0.2.5] - 2026-06-24
 
-- **[rigor-rails-i18n]** View-template lazy keys are now validated. `t('.title')` inside `app/views/setting/index.html.erb` expands to `setting.index.title` (the Rails virtual-path convention — partial `_`-prefixes and `+variant` suffixes are stripped) and is checked for key existence and per-locale coverage against `config/locales/*.yml`. ERB, Haml, and Slim templates under the configurable `view_search_paths` (default `["app/views"]`) are scanned; the results are cached and invalidated when templates change. Interpolation validation is skipped for templates — the hash may come from controller instance variables not visible in the template source. Plugin bumped to `0.3.0`.
+v0.2.5 adds i18n validation for view-template lazy keys in `rigor-rails-i18n`, so `t('.title')` calls inside ERB, Haml, and Slim templates are now expanded using the Rails virtual-path convention and checked against `config/locales/*.yml` for key existence and per-locale coverage.
+
+### Added
+
+- **[rigor-rails-i18n]** View-template lazy `t('.title')` calls are now validated against `config/locales/*.yml`.
+  - The key is expanded using the Rails virtual-path convention (partial `_`-prefixes and `+variant` suffixes are stripped) and checked for existence and per-locale coverage across ERB, Haml, and Slim templates under the configurable `view_search_paths`; results are cached and invalidated when templates change.
+  - Interpolation validation is skipped — the hash may come from controller instance variables not visible in the template source.
   - Known limitation: the view scan is a project-wide pass surfaced through the per-file diagnostic hook, so under `--workers` each fork-pool worker re-emits the full set (the same once-per-run limitation the `load-error` diagnostics already carry). Default sequential `rigor check` is unaffected.
-
-### Performance
-
-- **[spec suite]** Targeted profiling pass removes repeated per-example setup in three of the slowest spec groups, cutting roughly 50 seconds off the sequential suite run.
-  - `spec/rigor/environment/reflection_spec.rb` builds the immutable, frozen `Environment::Reflection` once per file via `before(:all)` instead of once per example. Every example only queries it, so the group drops from ~22s to ~2s across 22 examples.
-  - `spec/integration/plugins/rails_routes_plugin_spec.rb` opts its 84-example group into the existing process-wide shared plugin cache (`let(:default_run_plugin_cache_store) { :shared }`), reusing one env build instead of one per example. The rails-routes producer descriptor already tracks the routes file, its `draw` partials, and every helper file, so no stale cache output leaks between examples. The group drops from ~25s to ~4s.
-  - `spec/rigor/analysis/incremental_session_spec.rb` threads one shared `Environment` through the session's internal runs via a new optional `IncrementalSession.new(environment:)` parameter, so baseline / recheck / oracle runs stop rebuilding the same RBS universe; the group drops from ~16s to ~6s. The parameter defaults to `nil`, leaving the `rigor check` incremental path byte-identical.
+  - Plugin bumped to `0.3.0`.
 
 ## [0.2.4] - 2026-06-22
 
@@ -190,7 +190,8 @@ v0.2.0 is Rigor's first publicly-announced (general / evaluation) release, gover
 - **[cli]** `rigor explain call.unresolved-toplevel` now resolves — the [ADR-34](docs/adr/34-toplevel-unresolved-self-call-default.md) rule was missing from the catalogue despite being live since v0.1.14 — and a completeness spec now asserts every rule has a catalogue entry.
 - **[packaging]** The Docker build-context ignore file is scoped to the Dockerfile (`Dockerfile.dockerignore`) instead of a repo-wide `.dockerignore`, so external tools embedding the rigor source via BuildKit `--build-context` no longer get an empty context.
 
-[Unreleased]: https://github.com/rigortype/rigor/compare/v0.2.4...HEAD
+[Unreleased]: https://github.com/rigortype/rigor/compare/v0.2.5...HEAD
+[0.2.5]: https://github.com/rigortype/rigor/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/rigortype/rigor/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/rigortype/rigor/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/rigortype/rigor/compare/v0.2.1...v0.2.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rigortype (0.2.4)
+    rigortype (0.2.5)
       language_server-protocol (>= 3.17, < 4.0)
       prism (>= 1.0, < 2.0)
       rbs (>= 3.0, < 5.0)
@@ -148,7 +148,7 @@ CHECKSUMS
   rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25
   rbs-inline (0.14.0) sha256=eaf47b46690d63acddab1f6804c9cc205a4bc78e637cfc421a0b1239874ef51c
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
-  rigortype (0.2.4)
+  rigortype (0.2.5)
   rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836

--- a/lib/rigor/version.rb
+++ b/lib/rigor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rigor
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end


### PR DESCRIPTION
v0.2.5 adds i18n validation for view-template lazy keys in `rigor-rails-i18n`, so `t('.title')` calls inside ERB, Haml, and Slim templates are now expanded using the Rails virtual-path convention and checked against `config/locales/*.yml` for key existence and per-locale coverage.

### Added

- **[rigor-rails-i18n]** View-template lazy `t('.title')` calls are now validated against `config/locales/*.yml`.
  - The key is expanded using the Rails virtual-path convention (partial `_`-prefixes and `+variant` suffixes are stripped) and checked for existence and per-locale coverage across ERB, Haml, and Slim templates under the configurable `view_search_paths`; results are cached and invalidated when templates change.
  - Interpolation validation is skipped — the hash may come from controller instance variables not visible in the template source.
  - Known limitation: the view scan is a project-wide pass surfaced through the per-file diagnostic hook, so under `--workers` each fork-pool worker re-emits the full set (the same once-per-run limitation the `load-error` diagnostics already carry). Default sequential `rigor check` is unaffected.
  - Plugin bumped to `0.3.0`.
