### PR TITLE
Bump up version to 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,20 +11,28 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-06-27
+
+v0.2.6 sharpens how Rigor explains itself and tightens shape-aware inference. `rigor coverage --protection` now labels each untyped hole with why it is dynamic and whether a type can close it, and a new `rigor doctor` command routes setup problems to their fix. Literal hashes and arrays keep their precise shape through `freeze` / `dup` / `clone`, closing a folding gap on frozen constants. It also begins a plugin-contract cleanup ahead of the v1.0 freeze: the `type_specifier` hook is renamed to `narrowing_facts`, with the old name kept as a deprecated alias.
+
 ### Added
 
-- **`rigor coverage --protection`** now explains *why* each unprotected dispatch is untyped and whether a type can close it.
-  - Every `add_a_type_here` entry carries a `dynamic_origin` cause (`external_gem_without_rbs`, `framework_dsl_boundary`, `analyzer_budget_cutoff`, `explicit_untyped`, `unsupported_syntax`) and a derived `tractability` axis (`add_rbs` / `enable_plugin` / `engine_gap`), in both `--format json` and the text report — so you can prioritise the holes a hand-written or installed RBS can actually close and skip the ones that need a plugin / `pre_eval:` or an engine fix. A `tractability_summary` (per-axis dispatch-site totals) is emitted in the JSON and shown as a one-line `by tractability:` breakdown in the text report. ([ADR-75](docs/adr/75-dynamic-provenance.md), [ADR-73](docs/adr/73-skill-driven-user-experience.md) field-trial follow-up.)
-  - Provenance is a precision-additive side-channel: it never changes `untyped = Dynamic[top]` semantics, fires no diagnostic, and never feeds severity.
+- **[rigor coverage]** `rigor coverage --protection` now explains why each unprotected dispatch is untyped and whether a type can close it ([ADR-75](docs/adr/75-dynamic-provenance.md)).
+  - Every `add_a_type_here` entry carries a `dynamic_origin` cause (`external_gem_without_rbs`, `framework_dsl_boundary`, `analyzer_budget_cutoff`, `explicit_untyped`, `unsupported_syntax`) and a derived `tractability` axis (`add_rbs` / `enable_plugin` / `engine_gap`), in both `--format json` and the text report, so you can prioritise the holes an installed or hand-written RBS can actually close. A `tractability_summary` of per-axis dispatch-site totals is emitted in the JSON and shown as a one-line `by tractability:` breakdown in text.
+  - Provenance is precision-additive: it never changes `untyped = Dynamic[top]` semantics, fires no diagnostic, and never feeds severity.
+- **[rigor doctor]** New `rigor doctor` command classifies a project's existing findings into setup-problem vs clean-run and prints a routed next action for each, over a stable `checks[].id` JSON contract ([ADR-77](docs/adr/77-doctor-and-upgrade-commands.md)).
+  - It is a presentation layer over data `rigor check` already produces (config resolution, RBS environment, plugin load, baseline drift) and runs no new analysis. The companion `rigor upgrade` ships as a queued skeleton (ADR-50 WD7) that reports no migration target yet.
 
 ### Changed
 
-- **`{…}.freeze` / `.dup` / `.clone` / `.itself` on a literal hash or array now preserve the precise shape type** instead of degrading to a nominal `Hash` / `Array`, so `MESSAGES = {…}.freeze; MESSAGES[reason]` and `XS = […].freeze; XS[0]` fold the precise value rather than `Dynamic`. ([ADR-76](docs/adr/76-effect-modeling-freeze-dup-shape-preservation.md) WD2 / [ADR-78](docs/adr/78-reflexive-overfold-always-truthy.md) WD3.)
-- **Shape-carrier methods no longer fold a block-form call.** `tuple.any? { … }` / `.sum { … }` / `.count { … }` (and the hash-shape equivalents) previously folded the *no-block* result, ignoring the block; they now defer to the normal block/RBS path. Strictly precision-reducing (an unsound fold removed), and the fix that let array/tuple `freeze` preservation land without spurious `flow.always-truthy-condition`. ([ADR-78](docs/adr/78-reflexive-overfold-always-truthy.md) WD1.)
+- **[engine]** Literal hashes and arrays now preserve their precise shape through `freeze` / `dup` / `clone` / `itself` instead of degrading to a nominal `Hash` / `Array`, so `MESSAGES = {…}.freeze; MESSAGES[reason]` and `XS = […].freeze; XS[0]` fold the precise value rather than `Dynamic` ([ADR-76](docs/adr/76-effect-modeling-freeze-dup-shape-preservation.md) WD2 / [ADR-78](docs/adr/78-reflexive-overfold-always-truthy.md) WD3).
+- **[engine]** Shape-carrier methods (`tuple.any? { … }`, `.sum { … }`, `.count { … }`, and the hash-shape equivalents) no longer constant-fold a block-form call, deferring to the normal block/RBS path ([ADR-78](docs/adr/78-reflexive-overfold-always-truthy.md) WD1).
+  - They previously folded the no-block result, ignoring the block; the fix is strictly precision-reducing and removed the spurious `flow.always-truthy-condition` firings that blocked the shape-preservation change above.
 
 ### Deprecated
 
