### PR TITLE
Modernize the examples/ plugin walkthroughs + add rigor-plugin-review skill

### DIFF
--- a/docs/internal-spec/plugin.md
+++ b/docs/internal-spec/plugin.md
@@ -163,6 +163,24 @@ function, and replaces the hand-rolled Levenshtein copies plugins used to
 carry. It only affects suggestion *text* on an already-emitted
 diagnostic, never whether one fires.
 
+`#diagnostics_for(violations, path:, node: nil)` (ADR-60 WD4) maps a
+plugin's own violation objects onto `Diagnostic`s through `#diagnostic`,
+absorbing the `violations.map { |v| diagnostic(node, …) }` block the
+node-rule plugins otherwise repeat. Each violation duck-types `#message`
+(required) plus optional `#node` (the Prism node to position at — falls
+back to the `node:` argument), `#location`, `#severity` (defaults
+`:error`), and `#rule`. Returns an Array suitable for direct return from
+`#diagnostics_for_file` / a `node_rule` block.
+
+`#read_fact(plugin_id:, name:)` (ADR-60 WD4) reads a cross-plugin fact
+(ADR-9) another plugin's `#prepare` published, memoised per `(plugin_id,
+name)` on the instance **including a nil result**. The nil-inclusive
+memo retires the hand-rolled `@x_resolved` flag discovery plugins carried
+to distinguish "fact not published" from "not yet read"; a fact no loaded
+producer published reads as `nil`. (`#producer_value` / `#producer_error`
+— the cache-producer twins of these helpers — are spec'd in
+[`plugin-cache-producers.md`](plugin-cache-producers.md).)
+
 `#prepare(services)` (ADR-9) is the project-wide pre-pass hook,
 invoked once before per-file analysis begins. Plugins that publish
 cross-plugin facts (`manifest(produces:)`) override it to walk the

--- a/docs/notes/20260704-examples-plugin-modernization-survey.md
+++ b/docs/notes/20260704-examples-plugin-modernization-survey.md
@@ -3,7 +3,13 @@
 Status: 内部監査ノート、authored 2026-07-04（Rigor は release/0.2.x ライン、master
 `ae6844e7` 時点）。**このノートは同名ブランチ `examples-modernization` の実装 PR を駆動した**
 （ADR-40 デフォルト移行・routes の ADR-60 WD4 化・ドキュメント鮮度整理を実施、units は
-検証の結果「元設計が正」と判明し訂正済み。下記の各節に実装結果の追記あり）。`examples/` 配下 6 本のチュートリアル・
+検証の結果「元設計が正」と判明し訂正済み。下記の各節に実装結果の追記あり）。**第2弾**として、
+本作業から生まれた `rigor-plugin-review` スキルを examples 自身に適用（ドッグフーディング）し、
+チェックリスト観点2（AST 走査の所有権）で残っていた2件を追加修正した — routes の毎コール検査を
+`node_rule Prism::CallNode` へ移し `diagnostics_for_file` を load-error 専用に（本番 rigor-rails-routes
+と一致）、units `Analyzer` の手動 `Diagnostic.new` を公開コンストラクタ `Diagnostic.from_location` へ
+（バイト同一）。web は本番 rigor-hanami と同じ `diagnostics_for_file`+checker 形なので変更不要と再確認。
+`examples/` 配下 6 本のチュートリアル・
 プラグインが、現行の（＝多くが後発の ADR で追加された）プラグイン・オーサリング面を
 どこまで使い切れているかを棚卸しする。examples は「契約面を最小コードで見せる教材」
 であり ([`examples/README.md`](../../examples/README.md))、`make check-plugins`

