### PR TITLE
Modernize the production plugins onto the engine-owned walk (via rigor-plugin-review)

### DIFF
--- a/docs/notes/20260704-plugins-modernization-sweep.md
+++ b/docs/notes/20260704-plugins-modernization-sweep.md
@@ -1,0 +1,65 @@
+# `plugins/` 近代化スイープ — SKILL 適用による本番プラグインのドリフト監査
+
+Status: 内部監査ノート、authored 2026-07-04（Rigor は release/0.2.x ライン）。`examples/` 近代化
+（[`20260704-examples-plugin-modernization-survey.md`](20260704-examples-plugin-modernization-survey.md)、
+PR #35 で master マージ済み）で新設した `rigor-plugin-review` スキル
+（[`skills/rigor-plugin-review/`](../../skills/rigor-plugin-review/SKILL.md)）を、今度は本番 31
+プラグイン（`plugins/`）に適用した記録。ブランチ `plugins-modernization` の実装 PR を駆動。設計コミットメントなし。
+
+## 要旨 — 本番プラグインは概ね近代化済み、ドリフトは外科的
+
+本番プラグインは ADR-60 WD4 オーサリングヘルパ移行の *corpus* だったため、examples ほどの
+ドリフトはない、という事前仮説はスキャンで裏付けられた。スキルの9観点で全 31 プラグインを
+スキャンした結果：
+
+| 観点 | 結果 |
+| --- | --- |
+| 1. ADR-40 config デフォルト | **ドリフトなし**（`DEFAULT_*` を持つ playground/sorbet は config 非該当 — CLI ポート・sigil レベル内部定数） |
+| 3. `type_specifier`（→`narrowing_facts`）/ `flow_contribution_for` | **全移行済み**（author verb 使用 0、`flow_contribution_for` はコメントのみ） |
+| 4. 手書き Levenshtein | **なし**（全プラグイン `Base.suggest` 使用済み） |
+| 7. manifest 衛生（`external_files:`/`verbs:`/`name_arg_position:`） | **クリーン** |
+| 2. AST 走査の所有権 | genuine smell **1件**（hanami）— 他の `class_nodes`/`def walk` は discovery/collect パス（`#prepare`/`node_file_context` 由来で正当） |
+| 4. `Diagnostic.new` node-level | genuine smell **候補1件が誤検出**（rspec、下記） |
+| 8. doc 鮮度 | 微修正2件（activerecord コメント・sorbet README の `flow_contribution_for` 考古学） |
+
+## 実施した変更（外科的、各々 spec バイト同一ゲート）
+
+1. **rigor-hanami — ActionChecker を `node_rule(Prism::ClassNode)` へ**（観点2）。
+   ADR-28 protocol-contract の check 半分が `diagnostics_for_file` + 手書き `class_nodes`/`walk`
+   だった（web example と完全同型）。`ActionChecker#check_class` に分解し `class_nodes`/`walk` を削除。
+   本番の canonical な per-class 検査形へ。hanami spec 12/12 緑。examples の web 修正の本番版。
+2. **rigor-sorbet — 3つの `walk_for_*` を `node_rule(Prism::CallNode)` へ**（観点2）。
+   `T.absurd` 到達・`T.reveal_type`・`T.assert_type!` の各診断が `diagnostics_for_file` +
+   3本の手書き全走査だった。各々、推論フェーズ（`dynamic_return`/`narrowing_facts`）で
+   **object identity で記録**された集合（`@reachable_absurd_nodes` 等）への membership 照合。
+   node_rule は診断フェーズ（推論後）に発火するので集合は populate 済み、同一 parse tree で
+   identity 一致、membership が gate。`diagnostics_for_file` は parse-error 専用に縮小、6メソッド削除。
+   sorbet spec 68/68 緑。最複雑プラグインだが健全性の事前分析どおり。
+3. **doc 鮮度** — activerecord のコメントと sorbet README 表から `flow_contribution_for` の
+   考古学的言及を除去し、現行機構を直接記述（観点8）。
+
+## 教訓 — スキルの「オラクル規律」が誤検出を捕捉
+
+観点4の初期トリアージで **rspec/analyzer の `Diagnostic.new` を node-level smell と誤判定**し、
+`Diagnostic.from_location` へ置換したところ spec が 4 例失敗（診断が nil 化）。原因は
+`Diagnostic` が `Rigor::Analysis::Diagnostic` ではなく**プラグインローカルの `Struct`**（中間値
+オブジェクト）で、`from_location` を持たなかったこと（rspec.rb が後段で本物へ変換する二層構造）。
+即座に revert（47/47 緑に復帰）。**教訓**: `Diagnostic.new` の grep は engine の Diagnostic と
+プラグインローカルの値オブジェクトを区別できない → 置換前に `Diagnostic` の実体を確認せよ。
+スキルの「各ステップ後に spec をオラクルにする」規律が、複雑プラグインでの誤った近代化を
+コスト最小で捕捉した実例。
+
+## 触れなかったもの（churn 回避）
+
+- **discovery/collect ウォーカー**（activerecord/analyzer, activestorage/attachment_discoverer,
+  rails-routes/helper_discoverer, sorbet/catalog_walker 等）— `#prepare`/`node_file_context` の
+  collect 半分で、走査は必須（スキル観点2の明示的除外）。
+- **file-level `Diagnostic.new(line: 1)`**（各プラグインの load-error）— 位置すべき node が無く正当。
+- **rspec/analyzer のローカル `Diagnostic` Struct** — 中間値オブジェクトで smell でない（上記）。
+- ADR-40 / `narrowing_facts` / `suggest` / WD4 ヘルパ — 本番は既に採用済みで対象なし。
+
+## 参照
+
+- [`20260704-examples-plugin-modernization-survey.md`](20260704-examples-plugin-modernization-survey.md) — 姉妹作業（examples、PR #35）
+- [`skills/rigor-plugin-review/`](../../skills/rigor-plugin-review/SKILL.md) — 適用したスキル（同 PR で新設）
+- ADR-37（`node_rule` engine-owned walk）・ADR-52（`dynamic_return`）・ADR-60 WD4（オーサリングヘルパ）

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -105,6 +105,7 @@ Filenames are `YYYYMMDD-<slug>.md`, dated to authorship.
 | 2026-06-22 | [Rigor 0.2.x problem survey — type theory and Ruby runtime type model](20260622-rigor-0.2.x-problem-survey.md) |
 | 2026-06-22 | [Rigor 0.2.x compatibility-safe strengthening survey](20260622-rigor-0.2.x-compatibility-safe-strengthening-survey.md) |
 | 2026-07-04 | [`examples/` プラグイン近代化調査 — 最初期プラグインと現行契約面のギャップ](20260704-examples-plugin-modernization-survey.md) |