-- **The plugin hook `type_specifier` is renamed to `narrowing_facts`.** The old name read as a parallel to `dynamic_return` (which contributes a *type*) when it actually contributes post-return narrowing *facts*. `type_specifier` keeps working as an alias that emits a one-time deprecation warning per plugin and **will be removed in 0.3.0** — migrate `type_specifier methods: …` → `narrowing_facts methods: …` in your plugins. The bundled `rigor-minitest` / `rigor-sorbet` / `rigor-rspec` plugins are already migrated; the engine-facing `rigor plugins --capabilities` JSON field `type_specifier_methods` is unchanged for now. ([ADR-80](docs/adr/80-narrowing-facts-rename.md).)
+- **[plugin contract]** The plugin hook `type_specifier` is renamed to `narrowing_facts`; `type_specifier` keeps working as a deprecated alias and will be removed in 0.3.0 ([ADR-80](docs/adr/80-narrowing-facts-rename.md)).
+  - The old name read as a parallel to `dynamic_return` (which contributes a type) when it contributes post-return narrowing facts; migrate `type_specifier methods: …` → `narrowing_facts methods: …`, after which the one-time deprecation warning stops firing. The bundled `rigor-minitest` / `rigor-sorbet` / `rigor-rspec` plugins are already migrated, and the `rigor plugins --capabilities` JSON field `type_specifier_methods` is unchanged for now.
 
 ## [0.2.5] - 2026-06-24
 
@@ -205,7 +213,8 @@ v0.2.0 is Rigor's first publicly-announced (general / evaluation) release, gover
 - **[cli]** `rigor explain call.unresolved-toplevel` now resolves — the [ADR-34](docs/adr/34-toplevel-unresolved-self-call-default.md) rule was missing from the catalogue despite being live since v0.1.14 — and a completeness spec now asserts every rule has a catalogue entry.
 - **[packaging]** The Docker build-context ignore file is scoped to the Dockerfile (`Dockerfile.dockerignore`) instead of a repo-wide `.dockerignore`, so external tools embedding the rigor source via BuildKit `--build-context` no longer get an empty context.
 
-[Unreleased]: https://github.com/rigortype/rigor/compare/v0.2.5...HEAD
+[Unreleased]: https://github.com/rigortype/rigor/compare/v0.2.6...HEAD
+[0.2.6]: https://github.com/rigortype/rigor/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/rigortype/rigor/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/rigortype/rigor/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/rigortype/rigor/compare/v0.2.2...v0.2.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rigortype (0.2.5)
+    rigortype (0.2.6)
       language_server-protocol (>= 3.17, < 4.0)
       prism (>= 1.0, < 2.0)
       rbs (>= 3.0, < 5.0)
@@ -148,7 +148,7 @@ CHECKSUMS
   rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25
   rbs-inline (0.14.0) sha256=eaf47b46690d63acddab1f6804c9cc205a4bc78e637cfc421a0b1239874ef51c
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
-  rigortype (0.2.5)
+  rigortype (0.2.6)
   rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836

--- a/bench/baseline.json
+++ b/bench/baseline.json
@@ -1,13 +1,13 @@
 {
   "calibrated": true,
-  "calibrated_at": "2026-06-16T15:14:23Z",
-  "calibrated_on": "ubuntu-latest (GitHub Actions), release/0.2.0 @ run 27627812560",
-  "note": "Linux CI measurements. wall_s is wider than local macOS (runner noise); allocations is the tight signal. Refresh by triggering release-gate.yml, downloading the bench-baseline-* artifact, and committing its targets here. Recalibrated for the v0.2.0 cycle: allocations + peak_rss_kb grew with the detection-teeth / protection-coverage / constant-folding additions while wall_s held (GC kept pace).",
+  "calibrated_at": "2026-06-27T00:00:00Z",
+  "calibrated_on": "ubuntu-latest (GitHub Actions), release/0.2.6 @ run 28276063402",
+  "note": "Linux CI measurements. wall_s is wider than local macOS (runner noise); allocations is the tight signal. Refresh by triggering release-gate.yml, downloading the bench-baseline-* artifact, and committing its targets here. Recalibrated for the v0.2.6 cut: allocations grew ~+5.3% with the ADR-75 Dynamic-provenance side-table and the ADR-76/78 shape-carrier preservation; the OSS-corpus (Mastodon) sweep stayed green (no new false positives), so the increase is blessed feature cost, not a regression. peak_rss_kb and wall_s refreshed to the same run's values.",
   "targets": {
     "lib": {
-      "wall_s": 13.75,
-      "allocations": 18769957,
-      "peak_rss_kb": 232292,
+      "wall_s": 16.625,
+      "allocations": 19770221,
+      "peak_rss_kb": 237108,
       "diagnostics": 1
     }
   }

--- a/docs/install.md
+++ b/docs/install.md
@@ -152,7 +152,7 @@ without WSL). For all other environments, prefer Case A–D above.
 rigor --version
 ```
 
-A version string like `rigor 0.1.x` confirms a successful install.
+A version string like `rigor 0.2.x` confirms a successful install.
 If the command is not found, revisit Step 2 for your case.
 
 ---

--- a/docs/manual/11-ci.md
+++ b/docs/manual/11-ci.md
@@ -192,9 +192,9 @@ remains available for any other tool that wants the raw diagnostic stream.
 
 The workflow above installs whatever `rigortype` is current at run
 time. To pin a version — and keep CI reproducible — choose one of the
-options below. While the `0.1.x` line is in preview the surface is
-still settling, so pinning is recommended; what Rigor commits to
-keeping stable (and from which release) is enumerated in
+options below. While the `0.2.x` line is an evaluation trial the
+surface is still settling, so pinning is recommended; what Rigor
+commits to keeping stable (and from which release) is enumerated in
 [`docs/compatibility.md`](../compatibility.md).
 
 ### A CI-only `Gemfile` (recommended)
@@ -203,7 +203,7 @@ Commit a two-line `.github/rigor/Gemfile`:
 
 ```ruby
 source "https://rubygems.org"