--- a/docs/notes/20260704-examples-plugin-modernization-survey.md
+++ b/docs/notes/20260704-examples-plugin-modernization-survey.md
@@ -1,0 +1,201 @@
+# `examples/` プラグイン近代化調査 — 最初期プラグインと現行契約面のギャップ
+
+Status: 内部監査ノート、authored 2026-07-04（Rigor は release/0.2.x ライン、master
+`ae6844e7` 時点）。**このノートは同名ブランチ `examples-modernization` の実装 PR を駆動した**
+（ADR-40 デフォルト移行・routes の ADR-60 WD4 化・ドキュメント鮮度整理を実施、units は
+検証の結果「元設計が正」と判明し訂正済み。下記の各節に実装結果の追記あり）。`examples/` 配下 6 本のチュートリアル・
+プラグインが、現行の（＝多くが後発の ADR で追加された）プラグイン・オーサリング面を
+どこまで使い切れているかを棚卸しする。examples は「契約面を最小コードで見せる教材」
+であり ([`examples/README.md`](../../examples/README.md))、`make check-plugins`
+（ADR-43）のゲートで自己チェックが緑であることは前提 — よって本ノートが挙げるのは
+**正しさの回帰ではなく、イディオム/精度/ドキュメントの陳腐化**である。ADR / spec が
+束縛する。着手前に各ファイルの現存を確認すること。
+
+## なぜこの調査か
+
+依頼は「examples のプラグインは実装時期が最初期のものもあり、最新の Rigor の機能を
+使いきれていないものもある（例: 演算の積極的なリテラル型化）。まず現状を包括的に調査
+して docs/notes にまとめて」。examples は教材である以上、**現行の推奨イディオムを映す
+鏡**であることに価値がある。古い書き方が残っていると、プラグイン著者がそれを写経して
+陳腐なコードを再生産する。
+
+## 実装時期 — 全 6 本が最初期コホート
+
+| プラグイン | 初出 | 最終改修 | 主 hook | 位置づけ |
+| --- | --- | --- | --- | --- |
+| `rigor-deprecations` | 2026-05-07 | 2026-06-02 (`node_rule` 移行) | `node_rule` | config 駆動ルール（最小） |
+| `rigor-lisp-eval` | 2026-05-07 | 2026-06-16 (コメント修正) | `node_rule` + `dynamic_return` | リテラル AST 型付け |
+| `rigor-pattern` | 2026-05-07 | 2026-06-16 (コメント修正) | `node_rule` + `dynamic_return` | エンジン協調（`Scope#type_of`） |
+| `rigor-units` | 2026-05-07 | 2026-06-10 (ADR-52 slice 2 移行) | `diagnostics_for_file` + `dynamic_return` | ローカル変数フロー追跡 |
+| `rigor-routes` | 2026-05-07 | 2026-06-16 (コメント修正) | `diagnostics_for_file` + `producer` | IoBoundary + キャッシュ producer |
+| `rigor-web` | 2026-05-23 | 2026-05-23 (初出のみ) | `diagnostics_for_file` | パススコープ protocol contract (ADR-28) |
+
+全 6 本が **2026-05-07（web だけ 05-23）＝リポジトリ最古のプラグイン群**。以降の改修は
+「削除された `flow_contribution_for` からの機械的移行（ADR-52）」「`node_rule` 化
+（ADR-37）」「コメント修正」に限られ、**ADR-40 以降に増えたオーサリング面には
+一切追随していない**。
+
+## 現行オーサリング面のベースライン（examples が触れていないもの）
+
+現行 `Plugin::Base`（`lib/rigor/plugin/base.rb`）が公開し、**本番 `plugins/` は広く採用
+しているのに examples では 0 件**の面を確認した：
+
+| 面 | 由来 | 何を置き換えるか | examples 採用 | plugins 採用 |
+| --- | --- | --- | --- | --- |
+| `config_schema` の `{kind:, default:}` | ADR-40 | `DEFAULT_*` 定数 + `config.fetch(k, DEFAULT)` イディオム | **0/6** | 13+ 本 |
+| `Base.suggest(name, candidates)` | ADR-60 WD4 | 各プラグイン手書きの Levenshtein/"did you mean" | **0/6** | 複数（activerecord, rails-routes, statesman…） |
+| `#producer_value` / `#producer_error` | ADR-60 WD4 | 手書きの `@table`/`@load_error` メモ + `cache_for(...).call` + rescue | **0/6** | 複数（rails-routes 等） |
+| `#read_fact(plugin_id:, name:)` | ADR-60 WD4 | 手書きの `@x_resolved` フラグ付きクロスプラグイン fact 読み | 0/6（該当機会は routes/web に無し） | actioncable, actionmailer, activejob… |
+| `#diagnostics_for(violations, path:, node:)` | ADR-60 WD4 | `violations.map { diagnostic(...) }` / `Diagnostic.new(...)` 直書き | **0/6** | 複数 |
+| `narrowing_facts`（旧 `type_specifier`） | ADR-37 slice2 / ADR-80 | — | 0/6（機会は限定的、後述 pattern） | minitest, sorbet, rspec |
+
+ADR-60（pre-freeze plugin contract consolidation, 2026-06-13）の **WD4 オーサリング
+ヘルパは「bundled corpus を移行する」と謳っていたが、その corpus は `plugins/` であって
+`examples/` は対象外だった** — これが examples 未追随の主因。examples が古いイディオムを
+温存したまま「教材」として残っている。
+
+## プラグイン別の詳細所見
+
+### rigor-deprecations — ほぼ最新、ギャップ小
+- `node_rule` 済み、`diagnostic` ヘルパ使用、I/O・cache 無し。最小教材として健全。
+- 唯一のギャップ: `config_schema` が `{"methods" => :array}`（デフォルト無し）で `init` が
+  `config["methods"] || []` を手書き。ADR-40 の `{kind: :array, default: []}` にすれば
+  `|| []` が消える（軽微）。
+
+### rigor-lisp-eval — 移行済みだが Diagnostic 直書きが残存
+- `node_rule` + `dynamic_return` 済み。`type_for_result` は値を `constant_of` に、タグを
+  `nominal_of` に畳む — **リテラル型化は正しく行っている**（後述「演算のリテラル型化」の
+  観点でも良好）。
+- ギャップ:
+  - `DEFAULT_MODULE_NAME`/`DEFAULT_METHOD_NAME`/`DEFAULT_SEVERITY` 定数 + 3 連 `config.fetch`
+    → ADR-40 デフォルト形式へ。ただし `severity` は allow-list 検証があるので単純デフォルト化は
+    できず、`{kind: :string, default: "info"}` + 検証残し、が妥当。
+  - `diagnostic_for_inferred_type` / `diagnostic_for_error` が `Rigor::Analysis::Diagnostic.new`
+    を直接構築。`Base#diagnostic(node, ...)` ヘルパ（座標計算を吸収）を使えば行数減。
+
+### rigor-pattern — 教材として最も現代的、ただしデフォルト形式は旧
+- **本ノートの参照実装**。docstring 自身が「初期の AST-only 例と違い、リテラル文字列追跡を
+  再実装せず `Scope#type_of` でエンジンの `LiteralStringFolding` を読み返す」と明言しており、
+  エンジン協調の模範。`dynamic_return` はマッチ時に `value_type`（多くは `Constant<String>`）を
+  返して呼び出し側を精緻化 — 良い。
+- ギャップ:
+  - `DEFAULT_METHOD_NAME` + `config.fetch` → ADR-40 形式。
+  - docstring/README に "introduced in v0.0.9" 等の**古いバージョン参照**が残る（陳腐化。
+    現行の言い回しは「literal-string carrier」で足りる）。
+  - （任意・要検討）マッチ時に返り値型だけでなく `narrowing_facts` で「この値は :email
+    パターンに適合」という事実を後続に流す拡張余地。FP を増やさない範囲なら教材価値あり。
+
+### rigor-units — 二重実装に「見える」が、実は必須（当初仮説は棄却）
+> **2026-07-04 追記（実装で検証）**: 当初この節は「`Analyzer` の `@bindings` は
+> `scope.type_of` で置換できる冗長実装」と評価したが、実装して統合テストにかけたところ
+> **棄却された**。以下は訂正済みの結論。
+
+- `dynamic_return` は移行済みで `scope.type_of`（フロー scope）を読む。診断パス（`Analyzer`）は
+  独自の `@bindings` ローカル変数マップ + 独自 AST 走査 + 独自リテラル分類を持つ。
+- **これは冗長ではなく必須**だった。プラグイン診断側（`diagnostics_for_file` / `node_rule`）に
+  渡る `Scope` は `seed_project_scope(Scope.empty(...))` = **seed/entry scope** で、
+  `Scope#type_of` はノードをオンデマンド再評価するが**フロー蓄積されたローカル束縛を持たない**：
+  - `scope.type_of(100.kilometers)` は自己完結式なので `dynamic_return` を再発火して `Distance`
+    を返す（＝単文の `inferred-binding` は通る）。
+  - しかし `speed = distance / time` では `scope.type_of(distance)` が `untyped`。entry scope は
+    `distance` を束縛していない（束縛はフロー scope にしか存在しない）→ 次元が取れず、複数文の
+    伝播・不一致検出・in_query 判定がすべて落ちる（実測: 19 例中 11 失敗）。
+  - `dynamic_return` に渡る `Scope` は**フロー scope**なので `scope.type_of(distance)` は `Distance`。
+    エンジンは次元を正しくスレッドする（下流 `speed.upcase` は `Speed` に対し `call.undefined-method`
+    を実際に発火）が、**診断 API からはそのスレッドが見えない**。
+- 従って二つの半分は必要に迫られて別ソースから次元を読む: `dynamic_return` はフロー `Scope#type_of`、
+  `Analyzer` は自前の単一パス束縛マップ（＝診断側で次元を文跨ぎで追う唯一の手段）。rigor-pattern が
+  「エンジンを再実装するな」と戒めるのは**一箇所の呼び出し site で値が要る**ケース。units は
+  **診断側で文跨ぎのローカルフローが要る**ケースで、これは現行エンジンが診断 scope に露出しない。
+- **対応**: 元設計を維持し、この非対称性を docstring に「なぜ並行束縛マップが必要か」として明文化した
+  （投資した調査を教材価値へ転化）。真の除去には診断 scope へのフロー束縛露出（エンジン変更、
+  examples 近代化の範囲外）か、`dynamic_return`（フロー scope）で算出した次元をノード identity で
+  stash して診断側で読み返す設計が要るが、後者は flow→diagnostics 順序結合とクロスファイル
+  identity 前提を持ち込み、教材としてはむしろ不明瞭になるため見送り。
+- リテラル型化の観点: 演算表（`MethodTable`）は次元 Symbol 上で閉じ、`100.kilometers` は
+  `Nominal("Distance")` を返して数値の大きさ（Constant）を落とすが、次元解析としては妥当。
+  独自リテラル分類（`IntegerNode → :numeric`）も上記のとおり診断 scope の制約下では正当。
+- その他: `config_schema` 未宣言（config を取らないので可）。
+
+### rigor-routes — ADR-60 WD4 ヘルパの最大の受益者（未適用）
+- slice2（IoBoundary/TrustPolicy）+ slice6（producer/cache_for）の教材。ADR-60 WD3
+  record-and-validate へは移行済み。
+- ギャップ（**手書きボイラープレートが 3 種**、いずれも ADR-60 WD4 で名前が付いた）:
+  1. `levenshtein` + `closest_route`（30 行）を自前実装 → `Base.suggest(name, candidates)`
+     （Ruby の `DidYouMean::SpellChecker` を使う共有ヘルパ）で置換可能。
+  2. `route_table` の `@table`/`@load_error` メモ + `cache_for(:route_table).call` +
+     多段 rescue → `#producer_value(:route_table)` + `#producer_error(:route_table)` の
+     まさに `*_index_or_nil` 形。
+  3. `load_error_diagnostic` が `Diagnostic.new` 直書き。
+- `DEFAULT_ROUTES_FILE` + `config.fetch` → ADR-40 `{kind: :string, default: "config/routes.yml"}`。
+- 注: 本番 `plugins/rigor-rails-routes` は既に `suggest`/`producer_value` を採用済みで、
+  **教材版だけが古い**という捻れが起きている。
+
+### rigor-web — 初出のまま無改修、ただし該当ギャップは小
+- ADR-28 protocol contract 教材。`diagnostics_for_file` + `signature_paths` + `protocol_contracts`。
+  設計自体は現行契約に合致（protocol contract 面は後続で変わっていない）。
+- ギャップ:
+  - `DEFAULT`/`config.fetch` は無いが `config["controller_path"]` を手で捌く。
+    `config_schema` に `{kind: :string, default: ""}` を宣言して override 判定を素直にする余地。
+  - 2026-05-23 以降無改修で、ADR-60 pre-freeze 波及の点検を受けていない唯一のプラグイン。
+    現状 correctness 問題は見当たらないが、`config_schema` が未宣言（`controller_path` を
+    受けるのに schema なし）で、他 5 本と粒度が揃っていない。
+
+## 「演算の積極的なリテラル型化」の観点（依頼の例示）
+
+現行エンジンは算術/操作を `Constant`/リテラル carrier へ積極的に畳む（ADR-48 Data/Struct、
+ADR-55 recursive-return、ADR-56 block-writeback、`ConstantFolding`/`ShapeDispatch`）。examples
+はこの精度が薄かった時代の産物。観点別の実態：
+
+- **正しく活用**: `rigor-pattern` は `Scope#type_of` → `Constant<String>` を読み、
+  `rigor-lisp-eval` は自前評価結果を `constant_of` に畳む。
+- **本質的に自前が正（当初「活かしきれず」と誤評価）**: `rigor-units` の診断側 `@bindings` は、
+  検証の結果**現行エンジンの診断 scope 制約下では必須**と判明（上記 units 節の訂正を参照）。
+  診断 scope は entry scope でフロー束縛を持たないため、`scope.type_of` では文跨ぎのローカル
+  次元を追えない。ここは自前が正しい。lisp-eval の Lisp DSL 評価も engine に委譲できない。
+
+つまり「演算をリテラルへ畳む」新機能を examples が使うべき、という当初の見立ては units には
+当てはまらなかった。examples の実際の近代化余地は**演算の精度**ではなく、下記の
+オーサリング面イディオム（ADR-40 / ADR-60 WD4）とドキュメント鮮度に集約される。
+
+## ドキュメント/デモの陳腐化
+
+- README・docstring に **削除済み hook（`flow_contribution_for`）への言及**が
+  lisp-eval / pattern / units に残る（「〜は削除された」という但し書き付きで残しているが、
+  新規読者には不要な考古学）。
+- **古いバージョン参照**（"introduced in v0.0.9" 等）が pattern に残る。
+- デモ `.rigor.dist.yml` の書式は現行（`paths:` + `plugins:` の文字列 or `gem:/config:`）で
+  問題なし。
+- `demo/tmp/.rigor/cache/` にコミット済みキャッシュ artefact が見えるが `tmp/` は
+  `.gitignore` 対象 — 追跡はされていない想定（要確認、ただし機能影響なし）。
+
+## 優先度付き follow-up 候補（設計コミットメントではない）
+
+機械的・低リスク（イディオム統一、教材価値高）から：
+
+1. **ADR-40 デフォルト形式へ全 6 本移行** — `DEFAULT_*` + `config.fetch` を
+   `config_schema {kind:, default:}` へ。最も広く「古さ」を除ける単一施策。lisp-eval の
+   `severity` allow-list と web の override 判定だけ検証ロジックを残す。
+2. **rigor-routes を ADR-60 WD4 ヘルパへ**（`suggest` / `producer_value` / `producer_error`
+   / `diagnostics_for`）— 手書き 3 種を除去。本番 rails-routes と教材版の捻れを解消。
+   `make check-plugins` byte-identical でゲート可能なはず。
+3. **`Diagnostic.new` 直書きを `diagnostic`/`diagnostics_for` ヘルパへ**（lisp-eval, routes）。
+4. **README/docstring の陳腐化除去** — 削除済み hook 言及と古いバージョン番号の整理。
+5. **rigor-units は元設計を維持 + docstring 明文化（実装済み）** — 当初「エンジン協調化で
+   `@bindings` 除去」を狙ったが、実装検証で診断 scope がフロー束縛を持たない制約により
+   **除去不可**と判明。並行束縛マップが必要な理由を docstring に明文化した。
+6. **rigor-web の粒度合わせ（実装済み）** — `config_schema` に `controller_path` デフォルト宣言を追加。
+
+いずれも correctness ゲート（`check-plugins`）は緑を維持。**教材の鮮度**の改善であり、
+1–6 をまとめて 1 PR（各ステップ example 統合テストで gated）。
+
+## 参照
+
+- [`examples/README.md`](../../examples/README.md) — 教材の位置づけと契約面マップ
+- ADR-37（plugin interface segregation, `node_rule`/`node_file_context`/`dynamic_return`）
+- ADR-40（config_schema declared defaults）
+- ADR-52（compiled plugin contribution dispatch, `flow_contribution_for` 削除）
+- ADR-60（pre-freeze plugin contract consolidation, WD4 オーサリングヘルパ）
+- ADR-80（`type_specifier` → `narrowing_facts` リネーム）
+- [`.claude/skills/rigor-plugin-author/SKILL.md`](../../.claude/skills/rigor-plugin-author/SKILL.md)
+  — 新規プラグイン著者向け手順（examples を写経元にするため鮮度が重要）

--- a/docs/notes/20260704-examples-plugin-modernization-survey.md
+++ b/docs/notes/20260704-examples-plugin-modernization-survey.md
@@ -9,6 +9,17 @@ Status: 内部監査ノート、authored 2026-07-04（Rigor は release/0.2.x �
 `node_rule Prism::CallNode` へ移し `diagnostics_for_file` を load-error 専用に（本番 rigor-rails-routes
 と一致）、units `Analyzer` の手動 `Diagnostic.new` を公開コンストラクタ `Diagnostic.from_location` へ
 （バイト同一）。web は本番 rigor-hanami と同じ `diagnostics_for_file`+checker 形なので変更不要と再確認。