+| 2026-07-04 | [`plugins/` 近代化スイープ — SKILL 適用による本番プラグインのドリフト監査](20260704-plugins-modernization-sweep.md) |
 
 ## Adding a note
 

--- a/plugins/rigor-activerecord/lib/rigor/plugin/activerecord.rb
+++ b/plugins/rigor-activerecord/lib/rigor/plugin/activerecord.rb
@@ -208,9 +208,8 @@ module Rigor
       FINDER_METHOD_NAMES = %i[find find_by! find_by where all order limit none select].freeze
       private_constant :FINDER_METHOD_NAMES
 
-      # v0.1.2 — return-type contribution; ADR-52 slice 5b —
-      # migrated off `flow_contribution_for` onto the run-time
-      # `methods:` name gate. `Model.find(id)` narrows the call
+      # Return-type contribution via the run-time `methods:` name
+      # gate (ADR-52 slice 5b). `Model.find(id)` narrows the call
       # site's return type to `Nominal[Model]`, so chained calls
       # (`User.find(1).name`) resolve through the analyzer's
       # normal dispatch instead of the RBS-level untyped

--- a/plugins/rigor-hanami/README.md
+++ b/plugins/rigor-hanami/README.md
@@ -38,8 +38,8 @@ inside a file matching the glob, it substitutes
 `Dynamic[Top]` fallback — so type errors inside action bodies are
 caught precisely as core `call.undefined-method` diagnostics.
 