-gem "rigortype", "~> 0.1"
+gem "rigortype", "~> 0.2"
 ```
 
 plus its `Gemfile.lock`, and point the Rigor job at it through
@@ -242,7 +242,7 @@ updates:
 
 ### A pinned `gem install`
 
-`gem install rigortype -v "0.1.15"` in the workflow. Simpler, with no
+`gem install rigortype -v "0.2.6"` in the workflow. Simpler, with no
 extra files — but Dependabot does not see a version inside a `run:`
 step, so updates to the pin are manual.
 
@@ -258,7 +258,7 @@ docker run --rm -v "$PWD:/src" ghcr.io/rigortype/rigor check
 
 `rigor` is the image entrypoint, so subcommands and flags follow the
 image name. Pin a version with an explicit tag —
-`ghcr.io/rigortype/rigor:0.1.15`.
+`ghcr.io/rigortype/rigor:0.2.6`.
 
 ## Nix
 

--- a/lib/rigor/version.rb
+++ b/lib/rigor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rigor
-  VERSION = "0.2.5"
+  VERSION = "0.2.6"
 end


### PR DESCRIPTION
v0.2.6 — evaluation-trial line cut ([ADR-50](docs/adr/50-release-engineering-and-stability-strategy.md)).

v0.2.6 sharpens how Rigor explains itself and tightens shape-aware inference. `rigor coverage --protection` now labels each untyped hole with why it is dynamic and whether a type can close it, and a new `rigor doctor` command routes setup problems to their fix. Literal hashes and arrays keep their precise shape through `freeze` / `dup` / `clone`. It also begins a plugin-contract cleanup ahead of the v1.0 freeze: the `type_specifier` hook is renamed to `narrowing_facts`, with the old name kept as a deprecated alias.

## Highlights

- **Added** `rigor coverage --protection` provenance + tractability labels ([ADR-75](docs/adr/75-dynamic-provenance.md)).
- **Added** `rigor doctor` (setup-problem classifier; stable `checks[].id` JSON) + `rigor upgrade` skeleton ([ADR-77](docs/adr/77-doctor-and-upgrade-commands.md)).
- **Changed** shape-carrier preservation through `freeze`/`dup`/`clone`/`itself` + block-form over-fold guard ([ADR-76](docs/adr/76-effect-modeling-freeze-dup-shape-preservation.md) / [ADR-78](docs/adr/78-reflexive-overfold-always-truthy.md)).
- **Deprecated** plugin hook `type_specifier` → `narrowing_facts` (alias removed in 0.3.0; [ADR-80](docs/adr/80-narrowing-facts-rename.md)).
- Decision-only: [ADR-79](docs/adr/79-rbs-version-range-over-pinned-determinism.md) RBS version-range fidelity (no code change).

## Notes for review

- This cut is **BC-safe for plugin authors**: `type_specifier` keeps working with a one-time deprecation warning; the hard removal is 0.3.0.
- Release prep follows the `rigor-release-prep` skill: sealed CHANGELOG (release-style, ADR-77 entry added that was missing from `[Unreleased]`), version bump, regenerated lockfile; the 0.1.x→0.2.x doc-staleness refresh (`11-ci.md` / `install.md`) is a separate prior commit.
- `make verify` is green under a UTF-8 locale; `gem build` succeeds. (Under a US-ASCII locale `test-binpacker` crashes inside the binpacker gem's `String#strip` — a known dev-harness locale issue, not shipped code; CI runs UTF-8.)
- No open issues; no urgent fixes outstanding.