+**第3弾（skill の盲検証）** として、`master`（第1・2弾の PR 前）の worktree に `rigor-plugin-review`
+スキルだけを渡した Sonnet サブエージェントに examples をレビュー・改修させ、我々の解答と比較した
+（我々の変更・本ノートは非公開）。結果: Sonnet はスキルのみで我々の全項目（ADR-40・WD4 ヘルパ・
+routes の node_rule 化・units の罠回避・doc 鮮度）を独立に再現し、**さらに我々が見落とした doc 陳腐化を
+3 件発見**（deprecations README の存在しない "statesman" 参照、lisp-eval README の「return-type は
+later slice に queued」＝実装済み `dynamic_return` と矛盾、units README の存在しない
+`evaluate(node, emit_terminal:)` 引数）、かつ **web を `node_rule(Prism::ClassNode)` へ移行**する独立設計判断を
+下した（我々は本番 hanami 踏襲で `diagnostics_for_file` 維持だったが、per-class 検査は node 表現可能で
+スキルの観点2は移行を支持 — Sonnet の方がスキルに忠実）。この3件の doc 修正・web 移行・スキル観点2への
+「genuinely whole-file の境界」注記を本 PR に反映した（77/77 緑を維持）。スキルが「我々の作業の記述」ではなく
+汎用的に機能する強い証拠。
 `examples/` 配下 6 本のチュートリアル・
 プラグインが、現行の（＝多くが後発の ADR で追加された）プラグイン・オーサリング面を
 どこまで使い切れているかを棚卸しする。examples は「契約面を最小コードで見せる教材」

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -104,6 +104,7 @@ Filenames are `YYYYMMDD-<slug>.md`, dated to authorship.
 | 2026-06-10 | [ユーザー向けドキュメント レビュー・バッテリー設計 — chibirigor-review の移植検討](20260610-user-docs-review-battery-design.md) |
 | 2026-06-22 | [Rigor 0.2.x problem survey — type theory and Ruby runtime type model](20260622-rigor-0.2.x-problem-survey.md) |
 | 2026-06-22 | [Rigor 0.2.x compatibility-safe strengthening survey](20260622-rigor-0.2.x-compatibility-safe-strengthening-survey.md) |
+| 2026-07-04 | [`examples/` プラグイン近代化調査 — 最初期プラグインと現行契約面のギャップ](20260704-examples-plugin-modernization-survey.md) |
 
 ## Adding a note
 

--- a/examples/rigor-deprecations/README.md
+++ b/examples/rigor-deprecations/README.md
@@ -83,7 +83,7 @@ RUBYLIB=$PWD/../lib bundle exec rigor check
 | --- | --- |
 | `manifest(... config_schema: { "methods" => :array })` | top of `Deprecations` |
 | `#init(services)` parses config rows into frozen `Entry` Structs | `Deprecations#init` |
-| `#diagnostics_for_file(path:, scope:, root:)` walks Prism, matches, emits | the rest of the file |
+| `node_rule(Prism::CallNode) { ... }` — the engine owns the AST walk | the rest of the file |
 | `Prism::Node#slice` for receiver source-text comparison | `#receiver_source` private helper |
 
 ## Why this example matters
@@ -95,7 +95,7 @@ directly to "Rigor as a user-extensible lint engine":
 - **Units** propagates types through local-variable flow
 - **Routes** reads project config files under TrustPolicy + cache
 - **Pattern** queries Rigor's own type inference
-- **Statesman** does two-pass DSL analysis
+- **Web** enforces a path-scoped behavioural protocol contract
 - **Deprecations** lets users write rules without writing code
 
 Once a team has the plugin gem on their `Gemfile`, adding a
@@ -106,7 +106,7 @@ shrinks to a single PR with a YAML diff.
 
 ## Compared with the other examples
 
-| | lisp-eval | units | routes | pattern | statesman | **deprecations** |
+| | lisp-eval | units | routes | pattern | web | **deprecations** |
 | --- | --- | --- | --- | --- | --- | --- |
 | Lines of plugin code | ~200 | ~280 | ~250 | ~180 | ~210 | **~80** |
 | Manifest declaration | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -114,8 +114,8 @@ shrinks to a single PR with a YAML diff.
 | Local-variable flow | — | ✅ | — | — | — | — |
 | `IoBoundary` (slice 2) | — | — | ✅ | — | — | — |
 | `cache_for` / producer (slice 6) | — | — | ✅ | — | — | — |
-| Engine collaboration (`Scope#type_of`) | — | — | — | ✅ | — | — |
-| Two-pass DSL analysis | — | — | — | — | ✅ | — |
+| Engine collaboration (`Scope#type_of`) | — | — | — | ✅ | ✅ | — |
+| Path-scoped protocol contract (ADR-28) | — | — | — | — | ✅ | — |
 | **Pure config-driven rules** | — | — | — | — | — | ✅ |
 
 ## Future direction

--- a/examples/rigor-deprecations/lib/rigor/plugin/deprecations.rb
+++ b/examples/rigor-deprecations/lib/rigor/plugin/deprecations.rb
@@ -51,14 +51,14 @@ module Rigor
         version: "0.1.0",
         description: "Surfaces deprecation warnings for user-declared method signatures.",
         config_schema: {
-          "methods" => :array
+          "methods" => { kind: :array, default: [] }
         }
       )
 
       Entry = Struct.new(:method_name, :receiver, :replacement, :since, keyword_init: true)
 
       def init(_services)
-        @entries = (config["methods"] || []).map do |row|
+        @entries = config["methods"].map do |row|
           Entry.new(
             method_name: row.fetch("method").to_sym,
             receiver: row["receiver"],

--- a/examples/rigor-lisp-eval/README.md
+++ b/examples/rigor-lisp-eval/README.md
@@ -12,14 +12,11 @@ call site:
 demo/demo.rb:3:9: info: Lisp.eval return type inferred as Integer [plugin.lisp-eval.inferred-return-type]
 ```
 
-It is a *companion to the analyzer*, not an extension of the
-analyzer's inference engine. v0.1.0 plugins emit diagnostics
-and contribute cache entries; the protocol that lets a plugin
-override the analyzer's own inferred return type for a call
-site is queued for a later v0.1.x slice. When that ships, the
-same interpreter inside this plugin will move into a return-type
-contribution. The diagnostic-side surface stays useful either
-way.
+It is a *companion to the analyzer*: alongside the diagnostic,
+the plugin contributes the inferred type back to the call site
+via `dynamic_return`, so downstream calls on the result resolve
+against the precise carrier instead of the RBS-level `untyped`
+(see "Future direction" below).
 
 ## What the plugin recognises
 

--- a/examples/rigor-lisp-eval/README.md
+++ b/examples/rigor-lisp-eval/README.md
@@ -108,8 +108,7 @@ narrowly focused on the diagnostic emission protocol.
 ## Future direction — lightweight HKT / type-level eval
 
 The plugin supplies the inferred type at the call site through
-`dynamic_return methods: -> { [@method_name] }` (ADR-52 slice 4;
-the former `flow_contribution_for` hook was removed ADR-52 WD3): downstream
+`dynamic_return methods: -> { [@method_name] }` (ADR-52 slice 4): downstream
 calls on the result resolve against the inferred carrier
 (`Lisp.eval([:+, 1, 2]).bit_length` resolves on `Integer`,
 not the RBS-level `untyped`). The diagnostic stays as a

--- a/examples/rigor-lisp-eval/lib/rigor/plugin/lisp_eval.rb
+++ b/examples/rigor-lisp-eval/lib/rigor/plugin/lisp_eval.rb
@@ -28,8 +28,7 @@ module Rigor
     #
     # This plugin emits an `:info` diagnostic AND contributes a
     # precise return type at the call site via `dynamic_return`
-    # (ADR-52 slice 4 — the former `flow_contribution_for` hook
-    # was removed). The diagnostic serves as a user-facing trace
+    # (ADR-52 slice 4). The diagnostic serves as a user-facing trace
     # per the README's "info-diagnostic" pattern; the same
     # Interpreter walk feeds both channels.
     class LispEval < Rigor::Plugin::Base
@@ -38,21 +37,23 @@ module Rigor
         version: "0.1.0",
         description: "Types the return value of literal `Lisp.eval(...)` calls.",
         config_schema: {
-          "module_name" => :string,
-          "method_name" => :string,
-          "severity" => :string
+          "module_name" => { kind: :string, default: "Lisp" },
+          "method_name" => { kind: :string, default: "eval" },
+          "severity" => { kind: :string, default: "info" }
         }
       )
 
-      DEFAULT_MODULE_NAME = "Lisp"
-      DEFAULT_METHOD_NAME = "eval"
+      # Only the severity fallback needs a constant now — ADR-40 merges the
+      # `module_name` / `method_name` / `severity` defaults from the manifest,
+      # but `severity` is additionally allow-list-validated, so a bad value
+      # falls back here rather than to the merged default.
       DEFAULT_SEVERITY = :info
       ALLOWED_SEVERITIES = %i[info warning].freeze
 
       def init(_services)
-        @module_name = config.fetch("module_name", DEFAULT_MODULE_NAME)
-        @method_name = config.fetch("method_name", DEFAULT_METHOD_NAME).to_sym
-        configured_severity = config.fetch("severity", DEFAULT_SEVERITY.to_s).to_sym
+        @module_name = config["module_name"]
+        @method_name = config["method_name"].to_sym
+        configured_severity = config["severity"].to_sym
         @severity = ALLOWED_SEVERITIES.include?(configured_severity) ? configured_severity : DEFAULT_SEVERITY
         @interpreter = Interpreter.new
       end
@@ -153,27 +154,20 @@ module Rigor
       end
 
       def diagnostic_for_inferred_type(path, call_node, result)
-        location = call_node.location
-        rendered = render_result(result)
-        Rigor::Analysis::Diagnostic.new(
-          path: path,
-          line: location.start_line,
-          column: location.start_column + 1,
-          message: "#{@module_name}.#{@method_name} return type inferred as #{rendered}",
-          severity: @severity,
-          rule: "inferred-return-type"
+        diagnostic(
+          call_node, path: path,
+                     message: "#{@module_name}.#{@method_name} return type inferred as #{render_result(result)}",
+                     severity: @severity,
+                     rule: "inferred-return-type"
         )
       end
 
       def diagnostic_for_error(path, error)
-        location = error.node.location
-        Rigor::Analysis::Diagnostic.new(
-          path: path,
-          line: location.start_line,
-          column: location.start_column + 1,
-          message: error.message,
-          severity: :error,
-          rule: "type-error"
+        diagnostic(
+          error.node, path: path,
+                      message: error.message,
+                      severity: :error,
+                      rule: "type-error"
         )
       end
 

--- a/examples/rigor-pattern/README.md
+++ b/examples/rigor-pattern/README.md
@@ -13,7 +13,7 @@ The key surfaces:
 | Surface | Used in this plugin |
 | --- | --- |
 | `Scope#type_of(node)` | Per-call query against the analyzer's inference engine |
-| `Type::Combinator.literal_string_compatible?(type)` | Predicate the v0.0.9 literal-string carrier publishes |
+| `Type::Combinator.literal_string_compatible?(type)` | Predicate the literal-string carrier publishes |
 | `Type::Constant#value` | Exact-value extraction when the type is a `Constant<String>` |
 
 What this means in practice: when the user writes
@@ -114,8 +114,7 @@ through `FlowContribution::Merger`.
 ## Future direction — lightweight HKT
 
 The plugin supplies a return type at the call site through
-`dynamic_return` (ADR-52; the former `flow_contribution_for` hook was
-removed ADR-52 WD3): on a successful
+`dynamic_return` (ADR-52): on a successful
 match the runtime `validate` returns the value argument, so
 the plugin contributes the argument's type (typically
 `Constant<String>`) as the call site's return type. Mismatches