-**Check half (plugin-side):** the plugin's `#diagnostics_for_file` hook
-confirms each class in a matching file defines `#handle` with exactly
+**Check half (plugin-side):** the plugin's `node_rule(Prism::ClassNode)`
+rule confirms each class in a matching file defines `#handle` with exactly
 two parameters, emitting `missing-handle-method` / `handle-arity-mismatch`.
 
 The `action_path` config key is folded into the contract set at `init`
@@ -55,7 +55,7 @@ override, so an override reaches both the provide and check halves
 | `manifest(... config_schema:)` | The `action_path` glob override (static fallback to the manifest glob in `init`). |
 | `manifest(... signature_paths: ["sig"])` (ADR-25) | Loads the bundled `sig/hanami_action.rbs` stubs for Request / Response / Params. |
 | `#protocol_contracts` override | Folds the per-project `action_path` into the contract set so the override reaches the engine's provide tier. |
-| `#diagnostics_for_file` | The ADR-28 check half — delegates to `ActionChecker`. |
+| `node_rule(Prism::ClassNode)` | The ADR-28 check half — delegates to `ActionChecker#check_class`. |
 
 ## RBS stubs
 

--- a/plugins/rigor-hanami/lib/rigor/plugin/hanami.rb
+++ b/plugins/rigor-hanami/lib/rigor/plugin/hanami.rb
@@ -98,11 +98,18 @@ module Rigor
         @protocol_contracts || manifest.protocol_contracts
       end
 
-      def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
+      # ADR-37 — per-class-node validation over the engine-owned walk.
+      # Each `Prism::ClassNode` is checked against every contract
+      # independently, so the plugin no longer ships its own `class_nodes`
+      # traversal; `ActionChecker#check_class` keeps the per-class
+      # contract logic. (A per-class contract check is exactly what
+      # `node_rule` is for — the return type is void, so no `scope`
+      # query is needed.)
+      node_rule Prism::ClassNode do |node, _scope, path|
         contracts = protocol_contracts
-        return [] if contracts.empty?
+        next [] if contracts.empty?
 
-        ActionChecker.new(contracts: contracts).check(path: path, root: root)
+        ActionChecker.new(contracts: contracts).check_class(node, path: path)
       end
     end
 

--- a/plugins/rigor-hanami/lib/rigor/plugin/hanami/action_checker.rb
+++ b/plugins/rigor-hanami/lib/rigor/plugin/hanami/action_checker.rb
@@ -22,17 +22,20 @@ module Rigor
           @contracts = contracts
         end
 
-        def check(path:, root:)
-          @contracts.flat_map do |contract|
-            next [] unless path_matches?(contract.path_glob, path)
+        # Per-`ClassNode` check over the engine-owned walk (ADR-37):
+        # called once per class node the `node_rule` in `hanami.rb`
+        # dispatches, against every contract whose `path_glob` matches
+        # the file. No cross-class-node state is needed, so the checker
+        # ships no `class_nodes` traversal of its own.
+        def check_class(class_node, path:)
+          @contracts.filter_map do |contract|
+            next unless path_matches?(contract.path_glob, path)
 
-            class_nodes(root).filter_map do |class_node|
-              handle_def = find_handle(class_node, contract)
-              if handle_def.nil?
-                missing_handle_diagnostic(contract, path, class_node)
-              else
-                handle_arity_mismatch_diagnostic(contract, path, class_node, handle_def)
-              end
+            handle_def = find_handle(class_node, contract)
+            if handle_def.nil?
+              missing_handle_diagnostic(contract, path, class_node)
+            else
+              handle_arity_mismatch_diagnostic(contract, path, class_node, handle_def)
             end
           end
         end