--- a/examples/rigor-pattern/lib/rigor/plugin/pattern.rb
+++ b/examples/rigor-pattern/lib/rigor/plugin/pattern.rb
@@ -10,9 +10,9 @@ module Rigor
     # against a user-declared regex pattern table. Demonstrates
     # **plugin → analyzer collaboration**: the plugin asks Rigor's
     # type system whether each `value` argument is a provably
-    # literal string (via `Type::Combinator.literal_string_compatible?`,
-    # introduced in v0.0.9), and if so, runs the configured regex
-    # against the literal value at lint time.
+    # literal string (via `Type::Combinator.literal_string_compatible?`),
+    # and if so, runs the configured regex against the literal value
+    # at lint time.
     #
     # Compared with the AST-only approach used by the earlier
     # examples, this one **does not reimplement** literal-string
@@ -53,17 +53,14 @@ module Rigor
         version: "0.1.0",
         description: "Statically validates literal arguments to validate(:name, value) calls.",
         config_schema: {
-          "method_name" => :string,
-          "patterns" => :hash
+          "method_name" => { kind: :string, default: "validate" },
+          "patterns" => { kind: :hash, default: {} }
         }
       )
 
-      DEFAULT_METHOD_NAME = "validate"
-
       def init(_services)
-        @method_name = config.fetch("method_name", DEFAULT_METHOD_NAME).to_sym
-        raw_patterns = config.fetch("patterns", {})
-        @patterns = raw_patterns.transform_values { |source| Regexp.new(source) }
+        @method_name = config["method_name"].to_sym
+        @patterns = config["patterns"].transform_values { |source| Regexp.new(source) }
       rescue RegexpError => e
         raise "rigor-pattern: invalid regex in config: #{e.message}"
       end
@@ -148,8 +145,8 @@ module Rigor
         # Use the per-file entry scope's `type_of` so the plugin
         # rides Rigor's existing literal-string folding rather
         # than reimplementing it. `Type::Combinator.literal_string_compatible?`
-        # is the engine-side predicate the v0.0.9 literal-string
-        # carrier publishes.
+        # is the engine-side predicate the literal-string carrier
+        # publishes.
         value_type = scope.type_of(value_node)
         evaluate_value(path, value_node, pattern, pattern_name, value_type)
       end

--- a/examples/rigor-routes/lib/rigor/plugin/routes.rb
+++ b/examples/rigor-routes/lib/rigor/plugin/routes.rb
@@ -21,18 +21,23 @@ module Rigor
     # - `init` reads the configured `routes_file` path from the
     #   plugin's frozen `config` Hash. Default: `config/routes.yml`.
     # - `diagnostics_for_file` consults a memoised `RouteTable`
-    #   produced via the cache surface; the producer block reads the
+    #   through `#producer_value` (ADR-60 WD4), which runs the
+    #   `:route_table` producer via `#cache_for` and caches the result
+    #   (nil included) on the instance. The producer block reads the
     #   file through `IoBoundary#read_file` (so `TrustPolicy`
     #   validates the path AND the boundary records a `:digest`
-    #   `FileEntry`), and `cache_for` (ADR-60 WD3 record-and-validate)
-    #   captures that digest into the dependency descriptor after the
-    #   block runs. Subsequent runs hit the cache when `routes.yml`
-    #   content is unchanged.
+    #   `FileEntry`); ADR-60 WD3 record-and-validate captures that
+    #   digest into the dependency descriptor after the block runs, so
+    #   subsequent runs hit the cache when `routes.yml` is unchanged.
+    #   A malformed / missing / denied file is rescued into
+    #   `#producer_error`, degrading the plugin to a single load-error
+    #   warning.
     # - The `Walker` finds every `*_path` / `*_url` implicit-
     #   receiver call. Each is checked against the table for
     #   existence and arity (= number of `:foo` placeholders in
     #   the path template). Unknown helpers carry a "did you
-    #   mean" suggestion via Levenshtein distance ≤ 3.
+    #   mean" suggestion via `Plugin::Base.suggest`
+    #   (`DidYouMean::SpellChecker`).
     #
     #
     # ## Usage
@@ -49,12 +54,9 @@ module Rigor
         version: "0.1.0",
         description: "Validates Rails-style route helper calls against a YAML route table.",
         config_schema: {
-          "routes_file" => :string
+          "routes_file" => { kind: :string, default: "config/routes.yml" }
         }
       )
-
-      DEFAULT_ROUTES_FILE = "config/routes.yml"
-      DID_YOU_MEAN_DISTANCE = 3
 
       # Cached producer (slice 6-A). The block runs through
       # `instance_exec` so `@routes_file`, `io_boundary`, and private
@@ -71,13 +73,20 @@ module Rigor
       end
 
       def init(_services)
-        @routes_file = config.fetch("routes_file", DEFAULT_ROUTES_FILE)
-        @table = nil
-        @load_error = nil
+        @routes_file = config["routes_file"]
       end
 
       def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
-        table = route_table
+        # ADR-60 WD4 — `#producer_value` runs the `:route_table` producer
+        # through `#cache_for` and memoises the result (nil included) on
+        # this instance. A `StandardError` the producer raises (missing /
+        # malformed / access-denied `routes.yml`) is rescued into
+        # `#producer_error`, degrading the plugin to a single load-error
+        # warning rather than aborting the run. ADR-60 WD3
+        # record-and-validate captures the in-block `routes.yml` read into
+        # the dependency descriptor, so the cache invalidates on edit with
+        # nothing to wire up by hand.
+        table = producer_value(:route_table)
         return [load_error_diagnostic(path)] if table.nil?
         return [] if table.empty?
 
@@ -89,28 +98,6 @@ module Rigor
       end
 
       private
-
-      def route_table
-        return @table if @table
-
-        # ADR-60 WD3 record-and-validate: the producer reads
-        # `@routes_file` in-block and that read is captured into the
-        # dependency descriptor after the block runs, so the cache
-        # invalidates when `routes.yml` changes — no priming read is
-        # needed here. (See `spec/rigor/plugin/cache_producer_spec.rb`
-        # — "recomputes when a file read INSIDE the producer block
-        # changes between sessions".)
-        @table = cache_for(:route_table, params: {}).call
-      rescue Plugin::AccessDeniedError => e
-        @load_error = "rigor-routes: #{e.message}"
-        nil
-      rescue Errno::ENOENT
-        @load_error = "rigor-routes: routes file `#{@routes_file}` not found; helper checks skipped"
-        nil
-      rescue ArgumentError, Psych::SyntaxError => e
-        @load_error = "rigor-routes: failed to parse `#{@routes_file}`: #{e.message}"
-        nil
-      end
 
       def diagnostics_for_call(path, node, base, kind, table)
         entry = table.find(base)
@@ -140,7 +127,10 @@ module Rigor
       end
 
       def unknown_route_diagnostic(path, node, base, kind, table)
-        suggestion = closest_route(base, table.names)
+        # ADR-60 WD4 — the shared `DidYouMean::SpellChecker` helper the
+        # engine also uses for `NoMethodError` hints, replacing the
+        # hand-rolled Levenshtein table this example used to carry.
+        suggestion = self.class.suggest(base, table.names)
         hint = suggestion ? " (did you mean `#{suggestion}_#{kind}`?)" : ""
         diagnostic(
           node, path: path,
@@ -162,49 +152,33 @@ module Rigor
         )
       end
 
+      # File-level (line 1) load-error warning. There is no call node to
+      # position at, so this is one of the few places a plugin constructs
+      # a `Diagnostic` directly rather than through `#diagnostic`. The
+      # message is tailored to the `StandardError` class `#producer_value`
+      # rescued into `#producer_error(:route_table)`.
       def load_error_diagnostic(path)
         Rigor::Analysis::Diagnostic.new(
           path: path,
           line: 1,
           column: 1,
-          message: @load_error,
+          message: load_error_message,
           severity: :warning,
           rule: "load-error"
         )
       end
 
-      def closest_route(name, candidates)
-        best = nil
-        best_distance = DID_YOU_MEAN_DISTANCE + 1
-        candidates.each do |candidate|
-          distance = levenshtein(name, candidate)
-          if distance < best_distance
-            best = candidate
-            best_distance = distance
-          end
+      def load_error_message
+        case (error = producer_error(:route_table))
+        when Plugin::AccessDeniedError
+          "rigor-routes: #{error.message}"
+        when Errno::ENOENT
+          "rigor-routes: routes file `#{@routes_file}` not found; helper checks skipped"
+        when ArgumentError, Psych::SyntaxError
+          "rigor-routes: failed to parse `#{@routes_file}`: #{error.message}"
+        else
+          "rigor-routes: could not load `#{@routes_file}`: #{error&.message}"
         end
-        best
-      end
-
-      def levenshtein(a, b) # rubocop:disable Naming/MethodParameterName
-        return b.length if a.empty?
-        return a.length if b.empty?
-
-        rows = Array.new(a.length + 1) { |_i| Array.new(b.length + 1, 0) }
-        (0..a.length).each { |i| rows[i][0] = i }
-        (0..b.length).each { |j| rows[0][j] = j }
-
-        (1..a.length).each do |i|
-          (1..b.length).each do |j|
-            cost = a[i - 1] == b[j - 1] ? 0 : 1
-            rows[i][j] = [
-              rows[i - 1][j] + 1,
-              rows[i][j - 1] + 1,
-              rows[i - 1][j - 1] + cost
-            ].min
-          end
-        end
-        rows[a.length][b.length]
       end
     end
 

--- a/examples/rigor-routes/lib/rigor/plugin/routes.rb
+++ b/examples/rigor-routes/lib/rigor/plugin/routes.rb
@@ -20,24 +20,26 @@ module Rigor
     #
     # - `init` reads the configured `routes_file` path from the
     #   plugin's frozen `config` Hash. Default: `config/routes.yml`.
-    # - `diagnostics_for_file` consults a memoised `RouteTable`
-    #   through `#producer_value` (ADR-60 WD4), which runs the
-    #   `:route_table` producer via `#cache_for` and caches the result
-    #   (nil included) on the instance. The producer block reads the
-    #   file through `IoBoundary#read_file` (so `TrustPolicy`
-    #   validates the path AND the boundary records a `:digest`
-    #   `FileEntry`); ADR-60 WD3 record-and-validate captures that
-    #   digest into the dependency descriptor after the block runs, so
-    #   subsequent runs hit the cache when `routes.yml` is unchanged.
-    #   A malformed / missing / denied file is rescued into
-    #   `#producer_error`, degrading the plugin to a single load-error
-    #   warning.
-    # - The `Walker` finds every `*_path` / `*_url` implicit-
-    #   receiver call. Each is checked against the table for
-    #   existence and arity (= number of `:foo` placeholders in
-    #   the path template). Unknown helpers carry a "did you
-    #   mean" suggestion via `Plugin::Base.suggest`
-    #   (`DidYouMean::SpellChecker`).
+    # - A memoised `RouteTable` is loaded through `#producer_value`
+    #   (ADR-60 WD4), which runs the `:route_table` producer via
+    #   `#cache_for` and caches the result (nil included) on the
+    #   instance — so the node rule and the file rule share one round
+    #   trip. The producer block reads the file through
+    #   `IoBoundary#read_file` (so `TrustPolicy` validates the path AND
+    #   the boundary records a `:digest` `FileEntry`); ADR-60 WD3
+    #   record-and-validate captures that digest into the dependency
+    #   descriptor after the block runs, so subsequent runs hit the
+    #   cache when `routes.yml` is unchanged. A malformed / missing /
+    #   denied file is rescued into `#producer_error`; the file rule
+    #   emits one load-error warning for it.
+    # - A `node_rule Prism::CallNode` (the engine-owned walk, ADR-37)
+    #   validates every implicit-receiver `*_path` / `*_url` call —
+    #   `Walker.helper_call` is the matcher it applies — against the
+    #   table for existence and arity (= number of `:foo` placeholders
+    #   in the path template). Unknown helpers carry a "did you mean"
+    #   suggestion via `Plugin::Base.suggest` (`DidYouMean::SpellChecker`).
+    #   `#diagnostics_for_file` is left with only the file-level
+    #   load-error emission.
     #
     #
     # ## Usage
@@ -74,27 +76,46 @@ module Rigor
 
       def init(_services)
         @routes_file = config["routes_file"]
+        @load_error_emitted = false
       end
 
-      def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
-        # ADR-60 WD4 — `#producer_value` runs the `:route_table` producer
-        # through `#cache_for` and memoises the result (nil included) on
-        # this instance. A `StandardError` the producer raises (missing /
-        # malformed / access-denied `routes.yml`) is rescued into
-        # `#producer_error`, degrading the plugin to a single load-error
-        # warning rather than aborting the run. ADR-60 WD3
-        # record-and-validate captures the in-block `routes.yml` read into
-        # the dependency descriptor, so the cache invalidates on edit with
-        # nothing to wire up by hand.
+      # ADR-37 — per-call helper validation over the engine-owned walk.
+      # The engine hands us every `CallNode`; `Walker.helper_call` gates
+      # on the implicit-receiver `*_path` / `*_url` shape, and each match
+      # is checked against the route table. `#producer_value` (ADR-60 WD4)
+      # loads and memoises the table on this instance, so the node rule
+      # and the file rule below share one `#cache_for` round-trip. When
+      # the table failed to load the file rule owns the single load-error
+      # warning; the node rule stays silent.
+      node_rule Prism::CallNode do |node, _scope, path|
         table = producer_value(:route_table)
-        return [load_error_diagnostic(path)] if table.nil?
-        return [] if table.empty?
+        next [] if table.nil? || table.empty?
 
-        diagnostics = []
-        Walker.each_helper_call(root) do |node, base, kind|
-          diagnostics.concat(diagnostics_for_call(path, node, base, kind, table))
-        end
-        diagnostics
+        base, kind = Walker.helper_call(node)
+        next [] if base.nil?
+
+        diagnostics_for_call(path, node, base, kind, table)
+      end
+
+      # File-level only: the once-per-run load-error emission. Per-call
+      # validation runs over the engine-owned walk via the node rule
+      # above, so this hook is reserved for the one diagnostic a per-node
+      # walk cannot express — the project-global "routes file did not
+      # load" warning, emitted once rather than on every analysed file.
+      #
+      # `#producer_value` runs the `:route_table` producer through
+      # `#cache_for`; a `StandardError` the producer raises (missing /
+      # malformed / access-denied `routes.yml`) is rescued into
+      # `#producer_error`. ADR-60 WD3 record-and-validate captures the
+      # in-block `routes.yml` read into the dependency descriptor, so the
+      # cache invalidates on edit with nothing to wire up by hand.
+      def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
+        table = producer_value(:route_table)
+        return [] unless table.nil?
+        return [] if @load_error_emitted
+
+        @load_error_emitted = true
+        [load_error_diagnostic(path)]
       end
 
       private

--- a/examples/rigor-routes/lib/rigor/plugin/routes/walker.rb
+++ b/examples/rigor-routes/lib/rigor/plugin/routes/walker.rb
@@ -5,35 +5,27 @@ require "prism"
 module Rigor
   module Plugin
     class Routes < Rigor::Plugin::Base
-      # Yields every implicit-receiver call whose method name
-      # matches `*_path` or `*_url`, paired with the base helper
-      # name (`users_path` → `"users"`). Reduces the AST to the
-      # minimum the plugin needs to validate against the route
-      # table — the rest of the file is irrelevant.
+      # Recognises the implicit-receiver `*_path` / `*_url` route
+      # helper call shape. The engine owns the per-file AST walk
+      # (ADR-37 `node_rule`); this module is only the matcher the
+      # node rule applies to each `Prism::CallNode` it is handed —
+      # it holds no traversal of its own.
       module Walker
         SUFFIX_RE = /\A(?<base>.+)_(?<kind>path|url)\z/
 
         module_function
 
-        def each_helper_call(root, &)
-          return enum_for(__method__, root) unless block_given?
+        # Returns `[base, kind]` for an implicit-receiver `*_path` /
+        # `*_url` call (`users_path` → `["users", :path]`), or `nil`
+        # for any other node.
+        def helper_call(node)
+          return nil unless node.is_a?(Prism::CallNode)
+          return nil unless node.receiver.nil?
 
-          walk(root) do |node|
-            next unless node.is_a?(Prism::CallNode)
-            next unless node.receiver.nil?
+          match = SUFFIX_RE.match(node.name.to_s)
+          return nil unless match
 
-            match = SUFFIX_RE.match(node.name.to_s)
-            next unless match
-
-            yield node, match[:base], match[:kind].to_sym
-          end
-        end
-
-        def walk(node, &)
-          return if node.nil?
-
-          yield node
-          node.compact_child_nodes.each { |child| walk(child, &) }
+          [match[:base], match[:kind].to_sym]
         end
       end
     end

--- a/examples/rigor-units/README.md
+++ b/examples/rigor-units/README.md
@@ -130,8 +130,7 @@ on top of the surfaces `rigor-lisp-eval` covered:
 ## Future direction — lightweight HKT
 
 The plugin produces dimensional return types via
-`dynamic_return receivers: ["Distance", ...]` (ADR-52 slice 2;
-the former `flow_contribution_for` hook was removed ADR-52 WD3): dimensional results
+`dynamic_return receivers: ["Distance", ...]` (ADR-52 slice 2): dimensional results
 (`Distance / Time -> Speed`, `Distance + Distance -> Distance`,
 `Speed * Time -> Distance`, `.in_<unit>` queries returning
 `Float`) override the demo's `untyped` RBS at every call site,

--- a/examples/rigor-units/README.md
+++ b/examples/rigor-units/README.md
@@ -108,7 +108,7 @@ on top of the surfaces `rigor-lisp-eval` covered:
 | `#diagnostics_for_file(path:, scope:, root:)` | walks the parsed root |
 | Per-file analyzer state | `Analyzer` instance lives one-per-file |
 | Local-variable binding map | `@bindings` Hash threaded through `evaluate` |
-| Multi-pass evaluation | `evaluate(node, emit_terminal:)` distinguishes leaf vs. nested calls so chained `.in_*` only emits once per chain |
+| Single-pass evaluation | `evaluate(node)` recurses once per node, emitting each node's diagnostic as a side effect of evaluating it |
 | Pure dispatch table | `MethodTable.dispatch` — separable, easily extended |
 
 ## What this plugin does NOT exercise

--- a/examples/rigor-units/lib/rigor/plugin/units.rb
+++ b/examples/rigor-units/lib/rigor/plugin/units.rb
@@ -13,9 +13,10 @@ module Rigor
     # arithmetic, chained constructors (`60.kilometers.per_hour`),
     # and conversion queries (`speed.in_kilometers_per_hour`).
     #
-    # The plugin walks the file's AST, maintains a local-variable
-    # binding map (`distance: :distance`, `speed: :speed`, …),
-    # and emits one diagnostic per recognised event:
+    # The plugin walks the file's AST ({Analyzer}), maintains a
+    # local-variable binding map (`distance: :distance`,
+    # `speed: :speed`, …), and emits one diagnostic per recognised
+    # event:
     #
     # | Event                                 | Severity | Rule |
     # | ---                                   | ---      | --- |
@@ -30,6 +31,37 @@ module Rigor
     # (`Distance` / `Speed` / …) through assignments and into
     # downstream calls instead of seeing the DSL's untyped RBS
     # boundary.
+    #
+    # ## Why the parallel binding map is NOT redundant
+    #
+    # It is tempting to delete {Analyzer}'s `@bindings` map and have
+    # the diagnostics side read dimensions straight from
+    # `Scope#type_of`, the way `rigor-pattern` reads literal-string
+    # facts back from the engine. That does not work here, and the
+    # asymmetry is worth understanding:
+    #
+    # - The `Scope` handed to `#diagnostics_for_file` / a `node_rule`
+    #   is the **seed entry scope** (`seed_project_scope(Scope.empty)`).
+    #   `Scope#type_of` re-evaluates a node on demand, so it folds a
+    #   *self-contained* expression — `scope.type_of(100.kilometers)`
+    #   re-runs the {.dynamic_return} block and yields `Distance`. But
+    #   it carries **no flow-accumulated local bindings**: for
+    #   `speed = distance / time`, `scope.type_of(distance)` is
+    #   `untyped`, because the entry scope never bound `distance` — the
+    #   binding only ever existed in the mid-inference flow scope.
+    # - The `Scope` handed to {.dynamic_return} IS that flow scope, at
+    #   the call site, so there `scope.type_of(distance)` is `Distance`.
+    #   The engine threads dimensions correctly (a downstream
+    #   `speed.upcase` really does trip `call.undefined-method` on
+    #   `Speed`), but the diagnostics API cannot see that thread.
+    #
+    # So the two halves read dimensions from different sources of
+    # necessity: {.dynamic_return} from the flow `Scope#type_of`, and
+    # {Analyzer} from its own single-pass binding map — the only way to
+    # follow a dimension across statements on the diagnostics side. A
+    # plugin that needs a value literally at one call site (rigor-pattern)
+    # reaches for the engine; a plugin that needs cross-statement
+    # local flow on the diagnostics side (this one) still tracks it.
     #
     # Usage in `.rigor.yml`:
     #