@@ -47,12 +50,6 @@ module Rigor
 
           File.fnmatch?(glob, path, FNMATCH_FLAGS) ||
             File.fnmatch?(File.join("**", glob), path, FNMATCH_FLAGS)
-        end
-
-        def class_nodes(root)
-          found = []
-          walk(root) { |node| found << node if node.is_a?(Prism::ClassNode) }
-          found
         end
 
         def find_handle(class_node, contract)
@@ -106,13 +103,6 @@ module Rigor
         def class_name(class_node)
           path = class_node.constant_path
           path.respond_to?(:slice) ? path.slice : class_node.name.to_s
-        end
-
-        def walk(node, &)
-          return if node.nil?
-
-          yield node
-          node.compact_child_nodes.each { |child| walk(child, &) }
         end
       end
     end

--- a/plugins/rigor-sorbet/README.md
+++ b/plugins/rigor-sorbet/README.md
@@ -400,7 +400,7 @@ nix --extra-experimental-features 'nix-command flakes' develop --command \
 | ------------------------------------------ | -------- |
 | `manifest(...)` + `config_schema`          | declares the optional `paths:` config knob |
 | `Plugin::Base#io_boundary` (`read_file`)   | reads project source AND `sorbet/rbi/**/*.rbi` under the trusted scope |
-| `Plugin::Base#dynamic_return` / `#narrowing_facts` | contributes the parsed return type / `T.bind` narrowing facts at every call site (replaced `flow_contribution_for`, removed ADR-52 WD3) |
+| `Plugin::Base#dynamic_return` / `#narrowing_facts` | contributes the parsed return type / `T.bind` narrowing facts at every call site |
 | `Plugin::Base#diagnostics_for_file`        | emits `plugin.sorbet.parse-error` for malformed sig blocks |
 | `Scope#type_of` (via `dynamic_return` block) | resolves instance-side receivers to `Nominal[T]` for catalog lookup |
 | `Type::Combinator.{nominal_of,union,intersection,untyped,top,bot,constant_of}` | constructs the Rigor-side carriers from the Sorbet vocabulary |

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet.rb
@@ -147,11 +147,7 @@ module Rigor
         # symlink-bearing form here. Look up under both so the
         # match is symlink-agnostic.
         errors = @parse_errors_by_path[path] || @parse_errors_by_path[canonicalize(path)] || []
-        diagnostics = errors.map { |error| parse_error_diagnostic(path, error) }
-        diagnostics.concat(absurd_reachable_diagnostics(path, root))
-        diagnostics.concat(reveal_type_diagnostics(path, root))
-        diagnostics.concat(assert_type_mismatch_diagnostics(path, root))
-        diagnostics
+        errors.map { |error| parse_error_diagnostic(path, error) }
       end
 
       # ADR-52 slice 4 — per-call return-type path via the
@@ -177,6 +173,35 @@ module Rigor
       # contributes nothing.
       narrowing_facts methods: [:bind] do |call_node, scope|
         bind_post_return_facts(call_node, scope)
+      end
+
+      # ADR-37 — the three per-call diagnostics ride the engine-owned
+      # walk instead of three hand-rolled `walk_for_*` recursions. Each
+      # candidate `T.` call is *recorded by object identity* during the
+      # inference pass (the `dynamic_return` / `narrowing_facts` rules
+      # above call `record_*`), so by the time these node rules fire in
+      # the diagnostics phase the sets are populated; the membership
+      # `delete` both gates the emission and pops the entry so a re-run
+      # cannot double-fire. The recorded set is the gate — no per-node
+      # `AbsurdRecognizer` / name check is needed here.
+      node_rule Prism::CallNode do |node, _scope, path|
+        next [] unless @reachable_absurd_nodes.delete(node)
+
+        [absurd_diagnostic(path, node)]
+      end
+
+      node_rule Prism::CallNode do |node, _scope, path|
+        display = @reveal_type_calls.delete(node)
+        next [] if display.nil?
+
+        [reveal_type_diagnostic(path, node, display)]
+      end
+
+      node_rule Prism::CallNode do |node, _scope, path|
+        recorded = @assert_type_mismatches.delete(node)
+        next [] if recorded.nil?
+
+        [assert_type_mismatch_diagnostic(path, node, *recorded)]
       end
 
       private