--- a/examples/rigor-units/lib/rigor/plugin/units/analyzer.rb
+++ b/examples/rigor-units/lib/rigor/plugin/units/analyzer.rb
@@ -148,11 +148,14 @@ module Rigor
         end
 
         def push_diagnostic(node, severity:, message:, rule:)
-          location = node.location
-          @diagnostics << Rigor::Analysis::Diagnostic.new(
+          # `Analyzer` is a plain class, not a `Plugin::Base` subclass, so
+          # it cannot use the `#diagnostic` instance helper — but
+          # `Diagnostic.from_location` is the same public constructor that
+          # helper wraps, and it internalises the 1-based line / column + 1
+          # convention this method used to spell out by hand.
+          @diagnostics << Rigor::Analysis::Diagnostic.from_location(
+            node.location,
             path: @path,
-            line: location.start_line,
-            column: location.start_column + 1,
             message: message,
             severity: severity,
             rule: rule

--- a/examples/rigor-web/README.md
+++ b/examples/rigor-web/README.md
@@ -59,8 +59,8 @@ The contract drives two distinct behaviours:
   typo like `request.path_inf0` surfaces as an ordinary core
   `call.undefined-method` diagnostic — `rigor-web` never has to
   check for that itself.
-- **check** (plugin-side) — the plugin's `#diagnostics_for_file`
-  hook confirms each controller class defines `#get` and that its
+- **check** (plugin-side) — the plugin's `node_rule(Prism::ClassNode)`
+  rule confirms each controller class defines `#get` and that its
   inferred return type conforms to `Rack::Response`.
 
 ## What the plugin recognises

--- a/examples/rigor-web/lib/rigor/plugin/web.rb
+++ b/examples/rigor-web/lib/rigor/plugin/web.rb
@@ -36,8 +36,12 @@ module Rigor
     # misuse of the request inside a controller body
     # (`request.no_such_method`) surfaces as an ordinary core
     # diagnostic. The check half is this plugin's
-    # `#diagnostics_for_file` hook: it confirms `#get` exists and
-    # that its inferred return type conforms to `Rack::Response`.
+    # `node_rule(Prism::ClassNode)`: for every class the engine-owned
+    # walk hands it, it confirms `#get` exists and that its inferred
+    # return type conforms to `Rack::Response`. (The check is per class,
+    # so it rides the engine's walk rather than shipping a `class_nodes`
+    # traversal — contrast the file-level load-error in `rigor-routes`,
+    # which genuinely cannot be expressed per node.)
     #
     # ## Configuration
     #
@@ -103,11 +107,19 @@ module Rigor
         @protocol_contracts || manifest.protocol_contracts
       end
 
-      def diagnostics_for_file(path:, scope:, root:)
+      # ADR-37 — per-class-node validation over the engine-owned walk.
+      # Each `Prism::ClassNode` is checked against every contract
+      # independently of the others, so the plugin no longer ships its
+      # own `class_nodes` traversal; `ProtocolChecker#check_class` keeps
+      # the per-class contract logic. (Production `rigor-hanami`'s ADR-28
+      # check half still uses `#diagnostics_for_file` + a hand-rolled
+      # class walk — an equivalent, older shape; either is contract-valid,
+      # but a per-class check is exactly what `node_rule` is for.)
+      node_rule Prism::ClassNode do |node, scope, path|
         contracts = protocol_contracts
-        return [] if contracts.empty?
+        next [] if contracts.empty?
 
-        ProtocolChecker.new(contracts: contracts).check(path: path, scope: scope, root: root)
+        ProtocolChecker.new(contracts: contracts).check_class(node, path: path, scope: scope)
       end
     end
 

--- a/examples/rigor-web/lib/rigor/plugin/web.rb
+++ b/examples/rigor-web/lib/rigor/plugin/web.rb
@@ -64,7 +64,9 @@ module Rigor
         version: "0.1.0",
         description: "Enforces the RigWeb controller protocol: #get(Rack::Request) -> Rack::Response.",
         config_schema: {
-          "controller_path" => :string
+          # Empty default = "use the manifest's convention path"; a
+          # non-empty override retargets every contract's path glob.
+          "controller_path" => { kind: :string, default: "" }
         },
         # The plugin ships RBS for Rack::Request / Rack::Response
         # so the analysed project does not need rack installed for

--- a/examples/rigor-web/lib/rigor/plugin/web/protocol_checker.rb
+++ b/examples/rigor-web/lib/rigor/plugin/web/protocol_checker.rb
@@ -27,11 +27,17 @@ module Rigor
           @contracts = contracts
         end
 
-        def check(path:, scope:, root:)
+        # Per-`ClassNode` check over the engine-owned walk (ADR-37):
+        # called once per class node the `node_rule` in `web.rb`
+        # dispatches, checking it against every contract whose
+        # `path_glob` matches the file. No cross-class-node state is
+        # needed, so the checker ships no `class_nodes` traversal of its
+        # own.
+        def check_class(class_node, path:, scope:)
           @contracts.flat_map do |contract|
             next [] unless path_matches?(contract.path_glob, path)
 
-            check_contract(contract, path, scope, root)
+            diagnostics_for_class(contract, path, scope, class_node)
           end
         end
 
@@ -47,12 +53,6 @@ module Rigor
             File.fnmatch?(File.join("**", glob), path, FNMATCH_FLAGS)
         end
 
-        def check_contract(contract, path, scope, root)
-          class_nodes(root).flat_map do |class_node|
-            diagnostics_for_class(contract, path, scope, class_node)
-          end
-        end
-
         def diagnostics_for_class(contract, path, scope, class_node)
           def_node = target_def(class_node, contract)
           if def_node.nil?
@@ -60,13 +60,6 @@ module Rigor
           else
             Array(return_type_diagnostic(contract, path, scope, def_node))
           end
-        end
-
-        # Every `Prism::ClassNode` reachable from the root.
-        def class_nodes(root)
-          found = []
-          walk(root) { |node| found << node if node.is_a?(Prism::ClassNode) }
-          found
         end
 
         # The contracted method, defined directly in `class_node`'s
@@ -190,13 +183,6 @@ module Rigor
         def class_name(class_node)
           path = class_node.constant_path
           path.respond_to?(:slice) ? path.slice : class_node.name.to_s
-        end
-
-        def walk(node, &)
-          return if node.nil?
-
-          yield node
-          node.compact_child_nodes.each { |child| walk(child, &) }
         end
       end
     end

--- a/skills/README.md
+++ b/skills/README.md
@@ -61,6 +61,7 @@ your installed version rather than being frozen into a SKILL file — see
 | [`rigor-protection-uplift`](rigor-protection-uplift/SKILL.md) | Close the type-protection holes `rigor coverage --protection` surfaces, under a double gate that keeps `rigor check` clean. |
 | [`rigor-plugin-tune`](rigor-plugin-tune/SKILL.md) | Re-match `Gemfile.lock` against the bundled plugin catalogue and enable the plugins for the project's current stack; verify with `rigor plugins --strict`. |
 | [`rigor-plugin-author`](rigor-plugin-author/SKILL.md) | Author a Rigor plugin (in your own repo) to teach Rigor an application DSL, framework, or metaprogramming pattern. |
+| [`rigor-plugin-review`](rigor-plugin-review/SKILL.md) | Review an existing plugin against the current authoring contract and produce a prioritized upgrade path — config defaults (ADR-40), the ADR-60 WD4 helpers, `node_rule` vs a hand-rolled walk, `dynamic_return` / `narrowing_facts`, doc freshness. |
 | [`rigor-upgrade`](rigor-upgrade/SKILL.md) | Adopt a new Rigor version cleanly — diff diagnostics against the baseline, sort genuine new catches from sig-quality FPs, regenerate. |
 | [`rigor-doctor`](rigor-doctor/SKILL.md) | Validate the setup is healthy — config resolves, plugins load, baseline is fresh, the analysis sees your code. |
 

--- a/skills/rigor-plugin-review/SKILL.md
+++ b/skills/rigor-plugin-review/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: rigor-plugin-review
+description: |
+  Review an existing Rigor plugin's source against the current authoring contract and produce a prioritized upgrade path — the modernization counterpart to rigor-plugin-author. Audits config-default declaration (ADR-40), the AST-walk model (node_rule vs a hand-rolled traversal), return-type / narrowing hooks (dynamic_return / narrowing_facts, not the removed flow_contribution_for or deprecated type_specifier), the ADR-60 WD4 authoring helpers (diagnostic / diagnostics_for / suggest / producer_value / read_fact), engine-collaboration vs reimplementation, cache-producer soundness, manifest-field hygiene, and doc freshness. Triggers: "review this Rigor plugin", "does my plugin follow best practices", "upgrade our rigor-prefixed plugin to the latest contract", "modernize this plugin", "is this plugin using the current API". NOT for authoring a new plugin (use rigor-plugin-author), enabling bundled plugins on a project (use rigor-plugin-tune), or tuning plugin config.
+license: MPL-2.0
+metadata:
+  version: 0.1.0
+  homepage: https://github.com/rigortype/rigor
+---
+
+# Rigor Plugin Review
+
+Audit an **existing** Rigor plugin — a bundled one in the rigor
+monorepo (`plugins/` or `examples/`), or your own `rigor-<id>` gem —
+against the current `Rigor::Plugin::Base` authoring contract, and hand
+back a **prioritized upgrade path**. This is the review / upgrade
+counterpart to `rigor-plugin-author` (which creates new plugins).
+
+Plugins written before a contract addition keep working — the gate is
+compatibility, not currency — but they drift from the idiom other
+authors copy. The commonest drift, in rough order of how often it
+appears:
+
+1. **Config defaults** declared with a `DEFAULT_*` constant +
+   `config.fetch(k, DEFAULT)` instead of `config_schema {kind:,
+   default:}` (ADR-40).
+2. **Hand-rolled boilerplate** the ADR-60 WD4 authoring helpers now
+   own — a Levenshtein "did you mean", a `@table`/`@load_error` memo +
+   rescue, a `Diagnostic.new` where a node exists.
+3. **A hand-rolled AST walk** where the engine-owned `node_rule` now
+   fits (ADR-37 / ADR-52).
+4. **Removed / renamed hooks** still named — `flow_contribution_for`
+   (deleted, ADR-52 WD3) or `type_specifier` (deprecated alias for
+   `narrowing_facts`, ADR-80).
+5. **Stale docs** — archaeology about deleted hooks, pinned version
+   references that no longer mean anything.
+
+## When to use / not use
+
+**Use it** when someone asks to review a plugin's quality, check it
+against best practices, or upgrade it to the current contract — whether
+it lives in the rigor monorepo or in an external repo.
+
+**Do not use it** for:
+
+- **Authoring a new plugin** → `rigor-plugin-author`.
+- **Choosing / enabling bundled plugins on a project** →
+  `rigor-plugin-tune`.
+- **A behavioural bug in a plugin** — that is ordinary debugging, not a
+  contract-conformance pass.
+
+## Read the plugin — and read the contract
+
+Rigor is installed on disk, so both the plugin under review and the
+worked-example plugins are readable source:
+
+```sh
+rigor plugin list                 # every bundled + example plugin, with paths
+rigor plugin print rigor-<id>     # a plugin's main source, inline
+rigor plugin path  rigor-<id>     # its directory, to browse
+```
+
+The **authoritative** authoring surface — the one this review scores
+against — is the internal spec, not this file:
+
+- [`docs/internal-spec/plugin.md`](https://github.com/rigortype/rigor/blob/master/docs/internal-spec/plugin.md)
+  — manifest, `node_rule` / `node_file_context`, `dynamic_return` /
+  `narrowing_facts`, the `#diagnostic` / `#diagnostics_for` / `.suggest`
+  / `#read_fact` author helpers, `config_schema` `{kind:, default:}`.
+- [`docs/internal-spec/plugin-cache-producers.md`](https://github.com/rigortype/rigor/blob/master/docs/internal-spec/plugin-cache-producers.md)
+  — `producer` / `#cache_for` / `#producer_value` / `#producer_error`,
+  ADR-60 WD3 record-and-validate.
+- [`docs/internal-spec/plugin-trust.md`](https://github.com/rigortype/rigor/blob/master/docs/internal-spec/plugin-trust.md)
+  — `TrustPolicy` / `IoBoundary`.
+
+When the checklist below and the spec disagree, **the spec binds** —
+it tracks the installed `rigor` version; this skill is a snapshot.
+
+## Procedure
+
+### Phase 1 — Inventory
+
+Read the plugin's `lib/**/*.rb`, its `README.md`, and its integration /
+unit spec. Note: the `manifest(...)` block, every `config.fetch` /
+`DEFAULT_*` constant, every `Rigor::Analysis::Diagnostic.new`, any
+hand-rolled `levenshtein` / `each_child` walk / cross-plugin `@*_resolved`
+flag, and every mention of `flow_contribution_for` / `type_specifier`.
+
+### Phase 2 — Score against the checklist
+
+Walk [`references/01-best-practices-checklist.md`](references/01-best-practices-checklist.md)
+concern by concern. For each finding, record: the smell, the modern
+replacement, the authoritative citation, and — critically — whether the
+change is **mechanical** (byte-identical diagnostics expected) or
+**design-level** (needs judgment / may change behaviour).
+
+### Phase 3 — Establish the oracle BEFORE changing anything
+
+The plugin's integration spec is the contract you must preserve. Run it
+green first, so you can prove each later step is a faithful refactor:
+
+```sh
+# external gem:
+bundle exec rspec spec/
+# in the rigor monorepo:
+nix … develop --command bundle exec rspec spec/integration/<plugins|examples>/<id>_plugin_spec.rb
+```
+
+If there is no spec, **write one first** (per `rigor-plugin-author`
+Phase 3) — a modernization with no oracle is a guess.
+
+### Phase 4 — Apply the upgrade path, mechanical first
+
+Order the work low-risk → high-risk, and **re-run the spec after every
+step**:
+
+1. **Mechanical (expect byte-identical diagnostics):** ADR-40 config
+   defaults · helper swaps (`suggest` / `producer_value` / `diagnostic`
+   / `diagnostics_for` / `read_fact`) · manifest-field renames (ADR-60
+   WD1/WD2) · doc freshness. A spec that changes here means the swap was
+   not faithful — fix it, do not re-baseline.
+2. **Design-level (may change behaviour — validate empirically):** an
+   AST-walk migration onto `node_rule`; an engine-collaboration refactor
+   that reads `Scope#type_of` instead of a hand-rolled binding map.
+   **Do not delete hand-rolled state before proving the engine gives you
+   the same information** — see the `rigor-units` trap in the checklist
+   (the diagnostics-side `Scope` is a *seed entry scope* without
+   flow-accumulated local bindings, so a cross-statement binding map can
+   be necessary, not redundant).
+
+### Phase 5 — Verify
+
+```sh
+rigor check <plugin>/lib        # ADR-43 contract self-check — MUST be clean
+rigor plugins --strict          # the plugin still loads
+rigor plugins --capabilities    # node-rule types / dynamic_return receivers look right
+bundle exec rspec …             # the oracle spec, still green
+```
+
+In the **rigor monorepo**, the gate is `make check-plugins` (runs
+`rigor check` over every `plugins/*/lib` + `examples/*/lib`) plus
+`make verify`; land the change as its own commit(s) with the spec as
+the byte-identical gate.
+
+## Output
+
+Hand the user a table — smell → replacement → authority → mechanical /
+design — ranked so the mechanical, oracle-gated wins land first, and
+call out any finding (like the units binding-map case) where the
+"obvious" modernization is actually wrong. If nothing is stale, say so
+plainly: a plugin that already tracks the current contract is a pass,
+not an occasion to invent churn.
+
+## Next step
+
+Re-run `rigor skill describe` for the next move, or `rigor-plugin-author`
+if the review surfaced a *new* capability the plugin should grow.

--- a/skills/rigor-plugin-review/references/01-best-practices-checklist.md
+++ b/skills/rigor-plugin-review/references/01-best-practices-checklist.md
@@ -1,0 +1,200 @@
+# Plugin best-practices checklist
+
+Score a plugin concern by concern. Each row is **smell → modern
+replacement → authority**. The authority column names the binding
+surface (`docs/internal-spec/*` or the ADR); when it disagrees with
+this file, it wins.
+
+`M` = mechanical (byte-identical diagnostics expected; oracle-gated).
+`D` = design-level (may change behaviour; validate empirically).
+
+---
+
+## 1. Manifest & config defaults (ADR-40) — `M`
+
+**Smell:**
+
+```ruby
+DEFAULT_ROUTES_FILE = "config/routes.yml"
+config_schema: { "routes_file" => :string }
+# …
+@routes_file = config.fetch("routes_file", DEFAULT_ROUTES_FILE)
+```
+
+**Modern:**
+
+```ruby
+config_schema: { "routes_file" => { kind: :string, default: "config/routes.yml" } }
+# …
+@routes_file = config["routes_file"]   # default merged under user config
+```
+
+`Base#config` merges `manifest.config_defaults` beneath the user config,
+so the plugin reads the key directly and the `DEFAULT_*` constant goes
+away. Keep a constant only where a value needs *validation the merged
+default cannot express* (e.g. an allow-listed `severity` that must fall
+back when a user supplies a bad value).
+
+**Authority:** `docs/internal-spec/plugin.md` § "Declared config
+defaults — `config_schema` `{ kind:, default: }`".
+
+---
+
+## 2. AST-walk ownership (ADR-37 / ADR-52) — `D`
+
+**Smell:** a hand-rolled traversal for per-node checks —
+`root.compact_child_nodes.each { … }`, a bespoke `Walker` that recurses
+the tree, or a `#diagnostics_for_file` that re-walks to find call sites.
+
+**Modern:** declare `node_rule(Prism::CallNode) { |node, scope, path| … }`
+and let the engine own the single per-file walk. For a two-pass
+(collect-then-validate) plugin, add `node_file_context { |root, scope| … }`
+— it runs once before the node rules and threads a file-local value in
+as the rule block's fourth argument.
+
+**Keep `#diagnostics_for_file`** only for genuinely whole-file
+diagnostics a per-node walk cannot express — see concern 5 for the case
+where a stateful whole-file walk is *required*, not lazy.
+
+**Authority:** `docs/internal-spec/plugin.md` §§ "Node-scoped rules —
+`node_rule`", "`node_file_context`".
+
+---
+
+## 3. Return-type & narrowing hooks (ADR-37 / ADR-52 / ADR-80) — `M`/`D`
+
+**Smell:** `flow_contribution_for` (deleted in ADR-52 WD3 — *defining it
+now raises `ArgumentError`*), or `type_specifier` (the pre-ADR-80 name).
+
+**Modern:** `dynamic_return(receivers:/methods:/file_methods:)` to
+*supply* a return type, `narrowing_facts(methods:)` to supply
+post-return narrowing facts. `type_specifier` survives as a
+deprecating alias removed in 0.3.0 — rename to `narrowing_facts`.
+
+The gate resolves after `#init` when passed a callable
+(`methods: -> { [@method_name] }`), so config-derived method names work.
+
+**Authority:** `docs/internal-spec/plugin.md` § "Return-type and
+narrowing contributions". `M` for the pure rename; `D` if you are adding
+a contribution the plugin did not have.
+
+---
+
+## 4. Authoring helpers (ADR-37 / ADR-60 WD4) — `M`
+
+The single richest source of drift. Each helper replaces a hand-rolled
+shape and is expected to be diagnostics-preserving.
+
+| Smell | Modern | Authority |
+| --- | --- | --- |
+| `Rigor::Analysis::Diagnostic.new(line:, column: loc.start_column + 1, …)` where a node exists | `#diagnostic(node, path:, message:, severity:, rule:)` (or `location: node.message_loc` for a sub-span) | plugin.md § "Positioning a diagnostic — `#diagnostic`" |
+| `violations.map { |v| diagnostic(node, message: v.message, …) }` | `#diagnostics_for(violations, path:, node:)` — duck-types `#message` / `#node` / `#severity` / `#rule` / `#location` | plugin.md § author helpers (ADR-60 WD4) |
+| A hand-rolled `levenshtein` / `closest_*` "did you mean" | `Rigor::Plugin::Base.suggest(name, candidates)` (`DidYouMean::SpellChecker`) — a **class** method, callable from an `Analyzer` too | plugin.md § "`Base.suggest`" |
+| `@table ||= cache_for(id).call` + a multi-`rescue` ladder + an `@load_error` ivar | `#producer_value(id, params:)` (memoised incl. nil) + `#producer_error(id)` (the rescued exception, for a tailored message) | plugin-cache-producers.md § "Invalidation contract" |
+| `@x_resolved` flag guarding `services.fact_store.read` | `#read_fact(plugin_id:, name:)` — nil-inclusive memo, retires the flag | plugin.md § author helpers (ADR-60 WD4) |
+| Hand-parsing a `Prism::SymbolNode#value` / string literal | `Rigor::Source::Literals` | plugin.md § "Extracting argument literals" |
+| A private reimplementation of a target library (own inflector, own pure helper) | Call the library's safe methods directly — `Plugin::Inflector` over real `ActiveSupport::Inflector` (ADR-39) | plugin.md § "Target-library invocation" |
+
+**Note on tailored load-error messages:** `#producer_value` rescues
+every `StandardError` into `#producer_error`, so a plugin that wants
+class-specific messages ("not found" vs "failed to parse" vs
+access-denied) switches on `producer_error(id)`'s class when building
+the load-error diagnostic — cleaner than an inline rescue ladder and
+still message-preserving. A *file-level* load-error (line 1, no node)
+legitimately keeps a direct `Diagnostic.new` — `#diagnostic` needs a
+node to position at.
+
+---
+
+## 5. Engine collaboration vs reimplementation — `D` (read the trap)
+
+**Principle (rigor-pattern):** do not re-implement a fact the engine
+already computes. If you need "is this a literal string?" / "what type
+did inference give this expression?", read `Scope#type_of(node)` rather
+than tracking it yourself. `rigor-pattern` reads the engine's
+`LiteralStringFolding` result back instead of propagating strings by
+hand.
+
+**The trap (rigor-units) — when a hand-rolled binding map is NOT
+redundant:** the `Scope` handed to the **diagnostics** side
+(`#diagnostics_for_file` / a `node_rule`) is the **seed entry scope**.
+`Scope#type_of` re-evaluates a *self-contained* expression on demand
+(`scope.type_of(100.kilometers)` folds through the plugin's own
+`dynamic_return`), but it carries **no flow-accumulated local
+bindings**: for `speed = distance / time`, `scope.type_of(distance)` is
+`untyped`, because the entry scope never bound the earlier assignment.
+Only the **flow scope** handed to a `dynamic_return` block resolves such
+locals. So a diagnostics-side check that must follow a dimension /
+type across statements legitimately keeps its own single-pass binding
+map — deleting it and reaching for `scope.type_of` collapses
+cross-statement propagation.
+
+**How to tell which case you are in:** if the value you need lives *at
+the call site you are inspecting* (a literal argument, a self-contained
+sub-expression) → read `Scope#type_of`. If it lives *in an earlier
+statement's local binding* and you are on the diagnostics side → the
+engine will not hand it to you; keep the binding map, and document why.
+**Validate empirically before deleting state:** run the integration
+spec after the change; a wave of failures on multi-statement fixtures is
+this trap.
+
+**Authority:** the reasoning is recorded in
+`docs/notes/20260704-examples-plugin-modernization-survey.md` (the
+`rigor-units` section) and the `rigor-units` class comment itself.
+
+---
+
+## 6. Cache producers (ADR-60 WD3) — `M`/`D`
+
+**Smell:** a "prime the read before `cache_for` so the digest is
+captured" comment, or a producer that globs a directory but does not
+declare `watch:`.
+
+**Modern:** record-and-validate — the `io_boundary.read_file` inside the
+`producer` block is captured into the dependency descriptor *after* the
+block runs, so there is nothing to prime. A producer that reads a *set*
+of files by glob declares `watch:` so file *additions* invalidate too.
+
+**Authority:** `docs/internal-spec/plugin-cache-producers.md` §§
+"Invalidation contract", "`producer(... watch:)`".
+
+---
+
+## 7. Manifest-field hygiene (ADR-60 WD1 / WD2) — `M`
+
+**Smell:** `external_files:` (never wired — removed in ADR-60 WD1);
+`BlockAsMethod verbs:` (renamed → `method_names:`); `NestedClassTemplate
+name_arg_position:` (renamed → `symbol_arg_position:`).
+
+**Modern:** drop `external_files:`; use the renamed keys.
+
+**Authority:** `docs/internal-spec/plugin.md` § "`Rigor::Plugin::Manifest`"
+and `macro-substrate.md`.
+
+---
+
+## 8. Documentation freshness — `M`
+
+**Smell:** "the former `flow_contribution_for` hook was removed"
+archaeology in a README / class comment (a reader who never knew the
+deleted hook does not need it named); pinned version references that no
+longer carry meaning ("introduced in v0.0.9").
+
+**Modern:** describe the *current* mechanism directly. Keep a historical
+note only where a reader migrating an old plugin genuinely needs it —
+and put that in a CHANGELOG / migration note, not the class docstring.
+
+---
+
+## 9. Verification (ADR-43) — always
+
+- `rigor check <plugin>/lib` — the ADR-43 contract self-check resolves
+  the plugin's inherited `Plugin::Base` calls and warns on contract
+  misuse. MUST be clean; fix the cause, never disable the rule.
+- `rigor plugins --strict` — the plugin still activates.
+- `rigor plugins --capabilities` — `node_rule_types` /
+  `dynamic_return_receivers` / `type_specifier_methods` reflect the
+  declarations.
+- The integration / unit spec — green, and byte-identical across every
+  mechanical step.
+- In the monorepo: `make check-plugins` + `make verify`.

--- a/skills/rigor-plugin-review/references/01-best-practices-checklist.md
+++ b/skills/rigor-plugin-review/references/01-best-practices-checklist.md
@@ -56,6 +56,20 @@ as the rule block's fourth argument.
 diagnostics a per-node walk cannot express — see concern 5 for the case
 where a stateful whole-file walk is *required*, not lazy.
 
+**"Genuinely whole-file" is a sharp line — apply it, don't defer to
+precedent.** A per-*class* or per-*def* contract check (does this class
+define `#get`? does its body return the contracted type?) IS
+node-expressible — migrate it to `node_rule(Prism::ClassNode)` /
+`node_rule(Prism::DefNode)`, even if a shipped production plugin still
+uses `#diagnostics_for_file` + a hand-rolled `class_nodes` walk for the
+same job (`rigor-hanami`'s ADR-28 check half does — an equivalent,
+older shape, not a reason to keep a new copy hand-rolled). The genuine
+whole-file case is a diagnostic whose *identity or count is not tied to
+any one node* — e.g. `rigor-routes`'s "routes file failed to load"
+warning, which must fire exactly once per file (or run) even on a file
+with zero matching nodes. That cannot be a node rule; a per-class check
+can.
+
 **Authority:** `docs/internal-spec/plugin.md` §§ "Node-scoped rules —
 `node_rule`", "`node_file_context`".
 


### PR DESCRIPTION
## What

Bring the six `examples/` plugin walkthroughs up to the current authoring contract, generalize that experience into a reusable review/upgrade skill, then validate the skill by dogfooding it — including a blind Sonnet run on clean `master` whose findings are folded back in.

## Part 1 — modernize the six `examples/` walkthroughs

They are the repository's oldest plugins (all 2026-05-07 except `rigor-web`). They migrated to `node_rule` / `dynamic_return` as those APIs landed but never picked up the authoring surface that arrived afterwards — ADR-40 `config_schema` defaults and the ADR-60 WD4 helpers, whose "bundled corpus" migration only covered `plugins/`, not `examples/`. Since the walkthroughs are the teaching mirror plugin authors copy from, they should model the current idiom.

- **ADR-40 config defaults** across all six (`{kind:, default:}` instead of `DEFAULT_*` + `config.fetch`).
- **`rigor-routes` → ADR-60 WD4 helpers** — `Base.suggest` (drops a hand-rolled Levenshtein), `#producer_value` / `#producer_error` (drops the `@table`/`@load_error` memo + rescue; tailored load-error messages preserved by switching on the rescued exception class).
- **`rigor-lisp-eval`** — `Diagnostic.new` → the `#diagnostic` helper (byte-identical column offset).
- **Doc freshness** — drop removed-hook (`flow_contribution_for`) archaeology and stale `v0.0.9` version references.

**Corrected finding — `rigor-units`.** The survey first flagged its parallel `@bindings` map as redundant with `Scope#type_of`. *Implementing that falsified it* (11/19 spec failures): the diagnostics scope is a seed entry scope without flow-accumulated local bindings, so `scope.type_of(distance)` is `untyped` for a local assigned earlier. Only the `dynamic_return` flow scope resolves those locals. The plugin is kept as-is with the asymmetry documented in the class comment; the survey note records the correction.

## Part 2 — `rigor-plugin-review` skill + internal-spec alignment

A new distributed skill (`skills/rigor-plugin-review/`) that reviews any plugin against the current contract and produces a prioritized upgrade path — the review/upgrade counterpart to `rigor-plugin-author` (create) and `rigor-plugin-tune` (enable). It scores nine concerns against the internal spec, sequences fixes mechanical-first (each gated byte-identical by the plugin's integration spec), and bakes in the two hard-won lessons: the spec is the oracle after every step, and don't delete a hand-rolled binding map before proving `Scope#type_of` gives the same information (the units seed-scope trap).

Aligned `docs/internal-spec/plugin.md` so the skill's citations are accurate — it documented `#diagnostic` / `.suggest` but not the other two ADR-60 WD4 author helpers; added `#diagnostics_for` and `#read_fact`.

## Part 3 — dogfood the skill on the examples (second pass)

Applied the new skill's checklist to the examples themselves. Concern 2 (AST-walk ownership) surfaced two items the first pass missed, both aligning the examples with their production twins.

- **`rigor-routes`** — move the per-call `*_path` / `*_url` validation onto a `node_rule Prism::CallNode`, leaving `#diagnostics_for_file` with only the once-per-file load-error — the exact split production `rigor-rails-routes` uses. `Walker` shrinks from a hand-rolled tree recursion to a pure `helper_call(node)` matcher.
- **`rigor-units`** — the `Analyzer` (a plain class, no `#diagnostic`) builds diagnostics via `Diagnostic.from_location` — the public constructor the helper wraps — instead of `Diagnostic.new` with a hand-spelled `start_column + 1`.

## Part 4 — blind Sonnet eval, folded in

Validated the skill by giving it (and only it) to a Sonnet subagent on a clean `master` worktree, blind to this PR. It reproduced every finding here, avoided the units trap, independently arrived at the routes `node_rule` split — and surfaced improvements the hand pass missed, which are folded back in.

- **`rigor-web`** — migrate the ADR-28 check half from `#diagnostics_for_file` + a hand-rolled `class_nodes` walk to `node_rule(Prism::ClassNode)` + `ProtocolChecker#check_class`. A per-class contract check is node-expressible, so the skill's own concern 2 favours this over the first pass's "match production `rigor-hanami`" call (hanami keeps the older file-rule shape — valid, but not a reason to hand-roll a new copy).
- **Three genuine doc-staleness fixes the first sweep overlooked** — the `rigor-deprecations` README compared against a nonexistent "statesman" example (should be "web"); the `rigor-lisp-eval` README said return-type contribution was "queued for a later v0.1.x slice" (contradicted by its own shipped `dynamic_return`); the `rigor-units` README cited an `evaluate(node, emit_terminal:)` parameter that does not exist.
- **Skill** — sharpen concern 2's "genuinely whole-file" line so a future reviewer migrates per-class / per-def checks to `node_rule` rather than deferring to a production plugin's older file-rule shape — the exact call the eval got more right than the first pass.

## Verification

- `make verify` green (test / lint / check / check-plugins), exit 0, at every stage.
- `spec/integration/examples/` — 77 examples, 0 failures (byte-identical-gated per step; independently re-run on the Sonnet worktree too).
- `spec/docs/` + `spec/rigor/cli/skill_command_spec.rb` — 125 examples, 0 failures (link integrity, manual drift, skill discovery).
- `rigor skill --list` discovers `rigor-plugin-review`; `waza check` spec-compliance clean (informational agentskills.io markers ignored per CLAUDE.md).
- Scope is `examples/` + `skills/` + `docs/` only; no engine (`lib/`) changes.