@@ -536,31 +561,9 @@ module Rigor
         nil
       end
 
-      # Walks the per-file AST looking for `T.absurd(x)` call
-      # nodes and emits a `plugin.sorbet.absurd-reachable`
-      # warning for any whose object identity matches
-      # `@reachable_absurd_nodes` (populated during the engine's
-      # earlier pass through the `dynamic_return` rule). Pops
-      # matched entries so a duplicate run doesn't double-emit.
-      def absurd_reachable_diagnostics(path, root)
-        return [] if @reachable_absurd_nodes.empty?
-
-        diagnostics = []
-        walk_for_absurd(root) do |call_node|
-          next unless @reachable_absurd_nodes.delete(call_node)
-
-          diagnostics << absurd_diagnostic(path, call_node)
-        end
-        diagnostics
-      end
-
-      def walk_for_absurd(node, &)
-        return unless node.is_a?(Prism::Node)
-
-        yield node if node.is_a?(Prism::CallNode) && AbsurdRecognizer.absurd_call?(node)
-        node.compact_child_nodes.each { |child| walk_for_absurd(child, &) }
-      end
-
+      # Emits a `plugin.sorbet.absurd-reachable` warning for the
+      # `T.absurd(x)` call recorded in `@reachable_absurd_nodes` during
+      # inference; the node rule above does the identity match and pop.
       def absurd_diagnostic(path, call_node)
         Rigor::Analysis::Diagnostic.from_node(
           call_node,
@@ -589,29 +592,6 @@ module Rigor
         return "untyped" if type.nil?
 
         type.respond_to?(:describe) ? type.describe : type.inspect
-      end
-
-      def reveal_type_diagnostics(path, root)
-        return [] if @reveal_type_calls.empty?
-
-        diagnostics = []
-        walk_for_reveal_type(root) do |call_node|
-          display = @reveal_type_calls.delete(call_node)
-          next if display.nil?
-
-          diagnostics << reveal_type_diagnostic(path, call_node, display)
-        end
-        diagnostics
-      end
-
-      def walk_for_reveal_type(node, &)
-        return unless node.is_a?(Prism::Node)
-
-        if node.is_a?(Prism::CallNode) && node.name == :reveal_type &&
-           TypeTranslator.sorbet_t_namespaced?(node.receiver)
-          yield node
-        end
-        node.compact_child_nodes.each { |child| walk_for_reveal_type(child, &) }
       end
 
       def reveal_type_diagnostic(path, call_node, display)
@@ -645,29 +625,6 @@ module Rigor
         return unless result.no?
 
         @assert_type_mismatches[call_node] = [display_for_type(inferred), display_for_type(asserted)]
-      end
-
-      def assert_type_mismatch_diagnostics(path, root)
-        return [] if @assert_type_mismatches.empty?
-
-        diagnostics = []
-        walk_for_assert_type(root) do |call_node|
-          recorded = @assert_type_mismatches.delete(call_node)
-          next if recorded.nil?
-
-          diagnostics << assert_type_mismatch_diagnostic(path, call_node, *recorded)
-        end
-        diagnostics
-      end
-
-      def walk_for_assert_type(node, &)
-        return unless node.is_a?(Prism::Node)
-
-        if node.is_a?(Prism::CallNode) && node.name == :assert_type! &&
-           TypeTranslator.sorbet_t_namespaced?(node.receiver)
-          yield node
-        end
-        node.compact_child_nodes.each { |child| walk_for_assert_type(child, &) }
       end
 
       def assert_type_mismatch_diagnostic(path, call_node, inferred_display, asserted_display)


### PR DESCRIPTION
## What

Apply the `rigor-plugin-review` skill (from the sibling `examples-modernization` PR) to the 31 production plugins under `plugins/`. Unlike the `examples/` walkthroughs — the repository's oldest, most-drifted plugins — the production set was the ADR-60 WD4 migration corpus, so the scan found them **largely already modern**. The residual drift is surgical.

## Scan result (skill's 9 concerns × 31 plugins)

- **No drift**: ADR-40 config defaults (the only `DEFAULT_*` constants — playground's port, sorbet's sigil level — are not config), `type_specifier` → `narrowing_facts` (all migrated), hand-rolled Levenshtein (all on `Base.suggest`), manifest-field hygiene (no `external_files:` / `verbs:` / `name_arg_position:`), and the ADR-60 WD4 author helpers (all adopted).
- **Genuine drift**: two plugins still on a hand-rolled AST walk where the engine-owned `node_rule` now fits (concern 2), plus two doc-archaeology trims (concern 8).

## Changes (each spec-gated byte-identical)

- **`rigor-hanami`** — the ADR-28 check half moved from `#diagnostics_for_file` + a hand-rolled `ActionChecker#class_nodes` / `#walk` recursion to `node_rule(Prism::ClassNode)` + `ActionChecker#check_class`. A per-class contract check is node-expressible; this is the production twin of the `rigor-web` example migration. `hanami_plugin_spec` 12/12 green.
- **`rigor-sorbet`** — the `T.absurd`-reachable, `T.reveal_type`, and `T.assert_type!`-mismatch diagnostics each ran a hand-rolled full-tree `walk_for_*` recursion inside `#diagnostics_for_file` to re-find call nodes recorded by object identity during inference. Each is now a `node_rule(Prism::CallNode)` doing the identity `delete` against its recorded set (membership is the gate). Sound because the sets are populated during the inference pass (the `dynamic_return` / `narrowing_facts` rules) which runs before the diagnostics-phase node rules, over the same parsed tree. `#diagnostics_for_file` shrinks to parse-error rows; six methods removed. `sorbet_plugin_spec` 68/68 green.
- **Doc freshness** — trim `flow_contribution_for` archaeology from an activerecord comment and a sorbet README capability row.

## The oracle earned its keep

An initial concern-4 triage flagged `rspec/analyzer`'s `Diagnostic.new(line: decl.location.start_line, …)` as a node-level construction to move onto `Diagnostic.from_location`. The swap turned the `rspec_plugin_spec` red (4 failures, diagnostics went nil): that `Diagnostic` is a **plugin-local `Struct`** — an intermediate value object that `rspec.rb` later converts to the engine `Diagnostic` — not `Rigor::Analysis::Diagnostic`, so it has no `.from_location`. Reverted; `rspec_plugin_spec` back to 47/47. A `Diagnostic.new` grep cannot tell the engine class from a plugin-local value object — check what the constant resolves to before swapping. This is exactly the skill's "run the spec as the oracle after every step" discipline catching a wrong modernization at minimum cost.

## Not touched (churn avoided)

Discovery / collect walkers (`activerecord/analyzer`, `activestorage/attachment_discoverer`, `rails-routes/helper_discoverer`, `sorbet/catalog_walker`) are the `#prepare` / `node_file_context` collect half — a required walk, explicitly exempt under concern 2. File-level `Diagnostic.new(line: 1)` load-errors have no node to position at and stay as-is.

## Verification

- `make verify` green (test / lint / check / check-plugins), exit 0.
- `hanami` 12/12, `sorbet` 68/68, `rspec` 47/47, all plugin specs green.
- `git diff --check` clean; scope is `plugins/` + `docs/` only, no engine (`lib/`) changes.

## Note on branch base

Based on `master`, so it is independent of the `examples-modernization` PR (which introduces the `rigor-plugin-review` skill this work applies). The skill and the sibling survey note live on that PR; this PR references them by path. Mergeable in either order.
