### PR TITLE
Audit comments across examples, plugins, spec, and tool

### DIFF
--- a/examples/rigor-deprecations/demo/demo.rb
+++ b/examples/rigor-deprecations/demo/demo.rb
@@ -4,10 +4,8 @@
 #
 #   RUBYLIB=$PWD/../lib bundle exec rigor check
 #
-# rigor-deprecations is data-driven: every call site whose
-# (receiver, method) matches a config entry surfaces as a
-# :warning. No plugin code change is required to add a new
-# deprecation rule — edit `.rigor.yml`.
+# rigor-deprecations is data-driven: every call site whose (receiver, method) matches a config entry surfaces as a
+# :warning. No plugin code change is required to add a new deprecation rule — edit `.rigor.yml`.
 
 # Matches `methods[0]` — receiver pinned to User.
 User.find_by_sql("SELECT * FROM users WHERE id = 1")
@@ -18,10 +16,8 @@ silence_warnings { puts "..." }
 # Matches `methods[2]` — receiver pinned to ActiveRecord::Base.
 ActiveRecord::Base.with_lock { puts "..." }
 
-# Receiver text differs from the config — NOT a match. The
-# plugin compares Prism's source slice to the config string,
-# so `Account.find_by_sql` would not match the User-pinned
-# entry.
+# Receiver text differs from the config — NOT a match. The plugin compares Prism's source slice to the config string, so
+# `Account.find_by_sql` would not match the User-pinned entry.
 Account.find_by_sql("SELECT * FROM accounts")
 
 # Same method name, but no config entry — silent.

--- a/examples/rigor-deprecations/lib/rigor-deprecations.rb
+++ b/examples/rigor-deprecations/lib/rigor-deprecations.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-deprecations` under `plugins:`.
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists `rigor-deprecations` under `plugins:`.
 require_relative "rigor/plugin/deprecations"

--- a/examples/rigor-deprecations/lib/rigor/plugin/deprecations.rb
+++ b/examples/rigor-deprecations/lib/rigor/plugin/deprecations.rb
@@ -5,17 +5,12 @@ require "rigor/plugin"
 
 module Rigor
   module Plugin
-    # Example plugin: surfaces deprecation warnings at every
-    # call site that matches a user-declared method signature.
-    # The smallest worked example of the v0.1.0 plugin authoring
-    # surface, and the recommended starting point for "I want to
-    # write my own Rigor plugin" — under 80 lines of plugin
-    # code, no I/O, no cache, no engine query.
+    # Example plugin: surfaces deprecation warnings at every call site that matches a user-declared method signature.
+    # The smallest worked example of the v0.1.0 plugin authoring surface, and the recommended starting point for "I want
+    # to write my own Rigor plugin" — under 80 lines of plugin code, no I/O, no cache, no engine query.
     #
-    # The plugin's value is **user-extensibility**: a user
-    # extends Rigor's lint surface for their own deprecations
-    # by editing `.rigor.yml`, with no plugin-side code. The
-    # plugin is the engine; the rules are pure data.
+    # The plugin's value is **user-extensibility**: a user extends Rigor's lint surface for their own deprecations by
+    # editing `.rigor.yml`, with no plugin-side code. The plugin is the engine; the rules are pure data.
     #
     # ## Configuration
     #
@@ -34,11 +29,9 @@ module Rigor
     #               replacement: "Warning[:deprecated] = false"
     #               since: "v7.0"
     #
-    # `receiver:` matches the literal source text of the call's
-    # receiver (`User.find_by_sql(...)` matches `receiver: User`,
-    # `ActiveRecord::Base.find_by_sql(...)` matches
-    # `receiver: ActiveRecord::Base`). Omitting `receiver:`
-    # matches any receiver including no-receiver calls.
+    # `receiver:` matches the literal source text of the call's receiver (`User.find_by_sql(...)` matches `receiver:
+    # User`, `ActiveRecord::Base.find_by_sql(...)` matches `receiver: ActiveRecord::Base`). Omitting `receiver:` matches
+    # any receiver including no-receiver calls.
     #
     # ## Diagnostic
     #
@@ -68,10 +61,8 @@ module Rigor
         end
       end
 
-      # ADR-37 — the engine owns the AST walk and hands us every
-      # CallNode; we emit one diagnostic per call site that matches a
-      # configured deprecation. No hand-rolled traversal, no manual
-      # Diagnostic construction.
+      # ADR-37 — the engine owns the AST walk and hands us every CallNode; we emit one diagnostic per call site that
+      # matches a configured deprecation. No hand-rolled traversal, no manual Diagnostic construction.
       node_rule Prism::CallNode do |node, _scope, path|
         next [] if @entries.empty?
 

--- a/examples/rigor-lisp-eval/demo/demo.rb
+++ b/examples/rigor-lisp-eval/demo/demo.rb
@@ -2,8 +2,7 @@
 
 require_relative "lib/lisp"
 
-# Each `Lisp.eval(...)` call below produces an `info`
-# diagnostic from the rigor-lisp-eval plugin naming the
+# Each `Lisp.eval(...)` call below produces an `info` diagnostic from the rigor-lisp-eval plugin naming the
 # statically-inferred return type. Run from this directory:
 #
 #   RUBYLIB=$PWD/../lib bundle exec rigor check demo.rb
@@ -28,14 +27,12 @@ puts maybe
 both = Lisp.eval([:and, true, [:not, false]])
 puts both
 
-# Non-literal argument — the plugin stays silent rather than
-# guessing. The analyzer treats the call as `untyped` per the
+# Non-literal argument — the plugin stays silent rather than guessing. The analyzer treats the call as `untyped` per the
 # RBS signature.
 program = [:+, 1, 2]
 unknown = Lisp.eval(program)
 puts unknown
 
-# Ill-typed expression — surfaces as an error diagnostic.
-# Comment the next line out to silence the type-error path.
+# Ill-typed expression — surfaces as an error diagnostic. Comment the next line out to silence the type-error path.
 broken = Lisp.eval([:+, 1, true])
 puts broken

--- a/examples/rigor-lisp-eval/demo/lib/lisp.rb
+++ b/examples/rigor-lisp-eval/demo/lib/lisp.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-# Tiny S-expression-style interpreter the plugin types
-# statically. The runtime body is intentionally
-# straightforward; the demo's value is what `rigor check`
-# says about callers, not the runtime semantics here.
+# Tiny S-expression-style interpreter the plugin types statically. The runtime body is intentionally straightforward;
+# the demo's value is what `rigor check` says about callers, not the runtime semantics here.
 module Lisp
   module_function
 

--- a/examples/rigor-lisp-eval/lib/rigor-lisp-eval.rb
+++ b/examples/rigor-lisp-eval/lib/rigor-lisp-eval.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-lisp-eval` under `plugins:`. The
-# loader expects this `require` to side-effect a call to
-# `Rigor::Plugin.register`, which the body of
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists `rigor-lisp-eval` under `plugins:`. The
+# loader expects this `require` to side-effect a call to `Rigor::Plugin.register`, which the body of
 # `lib/rigor/plugin/lisp_eval.rb` performs at load time.
 require_relative "rigor/plugin/lisp_eval"

--- a/examples/rigor-lisp-eval/lib/rigor/plugin/lisp_eval.rb
+++ b/examples/rigor-lisp-eval/lib/rigor/plugin/lisp_eval.rb
@@ -6,10 +6,8 @@ require_relative "lisp_eval/interpreter"
 
 module Rigor
   module Plugin
-    # Example plugin: types the return value of `Lisp.eval`
-    # calls whose argument is a literal Lisp-style expression
-    # tree. Demonstrates the v0.1.0 plugin authoring surface —
-    # manifest, services, AST walking, diagnostic emission —
+    # Example plugin: types the return value of `Lisp.eval` calls whose argument is a literal Lisp-style expression
+    # tree. Demonstrates the v0.1.0 plugin authoring surface — manifest, services, AST walking, diagnostic emission —
     # without depending on any private analyzer internals.
     #
     # Usage in `.rigor.yml`:
@@ -26,11 +24,9 @@ module Rigor
     #         method_name: "eval"   # default
     #         severity: "info"      # info|warning — severity for the inferred-type note
     #
-    # This plugin emits an `:info` diagnostic AND contributes a
-    # precise return type at the call site via `dynamic_return`
-    # (ADR-52 slice 4). The diagnostic serves as a user-facing trace
-    # per the README's "info-diagnostic" pattern; the same
-    # Interpreter walk feeds both channels.
+    # This plugin emits an `:info` diagnostic AND contributes a precise return type at the call site via
+    # `dynamic_return` (ADR-52 slice 4). The diagnostic serves as a user-facing trace per the README's "info-diagnostic"
+    # pattern; the same Interpreter walk feeds both channels.
     class LispEval < Rigor::Plugin::Base
       manifest(
         id: "lisp-eval",
@@ -43,10 +39,9 @@ module Rigor
         }
       )
 
-      # Only the severity fallback needs a constant now — ADR-40 merges the
-      # `module_name` / `method_name` / `severity` defaults from the manifest,
-      # but `severity` is additionally allow-list-validated, so a bad value
-      # falls back here rather than to the merged default.
+      # Only the severity fallback needs a constant now — ADR-40 merges the `module_name` / `method_name` / `severity`
+      # defaults from the manifest, but `severity` is additionally allow-list-validated, so a bad value falls back here
+      # rather than to the merged default.
       DEFAULT_SEVERITY = :info
       ALLOWED_SEVERITIES = %i[info warning].freeze
 
@@ -58,11 +53,9 @@ module Rigor
         @interpreter = Interpreter.new
       end
 
-      # ADR-37 — per-call trace over the engine-owned walk. `eval_call?`
-      # (receiver + method-name match) is the gate the old hand-rolled
-      # walker applied, so the plugin no longer ships its own traversal;
-      # the `Walker` retains only the receiver-matching helper that this
-      # gate and `#dynamic_return` block share.
+      # ADR-37 — per-call trace over the engine-owned walk. `eval_call?` (receiver + method-name match) is the gate the
+      # old hand-rolled walker applied, so the plugin no longer ships its own traversal; the `Walker` retains only the
+      # receiver-matching helper that this gate and `#dynamic_return` block share.
       node_rule Prism::CallNode do |node, _scope, path|
         next [] unless eval_call?(node)
 
@@ -70,12 +63,10 @@ module Rigor
         found ? [found] : []
       end
 
-      # ADR-52 slice 4 — return-type contribution via the compiled
-      # dispatch DSL. The `methods:` callable resolves after `#init`
-      # so `@method_name` is available. The block re-checks `eval_call?`
-      # for the AST receiver guard, then delegates to the Interpreter;
-      # the engine wraps the bare `Rigor::Type` return in a
-      # `FlowContribution` automatically.
+      # ADR-52 slice 4 — return-type contribution via the compiled dispatch DSL. The `methods:` callable resolves after
+      # `#init` so `@method_name` is available. The block re-checks `eval_call?` for the AST receiver guard, then
+      # delegates to the Interpreter; the engine wraps the bare `Rigor::Type` return in a `FlowContribution`
+      # automatically.
       dynamic_return methods: -> { [@method_name] } do |call_node, _scope|
         next nil unless eval_call?(call_node)
 
@@ -102,9 +93,8 @@ module Rigor
         when Interpreter::TypeError
           diagnostic_for_error(path, result)
         when Interpreter::UnknownExpression
-          # Stay silent on call sites whose argument we cannot
-          # statically interpret — they are well-formed Ruby
-          # that just is not a literal Lisp expression.
+          # Stay silent on call sites whose argument we cannot statically interpret — they are well-formed Ruby that
+          # just is not a literal Lisp expression.
           nil
         else
           diagnostic_for_inferred_type(path, call_node, result)
@@ -194,10 +184,9 @@ module Rigor
         end
       end
 
-      # Receiver-matching helper shared by `#eval_call?` and
-      # the `dynamic_return` block. The AST walk itself is engine-owned
-      # via `node_rule`; Walker holds only the receiver-comparison
-      # logic so the integration spec can exercise it directly.
+      # Receiver-matching helper shared by `#eval_call?` and the `dynamic_return` block. The AST walk itself is
+      # engine-owned via `node_rule`; Walker holds only the receiver-comparison logic so the integration spec can
+      # exercise it directly.
       module Walker
         module_function
 

--- a/examples/rigor-lisp-eval/lib/rigor/plugin/lisp_eval/interpreter.rb
+++ b/examples/rigor-lisp-eval/lib/rigor/plugin/lisp_eval/interpreter.rb
@@ -5,14 +5,11 @@ require "prism"
 module Rigor
   module Plugin
     class LispEval < Rigor::Plugin::Base
-      # Static interpreter that walks a literal Lisp-style
-      # expression encoded as a Prism AST and returns a tag
-      # naming the type the runtime evaluation would produce.
+      # Static interpreter that walks a literal Lisp-style expression encoded as a Prism AST and returns a tag naming
+      # the type the runtime evaluation would produce.
       #
-      # Tags are kept as plain Symbols (`:integer`, `:float`,
-      # `:bool`) and translated to Rigor type carriers at the
-      # plugin boundary; that keeps the grammar table easy to
-      # read and the type API surface contained to one site.
+      # Tags are kept as plain Symbols (`:integer`, `:float`, `:bool`) and translated to Rigor type carriers at the
+      # plugin boundary; that keeps the grammar table easy to read and the type API surface contained to one site.
       #
       # The accepted grammar is intentionally small:
       #
@@ -24,10 +21,8 @@ module Rigor
       #              | :and | :or | :not  (boolean)
       #              | :if   (conditional)
       #
-      # Every expression that does not fit the grammar — a
-      # non-literal element, an unknown operator, a wrong arity
-      # — yields {UnknownExpression} so the caller can decide
-      # whether to stay silent or to publish a diagnostic.
+      # Every expression that does not fit the grammar — a non-literal element, an unknown operator, a wrong arity —
+      # yields {UnknownExpression} so the caller can decide whether to stay silent or to publish a diagnostic.
       class Interpreter
         # Static type tags the interpreter produces.
         INTEGER = :integer
@@ -36,23 +31,19 @@ module Rigor
 
         NUMERIC = [INTEGER, FLOAT].freeze
 
-        # Carries both a type tag and an optional concrete value.
-        # When `value` is non-nil the result is a precise constant
-        # (e.g. `[:+, 1, 2]` → tag `:integer`, value `3`).
+        # Carries both a type tag and an optional concrete value. When `value` is non-nil the result is a precise
+        # constant (e.g. `[:+, 1, 2]` → tag `:integer`, value `3`).
         Result = Struct.new(:tag, :value, keyword_init: true) do
           def error? = false
         end
 
-        # Produced when the expression is well-formed but its
-        # operands violate the operator's domain.
+        # Produced when the expression is well-formed but its operands violate the operator's domain.
         TypeError = Struct.new(:message, :node, keyword_init: true) do
           def error? = true
         end
 
-        # Produced when the expression is outside the supported
-        # grammar. Distinct from {TypeError} so the plugin can
-        # stay silent on user code that is just not a Lisp
-        # literal.
+        # Produced when the expression is outside the supported grammar. Distinct from {TypeError} so the plugin can
+        # stay silent on user code that is just not a Lisp literal.
         UnknownExpression = Struct.new(:reason, :node, keyword_init: true) do
           def error? = false
         end

--- a/examples/rigor-pattern/demo/demo.rb
+++ b/examples/rigor-pattern/demo/demo.rb
@@ -6,9 +6,8 @@ require_relative "lib/validators"
 #
 #   RUBYLIB=$PWD/../lib bundle exec rigor check
 #
-# rigor-pattern asks Rigor's type system whether each value
-# argument below is provably a literal string. When it is,
-# the configured regex runs at lint time:
+# rigor-pattern asks Rigor's type system whether each value argument below is provably a literal string. When it is, the
+# configured regex runs at lint time:
 #
 # - Constant<String>             → exact match (info / error)
 # - literal-string carrier       → "exact value not statically known" info
@@ -20,14 +19,12 @@ validate(:email, "not-an-email")        # error: does not match
 validate(:uuid,  "a1b2c3d4-1111-2222-3333-444455556666") # info: matches
 validate(:uuid,  "obviously-wrong") # error: does not match
 
-# String concatenation — Rigor's LiteralStringFolding lifts
-# all-Constant + chains so the plugin still gets a constant.
+# String concatenation — Rigor's LiteralStringFolding lifts all-Constant + chains so the plugin still gets a constant.
 validate(:email, "user@example.com") # info: matches
 
 # Unknown pattern name in config.
 validate(:zip, "12345") # error: unknown-pattern
 
-# Non-literal value — plugin stays silent and defers to
-# runtime behaviour (no static guarantee possible).
+# Non-literal value — plugin stays silent and defers to runtime behaviour (no static guarantee possible).
 external = ARGV.first || "user@example.com"
 validate(:email, external)

--- a/examples/rigor-pattern/demo/lib/validators.rb
+++ b/examples/rigor-pattern/demo/lib/validators.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Tiny runtime — the plugin's value is the static check it
-# performs at lint time. The runtime side is just enough to
+# Tiny runtime — the plugin's value is the static check it performs at lint time. The runtime side is just enough to
 # make demo.rb runnable.
 
 PATTERNS = {

--- a/examples/rigor-pattern/lib/rigor-pattern.rb
+++ b/examples/rigor-pattern/lib/rigor-pattern.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-pattern` under `plugins:`. The
-# loader expects this `require` to side-effect a call to
-# `Rigor::Plugin.register`, which the body of
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists `rigor-pattern` under `plugins:`. The
+# loader expects this `require` to side-effect a call to `Rigor::Plugin.register`, which the body of
 # `lib/rigor/plugin/pattern.rb` performs at load time.
 require_relative "rigor/plugin/pattern"

--- a/examples/rigor-pattern/lib/rigor/plugin/pattern.rb
+++ b/examples/rigor-pattern/lib/rigor/plugin/pattern.rb
@@ -6,22 +6,16 @@ require "rigor/source/literals"
 
 module Rigor
   module Plugin
-    # Example plugin: validates `validate(:name, value)` calls
-    # against a user-declared regex pattern table. Demonstrates
+    # Example plugin: validates `validate(:name, value)` calls against a user-declared regex pattern table. Demonstrates
     # **plugin → analyzer collaboration**: the plugin asks Rigor's
-    # type system whether each `value` argument is a provably
-    # literal string (via `Type::Combinator.literal_string_compatible?`),
-    # and if so, runs the configured regex against the literal value
-    # at lint time.
+    # type system whether each `value` argument is a provably literal string (via
+    # `Type::Combinator.literal_string_compatible?`), and if so, runs the configured regex against the literal value at
+    # lint time.
     #
-    # Compared with the AST-only approach used by the earlier
-    # examples, this one **does not reimplement** literal-string
-    # tracking. Rigor already folds `"user@" + "example.com"`
-    # to a literal-string carrier through its
-    # `LiteralStringFolding` tier; the plugin reads that fact
-    # back through `Scope#type_of` and uses it. Plugins that
-    # need to know "is this a literal string?" should reach for
-    # the engine surface rather than re-implementing string
+    # Compared with the AST-only approach used by the earlier examples, this one **does not reimplement** literal-string
+    # tracking. Rigor already folds `"user@" + "example.com"` to a literal-string carrier through its
+    # `LiteralStringFolding` tier; the plugin reads that fact back through `Scope#type_of` and uses it. Plugins that
+    # need to know "is this a literal string?" should reach for the engine surface rather than re-implementing string
     # propagation.
     #
     # ## Configuration
@@ -44,9 +38,8 @@ module Rigor
     # | provably literal-string but exact value unknown | `:info`  | `literal-unknown` |
     # | call site references an unknown pattern name    | `:error` | `unknown-pattern` |
     #
-    # Calls whose `value` argument is not provably a literal
-    # (e.g. `validate(:email, params[:email])`) stay silent —
-    # the plugin defers to runtime for those.
+    # Calls whose `value` argument is not provably a literal (e.g. `validate(:email, params[:email])`) stay silent — the
+    # plugin defers to runtime for those.
     class Pattern < Rigor::Plugin::Base
       manifest(
         id: "pattern",
@@ -65,9 +58,8 @@ module Rigor
         raise "rigor-pattern: invalid regex in config: #{e.message}"
       end
 
-      # ADR-37 — per-call validation over the engine-owned walk.
-      # `validate_call?` gates on the configured `method_name` with
-      # ≥2 args; the plugin ships no traversal of its own.
+      # ADR-37 — per-call validation over the engine-owned walk. `validate_call?` gates on the configured `method_name`
+      # with ≥2 args; the plugin ships no traversal of its own.
       node_rule Prism::CallNode do |node, scope, path|
         next [] if @patterns.empty?
         next [] unless validate_call?(node)
@@ -76,17 +68,12 @@ module Rigor
         found ? [found] : []
       end
 
-      # ADR-52 slice 4 — return-type contribution via the compiled
-      # dispatch DSL. The `methods:` callable resolves after `#init`
-      # so `@method_name` is available. Runtime `validate` returns
-      # its `value` argument when the regex matches and raises
-      # otherwise, so on a successful match we narrow the call
-      # site's return type to the value argument's type (typically
-      # `Constant<String>` after Rigor's literal-string folding).
-      # Mismatches keep the existing `literal-mismatch` diagnostic
-      # and stay at the RBS-level untyped return. The engine wraps
-      # the bare `Rigor::Type` return in a `FlowContribution`
-      # automatically.
+      # ADR-52 slice 4 — return-type contribution via the compiled dispatch DSL. The `methods:` callable resolves after
+      # `#init` so `@method_name` is available. Runtime `validate` returns its `value` argument when the regex matches
+      # and raises otherwise, so on a successful match we narrow the call site's return type to the value argument's
+      # type (typically `Constant<String>` after Rigor's literal-string folding). Mismatches keep the existing
+      # `literal-mismatch` diagnostic and stay at the RBS-level untyped return. The engine wraps the bare `Rigor::Type`
+      # return in a `FlowContribution` automatically.
       dynamic_return methods: -> { [@method_name] } do |call_node, scope|
         next nil unless validate_call?(call_node)
 
@@ -142,11 +129,9 @@ module Rigor
         value_node = call.arguments.arguments[1]
         return nil if value_node.nil?
 
-        # Use the per-file entry scope's `type_of` so the plugin
-        # rides Rigor's existing literal-string folding rather
-        # than reimplementing it. `Type::Combinator.literal_string_compatible?`
-        # is the engine-side predicate the literal-string carrier
-        # publishes.
+        # Use the per-file entry scope's `type_of` so the plugin rides Rigor's existing literal-string folding rather
+        # than reimplementing it. `Type::Combinator.literal_string_compatible?` is the engine-side predicate the
+        # literal-string carrier publishes.
         value_type = scope.type_of(value_node)
         evaluate_value(path, value_node, pattern, pattern_name, value_type)
       end
@@ -172,12 +157,9 @@ module Rigor
             )
           end
         else
-          # Provably literal-string-compatible but the exact
-          # value is not a `Type::Constant` — typically a
-          # refinement carrier produced through interpolation
-          # of a non-Constant literal-string. Surface as an
-          # info note so the user sees the engine collaboration
-          # without false-positive errors.
+          # Provably literal-string-compatible but the exact value is not a `Type::Constant` — typically a refinement
+          # carrier produced through interpolation of a non-Constant literal-string. Surface as an info note so the user
+          # sees the engine collaboration without false-positive errors.
           diagnostic(
             value_node, path: path,
                         severity: :info,

--- a/examples/rigor-routes/demo/demo.rb
+++ b/examples/rigor-routes/demo/demo.rb
@@ -6,11 +6,9 @@ require_relative "lib/route_helpers"
 #
 #   RUBYLIB=$PWD/../lib bundle exec rigor check
 #
-# rigor-routes reads `config/routes.yml` once (via
-# Plugin::IoBoundary), caches the parsed RouteTable
-# (--cache-stats shows the entry under `plugin.routes.route_table`),
-# and validates each *_path / *_url call below against the
-# table for existence + arity.
+# rigor-routes reads `config/routes.yml` once (via Plugin::IoBoundary), caches the parsed RouteTable (--cache-stats
+# shows the entry under `plugin.routes.route_table`), and validates each *_path / *_url call below against the table for
+# existence + arity.
 
 # ---- Recognised calls ----
 

--- a/examples/rigor-routes/demo/errors_demo.rb
+++ b/examples/rigor-routes/demo/errors_demo.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-# Intentionally ill-typed file — demonstrates the diagnostics
-# rigor-routes emits for unknown helpers and arity mismatches.
-# DO NOT run via `ruby errors_demo.rb` — the unknown helpers
-# would NoMethodError at runtime. Run `rigor check` instead.
+# Intentionally ill-typed file — demonstrates the diagnostics rigor-routes emits for unknown helpers and arity
+# mismatches. DO NOT run via `ruby errors_demo.rb` — the unknown helpers would NoMethodError at runtime. Run `rigor
+# check` instead.
 
 # Unknown route helpers (with did-you-mean suggestions).
 unknown_widget_path

--- a/examples/rigor-routes/demo/lib/route_helpers.rb
+++ b/examples/rigor-routes/demo/lib/route_helpers.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-# Tiny runtime — just enough to make demo.rb runnable. Real
-# Rails apps would generate these helpers from the routes
-# table at boot. The plugin's value is what `rigor check`
-# reports about callers, not what the runtime returns here.
+# Tiny runtime — just enough to make demo.rb runnable. Real Rails apps would generate these helpers from the routes
+# table at boot. The plugin's value is what `rigor check` reports about callers, not what the runtime returns here.
 
 def users_path = "/users"
 def users_url = "https://example.com/users"

--- a/examples/rigor-routes/lib/rigor-routes.rb
+++ b/examples/rigor-routes/lib/rigor-routes.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-routes` under `plugins:`. The
-# loader expects this `require` to side-effect a call to
-# `Rigor::Plugin.register`, which the body of
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists `rigor-routes` under `plugins:`. The loader
+# expects this `require` to side-effect a call to `Rigor::Plugin.register`, which the body of
 # `lib/rigor/plugin/routes.rb` performs at load time.
 require_relative "rigor/plugin/routes"

--- a/examples/rigor-routes/lib/rigor/plugin/routes.rb
+++ b/examples/rigor-routes/lib/rigor/plugin/routes.rb
@@ -7,14 +7,10 @@ require_relative "routes/walker"
 
 module Rigor
   module Plugin
-    # Example plugin: validates Rails-style route helper calls
-    # (`users_path`, `edit_user_path(@user.id)`, …) against a
-    # YAML route table read from the project. This is the
-    # reference example for **slice 2 (`Plugin::IoBoundary` /
-    # `Plugin::TrustPolicy`)** and **slice 6 (`Plugin::Base.producer`
-    # / `#cache_for`)** — the two facets the earlier
-    # `rigor-lisp-eval` and `rigor-units` examples did not
-    # exercise.
+    # Example plugin: validates Rails-style route helper calls (`users_path`, `edit_user_path(@user.id)`, …) against a
+    # YAML route table read from the project. This is the reference example for **slice 2 (`Plugin::IoBoundary` /
+    # `Plugin::TrustPolicy`)** and **slice 6 (`Plugin::Base.producer` / `#cache_for`)** — the two facets the earlier
+    # `rigor-lisp-eval` and `rigor-units` examples did not exercise.
     #
     # ## Architecture
     #
@@ -60,15 +56,11 @@ module Rigor
         }
       )
 
-      # Cached producer (slice 6-A). The block runs through
-      # `instance_exec` so `@routes_file`, `io_boundary`, and private
-      # helpers are all in scope. Under ADR-60 WD3 record-and-validate,
-      # the `io_boundary.read_file` BELOW runs inside the block, and
-      # its `FileEntry` digest is captured into the dependency
-      # descriptor *after* the block runs — so editing `routes.yml`
-      # invalidates the cache with nothing to wire up by hand. (A
-      # producer that globbed a directory would add `watch:` to cover
-      # file additions; this one reads a single named file.)
+      # Cached producer (slice 6-A). The block runs through `instance_exec` so `@routes_file`, `io_boundary`, and
+      # private helpers are all in scope. Under ADR-60 WD3 record-and-validate, the `io_boundary.read_file` BELOW runs
+      # inside the block, and its `FileEntry` digest is captured into the dependency descriptor *after* the block runs —
+      # so editing `routes.yml` invalidates the cache with nothing to wire up by hand. (A producer that globbed a
+      # directory would add `watch:` to cover file additions; this one reads a single named file.)
       producer :route_table do |_params|
         contents = io_boundary.read_file(@routes_file)
         RouteTable.parse(contents)
@@ -79,14 +71,11 @@ module Rigor
         @load_error_emitted = false
       end
 
-      # ADR-37 — per-call helper validation over the engine-owned walk.
-      # The engine hands us every `CallNode`; `Walker.helper_call` gates
-      # on the implicit-receiver `*_path` / `*_url` shape, and each match
-      # is checked against the route table. `#producer_value` (ADR-60 WD4)
-      # loads and memoises the table on this instance, so the node rule
-      # and the file rule below share one `#cache_for` round-trip. When
-      # the table failed to load the file rule owns the single load-error
-      # warning; the node rule stays silent.
+      # ADR-37 — per-call helper validation over the engine-owned walk. The engine hands us every `CallNode`;
+      # `Walker.helper_call` gates on the implicit-receiver `*_path` / `*_url` shape, and each match is checked against
+      # the route table. `#producer_value` (ADR-60 WD4) loads and memoises the table on this instance, so the node rule
+      # and the file rule below share one `#cache_for` round-trip. When the table failed to load the file rule owns the
+      # single load-error warning; the node rule stays silent.
       node_rule Prism::CallNode do |node, _scope, path|
         table = producer_value(:route_table)
         next [] if table.nil? || table.empty?
@@ -97,18 +86,14 @@ module Rigor
         diagnostics_for_call(path, node, base, kind, table)
       end
 
-      # File-level only: the once-per-run load-error emission. Per-call
-      # validation runs over the engine-owned walk via the node rule
-      # above, so this hook is reserved for the one diagnostic a per-node
-      # walk cannot express — the project-global "routes file did not
-      # load" warning, emitted once rather than on every analysed file.
+      # File-level only: the once-per-run load-error emission. Per-call validation runs over the engine-owned walk via
+      # the node rule above, so this hook is reserved for the one diagnostic a per-node walk cannot express — the
+      # project-global "routes file did not load" warning, emitted once rather than on every analysed file.
       #
-      # `#producer_value` runs the `:route_table` producer through
-      # `#cache_for`; a `StandardError` the producer raises (missing /
-      # malformed / access-denied `routes.yml`) is rescued into
-      # `#producer_error`. ADR-60 WD3 record-and-validate captures the
-      # in-block `routes.yml` read into the dependency descriptor, so the
-      # cache invalidates on edit with nothing to wire up by hand.
+      # `#producer_value` runs the `:route_table` producer through `#cache_for`; a `StandardError` the producer raises
+      # (missing / malformed / access-denied `routes.yml`) is rescued into `#producer_error`. ADR-60 WD3
+      # record-and-validate captures the in-block `routes.yml` read into the dependency descriptor, so the cache
+      # invalidates on edit with nothing to wire up by hand.
       def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
         table = producer_value(:route_table)
         return [] unless table.nil?
@@ -148,9 +133,8 @@ module Rigor
       end
 
       def unknown_route_diagnostic(path, node, base, kind, table)
-        # ADR-60 WD4 — the shared `DidYouMean::SpellChecker` helper the
-        # engine also uses for `NoMethodError` hints, replacing the
-        # hand-rolled Levenshtein table this example used to carry.
+        # ADR-60 WD4 — the shared `DidYouMean::SpellChecker` helper the engine also uses for `NoMethodError` hints,
+        # replacing the hand-rolled Levenshtein table this example used to carry.
         suggestion = self.class.suggest(base, table.names)
         hint = suggestion ? " (did you mean `#{suggestion}_#{kind}`?)" : ""
         diagnostic(
@@ -173,11 +157,9 @@ module Rigor
         )
       end
 
-      # File-level (line 1) load-error warning. There is no call node to
-      # position at, so this is one of the few places a plugin constructs
-      # a `Diagnostic` directly rather than through `#diagnostic`. The
-      # message is tailored to the `StandardError` class `#producer_value`
-      # rescued into `#producer_error(:route_table)`.
+      # File-level (line 1) load-error warning. There is no call node to position at, so this is one of the few places a
+      # plugin constructs a `Diagnostic` directly rather than through `#diagnostic`. The message is tailored to the
+      # `StandardError` class `#producer_value` rescued into `#producer_error(:route_table)`.
       def load_error_diagnostic(path)
         Rigor::Analysis::Diagnostic.new(
           path: path,

--- a/examples/rigor-routes/lib/rigor/plugin/routes/route_table.rb
+++ b/examples/rigor-routes/lib/rigor/plugin/routes/route_table.rb
@@ -5,15 +5,11 @@ require "yaml"
 module Rigor
   module Plugin
     class Routes < Rigor::Plugin::Base
-      # Frozen value object — the parsed route table the plugin
-      # caches. Each entry is keyed by the helper base name
-      # (`"users"`, `"edit_user"`, …) and carries the HTTP method,
-      # path template, and the ordered list of placeholders.
+      # Frozen value object — the parsed route table the plugin caches. Each entry is keyed by the helper base name
+      # (`"users"`, `"edit_user"`, …) and carries the HTTP method, path template, and the ordered list of placeholders.
       #
-      # Marshal-clean by construction so it round-trips through
-      # `Cache::Store#fetch_or_validate` (the record-and-validate path
-      # that `cache_for` uses) without needing a custom serialize /
-      # deserialize pair.
+      # Marshal-clean by construction so it round-trips through `Cache::Store#fetch_or_validate` (the
+      # record-and-validate path that `cache_for` uses) without needing a custom serialize / deserialize pair.
       class RouteTable
         Entry = Struct.new(:name, :method, :path, :params, keyword_init: true) do
           def arity = params.size

--- a/examples/rigor-routes/lib/rigor/plugin/routes/walker.rb
+++ b/examples/rigor-routes/lib/rigor/plugin/routes/walker.rb
@@ -5,19 +5,16 @@ require "prism"
 module Rigor
   module Plugin
     class Routes < Rigor::Plugin::Base
-      # Recognises the implicit-receiver `*_path` / `*_url` route
-      # helper call shape. The engine owns the per-file AST walk
-      # (ADR-37 `node_rule`); this module is only the matcher the
-      # node rule applies to each `Prism::CallNode` it is handed —
-      # it holds no traversal of its own.
+      # Recognises the implicit-receiver `*_path` / `*_url` route helper call shape. The engine owns the per-file AST
+      # walk (ADR-37 `node_rule`); this module is only the matcher the node rule applies to each `Prism::CallNode` it is
+      # handed — it holds no traversal of its own.
       module Walker
         SUFFIX_RE = /\A(?<base>.+)_(?<kind>path|url)\z/
 
         module_function
 
-        # Returns `[base, kind]` for an implicit-receiver `*_path` /
-        # `*_url` call (`users_path` → `["users", :path]`), or `nil`
-        # for any other node.
+        # Returns `[base, kind]` for an implicit-receiver `*_path` / `*_url` call (`users_path` → `["users", :path]`),
+        # or `nil` for any other node.
         def helper_call(node)
           return nil unless node.is_a?(Prism::CallNode)
           return nil unless node.receiver.nil?

--- a/examples/rigor-units/demo/demo.rb
+++ b/examples/rigor-units/demo/demo.rb
@@ -6,9 +6,8 @@ require_relative "lib/units"
 #
 #   RUBYLIB=$PWD/../lib bundle exec rigor check demo.rb
 #
-# Each local assignment with an inferred dimension surfaces as
-# an `info` diagnostic naming the dimension; each `.in_<unit>`
-# query emits a second `info` diagnostic naming the conversion.
+# Each local assignment with an inferred dimension surfaces as an `info` diagnostic naming the dimension; each
+# `.in_<unit>` query emits a second `info` diagnostic naming the conversion.
 
 # ==========================================
 # 1. Distance and Time
@@ -63,6 +62,5 @@ velocity_after_fall = gravity * fall_time
 
 puts velocity_after_fall.in_meters_per_second # => 29.4
 
-# Suppress runtime "unused variable" warnings for the demo's
-# read-only locals; the static analysis above is the point.
+# Suppress runtime "unused variable" warnings for the demo's read-only locals; the static analysis above is the point.
 _ = [distance, total_distance, wind_speed]

--- a/examples/rigor-units/demo/lib/units.rb
+++ b/examples/rigor-units/demo/lib/units.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
-# Tiny units-of-measure runtime the rigor-units plugin types
-# statically. The classes are minimal — just enough to make
-# the demo executable under MRI. The plugin's value is what
-# `rigor check` says about the call sites, not what the
+# Tiny units-of-measure runtime the rigor-units plugin types statically. The classes are minimal — just enough to make
+# the demo executable under MRI. The plugin's value is what `rigor check` says about the call sites, not what the
 # runtime does internally.
 
-# Internal storage is the SI base unit: meters for distance,
-# seconds for time, m/s for speed, m/s² for acceleration.
+# Internal storage is the SI base unit: meters for distance, seconds for time, m/s for speed, m/s² for acceleration.
 
 class Distance
   include Comparable

--- a/examples/rigor-units/lib/rigor-units.rb
+++ b/examples/rigor-units/lib/rigor-units.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-units` under `plugins:`. The
-# loader expects this `require` to side-effect a call to
-# `Rigor::Plugin.register`, which the body of
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists `rigor-units` under `plugins:`. The loader
+# expects this `require` to side-effect a call to `Rigor::Plugin.register`, which the body of
 # `lib/rigor/plugin/units.rb` performs at load time.
 require_relative "rigor/plugin/units"

--- a/examples/rigor-units/lib/rigor/plugin/units.rb
+++ b/examples/rigor-units/lib/rigor/plugin/units.rb
@@ -7,16 +7,12 @@ require_relative "units/analyzer"
 
 module Rigor
   module Plugin
-    # Example plugin: types a units-of-measure DSL that extends
-    # `Numeric` with constructor methods (`100.kilometers`,
-    # `2.hours`) and propagates dimensional types through
-    # arithmetic, chained constructors (`60.kilometers.per_hour`),
+    # Example plugin: types a units-of-measure DSL that extends `Numeric` with constructor methods (`100.kilometers`,
+    # `2.hours`) and propagates dimensional types through arithmetic, chained constructors (`60.kilometers.per_hour`),
     # and conversion queries (`speed.in_kilometers_per_hour`).
     #
-    # The plugin walks the file's AST ({Analyzer}), maintains a
-    # local-variable binding map (`distance: :distance`,
-    # `speed: :speed`, …), and emits one diagnostic per recognised
-    # event:
+    # The plugin walks the file's AST ({Analyzer}), maintains a local-variable binding map (`distance: :distance`,
+    # `speed: :speed`, …), and emits one diagnostic per recognised event:
     #
     # | Event                                 | Severity | Rule |
     # | ---                                   | ---      | --- |
@@ -25,20 +21,15 @@ module Rigor
     # | dimensional mismatch in `+`/`-`/`*`/`/`/comparison | `:error` | `dimension-mismatch` |
     # | wrong `.in_<unit>` for the dimension  | `:error` | `in-method-mismatch` |
     #
-    # In addition to diagnostics the plugin contributes return
-    # types for every recognised call site via {.dynamic_return},
-    # so the engine's flow analysis threads the dimensional type
-    # (`Distance` / `Speed` / …) through assignments and into
-    # downstream calls instead of seeing the DSL's untyped RBS
-    # boundary.
+    # In addition to diagnostics the plugin contributes return types for every recognised call site via
+    # {.dynamic_return}, so the engine's flow analysis threads the dimensional type (`Distance` / `Speed` / …) through
+    # assignments and into downstream calls instead of seeing the DSL's untyped RBS boundary.
     #
     # ## Why the parallel binding map is NOT redundant
     #
-    # It is tempting to delete {Analyzer}'s `@bindings` map and have
-    # the diagnostics side read dimensions straight from
-    # `Scope#type_of`, the way `rigor-pattern` reads literal-string
-    # facts back from the engine. That does not work here, and the
-    # asymmetry is worth understanding:
+    # It is tempting to delete {Analyzer}'s `@bindings` map and have the diagnostics side read dimensions straight from
+    # `Scope#type_of`, the way `rigor-pattern` reads literal-string facts back from the engine. That does not work here,
+    # and the asymmetry is worth understanding:
     #
     # - The `Scope` handed to `#diagnostics_for_file` / a `node_rule`
     #   is the **seed entry scope** (`seed_project_scope(Scope.empty)`).
@@ -55,13 +46,10 @@ module Rigor
     #   `speed.upcase` really does trip `call.undefined-method` on
     #   `Speed`), but the diagnostics API cannot see that thread.
     #
-    # So the two halves read dimensions from different sources of
-    # necessity: {.dynamic_return} from the flow `Scope#type_of`, and
-    # {Analyzer} from its own single-pass binding map — the only way to
-    # follow a dimension across statements on the diagnostics side. A
-    # plugin that needs a value literally at one call site (rigor-pattern)
-    # reaches for the engine; a plugin that needs cross-statement
-    # local flow on the diagnostics side (this one) still tracks it.
+    # So the two halves read dimensions from different sources of necessity: {.dynamic_return} from the flow
+    # `Scope#type_of`, and {Analyzer} from its own single-pass binding map — the only way to follow a dimension across
+    # statements on the diagnostics side. A plugin that needs a value literally at one call site (rigor-pattern) reaches
+    # for the engine; a plugin that needs cross-statement local flow on the diagnostics side (this one) still tracks it.
     #
     # Usage in `.rigor.yml`:
     #
@@ -74,9 +62,8 @@ module Rigor
         description: "Types a units-of-measure DSL (Distance / Time / Speed / Acceleration)."
       )
 
-      # Dimension → Rigor type. Used by the {.dynamic_return} rule
-      # to translate the {MethodTable} dispatch result back into
-      # the carrier the engine threads through call sites.
+      # Dimension → Rigor type. Used by the {.dynamic_return} rule to translate the {MethodTable} dispatch result back
+      # into the carrier the engine threads through call sites.
       DIMENSION_NOMINALS = {
         distance: "Distance",
         time: "Time",
@@ -85,9 +72,8 @@ module Rigor
         float: "Float"
       }.freeze
 
-      # Inverse map — Rigor type → dimension Symbol. Keyed on the
-      # nominal class name; non-class carriers (Constant, IntegerRange)
-      # fall through and the contribution declines.
+      # Inverse map — Rigor type → dimension Symbol. Keyed on the nominal class name; non-class carriers (Constant,
+      # IntegerRange) fall through and the contribution declines.
       NOMINAL_DIMENSIONS = {
         "Distance" => :distance,
         "Time" => :time,
@@ -99,11 +85,9 @@ module Rigor
       }.freeze
 
       # Union of every method name {MethodTable.dispatch} can recognise:
-      # numeric unit constructors, chained speed/acceleration constructors,
-      # arithmetic and comparison operators, and every `.in_<unit>` query
-      # across all receiver dimensions. Used as the `methods:` gate for the
-      # {.dynamic_return} declaration below so the engine skips this block
-      # for every call to an unrelated method.
+      # numeric unit constructors, chained speed/acceleration constructors, arithmetic and comparison operators, and
+      # every `.in_<unit>` query across all receiver dimensions. Used as the `methods:` gate for the {.dynamic_return}
+      # declaration below so the engine skips this block for every call to an unrelated method.
       RECOGNISED_METHODS = (
         MethodTable::DISTANCE_UNIT_METHODS +
         MethodTable::TIME_UNIT_METHODS +
@@ -118,14 +102,11 @@ module Rigor
         Analyzer.new(path: path).analyze(root).diagnostics
       end
 
-      # v0.1.2 — return-type contribution via the {.dynamic_return} DSL.
-      # The same {MethodTable} the diagnostics path consults supplies the
-      # call-site return type when both receiver and argument map cleanly
-      # to a known dimension. Dimensional mismatches stay at the RBS-level
-      # untyped return — surfacing the existing `dimension-mismatch` /
-      # `in-method-mismatch` error diagnostic without propagating `bot`
-      # downstream. The engine wraps a non-nil return in a
-      # `FlowContribution`; the block returns a bare `Rigor::Type`.
+      # v0.1.2 — return-type contribution via the {.dynamic_return} DSL. The same {MethodTable} the diagnostics path
+      # consults supplies the call-site return type when both receiver and argument map cleanly to a known dimension.
+      # Dimensional mismatches stay at the RBS-level untyped return — surfacing the existing `dimension-mismatch` /
+      # `in-method-mismatch` error diagnostic without propagating `bot` downstream. The engine wraps a non-nil return in
+      # a `FlowContribution`; the block returns a bare `Rigor::Type`.
       dynamic_return methods: RECOGNISED_METHODS do |call_node, scope|
         next nil unless call_node.is_a?(Prism::CallNode)
         next nil if call_node.receiver.nil?

--- a/examples/rigor-units/lib/rigor/plugin/units/analyzer.rb
+++ b/examples/rigor-units/lib/rigor/plugin/units/analyzer.rb
@@ -5,17 +5,12 @@ require "prism"
 module Rigor
   module Plugin
     class Units < Rigor::Plugin::Base
-      # Walks a single Ruby file, evaluates every expression
-      # against the {MethodTable} dispatch surface, and tracks
-      # local-variable bindings so dimensions flow through
-      # subsequent reads.
+      # Walks a single Ruby file, evaluates every expression against the {MethodTable} dispatch surface, and tracks
+      # local-variable bindings so dimensions flow through subsequent reads.
       #
-      # The walker is intentionally simple — no path-sensitive
-      # branching, no method-body scoping — because the demo's
-      # value is "what the plugin sees at the top level". An
-      # `if` / `else` body is recursed into for diagnostics, but
-      # any binding it writes is global to the analyser; there
-      # is no scope stack. That keeps the example small without
+      # The walker is intentionally simple — no path-sensitive branching, no method-body scoping — because the demo's
+      # value is "what the plugin sees at the top level". An `if` / `else` body is recursed into for diagnostics, but
+      # any binding it writes is global to the analyser; there is no scope stack. That keeps the example small without
       # surprising users with partial control-flow precision.
       class Analyzer
         DIMENSIONS = %i[distance time speed acceleration].freeze
@@ -35,10 +30,8 @@ module Rigor
 
         private
 
-        # Returns the dimension Symbol for a node, or `nil` when
-        # the analyzer cannot — or chooses not to — type it.
-        # Recursing down a tree always uses `evaluate`; the
-        # diagnostics each node owns fire as a side-effect of
+        # Returns the dimension Symbol for a node, or `nil` when the analyzer cannot — or chooses not to — type it.
+        # Recursing down a tree always uses `evaluate`; the diagnostics each node owns fire as a side-effect of
         # evaluating it, exactly once per node.
         def evaluate(node)
           return nil if node.nil?
@@ -148,11 +141,9 @@ module Rigor
         end
 
         def push_diagnostic(node, severity:, message:, rule:)
-          # `Analyzer` is a plain class, not a `Plugin::Base` subclass, so
-          # it cannot use the `#diagnostic` instance helper — but
-          # `Diagnostic.from_location` is the same public constructor that
-          # helper wraps, and it internalises the 1-based line / column + 1
-          # convention this method used to spell out by hand.
+          # `Analyzer` is a plain class, not a `Plugin::Base` subclass, so it cannot use the `#diagnostic` instance
+          # helper — but `Diagnostic.from_location` is the same public constructor that helper wraps, and it
+          # internalises the 1-based line / column + 1 convention this method used to spell out by hand.
           @diagnostics << Rigor::Analysis::Diagnostic.from_location(
             node.location,
             path: @path,

--- a/examples/rigor-units/lib/rigor/plugin/units/method_table.rb
+++ b/examples/rigor-units/lib/rigor/plugin/units/method_table.rb
@@ -3,15 +3,11 @@
 module Rigor
   module Plugin
     class Units < Rigor::Plugin::Base
-      # Dispatch table mapping (receiver dimension, method name,
-      # argument dimensions) tuples onto a result dimension or a
-      # dimensional-mismatch error message. Pure data — the
-      # {Analyzer} walks the AST and consults this module to
-      # decide what each call site contributes to the local
-      # binding map.
+      # Dispatch table mapping (receiver dimension, method name, argument dimensions) tuples onto a result dimension or
+      # a dimensional-mismatch error message. Pure data — the {Analyzer} walks the AST and consults this module to
+      # decide what each call site contributes to the local binding map.
       #
-      # Dimensions are kept as plain Symbols so the table reads
-      # like a small physical-units cheatsheet. The set is
+      # Dimensions are kept as plain Symbols so the table reads like a small physical-units cheatsheet. The set is
       # closed:
       #
       #   :numeric       — Integer / Float literal (no unit yet)
@@ -31,8 +27,7 @@ module Rigor
         DISTANCE_PER_TIME = %i[per_hour per_minute per_second].freeze
         DISTANCE_PER_TIME_SQUARED = %i[per_second_squared per_minute_squared per_hour_squared].freeze
 
-        # Allowed `.in_<unit>` queries per receiver dimension.
-        # Anything not listed here is a dimensional mismatch.
+        # Allowed `.in_<unit>` queries per receiver dimension. Anything not listed here is a dimensional mismatch.
         IN_METHODS = {
           distance: %i[in_kilometers in_meters in_miles in_feet].freeze,
           time: %i[in_seconds in_minutes in_hours].freeze,
@@ -79,9 +74,8 @@ module Rigor
           DIMENSION_LABELS.fetch(dimension, dimension.to_s)
         end
 
-        # Internal helpers below. Public-but-inside-the-module so
-        # the analyzer-side specs can poke at them; not part of the
-        # plugin's external API.
+        # Internal helpers below. Public-but-inside-the-module so the analyzer-side specs can poke at them; not part of
+        # the plugin's external API.
 
         def numeric_unit_constructor(receiver, method)
           return nil unless receiver == :numeric

--- a/examples/rigor-web/demo/lib/app.rb
+++ b/examples/rigor-web/demo/lib/app.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-# Wiring for the demo app: build a RigWeb router and register the
-# two controllers. This is the snippet from the rigor-web README,
-# made into a real analysable file.
+# Wiring for the demo app: build a RigWeb router and register the two controllers. This is the snippet from the
+# rigor-web README, made into a real analysable file.
 #
-# Run the analysis from this `demo/` directory with the plugin on
-# the load path:
+# Run the analysis from this `demo/` directory with the plugin on the load path:
 #
 #   RUBYLIB=$PWD/../lib bundle exec rigor check
 

--- a/examples/rigor-web/demo/lib/controller/hello_controller.rb
+++ b/examples/rigor-web/demo/lib/controller/hello_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# A second RigWeb controller. Reads a query parameter off the
-# request and echoes it back in the response body.
+# A second RigWeb controller. Reads a query parameter off the request and echoes it back in the response body.
 class HelloController
   def get(request)
     name = request.params.fetch("name", "world")

--- a/examples/rigor-web/demo/lib/controller/home_controller.rb
+++ b/examples/rigor-web/demo/lib/controller/home_controller.rb
@@ -2,17 +2,13 @@
 
 # A RigWeb controller.
 #
-# Notice what is NOT here: no base class, no `include`, no type
-# annotation. The rigor-web plugin enforces the controller
-# protocol — `#get` takes a `Rack::Request`, returns a
-# `Rack::Response` — purely because this file lives under
+# Notice what is NOT here: no base class, no `include`, no type annotation. The rigor-web plugin enforces the controller
+# protocol — `#get` takes a `Rack::Request`, returns a `Rack::Response` — purely because this file lives under
 # `lib/controller/`.
 #
-# Inside `#get`, `request` is analysed as a `Rack::Request`: the
-# engine *provides* that type into the body, so `request.path_info`
-# resolves against Rack's signature. A typo like
-# `request.path_inf0` would surface as an ordinary core
-# diagnostic, not something this plugin has to check for.
+# Inside `#get`, `request` is analysed as a `Rack::Request`: the engine *provides* that type into the body, so
+# `request.path_info` resolves against Rack's signature. A typo like `request.path_inf0` would surface as an ordinary
+# core diagnostic, not something this plugin has to check for.
 class HomeController
   def get(request)
     body = "Hello from #{request.path_info}"

--- a/examples/rigor-web/demo/lib/rig_web.rb
+++ b/examples/rigor-web/demo/lib/rig_web.rb
@@ -1,26 +1,19 @@
 # frozen_string_literal: true
 
-# RigWeb — a deliberately tiny routing layer, the virtual web
-# framework the rigor-web example is built around.
+# RigWeb — a deliberately tiny routing layer, the virtual web framework the rigor-web example is built around.
 #
-# A `RigWeb` instance maps a request path to a
-# `[ControllerClass, action]` handler. `#routes` dispatches an
-# incoming `Rack::Request` to the matching controller and returns
-# the controller's `Rack::Response`.
+# A `RigWeb` instance maps a request path to a `[ControllerClass, action]` handler. `#routes` dispatches an incoming
+# `Rack::Request` to the matching controller and returns the controller's `Rack::Response`.
 #
-# RigWeb asks nothing structural of a controller — no base class,
-# no `include`. The only requirement is behavioural: the action
-# method must accept a `Rack::Request` and return a
-# `Rack::Response`. The rigor-web plugin makes that unwritten
-# requirement statically enforced for every class under
-# `lib/controller/`.
+# RigWeb asks nothing structural of a controller — no base class, no `include`. The only requirement is behavioural: the
+# action method must accept a `Rack::Request` and return a `Rack::Response`. The rigor-web plugin makes that unwritten
+# requirement statically enforced for every class under `lib/controller/`.
 class RigWeb
   def initialize
     @routes = {}
   end
 
-  # Register a handler for GET requests to `path`. `handler` is a
-  # `[ControllerClass, action_symbol]` pair.
+  # Register a handler for GET requests to `path`. `handler` is a `[ControllerClass, action_symbol]` pair.
   def get(path, handler)
     @routes[path] = handler
   end

--- a/examples/rigor-web/lib/rigor-web.rb
+++ b/examples/rigor-web/lib/rigor-web.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-web` under `plugins:`. The loader
-# expects this `require` to side-effect a call to
-# `Rigor::Plugin.register`, which the body of
-# `lib/rigor/plugin/web.rb` performs at load time.
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists `rigor-web` under `plugins:`. The loader
+# expects this `require` to side-effect a call to `Rigor::Plugin.register`, which the body of `lib/rigor/plugin/web.rb`
+# performs at load time.
 require_relative "rigor/plugin/web"

--- a/examples/rigor-web/lib/rigor/plugin/web.rb
+++ b/examples/rigor-web/lib/rigor/plugin/web.rb
@@ -9,18 +9,13 @@ module Rigor
   module Plugin
     # Example plugin: enforces the RigWeb controller protocol.
     #
-    # RigWeb (see `demo/lib/rig_web.rb`) is a deliberately tiny
-    # routing layer. Its only requirement of a controller is a
-    # behavioural one — a controller's action method must take a
-    # `Rack::Request` and return a `Rack::Response`. RigWeb never
-    # asks a controller to `include` anything; the protocol is a
-    # convention, not a declaration.
+    # RigWeb (see `demo/lib/rig_web.rb`) is a deliberately tiny routing layer. Its only requirement of a controller is a
+    # behavioural one — a controller's action method must take a `Rack::Request` and return a `Rack::Response`. RigWeb
+    # never asks a controller to `include` anything; the protocol is a convention, not a declaration.
     #
-    # This plugin spotlights the **ADR-28 path-scoped
-    # method-protocol contract** extension point — the mechanism
-    # that lets a plugin make such a convention statically
-    # enforceable WITHOUT the controller class opting in. A
-    # contract names:
+    # This plugin spotlights the **ADR-28 path-scoped method-protocol contract** extension point — the mechanism that
+    # lets a plugin make such a convention statically enforceable WITHOUT the controller class opting in. A contract
+    # names:
     #
     # - a path glob (`lib/controller/**/*.rb`) — every class
     #   defined in a matching file is subject to the contract;
@@ -30,18 +25,13 @@ module Rigor
     # - the return type the method's body must **conform to**
     #   (`Rack::Response`).
     #
-    # "provide-and-check" is the heart of it. The provide half is
-    # engine-side: `Inference::MethodParameterBinder` substitutes
-    # `Rack::Request` for the usual `Dynamic[Top]` fallback, so a
-    # misuse of the request inside a controller body
-    # (`request.no_such_method`) surfaces as an ordinary core
-    # diagnostic. The check half is this plugin's
-    # `node_rule(Prism::ClassNode)`: for every class the engine-owned
-    # walk hands it, it confirms `#get` exists and that its inferred
-    # return type conforms to `Rack::Response`. (The check is per class,
-    # so it rides the engine's walk rather than shipping a `class_nodes`
-    # traversal — contrast the file-level load-error in `rigor-routes`,
-    # which genuinely cannot be expressed per node.)
+    # "provide-and-check" is the heart of it. The provide half is engine-side: `Inference::MethodParameterBinder`
+    # substitutes `Rack::Request` for the usual `Dynamic[Top]` fallback, so a misuse of the request inside a controller
+    # body (`request.no_such_method`) surfaces as an ordinary core diagnostic. The check half is this plugin's
+    # `node_rule(Prism::ClassNode)`: for every class the engine-owned walk hands it, it confirms `#get` exists and that
+    # its inferred return type conforms to `Rack::Response`. (The check is per class, so it rides the engine's walk
+    # rather than shipping a `class_nodes` traversal — contrast the file-level load-error in `rigor-routes`, which
+    # genuinely cannot be expressed per node.)
     #
     # ## Configuration
     #
@@ -59,8 +49,7 @@ module Rigor
     # | a controller class defines no `#get`                   | `:error` | `missing-protocol-method` |
     # | `#get`'s inferred return type is not a `Rack::Response` | `:error` | `protocol-return-mismatch`|
     #
-    # A `#get` whose return type the engine cannot pin down
-    # (`Dynamic[Top]`) stays silent — the plugin defers to runtime
+    # A `#get` whose return type the engine cannot pin down (`Dynamic[Top]`) stays silent — the plugin defers to runtime
     # rather than frighten code that may well be correct.
     class Web < Rigor::Plugin::Base
       manifest(
@@ -72,9 +61,8 @@ module Rigor
           # non-empty override retargets every contract's path glob.
           "controller_path" => { kind: :string, default: "" }
         },
-        # The plugin ships RBS for Rack::Request / Rack::Response
-        # so the analysed project does not need rack installed for
-        # the contract's type names to resolve.
+        # The plugin ships RBS for Rack::Request / Rack::Response so the analysed project does not need rack installed
+        # for the contract's type names to resolve.
         signature_paths: ["sig"],
         protocol_contracts: [
           Rigor::Plugin::ProtocolContract.new(
@@ -96,25 +84,19 @@ module Rigor
           end
       end
 
-      # ADR-28 — `Plugin::Base#protocol_contracts` indirection.
-      # The manifest declares the default convention path; this
-      # override folds in the per-project `controller_path:` config
-      # so `.rigor.yml` can retarget the contract (e.g. to Rails'
-      # `app/controllers/`). `Plugin::Registry` reads this when it
-      # aggregates contracts for the engine's parameter-provision
-      # tier; the plugin reads it again here for the check half.
+      # ADR-28 — `Plugin::Base#protocol_contracts` indirection. The manifest declares the default convention path; this
+      # override folds in the per-project `controller_path:` config so `.rigor.yml` can retarget the contract (e.g. to
+      # Rails' `app/controllers/`). `Plugin::Registry` reads this when it aggregates contracts for the engine's
+      # parameter-provision tier; the plugin reads it again here for the check half.
       def protocol_contracts
         @protocol_contracts || manifest.protocol_contracts
       end
 
-      # ADR-37 — per-class-node validation over the engine-owned walk.
-      # Each `Prism::ClassNode` is checked against every contract
-      # independently of the others, so the plugin no longer ships its
-      # own `class_nodes` traversal; `ProtocolChecker#check_class` keeps
-      # the per-class contract logic. (Production `rigor-hanami`'s ADR-28
-      # check half still uses `#diagnostics_for_file` + a hand-rolled
-      # class walk — an equivalent, older shape; either is contract-valid,
-      # but a per-class check is exactly what `node_rule` is for.)
+      # ADR-37 — per-class-node validation over the engine-owned walk. Each `Prism::ClassNode` is checked against every
+      # contract independently of the others, so the plugin no longer ships its own `class_nodes` traversal;
+      # `ProtocolChecker#check_class` keeps the per-class contract logic. (Production `rigor-hanami`'s ADR-28 check half
+      # still uses `#diagnostics_for_file` + a hand-rolled class walk — an equivalent, older shape; either is
+      # contract-valid, but a per-class check is exactly what `node_rule` is for.)
       node_rule Prism::ClassNode do |node, scope, path|
         contracts = protocol_contracts
         next [] if contracts.empty?

--- a/examples/rigor-web/lib/rigor/plugin/web/protocol_checker.rb
+++ b/examples/rigor-web/lib/rigor/plugin/web/protocol_checker.rb
@@ -14,12 +14,9 @@ module Rigor
       # 2. that method's inferred return type conforms to the
       #    contract's `return_type_name`.
       #
-      # The "provide" half — binding the contract's parameter types
-      # into the method body — happens engine-side in
-      # `Inference::MethodParameterBinder` before this checker runs.
-      # The checker re-binds the same parameter types onto its own
-      # query scope so `Scope#type_of` types the body identically to
-      # the engine's own per-file inference.
+      # The "provide" half — binding the contract's parameter types into the method body — happens engine-side in
+      # `Inference::MethodParameterBinder` before this checker runs. The checker re-binds the same parameter types onto
+      # its own query scope so `Scope#type_of` types the body identically to the engine's own per-file inference.
       class ProtocolChecker
         FNMATCH_FLAGS = File::FNM_PATHNAME | File::FNM_EXTGLOB
 
@@ -28,11 +25,9 @@ module Rigor
         end
 
         # Per-`ClassNode` check over the engine-owned walk (ADR-37):
-        # called once per class node the `node_rule` in `web.rb`
-        # dispatches, checking it against every contract whose
-        # `path_glob` matches the file. No cross-class-node state is
-        # needed, so the checker ships no `class_nodes` traversal of its
-        # own.
+        # called once per class node the `node_rule` in `web.rb` dispatches, checking it against every contract whose
+        # `path_glob` matches the file. No cross-class-node state is needed, so the checker ships no `class_nodes`
+        # traversal of its own.
         def check_class(class_node, path:, scope:)
           @contracts.flat_map do |contract|
             next [] unless path_matches?(contract.path_glob, path)
@@ -43,9 +38,8 @@ module Rigor
 
         private
 
-        # Contract globs are authored project-root-relative; the
-        # analyzer may pass a relative or an absolute path, so the
-        # glob is matched directly and as a `**/`-prefixed suffix.
+        # Contract globs are authored project-root-relative; the analyzer may pass a relative or an absolute path, so
+        # the glob is matched directly and as a `**/`-prefixed suffix.
         def path_matches?(glob, path)
           return false if path.nil?
 
@@ -62,8 +56,7 @@ module Rigor
           end
         end
 
-        # The contracted method, defined directly in `class_node`'s
-        # body (not in a nested class / module).
+        # The contracted method, defined directly in `class_node`'s body (not in a nested class / module).
         def target_def(class_node, contract)
           direct_defs(class_node).find do |def_node|
             def_node.name == contract.method_name &&
@@ -104,12 +97,9 @@ module Rigor
           )
         end
 
-        # Compares the inferred return type of the contracted method
-        # against the contract's declared return type. Stays silent
-        # when the protocol's RBS is not loaded (return type
-        # unresolvable) or when inference cannot pin the body type
-        # down (`Dynamic[Top]`) — the plugin defers to runtime
-        # rather than frighten code that may be correct.
+        # Compares the inferred return type of the contracted method against the contract's declared return type. Stays
+        # silent when the protocol's RBS is not loaded (return type unresolvable) or when inference cannot pin the body
+        # type down (`Dynamic[Top]`) — the plugin defers to runtime rather than frighten code that may be correct.
         def return_type_diagnostic(contract, path, scope, def_node)
           return nil if contract.return_type_name.nil?
 
@@ -134,8 +124,7 @@ module Rigor
           )
         end
 
-        # Re-binds the contract's parameter types onto the query
-        # scope so `type_of` analyses the body with the same
+        # Re-binds the contract's parameter types onto the query scope so `type_of` analyses the body with the same
         # parameter knowledge the engine's binder used.
         def bind_contract_params(contract, scope, def_node)
           contract.param_types.reduce(scope) do |acc, param_type|

--- a/plugins/rigor-actioncable/demo/app/channels/chat_channel.rb
+++ b/plugins/rigor-actioncable/demo/app/channels/chat_channel.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 
-# Sample ActionCable channel — rigor-actioncable
-# discovers this class because its direct superclass is
-# `ApplicationCable::Channel` (one of the configured
-# `channel_base_classes`).
+# Sample ActionCable channel — rigor-actioncable discovers this class because its direct superclass is
+# `ApplicationCable::Channel` (one of the configured `channel_base_classes`).
 
 module ApplicationCable
   class Channel
-    # Stand-in base class so this file parses standalone.
-    # rigor-actioncable doesn't care whether the base class
-    # is declared here or anywhere else — it only matches
-    # by name against `channel_base_classes`.
+    # Stand-in base class so this file parses standalone. rigor-actioncable doesn't care whether the
+    # base class is declared here or anywhere else — it only matches by name against
+    # `channel_base_classes`.
     def self.broadcast_to(*); end
 
     def stream_from(_name); end

--- a/plugins/rigor-actioncable/demo/demo.rb
+++ b/plugins/rigor-actioncable/demo/demo.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
-# Demo: rigor-actioncable recognises every
-# `<Channel>.broadcast_to(...)` and
-# `ActionCable.server.broadcast(stream_name, ...)` call
-# and validates against the discovered channel index.
-# Run with `bundle exec rigor check` from this directory.
+# Demo: rigor-actioncable recognises every `<Channel>.broadcast_to(...)` and
+# `ActionCable.server.broadcast(stream_name, ...)` call and validates against the discovered channel
+# index. Run with `bundle exec rigor check` from this directory.
 
-# Stand-in `ActionCable.server.broadcast` so this file
-# parses standalone.
+# Stand-in `ActionCable.server.broadcast` so this file parses standalone.
 module ActionCable
   def self.server
     @server ||= Server.new
@@ -18,13 +15,10 @@ module ActionCable
   end
 end
 
-# `ChatChannel.broadcast_to(record, data)` —
-# class-targeted broadcast. The plugin checks that
+# `ChatChannel.broadcast_to(record, data)` — class-targeted broadcast. The plugin checks that
 # `ChatChannel` is in the discovered index.
 ChatChannel.broadcast_to(:my_room, message: "Welcome!")
 
-# `ActionCable.server.broadcast("chat_room_5", data)` —
-# stream-name-targeted broadcast. The plugin checks that
-# `chat_room_5` was registered via `stream_from` in some
-# discovered channel.
+# `ActionCable.server.broadcast("chat_room_5", data)` — stream-name-targeted broadcast. The plugin
+# checks that `chat_room_5` was registered via `stream_from` in some discovered channel.
 ActionCable.server.broadcast("chat_room_5", message: "Welcome!")

--- a/plugins/rigor-actioncable/demo/errors_demo.rb
+++ b/plugins/rigor-actioncable/demo/errors_demo.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# DO NOT run via `ruby errors_demo.rb` — analyse with
-# `bundle exec rigor check` to see rigor-actioncable's
-# diagnostics.
+# DO NOT run via `ruby errors_demo.rb` — analyse with `bundle exec rigor check` to see
+# rigor-actioncable's diagnostics.
 
 module ActionCable
   def self.server

--- a/plugins/rigor-actioncable/lib/rigor/plugin/actioncable.rb
+++ b/plugins/rigor-actioncable/lib/rigor/plugin/actioncable.rb
@@ -8,14 +8,11 @@ require_relative "actioncable/analyzer"
 
 module Rigor
   module Plugin
-    # rigor-actioncable — validates ActionCable
-    # `<Channel>.broadcast_to(...)` and
-    # `ActionCable.server.broadcast(stream_name, ...)`
-    # call sites against the discovered channel index.
+    # rigor-actioncable — validates ActionCable `<Channel>.broadcast_to(...)` and
+    # `ActionCable.server.broadcast(stream_name, ...)` call sites against the discovered channel index.
     #
     # Tier 3F of the [Rails plugins roadmap](../../../../docs/design/20260508-rails-plugins-roadmap.md).
-    # Statically discovers channel classes by walking
-    # `channel_search_paths` and parsing each file with
+    # Statically discovers channel classes by walking `channel_search_paths` and parsing each file with
     # Prism — no `actioncable` runtime dependency.
     #
     # ## Configuration
@@ -28,33 +25,22 @@ module Rigor
     #
     # ## What it checks
     #
-    # 1. **Channel class existence** — `<X>.broadcast_to(...)`
-    #    where `X` ends in `Channel` must resolve to a
-    #    discovered channel.
-    # 2. **Stream-name registration** —
-    #    `ActionCable.server.broadcast("stream_name", ...)`
-    #    with a literal stream name is checked against
-    #    every discovered channel's `stream_from "..."`
-    #    registrations. The check is suppressed when ANY
-    #    discovered channel uses a dynamic registration
-    #    (`stream_from interpolated_string` or
-    #    `stream_for record`) — the absence of a literal
-    #    match doesn't prove absence.
+    # 1. **Channel class existence** — `<X>.broadcast_to(...)` where `X` ends in `Channel` must resolve
+    #    to a discovered channel.
+    # 2. **Stream-name registration** — `ActionCable.server.broadcast("stream_name", ...)` with a
+    #    literal stream name is checked against every discovered channel's `stream_from "..."`
+    #    registrations. The check is suppressed when ANY discovered channel uses a dynamic registration
+    #    (`stream_from interpolated_string` or `stream_for record`) — the absence of a literal match
+    #    doesn't prove absence.
     #
     # ## Limitations
     #
-    # - **Direct-superclass match only.** Indirect
-    #   inheritance (`AdminChannel < BaseChannel <
-    #   ApplicationCable::Channel`) needs `BaseChannel`
-    #   listed in `channel_base_classes`.
-    # - **Action method invocations are not validated.**
-    #   ActionCable actions are invoked from JS via
-    #   `subscription.perform("action_name", data)`; we
-    #   don't analyse JS so the action-method index is
-    #   informational only (deferred: cross-plugin handoff
-    #   to a JS-side analyzer).
-    # - **`broadcast_to` arity isn't checked.** The method
-    #   takes any record + any data hash; there's no
+    # - **Direct-superclass match only.** Indirect inheritance (`AdminChannel < BaseChannel <
+    #   ApplicationCable::Channel`) needs `BaseChannel` listed in `channel_base_classes`.
+    # - **Action method invocations are not validated.** ActionCable actions are invoked from JS via
+    #   `subscription.perform("action_name", data)`; we don't analyse JS so the action-method index is
+    #   informational only (deferred: cross-plugin handoff to a JS-side analyzer).
+    # - **`broadcast_to` arity isn't checked.** The method takes any record + any data hash; there's no
     #   useful arity envelope.
     class Actioncable < Rigor::Plugin::Base
       manifest(
@@ -70,11 +56,9 @@ module Rigor
         }
       )
 
-      # `watch:` covers every `.rb` file under the channel search paths
-      # so the cache invalidates when channels are added, removed, or
-      # edited (ADR-60 WD3). The dependency descriptor is recorded after
-      # the discoverer runs, so the `io_boundary` reads inside it are
-      # captured too.
+      # `watch:` covers every `.rb` file under the channel search paths so the cache invalidates when
+      # channels are added, removed, or edited (ADR-60 WD3). The dependency descriptor is recorded after
+      # the discoverer runs, so the `io_boundary` reads inside it are captured too.
       producer :channel_index, watch: -> { [[@channel_search_paths, "**/*.rb"]] } do |_params|
         ChannelDiscoverer.new(
           io_boundary: io_boundary,
@@ -88,10 +72,9 @@ module Rigor
         @channel_base_classes = Array(config.fetch("channel_base_classes")).map(&:to_s)
       end
 
-      # File-level only: the load-error emission. Per-call broadcast
-      # validation runs over the engine-owned walk via the node_rule
-      # below (ADR-37). The channel index is lazily loaded + memoised by
-      # `producer_value`, shared by both surfaces.
+      # File-level only: the load-error emission. Per-call broadcast validation runs over the
+      # engine-owned walk via the node_rule below (ADR-37). The channel index is lazily loaded +
+      # memoised by `producer_value`, shared by both surfaces.
       def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
         index = producer_value(:channel_index)
         return [load_error_diagnostic(path)] if index.nil? && producer_error(:channel_index)

--- a/plugins/rigor-actioncable/lib/rigor/plugin/actioncable/analyzer.rb
+++ b/plugins/rigor-actioncable/lib/rigor/plugin/actioncable/analyzer.rb
@@ -6,43 +6,34 @@ require "prism"
 module Rigor
   module Plugin
     class Actioncable < Rigor::Plugin::Base
-      # Walks a parsed file's AST looking for ActionCable
-      # entry-point calls and validates each against the
-      # {ChannelIndex}.
+      # Walks a parsed file's AST looking for ActionCable entry-point calls and validates each against
+      # the {ChannelIndex}.
       #
       # Recognised shapes:
       #
-      # - `<ChannelClass>.broadcast_to(record, data)` —
-      #   class-targeted broadcast. The class must exist in
-      #   the index.
-      # - `ActionCable.server.broadcast(stream_name, data)`
-      #   — string-targeted broadcast. When `stream_name`
-      #   is a literal string and the index has at least
-      #   one channel with no dynamic stream registrations,
-      #   we check that the name appears in
-      #   `index.all_stream_names`. Otherwise the
-      #   `unknown-stream` warning is suppressed (we can't
-      #   prove absence).
+      # - `<ChannelClass>.broadcast_to(record, data)` — class-targeted broadcast. The class must exist
+      #   in the index.
+      # - `ActionCable.server.broadcast(stream_name, data)` — string-targeted broadcast. When
+      #   `stream_name` is a literal string and the index has at least one channel with no dynamic
+      #   stream registrations, we check that the name appears in `index.all_stream_names`. Otherwise
+      #   the `unknown-stream` warning is suppressed (we can't prove absence).
       module Analyzer
-        # `ActionCable.server.broadcast(...)` — the receiver
-        # path we recognise as a server-targeted broadcast.
-        # Single-symbol form (just `broadcast`) is too
-        # ambiguous to validate.
+        # `ActionCable.server.broadcast(...)` — the receiver path we recognise as a server-targeted
+        # broadcast. Single-symbol form (just `broadcast`) is too ambiguous to validate.
         SERVER_BROADCAST_RECEIVER_NAMES = %w[
           ActionCable.server
           ::ActionCable.server
         ].freeze
 
-        # One broadcast observation. Carries no path/location — the
-        # caller (the `node_rule` block) positions it via
-        # `Plugin::Base#diagnostic`.
+        # One broadcast observation. Carries no path/location — the caller (the `node_rule` block)
+        # positions it via `Plugin::Base#diagnostic`.
         Violation = Struct.new(:rule, :severity, :message, keyword_init: true)
 
         module_function
 
-        # The broadcast violations for a single call node, or `[]` when
-        # the node is not a `broadcast_to` / `ActionCable.server.broadcast`
-        # call this plugin recognises. ADR-37: the engine owns the walk.
+        # The broadcast violations for a single call node, or `[]` when the node is not a
+        # `broadcast_to` / `ActionCable.server.broadcast` call this plugin recognises. ADR-37: the
+        # engine owns the walk.
         #
         # @param call_node [Prism::Node]
         # @param channel_index [ChannelIndex]
@@ -61,10 +52,8 @@ module Rigor
           class_name = constant_receiver_name(call_node.receiver)
           return [] if class_name.nil?
 
-          # broadcast_to with a class-name receiver that
-          # doesn't end in "Channel" is almost certainly
-          # not ActionCable — pass through silently to
-          # avoid flagging unrelated `broadcast_to` methods.
+          # broadcast_to with a class-name receiver that doesn't end in "Channel" is almost certainly
+          # not ActionCable — pass through silently to avoid flagging unrelated `broadcast_to` methods.
           return [] unless class_name.end_with?("Channel")
 
           entry = channel_index.find(class_name) || channel_index.find("::#{class_name}")
@@ -127,8 +116,7 @@ module Rigor
           )
         end
 
-        # Renders an `A.b.c` chain as a string (used to
-        # detect `ActionCable.server`). Returns nil for
+        # Renders an `A.b.c` chain as a string (used to detect `ActionCable.server`). Returns nil for
         # non-chained nodes.
         def call_chain_string(node)
           parts = []

--- a/plugins/rigor-actioncable/lib/rigor/plugin/actioncable/channel_discoverer.rb
+++ b/plugins/rigor-actioncable/lib/rigor/plugin/actioncable/channel_discoverer.rb
@@ -7,36 +7,27 @@ require_relative "channel_index"
 module Rigor
   module Plugin
     class Actioncable < Rigor::Plugin::Base
-      # Walks the configured channel-search paths via the
-      # plugin's `IoBoundary`, parses each `.rb` file with
-      # Prism, and collects classes whose immediate
-      # superclass is one of the configured base classes.
+      # Walks the configured channel-search paths via the plugin's `IoBoundary`, parses each `.rb` file
+      # with Prism, and collects classes whose immediate superclass is one of the configured base
+      # classes.
       #
       # For each discovered channel, the discoverer:
       #
-      # - Records every public instance-side `def` whose
-      #   name isn't an ActionCable framework hook
-      #   (`subscribed`, `unsubscribed`, `_`-prefixed).
-      #   These are the action methods clients can invoke
+      # - Records every public instance-side `def` whose name isn't an ActionCable framework hook
+      #   (`subscribed`, `unsubscribed`, `_`-prefixed). These are the action methods clients can invoke
       #   via `subscription.perform("action_name", data)`.
-      # - Records every literal-string `stream_from "name"`
-      #   call as a registered stream name.
-      # - Sets `dynamic_streams: true` when the channel has
-      #   ANY non-literal `stream_from` argument (or a
-      #   `stream_for` call) so the analyzer knows it can't
-      #   be sure of every stream name.
+      # - Records every literal-string `stream_from "name"` call as a registered stream name.
+      # - Sets `dynamic_streams: true` when the channel has ANY non-literal `stream_from` argument (or a
+      #   `stream_for` call) so the analyzer knows it can't be sure of every stream name.
       #
       # Intentional limitations:
       #
       # - Direct-superclass match only.
-      # - Public-vs-private is not tracked; the framework
-      #   hooks (`subscribed`/`unsubscribed`) are excluded
-      #   by name. Methods marked `private` after a
-      #   `private` keyword would still appear in the
+      # - Public-vs-private is not tracked; the framework hooks (`subscribed`/`unsubscribed`) are
+      #   excluded by name. Methods marked `private` after a `private` keyword would still appear in the
       #   `action_methods` set.
-      # - `stream_for(record)` (model-scoped streams) is
-      #   recognised as setting `dynamic_streams: true` but
-      #   not introspected further.
+      # - `stream_for(record)` (model-scoped streams) is recognised as setting `dynamic_streams: true`
+      #   but not introspected further.
       class ChannelDiscoverer
         FRAMEWORK_HOOKS = %i[subscribed unsubscribed].to_set.freeze
 
@@ -126,12 +117,9 @@ module Rigor
           )
         end
 
-        # Walks the channel body recursively (so
-        # `stream_from` / `stream_for` calls inside
-        # `subscribed` / helper methods are picked up).
-        # Returns `[Array<String>, bool]` — the literal
-        # stream names + whether any dynamic registration
-        # was seen.
+        # Walks the channel body recursively (so `stream_from` / `stream_for` calls inside `subscribed`
+        # / helper methods are picked up). Returns `[Array<String>, bool]` — the literal stream names +
+        # whether any dynamic registration was seen.
         def collect_stream_registrations(node, names: [], dynamic: false)
           return [names, dynamic] if node.nil?
 
@@ -145,8 +133,7 @@ module Rigor
                 dynamic = true
               end
             when :stream_for
-              # Model-scoped stream — name is computed from
-              # the record at runtime; treat as dynamic.
+              # Model-scoped stream — name is computed from the record at runtime; treat as dynamic.
               dynamic = true
             end
           end

--- a/plugins/rigor-actioncable/lib/rigor/plugin/actioncable/channel_index.rb
+++ b/plugins/rigor-actioncable/lib/rigor/plugin/actioncable/channel_index.rb
@@ -3,23 +3,16 @@
 module Rigor
   module Plugin
     class Actioncable < Rigor::Plugin::Base
-      # Frozen catalogue of discovered ActionCable channel
-      # classes keyed by qualified class name. Each entry
-      # holds:
+      # Frozen catalogue of discovered ActionCable channel classes keyed by qualified class name. Each
+      # entry holds:
       #
-      # - `action_methods` — the set of public instance
-      #   methods that aren't ActionCable framework hooks
-      #   (`subscribed` / `unsubscribed`). These are the
-      #   methods clients invoke via
+      # - `action_methods` — the set of public instance methods that aren't ActionCable framework hooks
+      #   (`subscribed` / `unsubscribed`). These are the methods clients invoke via
       #   `subscription.perform("action_name", data)`.
-      # - `stream_names` — the set of literal-string stream
-      #   names registered via `stream_from "name"` calls
-      #   inside the channel body. Dynamic registrations
-      #   (`stream_from interpolated_string`) are recorded
-      #   separately as `dynamic_streams: true` so the
-      #   analyzer can suppress unknown-stream warnings on
-      #   any channel that has at least one dynamic
-      #   registration.
+      # - `stream_names` — the set of literal-string stream names registered via `stream_from "name"`
+      #   calls inside the channel body. Dynamic registrations (`stream_from interpolated_string`) are
+      #   recorded separately as `dynamic_streams: true` so the analyzer can suppress unknown-stream
+      #   warnings on any channel that has at least one dynamic registration.
       class ChannelIndex
         Entry = Data.define(:class_name, :file_path, :action_methods, :stream_names, :dynamic_streams) do
           def includes_action?(name)
@@ -60,18 +53,14 @@ module Rigor
           @by_name.keys
         end
 
-        # All literal stream names registered across every
-        # discovered channel.
+        # All literal stream names registered across every discovered channel.
         def all_stream_names
           @entries.flat_map { |e| e.stream_names.to_a }.to_set
         end
 
-        # True when at least one discovered channel uses a
-        # dynamic stream registration. The analyzer treats
-        # this as "we can't be sure any literal name is
-        # missing" and skips the `unknown-stream` warning
-        # entirely — absence of a literal match doesn't prove
-        # the name is wrong.
+        # True when at least one discovered channel uses a dynamic stream registration. The analyzer
+        # treats this as "we can't be sure any literal name is missing" and skips the `unknown-stream`
+        # warning entirely — absence of a literal match doesn't prove the name is wrong.
         def any_dynamic_streams?
           @entries.any?(&:dynamic_streams)
         end

--- a/plugins/rigor-actionmailer/demo/app/mailers/user_mailer.rb
+++ b/plugins/rigor-actionmailer/demo/app/mailers/user_mailer.rb
@@ -1,18 +1,14 @@
 # frozen_string_literal: true
 
-# Sample mailer — rigor-actionmailer discovers this class
-# because its direct superclass is `ApplicationMailer` (one
-# of the default `mailer_base_classes`). The discoverer
-# reads each instance-side `def`'s parameter list to
-# compute arity, and checks for matching view templates
-# under `app/views/user_mailer/`.
+# Sample mailer — rigor-actionmailer discovers this class because its direct superclass is
+# `ApplicationMailer` (one of the default `mailer_base_classes`). The discoverer reads each
+# instance-side `def`'s parameter list to compute arity, and checks for matching view templates under
+# `app/views/user_mailer/`.
 
 class ApplicationMailer
-  # Stand-in base class so `ruby app/mailers/user_mailer.rb`
-  # parses standalone (without ActionMailer loaded).
-  # rigor-actionmailer doesn't care whether the class is
-  # declared here or anywhere else — it only matches by
-  # name against `mailer_base_classes`.
+  # Stand-in base class so `ruby app/mailers/user_mailer.rb` parses standalone (without ActionMailer
+  # loaded). rigor-actionmailer doesn't care whether the class is declared here or anywhere else — it
+  # only matches by name against `mailer_base_classes`.
   def self.with(*)
     self
   end

--- a/plugins/rigor-actionmailer/demo/demo.rb
+++ b/plugins/rigor-actionmailer/demo/demo.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-# Demo: rigor-actionmailer recognises every
-# `Mailer.action(args).deliver_*` call and validates arity
-# against the discovered action methods. Run with `bundle
-# exec rigor check` from this directory.
+# Demo: rigor-actionmailer recognises every `Mailer.action(args).deliver_*` call and validates arity
+# against the discovered action methods. Run with `bundle exec rigor check` from this directory.
 
 # `UserMailer#welcome(user, locale = "en")` → arity 1..2.
 UserMailer.welcome(:alice).deliver_now

--- a/plugins/rigor-actionmailer/demo/errors_demo.rb
+++ b/plugins/rigor-actionmailer/demo/errors_demo.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-# DO NOT run via `ruby errors_demo.rb` — analyse with
-# `bundle exec rigor check` to see rigor-actionmailer's
-# diagnostics.
+# DO NOT run via `ruby errors_demo.rb` — analyse with `bundle exec rigor check` to see
+# rigor-actionmailer's diagnostics.
 
-# `UserMailer#welcome(user, locale = "en")` → arity 1..2.
-# These call sites are wrong:
+# `UserMailer#welcome(user, locale = "en")` → arity 1..2. These call sites are wrong:
 
 # Missing required user:
 #   plugin.actionmailer.wrong-arity
@@ -19,8 +17,6 @@ UserMailer.welcome(:alice, "ja", :extra).deliver_later
 #   plugin.actionmailer.unknown-action
 UserMailer.does_not_exist(:alice).deliver_now
 
-# NOTE: `UserMailer#digest` has no view template under
-# `app/views/user_mailer/digest.{html,text}.erb`, so the
-# plugin emits a `plugin.actionmailer.missing-view`
-# diagnostic anchored on the action's `def` line in
-# `app/mailers/user_mailer.rb`.
+# NOTE: `UserMailer#digest` has no view template under `app/views/user_mailer/digest.{html,text}.erb`,
+# so the plugin emits a `plugin.actionmailer.missing-view` diagnostic anchored on the action's `def`
+# line in `app/mailers/user_mailer.rb`.

--- a/plugins/rigor-actionmailer/lib/rigor/plugin/actionmailer.rb
+++ b/plugins/rigor-actionmailer/lib/rigor/plugin/actionmailer.rb
@@ -8,12 +8,10 @@ require_relative "actionmailer/analyzer"
 
 module Rigor
   module Plugin
-    # rigor-actionmailer — validates `Mailer.action(args)`
-    # call sites and detects missing view templates.
+    # rigor-actionmailer — validates `Mailer.action(args)` call sites and detects missing view templates.
     #
     # Tier 1C of the [Rails plugins roadmap](../../../../docs/design/20260508-rails-plugins-roadmap.md).
-    # Statically discovers mailer classes by walking
-    # `mailer_search_paths` and parsing each file with
+    # Statically discovers mailer classes by walking `mailer_search_paths` and parsing each file with
     # Prism — no `action_mailer` runtime dependency.
     #
     # ## Configuration
@@ -27,35 +25,27 @@ module Rigor
     #
     # ## What it checks
     #
-    # 1. **Method existence** — `UserMailer.welcome(user)`
-    #    is flagged when `welcome` is not defined on
+    # 1. **Method existence** — `UserMailer.welcome(user)` is flagged when `welcome` is not defined on
     #    `UserMailer`.
-    # 2. **Argument arity** — calls with too few / too many
-    #    positional arguments emit `wrong-arity`.
-    # 3. **View template existence** — for every action
-    #    method, at least one of
-    #    `app/views/<mailer_underscore>/<action>.{html,text}.{erb,haml,slim}`
-    #    must exist. Missing actions get a `missing-view`
-    #    diagnostic anchored on the action's `def`.
+    # 2. **Argument arity** — calls with too few / too many positional arguments emit `wrong-arity`.
+    # 3. **View template existence** — for every action method, at least one of
+    #    `app/views/<mailer_underscore>/<action>.{html,text}.{erb,haml,slim}` must exist. Missing
+    #    actions get a `missing-view` diagnostic anchored on the action's `def`.
     #
     # ## Limitations (v0.1.0)
     #
     # - Direct-superclass match only.
-    # - Action methods are read from the syntactic instance-
-    #   side `def` list. `define_method` actions are out of
-    #   scope.
-    # - Adding a brand-new view file does not invalidate the
-    #   cache until something the mailer file touches
-    #   changes.
+    # - Action methods are read from the syntactic instance-side `def` list. `define_method` actions are
+    #   out of scope.
+    # - Adding a brand-new view file does not invalidate the cache until something the mailer file
+    #   touches changes.
     class Actionmailer < Rigor::Plugin::Base
       manifest(
         id: "actionmailer",
-        # Bumped 2026-05-28 — extended RESERVED_CLASS_METHODS to
-        # include `respond_to?` / `public_send` / `send` /
-        # `__send__` / `method` and friends so dynamic-dispatch
-        # idioms (`Mailer.respond_to?(action)` /
-        # `Mailer.public_send(action)`) stop firing
-        # `unknown-action` against the Ruby reflection method.
+        # Bumped 2026-05-28 — extended RESERVED_CLASS_METHODS to include `respond_to?` / `public_send` /
+        # `send` / `__send__` / `method` and friends so dynamic-dispatch idioms
+        # (`Mailer.respond_to?(action)` / `Mailer.public_send(action)`) stop firing `unknown-action`
+        # against the Ruby reflection method.
         version: "0.4.0",
         description: "Validates ActionMailer call shape and view template existence.",
         config_schema: {
@@ -65,11 +55,10 @@ module Rigor
         }
       )
 
-      # `watch:` covers every mailer class under `mailer_search_paths`
-      # AND every view template under `views_root` (ADR-60 WD3) — a
-      # newly-added view a mailer references must invalidate the index,
-      # and `view_exists?` failures the producer never records would
-      # otherwise be invisible to the dependency descriptor.
+      # `watch:` covers every mailer class under `mailer_search_paths` AND every view template under
+      # `views_root` (ADR-60 WD3) — a newly-added view a mailer references must invalidate the index,
+      # and `view_exists?` failures the producer never records would otherwise be invisible to the
+      # dependency descriptor.
       producer :mailer_index,
                watch: -> { [[@mailer_search_paths, "**/*.rb"], [@views_root, "**/*"]] } do |_params|
         MailerDiscoverer.new(
@@ -86,11 +75,10 @@ module Rigor
         @views_root = config.fetch("views_root").to_s
       end
 
-      # File-level: load-error + the missing-view check (anchored on the
-      # mailer's own source file, so it is genuinely per-file, not
-      # per-call). The per-call mailer validation (action existence /
-      # arity) runs over the engine-owned walk via the node_rule below
-      # (ADR-37). The mailer index is lazily loaded + memoised, shared.
+      # File-level: load-error + the missing-view check (anchored on the mailer's own source file, so it
+      # is genuinely per-file, not per-call). The per-call mailer validation (action existence / arity)
+      # runs over the engine-owned walk via the node_rule below (ADR-37). The mailer index is lazily
+      # loaded + memoised, shared.
       def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
         index = producer_value(:mailer_index)
         return [load_error_diagnostic(path)] if index.nil? && producer_error(:mailer_index)
@@ -108,10 +96,9 @@ module Rigor
 
       private
 
-      # Anchors `missing-view` diagnostics on the mailer file
-      # itself: when the file currently being analysed is the
-      # mailer's source file, emit one diagnostic per missing
-      # action template at the action's `def` location.
+      # Anchors `missing-view` diagnostics on the mailer file itself: when the file currently being
+      # analysed is the mailer's source file, emit one diagnostic per missing action template at the
+      # action's `def` location.
       def missing_view_diagnostics(path, index)
         canonical = canonical_path(path)
         class_entry = index.find_by_file(canonical)

--- a/plugins/rigor-actionmailer/lib/rigor/plugin/actionmailer/analyzer.rb
+++ b/plugins/rigor-actionmailer/lib/rigor/plugin/actionmailer/analyzer.rb
@@ -5,36 +5,25 @@ require "prism"
 module Rigor
   module Plugin
     class Actionmailer < Rigor::Plugin::Base
-      # Walks a parsed file's AST looking for
-      # `<MailerClass>.<action>(...)` calls and validates
-      # each against the {MailerIndex}. Recognises both:
+      # Walks a parsed file's AST looking for `<MailerClass>.<action>(...)` calls and validates each
+      # against the {MailerIndex}. Recognises both:
       #
-      # - `UserMailer.welcome(user)` — direct action call
-      #   (the call returns a `Mail::Message` ready for
+      # - `UserMailer.welcome(user)` — direct action call (the call returns a `Mail::Message` ready for
       #   `.deliver_now` / `.deliver_later`).
-      # - `UserMailer.with(user: u).welcome` — parametrized
-      #   action call. The `.with(...)` call is treated as a
-      #   pass-through; the action's argument shape is
-      #   validated on the trailing `.welcome` invocation
-      #   even though the receiver is a method-call chain
-      #   rather than a constant.
+      # - `UserMailer.with(user: u).welcome` — parametrized action call. The `.with(...)` call is
+      #   treated as a pass-through; the action's argument shape is validated on the trailing `.welcome`
+      #   invocation even though the receiver is a method-call chain rather than a constant.
       #
-      # The analyzer is purely syntactic: it does not look
-      # at runtime mailer state. Constants that don't appear
-      # in the index are silently ignored — the rule has no
-      # opinion on non-mailer call shapes.
+      # The analyzer is purely syntactic: it does not look at runtime mailer state. Constants that don't
+      # appear in the index are silently ignored — the rule has no opinion on non-mailer call shapes.
       module Analyzer
-        # `.with(...)` is recognised as a forwarding step:
-        # the receiver of `.with(...)` is the mailer class,
-        # so the trailing action-method call's class context
-        # is the same.
+        # `.with(...)` is recognised as a forwarding step: the receiver of `.with(...)` is the mailer
+        # class, so the trailing action-method call's class context is the same.
         WITH_METHODS = %i[with].freeze
 
-        # Ruby method names that ActionMailer reserves on the
-        # class itself. We don't validate against these as
-        # actions even if a mailer happens to override them
-        # — the user almost certainly meant the framework
-        # method, not their own action.
+        # Ruby method names that ActionMailer reserves on the class itself. We don't validate against
+        # these as actions even if a mailer happens to override them — the user almost certainly meant
+        # the framework method, not their own action.
         RESERVED_CLASS_METHODS = %i[
           new allocate name superclass class
           deliver_later deliver_now deliver_later! deliver_now!
@@ -45,16 +34,14 @@ module Rigor
           method instance_method methods
         ].freeze
 
-        # One mailer-call observation. Carries no path/location — the
-        # caller (the `node_rule` block) positions it via
-        # `Plugin::Base#diagnostic`.
+        # One mailer-call observation. Carries no path/location — the caller (the `node_rule` block)
+        # positions it via `Plugin::Base#diagnostic`.
         Violation = Struct.new(:rule, :severity, :message, keyword_init: true)
 
         module_function
 
-        # The mailer-call violations for a single call node (0..2), or
-        # `[]` when it is not a `<Mailer>.action(...)` call on a known
-        # mailer. ADR-37: the engine owns the walk.
+        # The mailer-call violations for a single call node (0..2), or `[]` when it is not a
+        # `<Mailer>.action(...)` call on a known mailer. ADR-37: the engine owns the walk.
         #
         # @param call_node [Prism::Node]
         # @param mailer_index [MailerIndex]
@@ -71,9 +58,8 @@ module Rigor
 
           action_entry = class_entry.find_action(call_node.name)
           if action_entry.nil?
-            # Skip `unknown-action` when the mailer's include set has any
-            # unresolved module — it may legitimately define the action
-            # (gem-shipped concern, dynamically loaded extension).
+            # Skip `unknown-action` when the mailer's include set has any unresolved module — it may
+            # legitimately define the action (gem-shipped concern, dynamically loaded extension).
             return [] if class_entry.unresolved_includes?
 
             return [unknown_action_violation(call_node, class_entry)]
@@ -86,19 +72,16 @@ module Rigor
         end
 
         def action_call_candidate?(node)
-          # Skip anything that doesn't look like a mailer
-          # action call: no receiver, or a non-constant /
+          # Skip anything that doesn't look like a mailer action call: no receiver, or a non-constant /
           # non-`.with(...)` receiver.
           return false if node.receiver.nil?
 
           mailer_class_for_call(node) ? true : false
         end
 
-        # Extracts the mailer class name when the call's
-        # receiver is either:
+        # Extracts the mailer class name when the call's receiver is either:
         # - A constant (`UserMailer.welcome(...)`), or
-        # - A `.with(...)` call whose receiver is a constant
-        #   (`UserMailer.with(user: u).welcome`).
+        # - A `.with(...)` call whose receiver is a constant (`UserMailer.with(user: u).welcome`).
         def mailer_class_for_call(node)
           receiver = node.receiver
           case receiver
@@ -125,13 +108,10 @@ module Rigor
           actual = args.size
           return nil if action_entry.accepts?(actual)
 
-          # Trailing keyword-hash relaxation. `Notify.foo(uid,
-          # gid, success_count: 5)` is 3 positional args from
-          # Prism's perspective (2 + a KeywordHashNode); the
-          # action's `def foo(uid, gid, success_count:)` has
-          # arity 2. When the call's trailing arg is a kwargs
-          # hash, allow `(actual - 1) ≤ max_arity` so kwargs-
-          # carrying calls don't surface as wrong-arity.
+          # Trailing keyword-hash relaxation. `Notify.foo(uid, gid, success_count: 5)` is 3 positional
+          # args from Prism's perspective (2 + a KeywordHashNode); the action's `def foo(uid, gid,
+          # success_count:)` has arity 2. When the call's trailing arg is a kwargs hash, allow `(actual
+          # - 1) ≤ max_arity` so kwargs-carrying calls don't surface as wrong-arity.
           return nil if args.last.is_a?(Prism::KeywordHashNode) && action_entry.accepts?(actual - 1)
 
           Violation.new(

--- a/plugins/rigor-actionmailer/lib/rigor/plugin/actionmailer/mailer_discoverer.rb
+++ b/plugins/rigor-actionmailer/lib/rigor/plugin/actionmailer/mailer_discoverer.rb
@@ -8,54 +8,38 @@ require_relative "mailer_index"
 module Rigor
   module Plugin
     class Actionmailer < Rigor::Plugin::Base
-      # Walks the configured mailer-search paths via the
-      # plugin's `IoBoundary`, parses each `.rb` file with
-      # Prism, and collects classes whose immediate superclass
-      # is one of the configured base classes.
+      # Walks the configured mailer-search paths via the plugin's `IoBoundary`, parses each `.rb` file
+      # with Prism, and collects classes whose immediate superclass is one of the configured base
+      # classes.
       #
       # For each discovered class, the discoverer:
       #
-      # - Reads the instance-side `def` nodes and records each
-      #   one as an action method, capturing the arity envelope.
-      # - For each (class, action) pair, attempts to read every
-      #   candidate view template under
-      #   `app/views/<mailer_underscore>/<action>.{html,text}.erb`.
-      #   Existing templates feed the IoBoundary's cache
-      #   descriptor (so the cache invalidates when the
-      #   template changes); missing templates are recorded so
-      #   the plugin can surface a diagnostic on the mailer
-      #   class definition.
+      # - Reads the instance-side `def` nodes and records each one as an action method, capturing the
+      #   arity envelope.
+      # - For each (class, action) pair, attempts to read every candidate view template under
+      #   `app/views/<mailer_underscore>/<action>.{html,text}.erb`. Existing templates feed the
+      #   IoBoundary's cache descriptor (so the cache invalidates when the template changes); missing
+      #   templates are recorded so the plugin can surface a diagnostic on the mailer class definition.
       #
       # Limitations (intentional for v0.1.0):
       #
-      # - Direct-superclass match only. `class CustomerMailer
-      #   < BaseMailer` where `BaseMailer < ApplicationMailer`
-      #   is NOT discovered. Add `BaseMailer` to
-      #   `mailer_base_classes` if needed.
-      # - Action methods are read from the syntactic instance-
-      #   side `def` list. Methods built via `define_method`,
-      #   `private`, or non-action helpers (e.g. methods
-      #   starting with `_`) are out of scope. The discoverer
-      #   filters obvious non-actions (`initialize`, names
-      #   prefixed with `_`).
-      # - Adding a brand-new view file under
-      #   `app/views/<mailer>/` will NOT invalidate the
-      #   cached index until something the mailer file
-      #   touches changes. This is the standard read-tracking
-      #   trade-off — only files we successfully read get
-      #   digested into the descriptor.
+      # - Direct-superclass match only. `class CustomerMailer < BaseMailer` where `BaseMailer <
+      #   ApplicationMailer` is NOT discovered. Add `BaseMailer` to `mailer_base_classes` if needed.
+      # - Action methods are read from the syntactic instance-side `def` list. Methods built via
+      #   `define_method`, `private`, or non-action helpers (e.g. methods starting with `_`) are out of
+      #   scope. The discoverer filters obvious non-actions (`initialize`, names prefixed with `_`).
+      # - Adding a brand-new view file under `app/views/<mailer>/` will NOT invalidate the cached index
+      #   until something the mailer file touches changes. This is the standard read-tracking trade-off
+      #   — only files we successfully read get digested into the descriptor.
       class MailerDiscoverer
         DEFAULT_VIEWS_ROOT = "app/views"
         VIEW_FORMATS = %w[html text].freeze
         VIEW_EXTENSIONS = %w[erb haml slim].freeze
 
         # @param io_boundary [Rigor::Plugin::IoBoundary]
-        # @param search_paths [Array<String>] absolute or
-        #   project-relative paths to scan for mailers.
-        # @param base_classes [Array<String>] direct
-        #   superclasses that mark a class as a mailer.
-        # @param views_root [String] absolute or project-
-        #   relative path to the views directory (typically
+        # @param search_paths [Array<String>] absolute or project-relative paths to scan for mailers.
+        # @param base_classes [Array<String>] direct superclasses that mark a class as a mailer.
+        # @param views_root [String] absolute or project-relative path to the views directory (typically
         #   `app/views`).
         def initialize(io_boundary:, search_paths:, base_classes:, views_root: DEFAULT_VIEWS_ROOT)
           @io_boundary = io_boundary
@@ -66,11 +50,9 @@ module Rigor
 
         # @return [MailerIndex]
         def discover
-          # Two-pass: first collect every module's defs (for
-          # the include-following step), then build per-class
-          # entries that pull in actions from include'd modules.
-          # GitLab's `Notify` mailer derives every action from
-          # `Emails::*` concerns under `app/mailers/emails/`.
+          # Two-pass: first collect every module's defs (for the include-following step), then build
+          # per-class entries that pull in actions from include'd modules. GitLab's `Notify` mailer
+          # derives every action from `Emails::*` concerns under `app/mailers/emails/`.
           module_actions = {} # module_fqn => Hash<Symbol, ActionEntry>
           class_visits = []   # collected (class_name, path, def_nodes, includes)
 
@@ -135,10 +117,8 @@ module Rigor
           walk_for_mailers(node.body, inner_path, &) if node.body
         end
 
-        # Collects qualified-constant names passed to `include
-        # X` calls inside the class body. Used to look up
-        # concern-module action definitions (GitLab's
-        # `Notify` mailer derives every action from
+        # Collects qualified-constant names passed to `include X` calls inside the class body. Used to
+        # look up concern-module action definitions (GitLab's `Notify` mailer derives every action from
         # `Emails::Issues`, `Emails::MergeRequests`, etc.).
         def collect_includes(body)
           return [] if body.nil?
@@ -155,10 +135,9 @@ module Rigor
           names
         end
 
-        # Walks the AST collecting every module's instance-side
-        # def nodes by fully-qualified module name. The same
-        # `collect_action_defs` filter applies (private /
-        # `_`-prefixed / callback-target methods skipped).
+        # Walks the AST collecting every module's instance-side def nodes by fully-qualified module
+        # name. The same `collect_action_defs` filter applies (private / `_`-prefixed / callback-target
+        # methods skipped).
         def collect_module_actions(node, lexical_path, accumulator)
           return if node.nil?
 
@@ -210,25 +189,18 @@ module Rigor
           end
         end
 
-        # Returns the instance-side `def` nodes that look like
-        # mailer actions. Filters non-actions:
+        # Returns the instance-side `def` nodes that look like mailer actions. Filters non-actions:
         # - `initialize`
-        # - methods starting with `_` (Ruby convention for
-        #   private/internal)
+        # - methods starting with `_` (Ruby convention for private/internal)
         # - `def self.<name>` (singleton-side)
-        # - methods after a bare `private` (or
-        #   `public` → `private` transition) — these are
-        #   internal helpers, not actions
+        # - methods after a bare `private` (or `public` → `private` transition) — these are internal
+        #   helpers, not actions
         # - methods named as a `private :foo` argument
-        # - methods named as a callback target
-        #   (`before_action :name`, `after_action`,
-        #   `around_action`)
+        # - methods named as a callback target (`before_action :name`, `after_action`, `around_action`)
         #
-        # Pre-fix, Mastodon's `AdminMailer#process_params` /
-        # `set_instance` / `set_locale` / `set_important_headers!`
-        # all surfaced as missing-view because the bare `private`
-        # keyword wasn't honoured. ~19 false positives across
-        # Mastodon's mailers.
+        # Pre-fix, Mastodon's `AdminMailer#process_params` / `set_instance` / `set_locale` /
+        # `set_important_headers!` all surfaced as missing-view because the bare `private` keyword
+        # wasn't honoured. ~19 false positives across Mastodon's mailers.
         CALLBACK_DECLARATIONS = %i[before_action after_action around_action].freeze
         private_constant :CALLBACK_DECLARATIONS
 
@@ -252,11 +224,9 @@ module Rigor
           end
         end
 
-        # First pass over the class body: collect (a) names
-        # passed to `private :foo` / `protected :foo` (explicit
-        # visibility-on-existing-method form), and (b) Symbol
-        # arguments to callback declarations
-        # (`before_action :setup`, etc.).
+        # First pass over the class body: collect (a) names passed to `private :foo` / `protected :foo`
+        # (explicit visibility-on-existing-method form), and (b) Symbol arguments to callback
+        # declarations (`before_action :setup`, etc.).
         def collect_visibility_and_callbacks(body)
           private_names = []
           callback_names = []
@@ -278,10 +248,9 @@ module Rigor
           [private_names.to_set, callback_names.to_set]
         end
 
-        # Returns the new visibility scope state after observing
-        # `node`. Bare `private` / `protected` / `public` switch
-        # state; the `private :foo` arg-bearing form does NOT
-        # (already handled by `collect_visibility_and_callbacks`).
+        # Returns the new visibility scope state after observing `node`. Bare `private` / `protected` /
+        # `public` switch state; the `private :foo` arg-bearing form does NOT (already handled by
+        # `collect_visibility_and_callbacks`).
         def next_visibility(node, current)
           return current unless node.is_a?(Prism::CallNode)
           return current unless node.receiver.nil?
@@ -301,11 +270,9 @@ module Rigor
             [entry.method_name, entry]
           end
 
-          # Merge actions from include'd modules (pre-collected
-          # in `module_actions` keyed by fully-qualified name).
-          # Unresolvable includes are tracked; `unresolved_includes?`
-          # (consumed by the analyzer) downgrades `unknown-action`
-          # to silence when any include remains unresolved.
+          # Merge actions from include'd modules (pre-collected in `module_actions` keyed by
+          # fully-qualified name). Unresolvable includes are tracked; `unresolved_includes?` (consumed
+          # by the analyzer) downgrades `unknown-action` to silence when any include remains unresolved.
           unresolved_includes = []
           includes.each do |include_name|
             inc_actions = module_actions[include_name]
@@ -357,17 +324,14 @@ module Rigor
         end
 
         # Checks whether *any* template under
-        # `app/views/<underscore>/<action>.{html,text}.{erb,haml,slim}`
-        # exists, by attempting to read each candidate via the
-        # IoBoundary. Successful reads are recorded by the
-        # boundary; failed reads (missing file or access
-        # denied) are swallowed.
+        # `app/views/<underscore>/<action>.{html,text}.{erb,haml,slim}` exists, by attempting to read
+        # each candidate via the IoBoundary. Successful reads are recorded by the boundary; failed reads
+        # (missing file or access denied) are swallowed.
         def view_exists?(class_name, action_name)
           views_root_absolute = File.expand_path(@views_root)
-          # ADR-39: the real ActiveSupport::Inflector resolves the mailer's
-          # view directory (`Foo::BarMailer` → `foo/bar_mailer`), so a
-          # divergence from Rails' real underscore can't point the
-          # missing-view check at the wrong directory.
+          # ADR-39: the real ActiveSupport::Inflector resolves the mailer's view directory
+          # (`Foo::BarMailer` → `foo/bar_mailer`), so a divergence from Rails' real underscore can't
+          # point the missing-view check at the wrong directory.
           underscore_path = Rigor::Plugin::Inflector.underscore(class_name.delete_prefix("::"))
           mailer_dir = File.join(views_root_absolute, underscore_path)
 

--- a/plugins/rigor-actionmailer/lib/rigor/plugin/actionmailer/mailer_index.rb
+++ b/plugins/rigor-actionmailer/lib/rigor/plugin/actionmailer/mailer_index.rb
@@ -3,17 +3,13 @@
 module Rigor
   module Plugin
     class Actionmailer < Rigor::Plugin::Base
-      # Frozen catalogue of discovered Mailer classes, each
-      # carrying:
+      # Frozen catalogue of discovered Mailer classes, each carrying:
       #
-      # - the action methods it defines (arity envelope per
-      #   action; same shape as `rigor-activejob`'s
+      # - the action methods it defines (arity envelope per action; same shape as `rigor-activejob`'s
       #   `JobIndex::Entry`)
-      # - the source file path the class was declared in
-      #   (used to anchor missing-view diagnostics on the
-      #   mailer file)
-      # - the list of `(action, location)` pairs whose view
-      #   templates are missing from `app/views/`
+      # - the source file path the class was declared in (used to anchor missing-view diagnostics on
+      #   the mailer file)
+      # - the list of `(action, location)` pairs whose view templates are missing from `app/views/`
       class MailerIndex
         ActionEntry = Data.define(:method_name, :min_arity, :max_arity, :def_line, :def_column) do
           def arity_label
@@ -33,12 +29,10 @@ module Rigor
             actions[method_name.to_sym]
           end
 
-          # True when the mailer `include`s a module whose
-          # source we couldn't index (typically a gem-shipped
-          # concern that defines additional mailer actions).
-          # Analyzer downgrades `unknown-action` to silence in
-          # this case — the unresolved module may legitimately
-          # provide the action.
+          # True when the mailer `include`s a module whose source we couldn't index (typically a
+          # gem-shipped concern that defines additional mailer actions). Analyzer downgrades
+          # `unknown-action` to silence in this case — the unresolved module may legitimately provide
+          # the action.
           def unresolved_includes?
             !unresolved_includes.empty?
           end
@@ -61,8 +55,7 @@ module Rigor
           @by_name.key?(class_name.to_s)
         end
 
-        # @param file_path [String] absolute path of a mailer
-        #   file (canonicalised — see plugin entry's
+        # @param file_path [String] absolute path of a mailer file (canonicalised — see plugin entry's
         #   `harvest`)
         # @return [ClassEntry, nil]
         def find_by_file(file_path)

--- a/plugins/rigor-actionpack/demo/app/controllers/application_controller.rb
+++ b/plugins/rigor-actionpack/demo/app/controllers/application_controller.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-# Conventional Rails base controller. Discovered by
-# rigor-actionpack's controller index so subclasses' Phase 2
-# filter chains can reference inherited methods (one level of
-# inheritance is walked).
+# Conventional Rails base controller. Discovered by rigor-actionpack's controller index so subclasses'
+# Phase 2 filter chains can reference inherited methods (one level of inheritance is walked).
 
 class ApplicationController
   def authenticate_admin!
-    # Inherited filter — UsersController would resolve
-    # `before_action :authenticate_admin!` against this method.
+    # Inherited filter — UsersController would resolve `before_action :authenticate_admin!` against
+    # this method.
   end
 end

--- a/plugins/rigor-actionpack/demo/app/controllers/errors_controller.rb
+++ b/plugins/rigor-actionpack/demo/app/controllers/errors_controller.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 
-# Demo controller that triggers each error path
-# rigor-actionpack Phase 4 emits:
+# Demo controller that triggers each error path rigor-actionpack Phase 4 emits:
 #
 # - unknown-helper (with did-you-mean) — `usres_path` typo.
-# - wrong-helper-arity — `user_path` (arity 1) called with 0
-#   args, and `user_post_path` (arity 2) called with 1.
+# - wrong-helper-arity — `user_path` (arity 1) called with 0 args, and `user_post_path` (arity 2)
+#   called with 1.
 
 class ErrorsController < ApplicationController
-  # Phase 2 — `:authenticate!` is not defined on this
-  # controller (or its parent), so the filter reference is an
-  # error.
+  # Phase 2 — `:authenticate!` is not defined on this controller (or its parent), so the filter
+  # reference is an error.
   before_action :authenticate!
 
   def typo
@@ -29,8 +27,8 @@ class ErrorsController < ApplicationController
   end
 
   def missing_view
-    # Phase 3 — `app/views/errors/nope.html.erb` doesn't exist;
-    # the plugin emits `missing-template` here.
+    # Phase 3 — `app/views/errors/nope.html.erb` doesn't exist; the plugin emits `missing-template`
+    # here.
     render :nope
   end
 end

--- a/plugins/rigor-actionpack/demo/app/controllers/users_controller.rb
+++ b/plugins/rigor-actionpack/demo/app/controllers/users_controller.rb
@@ -1,19 +1,16 @@
 # frozen_string_literal: true
 
-# Demo controller exercising the route-helper call shapes
-# rigor-actionpack Phase 4 recognises:
+# Demo controller exercising the route-helper call shapes rigor-actionpack Phase 4 recognises:
 #
 # - bare helper (`users_path`)
 # - helper with positional argument (`user_path(@user)`)
 # - nested helper (`user_post_path(@user, @post)`)
 # - namespaced helper (`admin_widget_path(@widget)`)
 # - the `_url` form is recognised the same way
-# - keyword-only options (`format: :json`) don't count
-#   against arity
+# - keyword-only options (`format: :json`) don't count against arity
 #
-# The `redirect_to`, `link_to`, etc. shapes are pass-through:
-# Rigor sees the `*_path` argument before it reaches the
-# framework method.
+# The `redirect_to`, `link_to`, etc. shapes are pass-through: Rigor sees the `*_path` argument before
+# it reaches the framework method.
 
 class UsersController < ApplicationController
   before_action :authenticate!
@@ -46,22 +43,19 @@ class UsersController < ApplicationController
   end
 
   def render_template
-    # Phase 3 — `:show` resolves to `app/views/users/show.html.erb`
-    # if that view exists.
+    # Phase 3 — `:show` resolves to `app/views/users/show.html.erb` if that view exists.
     render :show
   end
 
   def render_partial
-    # Phase 3 — `partial: "user"` resolves to
-    # `app/views/users/_user.html.erb`.
+    # Phase 3 — `partial: "user"` resolves to `app/views/users/_user.html.erb`.
     render partial: "user"
   end
 
   private
 
   def authenticate!
-    # Filter callback — defined here so the before_action /
-    # skip_before_action references resolve.
+    # Filter callback — defined here so the before_action / skip_before_action references resolve.
   end
 
   def set_user

--- a/plugins/rigor-actionpack/demo/config/routes.rb
+++ b/plugins/rigor-actionpack/demo/config/routes.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-# Sample Rails routes file for the rigor-actionpack demo.
-# rigor-rails-routes statically interprets this DSL and
-# publishes the helper table; rigor-actionpack consumes it
-# at every controller-side call site.
+# Sample Rails routes file for the rigor-actionpack demo. rigor-rails-routes statically interprets
+# this DSL and publishes the helper table; rigor-actionpack consumes it at every controller-side call
+# site.
 
 Rails.application.routes.draw do
   root to: "home#index"

--- a/plugins/rigor-actionpack/lib/rigor/plugin/actionpack.rb
+++ b/plugins/rigor-actionpack/lib/rigor/plugin/actionpack.rb
@@ -8,20 +8,15 @@ require_relative "actionpack/controller_index"
 
 module Rigor
   module Plugin
-    # rigor-actionpack — validates Action Pack DSL calls in
-    # controller files.
+    # rigor-actionpack — validates Action Pack DSL calls in controller files.
     #
-    # **Phase 4 of the Action Pack plugin family** (route-helper
-    # consumption). Reads the `:helper_table` fact published by
-    # `rigor-rails-routes` (ADR-9 cross-plugin API) and validates
-    # every implicit-self `*_path` / `*_url` call inside files
-    # under `controller_search_paths` (default `app/controllers`).
+    # **Phase 4 of the Action Pack plugin family** (route-helper consumption). Reads the `:helper_table`
+    # fact published by `rigor-rails-routes` (ADR-9 cross-plugin API) and validates every implicit-self
+    # `*_path` / `*_url` call inside files under `controller_search_paths` (default `app/controllers`).
     #
     # Tier 2 of the [Rails plugins roadmap](../../../../docs/design/20260508-rails-plugins-roadmap.md).
-    # Phase 1 (strong-parameters → AR column validation), Phase 2
-    # (filter chains), and Phase 3 (render targets) ship as
-    # separate slices; each phase composes additively under the
-    # same plugin id.
+    # Phase 1 (strong-parameters → AR column validation), Phase 2 (filter chains), and Phase 3 (render
+    # targets) ship as separate slices; each phase composes additively under the same plugin id.
     #
     # ## Configuration
     #
@@ -36,46 +31,35 @@ module Rigor
     #
     # ## What it checks
     #
-    # - **Helper existence** — every `*_path` / `*_url` call
-    #   inside a controller file is looked up in the helper
-    #   table. Missing entries emit `unknown-helper` with a
-    #   `DidYouMean` suggestion drawn from the table.
-    # - **Helper arity** — the call's positional-argument count
-    #   is matched against the helper's recorded arity (a
-    #   trailing `KeywordHashNode` like `users_path(format: :json)`
-    #   is excluded; same convention `rigor-rails-routes` uses).
-    #   Mismatches emit `wrong-helper-arity`.
-    # - **Trace** — recognised helpers also emit a
-    #   `helper-call` info diagnostic naming the action and
+    # - **Helper existence** — every `*_path` / `*_url` call inside a controller file is looked up in
+    #   the helper table. Missing entries emit `unknown-helper` with a `DidYouMean` suggestion drawn
+    #   from the table.
+    # - **Helper arity** — the call's positional-argument count is matched against the helper's
+    #   recorded arity (a trailing `KeywordHashNode` like `users_path(format: :json)` is excluded; same
+    #   convention `rigor-rails-routes` uses). Mismatches emit `wrong-helper-arity`.
+    # - **Trace** — recognised helpers also emit a `helper-call` info diagnostic naming the action and
     #   path, mirroring the trace shape of the upstream plugin.
     #
     # ## Limitations
     #
-    # - Implicit-self calls only. `Rails.application.routes.url_helpers.users_path`
-    #   and other explicit-receiver shapes are passed through;
-    #   they're rare in controller code and the helper table
-    #   doesn't include any extra context to validate them.
-    # - Files outside `controller_search_paths` are skipped.
-    #   The plugin doesn't try to detect "is this a controller?"
-    #   by class hierarchy — Phase 1's strong-parameters work
-    #   needs that, so it lives there. Phase 4's job is the
-    #   single-purpose helper check.
-    # - When `rigor-rails-routes` is not installed (or its
-    #   helper table is empty), Phase 4 silently degrades to a
-    #   no-op. No load-error diagnostic is emitted; the user
-    #   gets the "no checks happened" failure mode rather than
-    #   a wall of "is this configured right?" warnings.
+    # - Implicit-self calls only. `Rails.application.routes.url_helpers.users_path` and other
+    #   explicit-receiver shapes are passed through; they're rare in controller code and the helper
+    #   table doesn't include any extra context to validate them.
+    # - Files outside `controller_search_paths` are skipped. The plugin doesn't try to detect "is this
+    #   a controller?" by class hierarchy — Phase 1's strong-parameters work needs that, so it lives
+    #   there. Phase 4's job is the single-purpose helper check.
+    # - When `rigor-rails-routes` is not installed (or its helper table is empty), Phase 4 silently
+    #   degrades to a no-op. No load-error diagnostic is emitted; the user gets the "no checks
+    #   happened" failure mode rather than a wall of "is this configured right?" warnings.
     class Actionpack < Rigor::Plugin::Base
       manifest(
         id: "actionpack",
-        # ADR-37: the four phases (helper / filter / render /
-        # strong-params) run per-call over the engine-owned walk;
-        # the enclosing controller is read from the node-rule
-        # `NodeContext` ancestors. Nested-module qualification is
-        # preserved — `module Admin; class DomainBlocksController`
-        # resolves as `Admin::DomainBlocksController` (matching the
-        # `ControllerDiscoverer`), so render paths and filter-chain
-        # validation on nested controllers are correct.
+        # ADR-37: the four phases (helper / filter / render / strong-params) run per-call over the
+        # engine-owned walk; the enclosing controller is read from the node-rule `NodeContext`
+        # ancestors. Nested-module qualification is preserved — `module Admin; class
+        # DomainBlocksController` resolves as `Admin::DomainBlocksController` (matching the
+        # `ControllerDiscoverer`), so render paths and filter-chain validation on nested controllers are
+        # correct.
         version: "0.9.0",
         description: "Validates Action Pack route-helper calls and filter chains inside controllers, and types the request-context readers (`params` / `session` / `request`).",
         config_schema: {
@@ -88,12 +72,10 @@ module Rigor
         ]
       )
 
-      # Phase 2 cached producer — the controller index built from
-      # `controller_search_paths`. `watch:` (ADR-60 WD3) covers every
-      # `.rb` file under those roots so the cache invalidates when a
-      # controller is added, removed, or edited; the discoverer's
-      # in-block `io_boundary` reads are captured into the dependency
-      # descriptor too, so no explicit priming is needed.
+      # Phase 2 cached producer — the controller index built from `controller_search_paths`. `watch:`
+      # (ADR-60 WD3) covers every `.rb` file under those roots so the cache invalidates when a
+      # controller is added, removed, or edited; the discoverer's in-block `io_boundary` reads are
+      # captured into the dependency descriptor too, so no explicit priming is needed.
       producer :controller_index, watch: -> { [[@controller_search_paths, "**/*.rb"]] } do |_params|
         ControllerDiscoverer.new(
           io_boundary: io_boundary,
@@ -106,18 +88,15 @@ module Rigor
         @view_search_paths = Array(config.fetch("view_search_paths")).map(&:to_s)
       end
 
-      # ADR-37 — the four Action Pack phases run per-call over the
-      # engine-owned walk. Each rule gates on `controller_file?(path)` (the
-      # plugin only validates files under `controller_search_paths`,
-      # exactly as the former `diagnostics_for_file` top-level guard did),
-      # then delegates to a per-node `Analyzer.*_violations_for` and
-      # positions each location-free `Violation` with `Base#diagnostic`.
-      # The filter / render phases read the enclosing controller from the
-      # node-rule `NodeContext` ancestors (its fifth block argument).
+      # ADR-37 — the four Action Pack phases run per-call over the engine-owned walk. Each rule gates on
+      # `controller_file?(path)` (the plugin only validates files under `controller_search_paths`,
+      # exactly as the former `diagnostics_for_file` top-level guard did), then delegates to a per-node
+      # `Analyzer.*_violations_for` and positions each location-free `Violation` with `Base#diagnostic`.
+      # The filter / render phases read the enclosing controller from the node-rule `NodeContext`
+      # ancestors (its fifth block argument).
 
-      # Phase 4 — route-helper consumption. `:helper_table` is
-      # rigor-rails-routes's published fact (ADR-9), read lazily via
-      # `read_fact`.
+      # Phase 4 — route-helper consumption. `:helper_table` is rigor-rails-routes's published fact
+      # (ADR-9), read lazily via `read_fact`.
       node_rule Prism::CallNode do |node, _scope, path|
         next [] unless controller_file?(path)
 
@@ -127,9 +106,8 @@ module Rigor
         diagnostics_for(Analyzer.helper_violations_for(call_node: node, helper_table: table), path: path, node: node)
       end
 
-      # Phase 2 — filter-chain validation. Skips silently when the
-      # controller index is absent or doesn't recognise the enclosing
-      # class.
+      # Phase 2 — filter-chain validation. Skips silently when the controller index is absent or
+      # doesn't recognise the enclosing class.
       node_rule Prism::CallNode do |node, _scope, path, _fc, context|
         next [] unless controller_file?(path)
 
@@ -142,11 +120,9 @@ module Rigor
         )
       end
 
-      # Phase 3 — render-target validation against the configured
-      # `view_search_paths`. Recognised purely from the call site + the
-      # enclosing controller name, so no per-controller pre-discovery is
-      # needed; the controller index is consulted only to suppress
-      # gem-shipped-view false positives.
+      # Phase 3 — render-target validation against the configured `view_search_paths`. Recognised purely
+      # from the call site + the enclosing controller name, so no per-controller pre-discovery is
+      # needed; the controller index is consulted only to suppress gem-shipped-view false positives.
       node_rule Prism::CallNode do |node, _scope, path, _fc, context|
         next [] unless controller_file?(path)
 
@@ -159,11 +135,9 @@ module Rigor
         )
       end
 
-      # Phase 1 — strong-parameter validation. Reads the `:model_index`
-      # fact from the cross-plugin fact store (published by
-      # rigor-activerecord) and validates every
-      # `params.require(:user).permit(:name, :email)` chain against the
-      # User model's column list.
+      # Phase 1 — strong-parameter validation. Reads the `:model_index` fact from the cross-plugin fact
+      # store (published by rigor-activerecord) and validates every `params.require(:user).permit(:name,
+      # :email)` chain against the User model's column list.
       node_rule Prism::CallNode do |node, _scope, path|
         next [] unless controller_file?(path)
 
@@ -173,28 +147,21 @@ module Rigor
         diagnostics_for(Analyzer.permit_violations_for(call_node: node, model_index: index), path: path, node: node)
       end
 
-      # Phase 5 (2026-07-04) — type the implicit-self request-context
-      # readers (`params`, `session`, `request`, `flash`, `cookies`)
-      # inside controllers. The
-      # typing-obstacle probe
-      # (docs/notes/20260704-rails-coverage-onboarding-carrier-trap.md,
-      # obstacle O3) found `params` typing to `Dynamic[top]` the single
-      # largest protection-coverage hole on real Rails apps: `params[:x]`
-      # is the #1 dispatch cluster (redmine app+lib: `[]` 2378 sites) and
-      # `session[:x] =` a large share of the `[]=` cluster, all
-      # unprotected because the receiver is Dynamic.
+      # Phase 5 (2026-07-04) — type the implicit-self request-context readers (`params`, `session`,
+      # `request`, `flash`, `cookies`) inside controllers. The typing-obstacle probe
+      # (docs/notes/20260704-rails-coverage-onboarding-carrier-trap.md, obstacle O3) found `params`
+      # typing to `Dynamic[top]` the single largest protection-coverage hole on real Rails apps:
+      # `params[:x]` is the #1 dispatch cluster (redmine app+lib: `[]` 2378 sites) and `session[:x] =` a
+      # large share of the `[]=` cluster, all unprotected because the receiver is Dynamic.
       #
-      # Each returns a bare nominal with NO bundled RBS on purpose. That
-      # makes the reader a *concrete* receiver (so `coverage --protection`
-      # counts the site as protected and the dispatch resolves against a
-      # named class) while its method surface stays engine-lenient — Rigor
-      # does not fire `undefined-method` on a class it has no RBS for, so
-      # `params.require(...).permit(...)`, `session.delete(:x)`,
-      # `request.xhr?`, and every other method on these stay FP-safe.
-      # Shipping a partial RBS would re-introduce the carrier-additivity
-      # trap (a declared class drops every member the RBS omits → false
-      # `undefined-method`). ADR-5: this types the container, never the
-      # caller's argument, so the values stay lenient.
+      # Each returns a bare nominal with NO bundled RBS on purpose. That makes the reader a *concrete*
+      # receiver (so `coverage --protection` counts the site as protected and the dispatch resolves
+      # against a named class) while its method surface stays engine-lenient — Rigor does not fire
+      # `undefined-method` on a class it has no RBS for, so `params.require(...).permit(...)`,
+      # `session.delete(:x)`, `request.xhr?`, and every other method on these stay FP-safe. Shipping a
+      # partial RBS would re-introduce the carrier-additivity trap (a declared class drops every member
+      # the RBS omits → false `undefined-method`). ADR-5: this types the container, never the caller's
+      # argument, so the values stay lenient.
       REQUEST_CONTEXT_READER_TYPES = {
         params: "ActionController::Parameters",
         session: "ActionDispatch::Request::Session",
@@ -217,12 +184,10 @@ module Rigor
 
       private
 
-      # True when the current `self` is a controller — the enclosing
-      # class is one the discoverer indexed, or its name follows the
-      # Rails `*Controller` convention (covering controllers outside
-      # `controller_search_paths`, e.g. one shipped by an engine).
-      # Typing `params` is precision-additive, so the name-convention
-      # fallback is FP-safe.
+      # True when the current `self` is a controller — the enclosing class is one the discoverer
+      # indexed, or its name follows the Rails `*Controller` convention (covering controllers outside
+      # `controller_search_paths`, e.g. one shipped by an engine). Typing `params` is precision-additive,
+      # so the name-convention fallback is FP-safe.
       def controller_scope?(scope)
         self_type = scope&.self_type
         return false unless self_type.respond_to?(:class_name)
@@ -238,12 +203,10 @@ module Rigor
 
       def controller_file?(path)
         @controller_search_paths.any? do |root|
-          # The runner may pass `path` as either an absolute
-          # path (when `paths:` was configured absolutely) or a
-          # relative one (when configured relatively). The
-          # `controller_search_paths` knob is always project-
-          # root-relative. Match the configured root as a
-          # /-bracketed substring so both shapes resolve.
+          # The runner may pass `path` as either an absolute path (when `paths:` was configured
+          # absolutely) or a relative one (when configured relatively). The `controller_search_paths`
+          # knob is always project-root-relative. Match the configured root as a /-bracketed substring
+          # so both shapes resolve.
           path.include?("/#{root}/") || path.start_with?("#{root}/") || path == root
         end
       end

--- a/plugins/rigor-actionpack/lib/rigor/plugin/actionpack/analyzer.rb
+++ b/plugins/rigor-actionpack/lib/rigor/plugin/actionpack/analyzer.rb
@@ -7,49 +7,40 @@ require "rigor/source/literals"
 module Rigor
   module Plugin
     class Actionpack < Rigor::Plugin::Base
-      # Per-node validators for the Action Pack DSL inside controller
-      # files. ADR-37: the engine owns the single AST walk (the plugin
-      # declares `node_rule(Prism::CallNode)`), so each method here
-      # validates ONE call node and returns location-bearing
-      # {Violation}s — the `node_rule` block positions them via
-      # `Plugin::Base#diagnostic`. The enclosing-controller context the
-      # filter / render phases need is read from the node-rule
-      # `NodeContext` ancestors rather than re-derived by a forward walk.
+      # Per-node validators for the Action Pack DSL inside controller files. ADR-37: the engine owns the
+      # single AST walk (the plugin declares `node_rule(Prism::CallNode)`), so each method here
+      # validates ONE call node and returns location-bearing {Violation}s — the `node_rule` block
+      # positions them via `Plugin::Base#diagnostic`. The enclosing-controller context the filter /
+      # render phases need is read from the node-rule `NodeContext` ancestors rather than re-derived by
+      # a forward walk.
       #
       # The recogniser keys on call-method-name suffix:
       #
       # - `users_path`, `edit_user_path(@user)` → `_path` family.
       # - `users_url`, `edit_user_url(@user)` → `_url` family.
       #
-      # Any call whose name doesn't end in `_path` / `_url` is
-      # silently passed through. Calls with an explicit non-self
-      # receiver (`other_helper.users_path`) are also skipped —
-      # the helper is implicit-self in real controllers, and a
-      # custom-receiver call is almost certainly someone's own
+      # Any call whose name doesn't end in `_path` / `_url` is silently passed through. Calls with an
+      # explicit non-self receiver (`other_helper.users_path`) are also skipped — the helper is
+      # implicit-self in real controllers, and a custom-receiver call is almost certainly someone's own
       # method that happens to share the suffix.
       module Analyzer
         SUFFIXES = %w[_path _url].freeze
 
-        # Phase 2 — filter-chain DSL methods. Each takes a
-        # variadic list of filter names (Symbols / Strings) plus
-        # optional `only:` / `except:` / `if:` / `unless:`
-        # modifiers. Only the filter NAMES are validated; the
-        # `only:`/`except:` action-name arguments are not (deferred).
+        # Phase 2 — filter-chain DSL methods. Each takes a variadic list of filter names (Symbols /
+        # Strings) plus optional `only:` / `except:` / `if:` / `unless:` modifiers. Only the filter
+        # NAMES are validated; the `only:`/`except:` action-name arguments are not (deferred).
         FILTER_DSL_METHODS = %i[
           before_action after_action around_action
           skip_before_action skip_after_action skip_around_action
           prepend_before_action prepend_after_action prepend_around_action
         ].freeze
 
-        # Phase 3 — render-target template extensions checked in
-        # priority order. Covers the engines used by surveyed
-        # projects: ERB (Rails default — `.html.erb`, `.text.erb`),
-        # HAML (Mastodon, Solidus admin — `.html.haml`), Slim, and
-        # JSON (`.json.jbuilder` plus `.json.erb` for hand-rolled API
-        # responses). When a template exists under any of these
-        # extensions, the missing-template diagnostic stays silent.
-        # A configurable extension list is deferred; this set is wide
-        # enough to cover surveyed real-world projects without FPs.
+        # Phase 3 — render-target template extensions checked in priority order. Covers the engines used
+        # by surveyed projects: ERB (Rails default — `.html.erb`, `.text.erb`), HAML (Mastodon, Solidus
+        # admin — `.html.haml`), Slim, and JSON (`.json.jbuilder` plus `.json.erb` for hand-rolled API
+        # responses). When a template exists under any of these extensions, the missing-template
+        # diagnostic stays silent. A configurable extension list is deferred; this set is wide enough to
+        # cover surveyed real-world projects without FPs.
         RENDER_TEMPLATE_EXTENSIONS = %w[
           .html.erb
           .text.erb
@@ -62,39 +53,31 @@ module Rigor
           .xml.erb
         ].freeze
 
-        # Phase 1 — strong-parameter call shapes that begin a
-        # validatable chain. The walker matches the
-        # `params.require(:user).permit(:name, :email)` chain
-        # by looking for `:permit` call sites whose receiver is
-        # `params.require(:symbol)`.
+        # Phase 1 — strong-parameter call shapes that begin a validatable chain. The walker matches the
+        # `params.require(:user).permit(:name, :email)` chain by looking for `:permit` call sites whose
+        # receiver is `params.require(:symbol)`.
         STRONG_PARAMS_RECEIVER_NAMES = %i[require permit_params strong_params].freeze
 
-        # One Action Pack observation. Carries no path — the caller
-        # (the `node_rule` block) positions it via
-        # `Plugin::Base#diagnostic`. `location` is the Prism location the
-        # diagnostic should point at (a call's `message_loc` for the call
-        # itself, or a sub-argument's location for `unknown-*-key`-style
-        # diagnostics that point at the offending Symbol).
+        # One Action Pack observation. Carries no path — the caller (the `node_rule` block) positions
+        # it via `Plugin::Base#diagnostic`. `location` is the Prism location the diagnostic should point
+        # at (a call's `message_loc` for the call itself, or a sub-argument's location for
+        # `unknown-*-key`-style diagnostics that point at the offending Symbol).
         Violation = Data.define(:location, :message, :severity, :rule)
 
         module_function
 
-        # Phase 4 — route-helper consumption. The helper-existence /
-        # arity check for ONE call node. Only the **info-level** route
-        # resolution (`helper-call`) is the value this plugin adds — it
-        # surfaces the resolved HTTP method + path + action alongside the
-        # call site, which `rigor-rails-routes` does not. Unknown-helper
-        # and wrong-arity diagnostics are produced canonically by
-        # `rigor-rails-routes`'s own analyzer (same `:helper_table` source
-        # of truth), so emitting them here would double every call-site
-        # error. Real-world impact pre-fix: ~301 duplicates on Mastodon and
-        # ~119 on Redmine, exactly stacked with the rails-routes
-        # diagnostics. Returns `[]` for unknown / arity-mismatch shapes.
+        # Phase 4 — route-helper consumption. The helper-existence / arity check for ONE call node.
+        # Only the **info-level** route resolution (`helper-call`) is the value this plugin adds — it
+        # surfaces the resolved HTTP method + path + action alongside the call site, which
+        # `rigor-rails-routes` does not. Unknown-helper and wrong-arity diagnostics are produced
+        # canonically by `rigor-rails-routes`'s own analyzer (same `:helper_table` source of truth), so
+        # emitting them here would double every call-site error. Real-world impact pre-fix: ~301
+        # duplicates on Mastodon and ~119 on Redmine, exactly stacked with the rails-routes diagnostics.
+        # Returns `[]` for unknown / arity-mismatch shapes.
         #
         # @param call_node [Prism::Node]
-        # @param helper_table [Hash{String => Hash}] each entry carries
-        #   `name`, `arity`, `acceptable_arities`, `path`, `http_method`,
-        #   `action`.
+        # @param helper_table [Hash{String => Hash}] each entry carries `name`, `arity`,
+        #   `acceptable_arities`, `path`, `http_method`, `action`.
         # @return [Array<Violation>]
         def helper_violations_for(call_node:, helper_table:)
           return [] unless implicit_helper_call?(call_node)
@@ -103,24 +86,20 @@ module Rigor
           return [] if entry.nil?
 
           actual_arity = positional_arg_count(call_node)
-          # The `:helper_table` fact entry carries both `:arity` (the
-          # first registered entry's arity) and `:acceptable_arities`
-          # (the full Array — populated for uncountable-noun resources
-          # like `resources :news` which share a helper name across
-          # index/show). Honour the full set; fall back to the single
-          # arity for consumers compiled against an older fact shape.
+          # The `:helper_table` fact entry carries both `:arity` (the first registered entry's arity)
+          # and `:acceptable_arities` (the full Array — populated for uncountable-noun resources like
+          # `resources :news` which share a helper name across index/show). Honour the full set; fall
+          # back to the single arity for consumers compiled against an older fact shape.
           acceptable = entry[:acceptable_arities] || [entry[:arity]]
           return [] unless acceptable.include?(actual_arity)
 
           [helper_call_violation(call_node, entry)]
         end
 
-        # Phase 2 — filter-chain validation for ONE filter-DSL call
-        # (`before_action :name`, …). The enclosing controller is read
-        # from the node-rule `NodeContext` ancestors, looked up in the
-        # controller index to get the effective method set (including one
-        # level of inheritance), and each filter name reference is
-        # validated against it. Calls outside a known controller
+        # Phase 2 — filter-chain validation for ONE filter-DSL call (`before_action :name`, …). The
+        # enclosing controller is read from the node-rule `NodeContext` ancestors, looked up in the
+        # controller index to get the effective method set (including one level of inheritance), and
+        # each filter name reference is validated against it. Calls outside a known controller
         # contribute nothing.
         #
         # @param call_node [Prism::Node]
@@ -136,13 +115,11 @@ module Rigor
 
           methods = controller_index.effective_methods_for(class_name)
           spell_checker = DidYouMean::SpellChecker.new(dictionary: methods.map(&:to_s))
-          # When the controller (or its parent) `include`s a module the
-          # discoverer couldn't resolve — typically a gem-shipped concern
-          # such as `Devise::Controllers::Helpers` or
-          # `Pundit::Authorization` — any `before_action :name` MIGHT be
-          # defined in that unresolved module. Suppress
-          # `unknown-filter-method` in that case rather than FPing on
-          # legitimate gem-provided callback names.
+          # When the controller (or its parent) `include`s a module the discoverer couldn't resolve —
+          # typically a gem-shipped concern such as `Devise::Controllers::Helpers` or
+          # `Pundit::Authorization` — any `before_action :name` MIGHT be defined in that unresolved
+          # module. Suppress `unknown-filter-method` in that case rather than FPing on legitimate
+          # gem-provided callback names.
           ambiguous_filters = controller_index.unresolved_include?(class_name)
 
           filter_name_args(call_node).filter_map do |arg_node|
@@ -156,12 +133,10 @@ module Rigor
           end
         end
 
-        # Phase 1 — strong-parameter validation for ONE `permit` call.
-        # Recognises the `params.require(:symbol).permit(:key, :key, ...)`
-        # chain and validates each `:key` against the AR model's column
-        # list (looked up via the model_index fact published by
-        # `rigor-activerecord`). Calls whose `:require` argument is a
-        # non-literal Symbol are passed through; namespaced models
+        # Phase 1 — strong-parameter validation for ONE `permit` call. Recognises the
+        # `params.require(:symbol).permit(:key, :key, ...)` chain and validates each `:key` against the
+        # AR model's column list (looked up via the model_index fact published by `rigor-activerecord`).
+        # Calls whose `:require` argument is a non-literal Symbol are passed through; namespaced models
         # (`params.require(:admin_user)` → `Admin::User`) are deferred.
         #
         # @param call_node [Prism::Node]
@@ -185,23 +160,19 @@ module Rigor
           end
         end
 
-        # Phase 3 — render-target validation for ONE `render` call. Derive
-        # the candidate view template path(s) from the controller class
-        # name + the render argument shape, then check existence under the
-        # configured `view_search_paths` (default `["app/views"]`).
-        # Recognised call shapes:
+        # Phase 3 — render-target validation for ONE `render` call. Derive the candidate view template
+        # path(s) from the controller class name + the render argument shape, then check existence
+        # under the configured `view_search_paths` (default `["app/views"]`). Recognised call shapes:
         #
         # - `render :symbol` — `<views>/<controller_path>/<symbol>.html.erb`
         # - `render "string/path"` — `<views>/<string_path>.html.erb`
         # - `render partial: "name"` — `<views>/<controller_path>/_<name>.html.erb`
         # - `render partial: "string/path"` — `<views>/<string_path with _ prefix>.html.erb`
         #
-        # `render layout:`, `render plain:`, `render json:`, `render
-        # text:`, `render inline:`, `render :nothing => true`, etc. are
-        # pass-through (no template lookup). Implicit-render (a controller
-        # method that doesn't call `render`) is also skipped — Phase 3
-        # validates explicit renders only, since the implicit path would
-        # false-positive on `redirect_to` / `head` / early returns.
+        # `render layout:`, `render plain:`, `render json:`, `render text:`, `render inline:`, `render
+        # :nothing => true`, etc. are pass-through (no template lookup). Implicit-render (a controller
+        # method that doesn't call `render`) is also skipped — Phase 3 validates explicit renders only,
+        # since the implicit path would false-positive on `redirect_to` / `head` / early returns.
         #
         # @param call_node [Prism::Node]
         # @param ancestors [Array<Prism::Node>] the lexical ancestor chain
@@ -215,41 +186,32 @@ module Rigor
           class_name = enclosing_controller_name(ancestors)
           return [] if class_name.nil?
 
-          # Prefer the file-path-derived controller path when the source
-          # lives under `app/controllers/` — Rails autoload is the runtime
-          # authority on `Admin::Users::RolesController` vs
-          # `Users::RolesController` (a declaration like `module Admin;
-          # class Users::RolesController` resolves to whichever `Users`
-          # constant Ruby finds first, and the file path is the
-          # disambiguator Rails picks). Fall back to the AST-derived class
-          # name for files outside `app/controllers/` (libraries, test
-          # fixtures).
+          # Prefer the file-path-derived controller path when the source lives under `app/controllers/`
+          # — Rails autoload is the runtime authority on `Admin::Users::RolesController` vs
+          # `Users::RolesController` (a declaration like `module Admin; class Users::RolesController`
+          # resolves to whichever `Users` constant Ruby finds first, and the file path is the
+          # disambiguator Rails picks). Fall back to the AST-derived class name for files outside
+          # `app/controllers/` (libraries, test fixtures).
           controller_path = controller_path_from_file(path) || controller_path_for(class_name)
           return [] if controller_path.nil?
 
-          # Render checks silence when the controller (or its ancestor
-          # chain) inherits from a gem-shipped parent
-          # (Devise::ConfirmationsController,
-          # Doorkeeper::ApplicationsController, …). The gem ships its own
-          # views; the local subclass calling `render :show` resolves
-          # through the gem's view path, which our static analyser doesn't
-          # know about.
+          # Render checks silence when the controller (or its ancestor chain) inherits from a
+          # gem-shipped parent (Devise::ConfirmationsController, Doorkeeper::ApplicationsController, …).
+          # The gem ships its own views; the local subclass calling `render :show` resolves through the
+          # gem's view path, which our static analyser doesn't know about.
           if controller_index&.known?(class_name) &&
              controller_index.unresolved_include?(class_name)
             return []
           end
 
-          # Abstract base controllers: a `*BaseController` (`Admin::
-          # BaseController`, `Settings::Preferences::BaseController`, …)
-          # typically has no view of its own; its `render :show` bodies
-          # are resolved by Rails against the calling subclass's
-          # controller path at request time, NOT the base's. Same for
-          # parent controllers whose view directory exists but contains
-          # only subdirectories (Mastodon's `Admin::SettingsController`
-          # whose `app/views/admin/settings/` holds about/, appearance/,
-          # … but no top-level templates). Skip render checks for these —
-          # the diagnostic would be a false positive against intentional
-          # Rails abstract-base layouts.
+          # Abstract base controllers: a `*BaseController` (`Admin::BaseController`,
+          # `Settings::Preferences::BaseController`, …) typically has no view of its own; its `render
+          # :show` bodies are resolved by Rails against the calling subclass's controller path at
+          # request time, NOT the base's. Same for parent controllers whose view directory exists but
+          # contains only subdirectories (Mastodon's `Admin::SettingsController` whose
+          # `app/views/admin/settings/` holds about/, appearance/, … but no top-level templates). Skip
+          # render checks for these — the diagnostic would be a false positive against intentional Rails
+          # abstract-base layouts.
           return [] if abstract_base_controller?(class_name, controller_path, view_search_roots)
 
           target = render_target_for(call_node, controller_path)
@@ -259,27 +221,22 @@ module Rigor
           violation ? [violation] : []
         end
 
-        # Resolves the qualified name of the controller class the node
-        # sits in from its lexical ancestors (the node-rule
-        # `NodeContext#ancestors`, outermost first). The OUTERMOST
-        # `ClassNode` is the controller — matching the old forward walk,
-        # which returned the first `ClassNode` reachable from the file
-        # root and validated nested-class call sites against it. Enclosing
-        # `ModuleNode`s above it contribute the namespace, so the
-        # nested-module declaration shape
+        # Resolves the qualified name of the controller class the node sits in from its lexical
+        # ancestors (the node-rule `NodeContext#ancestors`, outermost first). The OUTERMOST `ClassNode`
+        # is the controller — matching the old forward walk, which returned the first `ClassNode`
+        # reachable from the file root and validated nested-class call sites against it. Enclosing
+        # `ModuleNode`s above it contribute the namespace, so the nested-module declaration shape
         #
         #   module Admin
         #     class DomainBlocksController < BaseController
         #     end
         #   end
         #
-        # is recovered as `Admin::DomainBlocksController` — the same name
-        # the `ControllerDiscoverer` registers under. Without this, a bare
-        # inner-class name would be used for index lookups +
-        # `controller_path_for`, silently skipping filter validation and
-        # pointing render template paths at the wrong directory
-        # (Mastodon's `admin/domain_blocks` rendered as bare
-        # `domain_blocks`). Returns nil when no enclosing class exists.
+        # is recovered as `Admin::DomainBlocksController` — the same name the `ControllerDiscoverer`
+        # registers under. Without this, a bare inner-class name would be used for index lookups +
+        # `controller_path_for`, silently skipping filter validation and pointing render template paths
+        # at the wrong directory (Mastodon's `admin/domain_blocks` rendered as bare `domain_blocks`).
+        # Returns nil when no enclosing class exists.
         def enclosing_controller_name(ancestors)
           class_index = ancestors.index { |n| n.is_a?(Prism::ClassNode) }
           return nil if class_index.nil?
@@ -296,10 +253,9 @@ module Rigor
           path ? path.split("::") : []
         end
 
-        # Resolves a class-name AST node against an enclosing namespace
-        # chain. A `ConstantPathNode` (e.g. `class Admin::Foo`) is already
-        # absolute and ignores the chain; a `ConstantReadNode` (bare
-        # `class Foo` inside `module Admin`) is qualified against it.
+        # Resolves a class-name AST node against an enclosing namespace chain. A `ConstantPathNode`
+        # (e.g. `class Admin::Foo`) is already absolute and ignores the chain; a `ConstantReadNode`
+        # (bare `class Foo` inside `module Admin`) is qualified against it.
         def qualified_name_with_enclosing(node, enclosing)
           return nil unless node.is_a?(Prism::Node)
 
@@ -334,9 +290,8 @@ module Rigor
           node.is_a?(Prism::CallNode) && node.receiver.nil? && node.name == :render
         end
 
-        # Drops the trailing keyword hash (`only:` / `except:` / `if:` /
-        # `unless:`) so the modifier args don't get treated as filter
-        # names.
+        # Drops the trailing keyword hash (`only:` / `except:` / `if:` / `unless:`) so the modifier args
+        # don't get treated as filter names.
         def filter_name_args(call_node)
           args = call_node.arguments&.arguments || []
           args = args[0..-2] if args.last.is_a?(Prism::KeywordHashNode)
@@ -351,9 +306,8 @@ module Rigor
           if methods.include?(filter_name.to_sym)
             filter_call_violation(call_node, filter_name)
           elsif ambiguous_filters
-            # An unresolved include shadows our judgment — emit the
-            # recognized-filter info anyway so the call site is still
-            # indexed, but skip the error.
+            # An unresolved include shadows our judgment — emit the recognized-filter info anyway so
+            # the call site is still indexed, but skip the error.
             filter_call_violation(call_node, filter_name)
           else
             unknown_filter_violation(arg_node, call_node, filter_name, spell_checker)
@@ -373,11 +327,9 @@ module Rigor
         def model_class_for_permit(permit_call)
           require_call = permit_call.receiver
           symbol_node = require_call.arguments.arguments.first
-          # `:user` → `User`, `:order_item` → `OrderItem`. ADR-39: the
-          # shared inflector camelizes through the real
-          # `ActiveSupport::Inflector` when present (so the multi-word
-          # case the former `split("_").map(&:capitalize)` only
-          # approximated is authoritative), falling back otherwise.
+          # `:user` → `User`, `:order_item` → `OrderItem`. ADR-39: the shared inflector camelizes
+          # through the real `ActiveSupport::Inflector` when present (so the multi-word case the former
+          # `split("_").map(&:capitalize)` only approximated is authoritative), falling back otherwise.
           Rigor::Plugin::Inflector.camelize(symbol_node.value.to_s)
         end
 
@@ -405,29 +357,24 @@ module Rigor
           )
         end
 
-        # Convert `<root>/app/controllers/admin/users/roles_controller.rb`
-        # to `admin/users/roles`. Returns nil if the path is not under an
-        # `app/controllers/` segment.
+        # Convert `<root>/app/controllers/admin/users/roles_controller.rb` to `admin/users/roles`.
+        # Returns nil if the path is not under an `app/controllers/` segment.
         def controller_path_from_file(path)
           match = path.match(%r{(?:\A|/)app/controllers/(.+)_controller\.rb\z})
           match&.[](1)
         end
 
-        # An abstract base controller — its `render` bodies don't validate
-        # against its own controller_path because Rails resolves at
-        # request time against the actual subclass. Two conservative
-        # heuristics:
-        #   (1) The class name ends with `BaseController`. Strong
-        #       Rails-convention signal (Settings::Preferences::
-        #       BaseController, Admin::BaseController, …).
-        #   (2) The controller's view directory exists but contains ONLY
-        #       subdirectories (no template files at its top). Mastodon's
-        #       Admin::SettingsController whose app/views/admin/settings/
-        #       holds only about/, appearance/, … — the parent of nested
+        # An abstract base controller — its `render` bodies don't validate against its own
+        # controller_path because Rails resolves at request time against the actual subclass. Two
+        # conservative heuristics:
+        #   (1) The class name ends with `BaseController`. Strong Rails-convention signal
+        #       (Settings::Preferences::BaseController, Admin::BaseController, …).
+        #   (2) The controller's view directory exists but contains ONLY subdirectories (no template
+        #       files at its top). Mastodon's Admin::SettingsController whose
+        #       app/views/admin/settings/ holds only about/, appearance/, … — the parent of nested
         #       controllers.
-        # Deliberately NOT triggered by "no view directory at all" because
-        # that fires the diagnostic we DO want for genuinely-missing views
-        # (the typo / forgot-to-create case).
+        # Deliberately NOT triggered by "no view directory at all" because that fires the diagnostic we
+        # DO want for genuinely-missing views (the typo / forgot-to-create case).
         def abstract_base_controller?(class_name, controller_path, view_search_roots)
           return true if class_name.end_with?("BaseController")
 
@@ -440,12 +387,10 @@ module Rigor
           end
         end
 
-        # Returns `[kind, view_relative_path]` where kind is `:template`
-        # or `:partial`, and view_relative_path is the path under
-        # view_search_roots WITHOUT extension (the extension family is
-        # appended at lookup time). Returns nil for shapes Phase 3 doesn't
-        # validate (`layout:` / `plain:` / `json:` / `text:` / `inline:` /
-        # `:nothing` / no parseable target).
+        # Returns `[kind, view_relative_path]` where kind is `:template` or `:partial`, and
+        # view_relative_path is the path under view_search_roots WITHOUT extension (the extension
+        # family is appended at lookup time). Returns nil for shapes Phase 3 doesn't validate (`layout:`
+        # / `plain:` / `json:` / `text:` / `inline:` / `:nothing` / no parseable target).
         def render_target_for(call_node, controller_path)
           args = call_node.arguments&.arguments || []
           return nil if args.empty?
@@ -454,9 +399,8 @@ module Rigor
           # `render partial: "..."` — the keyword form.
           return partial_target_from_kwargs(first, controller_path) if first.is_a?(Prism::KeywordHashNode)
 
-          # `render :symbol` / `render "path"`. A trailing KeywordHashNode
-          # is allowed (e.g. `render :show, status: :ok`); the leading
-          # positional carries the template name.
+          # `render :symbol` / `render "path"`. A trailing KeywordHashNode is allowed (e.g. `render
+          # :show, status: :ok`); the leading positional carries the template name.
           template_target_from_positional(first, controller_path)
         end
 
@@ -487,15 +431,13 @@ module Rigor
 
         # `UsersController` → "users".
         # `Admin::WidgetsController` → "admin/widgets".
-        # Returns nil for class names that don't end with the `Controller`
-        # suffix.
+        # Returns nil for class names that don't end with the `Controller` suffix.
         def controller_path_for(class_name)
           return nil unless class_name.end_with?("Controller")
 
           stripped = class_name.delete_suffix("Controller")
-          # ADR-39: the shared inflector flattens `::` → `/` and applies
-          # Rails' real underscore (the per-segment hand-rolled version
-          # produced the same result for the common case but missed
+          # ADR-39: the shared inflector flattens `::` → `/` and applies Rails' real underscore (the
+          # per-segment hand-rolled version produced the same result for the common case but missed
           # acronym handling). `Admin::Widgets` → `admin/widgets`.
           Rigor::Plugin::Inflector.underscore(stripped)
         end

--- a/plugins/rigor-actionpack/lib/rigor/plugin/actionpack/controller_discoverer.rb
+++ b/plugins/rigor-actionpack/lib/rigor/plugin/actionpack/controller_discoverer.rb
@@ -7,15 +7,11 @@ require_relative "controller_index"
 module Rigor
   module Plugin
     class Actionpack < Rigor::Plugin::Base
-      # Walks `controller_search_paths` building a
-      # {ControllerIndex} of `(class_name, methods,
-      # parent_class_name)` triples. Used by Phase 2 (filter
-      # chains) to validate that `before_action :name`
-      # references a method defined on the controller or its
-      # ancestor chain.
+      # Walks `controller_search_paths` building a {ControllerIndex} of `(class_name, methods,
+      # parent_class_name)` triples. Used by Phase 2 (filter chains) to validate that `before_action
+      # :name` references a method defined on the controller or its ancestor chain.
       #
-      # Two declaration shapes are recognised and qualified
-      # the same way:
+      # Two declaration shapes are recognised and qualified the same way:
       #
       #   class Admin::AccountsController < BaseController
       #     # → registered as "Admin::AccountsController"
@@ -26,25 +22,18 @@ module Rigor
       #     end
       #   end
       #
-      # Pre-fix the nested form ignored the enclosing `module
-      # Admin` and registered the inner class as bare
-      # `"AccountsController"`, overwriting the top-level
-      # `app/controllers/accounts_controller.rb` entry. Mastodon
-      # has both shapes for the same logical name (top-level
-      # `AccountsController` + `Admin::AccountsController` +
-      # `Api::V1::AccountsController`) and the overwrite caused
-      # the wrong inheritance / method set to flow downstream,
-      # producing dozens of false `unknown-filter-method`
+      # Pre-fix the nested form ignored the enclosing `module Admin` and registered the inner class as
+      # bare `"AccountsController"`, overwriting the top-level `app/controllers/accounts_controller.rb`
+      # entry. Mastodon has both shapes for the same logical name (top-level `AccountsController` +
+      # `Admin::AccountsController` + `Api::V1::AccountsController`) and the overwrite caused the wrong
+      # inheritance / method set to flow downstream, producing dozens of false `unknown-filter-method`
       # diagnostics.
       #
-      # Multi-level inheritance is also walked: `Admin::AccountsController
-      # < BaseController < ApplicationController` resolves
-      # methods from all three. Cycle-safe via a visited set.
-      # The parent-name lookup is **lexically scoped** — a bare
-      # `BaseController` reference inside `module Admin` first
-      # tries `Admin::BaseController`, then falls through to
-      # top-level `BaseController`, matching Ruby's constant-
-      # resolution semantics.
+      # Multi-level inheritance is also walked: `Admin::AccountsController < BaseController <
+      # ApplicationController` resolves methods from all three. Cycle-safe via a visited set. The
+      # parent-name lookup is **lexically scoped** — a bare `BaseController` reference inside `module
+      # Admin` first tries `Admin::BaseController`, then falls through to top-level `BaseController`,
+      # matching Ruby's constant-resolution semantics.
       class ControllerDiscoverer
         def initialize(io_boundary:, search_paths:)
           @io_boundary = io_boundary
@@ -84,15 +73,12 @@ module Rigor
           nil
         end
 
-        # Walks every `ClassNode` / `ModuleNode` in the AST,
-        # yielding `[declaration_node, enclosing_namespace_array]`
-        # for each. `enclosing` is the chain of module / class
-        # qualifiers OUTSIDE the yielded declaration (e.g. for
-        # `module Admin; class AccountsController; end; end`
-        # the inner class yields with enclosing
-        # `["Admin"]`). The yielded declaration's own segment
-        # is added to the chain for its body's recursion so
-        # constants nested two levels deep qualify correctly.
+        # Walks every `ClassNode` / `ModuleNode` in the AST, yielding `[declaration_node,
+        # enclosing_namespace_array]` for each. `enclosing` is the chain of module / class qualifiers
+        # OUTSIDE the yielded declaration (e.g. for `module Admin; class AccountsController; end; end`
+        # the inner class yields with enclosing `["Admin"]`). The yielded declaration's own segment is
+        # added to the chain for its body's recursion so constants nested two levels deep qualify
+        # correctly.
         def walk_declarations(node, namespace:, &)
           return unless node.is_a?(Prism::Node)
 
@@ -109,11 +95,9 @@ module Rigor
           end
         end
 
-        # The segments contributed by a declaration to the
-        # qualifier chain of its body. For `class A::B` this is
-        # `["A", "B"]`; for `module Outer` it is `["Outer"]`.
-        # Returns `[]` for an anonymous declaration the walker
-        # cannot qualify.
+        # The segments contributed by a declaration to the qualifier chain of its body. For `class A::B`
+        # this is `["A", "B"]`; for `module Outer` it is `["Outer"]`. Returns `[]` for an anonymous
+        # declaration the walker cannot qualify.
         def namespace_segments_for(declaration_node)
           path = qualified_name_for(declaration_node.constant_path)
           path ? path.split("::") : []
@@ -133,13 +117,10 @@ module Rigor
           )
         end
 
-        # Resolves the declared name against the enclosing
-        # namespace chain. A `ConstantPathNode` (e.g.
-        # `Admin::Foo` in `class Admin::Foo`) is already
-        # absolute and ignores the enclosing chain. A
-        # `ConstantReadNode` (bare `Foo` in `module Admin;
-        # class Foo`) is qualified against the chain so the
-        # name becomes `Admin::Foo`.
+        # Resolves the declared name against the enclosing namespace chain. A `ConstantPathNode` (e.g.
+        # `Admin::Foo` in `class Admin::Foo`) is already absolute and ignores the enclosing chain. A
+        # `ConstantReadNode` (bare `Foo` in `module Admin; class Foo`) is qualified against the chain so
+        # the name becomes `Admin::Foo`.
         def qualified_name_with_enclosing(node, enclosing)
           return nil unless node.is_a?(Prism::Node)
 
@@ -165,11 +146,9 @@ module Rigor
           accumulator
         end
 
-        # Collects the qualified-constant targets passed to
-        # `include` calls inside the body. Stops at nested
-        # `ClassNode` / `ModuleNode` boundaries so a class
-        # declared inside a concern doesn't pull the concern's
-        # includes into itself.
+        # Collects the qualified-constant targets passed to `include` calls inside the body. Stops at
+        # nested `ClassNode` / `ModuleNode` boundaries so a class declared inside a concern doesn't pull
+        # the concern's includes into itself.
         def collect_include_targets(node, accumulator = [])
           return accumulator unless node.is_a?(Prism::Node)
           return accumulator if node.is_a?(Prism::ClassNode) || node.is_a?(Prism::ModuleNode)

--- a/plugins/rigor-actionpack/lib/rigor/plugin/actionpack/controller_index.rb
+++ b/plugins/rigor-actionpack/lib/rigor/plugin/actionpack/controller_index.rb
@@ -3,13 +3,11 @@
 module Rigor
   module Plugin
     class Actionpack < Rigor::Plugin::Base
-      # Per-run frozen index of discovered controllers AND
-      # concerns (modules) in `controller_search_paths`. Phase 2
-      # (filter-chain validation) consults the index at every
-      # call site to check that `before_action :name` references
-      # a method that actually exists on the controller, its
-      # parent (one level of inheritance), or any module the
-      # controller or its ancestor chain transitively `include`s.
+      # Per-run frozen index of discovered controllers AND concerns (modules) in
+      # `controller_search_paths`. Phase 2 (filter-chain validation) consults the index at every call
+      # site to check that `before_action :name` references a method that actually exists on the
+      # controller, its parent (one level of inheritance), or any module the controller or its ancestor
+      # chain transitively `include`s.
       #
       # Real-world example (Mastodon):
       #   AccountsController < ApplicationController
@@ -19,23 +17,17 @@ module Rigor
       #   SignatureVerification < module
       #     def require_account_signature!        # ← the filter target
       #
-      # The include chain spans three concern modules.
-      # `effective_methods_for("AccountsController")` walks all
-      # of them transitively to collect `require_account_signature!`.
+      # The include chain spans three concern modules. `effective_methods_for("AccountsController")`
+      # walks all of them transitively to collect `require_account_signature!`.
       class ControllerIndex
-        # `defined_methods` carries the discovered method names
-        # (Symbols). `included_module_names` carries the constant
-        # names passed to `include X` calls inside the
-        # class / module body (Strings). `parent_class_name` is
-        # the immediate superclass (nil for plain modules).
-        # `enclosing_namespace` is the qualifier chain of the
-        # declaration's *lexical* enclosing scope (e.g.
-        # `["Admin"]` for an `Admin::Foo` declared via
-        # `module Admin; class Foo; end; end`). Used by the
-        # index's parent / module lookup to try lexically-scoped
-        # constant resolution before falling through to the
-        # top-level form — Ruby's constant lookup walks the
-        # enclosing scope chain before `Object`.
+        # `defined_methods` carries the discovered method names (Symbols). `included_module_names`
+        # carries the constant names passed to `include X` calls inside the class / module body
+        # (Strings). `parent_class_name` is the immediate superclass (nil for plain modules).
+        # `enclosing_namespace` is the qualifier chain of the declaration's *lexical* enclosing scope
+        # (e.g. `["Admin"]` for an `Admin::Foo` declared via `module Admin; class Foo; end; end`). Used
+        # by the index's parent / module lookup to try lexically-scoped constant resolution before
+        # falling through to the top-level form — Ruby's constant lookup walks the enclosing scope chain
+        # before `Object`.
         Entry = Data.define(:class_name, :defined_methods, :parent_class_name, :included_module_names,
                             :enclosing_namespace)
 
@@ -51,20 +43,15 @@ module Rigor
           @entries[class_name]
         end
 
-        # Resolves the **effective** method set for a controller,
-        # including methods contributed by every module the
-        # controller / any ancestor transitively `include`s AND
-        # methods inherited from the ancestor chain (unbounded
-        # depth, cycle-safe via a visited set).
+        # Resolves the **effective** method set for a controller, including methods contributed by
+        # every module the controller / any ancestor transitively `include`s AND methods inherited from
+        # the ancestor chain (unbounded depth, cycle-safe via a visited set).
         #
-        # Parent / module lookups are **lexically scoped** — a
-        # bare `BaseController` reference inside `module Admin`
-        # first tries `Admin::BaseController`, then falls
-        # through to the top-level `BaseController`. Matches
-        # Ruby's constant-resolution semantics. Without this an
-        # `Admin::Foo < BaseController` declaration would
-        # incorrectly walk the top-level `BaseController` even
-        # when an `Admin::BaseController` exists.
+        # Parent / module lookups are **lexically scoped** — a bare `BaseController` reference inside
+        # `module Admin` first tries `Admin::BaseController`, then falls through to the top-level
+        # `BaseController`. Matches Ruby's constant-resolution semantics. Without this an `Admin::Foo <
+        # BaseController` declaration would incorrectly walk the top-level `BaseController` even when an
+        # `Admin::BaseController` exists.
         def effective_methods_for(class_name)
           seen_classes = {}
           seen_modules = {}
@@ -81,11 +68,9 @@ module Rigor
               collect_methods(resolved_include, seen_modules, methods)
             end
             next_parent = entry.parent_class_name
-            # Same self-reference guard as `unresolved_include?`:
-            # `class ActivityPub::ApplicationController <
-            # ::ApplicationController` lexically resolves
-            # `ApplicationController` to itself; fall back to
-            # the unprefixed top-level name in that case.
+            # Same self-reference guard as `unresolved_include?`: `class ActivityPub::ApplicationController
+            # < ::ApplicationController` lexically resolves `ApplicationController` to itself; fall back
+            # to the unprefixed top-level name in that case.
             current = if next_parent
                         resolved = resolve_constant_lexically(next_parent, entry.enclosing_namespace)
                         resolved == current ? next_parent.sub(/\A::/, "") : resolved
@@ -94,30 +79,23 @@ module Rigor
           methods.uniq.freeze
         end
 
-        # @return [Boolean] true when the class has at least one
-        #   include OR parent class we couldn't resolve in the
-        #   index (typically a gem-shipped concern such as Devise's
-        #   `Devise::Controllers::Helpers`, or a gem-shipped
-        #   parent controller such as `Devise::ConfirmationsController`
-        #   or `Doorkeeper::AuthorizedApplicationsController`).
-        #   Phase 2 uses this to downgrade `unknown-filter-method`
-        #   to silence — the unresolved module / parent may
-        #   legitimately contribute the filter (either directly,
-        #   or via its own ancestor chain which the static
-        #   analyzer cannot follow), and there's no way to verify.
+        # @return [Boolean] true when the class has at least one include OR parent class we couldn't
+        #   resolve in the index (typically a gem-shipped concern such as Devise's
+        #   `Devise::Controllers::Helpers`, or a gem-shipped parent controller such as
+        #   `Devise::ConfirmationsController` or `Doorkeeper::AuthorizedApplicationsController`). Phase
+        #   2 uses this to downgrade `unknown-filter-method` to silence — the unresolved module / parent
+        #   may legitimately contribute the filter (either directly, or via its own ancestor chain which
+        #   the static analyzer cannot follow), and there's no way to verify.
         def unresolved_include?(class_name)
           entry = @entries[class_name]
           return false if entry.nil?
 
-          # Walk the full ancestor chain. `Admin::Foo <
-          # BaseController < ApplicationController` should report
-          # an unresolved include if ANY of the three references
-          # a gem-shipped concern OR a gem-shipped parent class
-          # we cannot index. The first iteration's `current_entry`
-          # is always resolved (caller verified `known?`); a nil
-          # `current_entry` on a subsequent iteration means the
-          # AST-side `< Parent` reached a gem-shipped class
-          # whose ancestor methods are invisible to us.
+          # Walk the full ancestor chain. `Admin::Foo < BaseController < ApplicationController` should
+          # report an unresolved include if ANY of the three references a gem-shipped concern OR a
+          # gem-shipped parent class we cannot index. The first iteration's `current_entry` is always
+          # resolved (caller verified `known?`); a nil `current_entry` on a subsequent iteration means
+          # the AST-side `< Parent` reached a gem-shipped class whose ancestor methods are invisible to
+          # us.
           seen_classes = {}
           current = class_name
           first = true
@@ -136,15 +114,11 @@ module Rigor
               return true if resolved.nil? || !@entries.key?(resolved)
             end
             next_parent = current_entry.parent_class_name
-            # Avoid lexically resolving to ourselves. `class
-            # ActivityPub::ApplicationController < ::ApplicationController`
-            # would otherwise resolve `ApplicationController` (in
-            # the lexical scope `["ActivityPub"]`) to
-            # `ActivityPub::ApplicationController` and short-
-            # circuit the walk before reaching the top-level
-            # parent. When the lexical match is the current
-            # class itself, fall back to the unprefixed
-            # top-level name.
+            # Avoid lexically resolving to ourselves. `class ActivityPub::ApplicationController <
+            # ::ApplicationController` would otherwise resolve `ApplicationController` (in the lexical
+            # scope `["ActivityPub"]`) to `ActivityPub::ApplicationController` and short-circuit the walk
+            # before reaching the top-level parent. When the lexical match is the current class itself,
+            # fall back to the unprefixed top-level name.
             current = if next_parent
                         resolved = resolve_constant_lexically(next_parent, current_entry.enclosing_namespace)
                         resolved == current ? next_parent.sub(/\A::/, "") : resolved
@@ -181,37 +155,28 @@ module Rigor
           end
         end
 
-        # Ruby's constant-lookup walk: a bare constant name
-        # inside `module Admin` first tries `Admin::Const`,
-        # then walks outward, and finally falls through to
-        # top-level `Const`. We approximate that by trying
-        # the candidate `enclosing + name` chains from
-        # deepest to shallowest, and returning the first
-        # candidate that has an entry in the index. When
-        # nothing resolves, return the original name
-        # unchanged — the caller treats unresolved entries as
-        # "gem-shipped concerns we cannot see" (the
-        # `unresolved_include?` predicate).
+        # Ruby's constant-lookup walk: a bare constant name inside `module Admin` first tries
+        # `Admin::Const`, then walks outward, and finally falls through to top-level `Const`. We
+        # approximate that by trying the candidate `enclosing + name` chains from deepest to shallowest,
+        # and returning the first candidate that has an entry in the index. When nothing resolves,
+        # return the original name unchanged — the caller treats unresolved entries as "gem-shipped
+        # concerns we cannot see" (the `unresolved_include?` predicate).
         #
-        # `name` may already be qualified (`Foo::Bar`); we
-        # only try lexical prefixing when the unqualified
-        # first segment doesn't match a top-level entry.
+        # `name` may already be qualified (`Foo::Bar`); we only try lexical prefixing when the
+        # unqualified first segment doesn't match a top-level entry.
         def resolve_constant_lexically(name, enclosing)
           return nil if name.nil?
 
-          # A leading `::` denotes the top-level constant
-          # explicitly (`< ::ApplicationController`). Strip it
-          # for index lookup — the discoverer registers entries
-          # under their unprefixed name. Without this strip a
-          # `class ActivityPub::ApplicationController <
-          # ::ApplicationController` parent never resolved.
+          # A leading `::` denotes the top-level constant explicitly (`< ::ApplicationController`).
+          # Strip it for index lookup — the discoverer registers entries under their unprefixed name.
+          # Without this strip a `class ActivityPub::ApplicationController < ::ApplicationController`
+          # parent never resolved.
           name = name.sub(/\A::/, "")
 
           # Constant already absolute or no enclosing scope.
           return name if enclosing.nil? || enclosing.empty?
 
-          # Try the deepest enclosing scope first, walking
-          # outward. `enclosing = ["A", "B"]` produces
+          # Try the deepest enclosing scope first, walking outward. `enclosing = ["A", "B"]` produces
           # candidates `["A::B::name", "A::name", "name"]`.
           enclosing.length.downto(0).each do |depth|
             prefix = enclosing[0, depth]

--- a/plugins/rigor-activejob/demo/app/jobs/welcome_email_job.rb
+++ b/plugins/rigor-activejob/demo/app/jobs/welcome_email_job.rb
@@ -1,31 +1,27 @@
 # frozen_string_literal: true
 
-# Sample job — rigor-activejob discovers this class because
-# its direct superclass is `ApplicationJob` (one of the
-# default `job_base_classes`). The discoverer reads the
-# `#perform` method's parameter list to compute arity.
+# Sample job — rigor-activejob discovers this class because its direct superclass is `ApplicationJob`
+# (one of the default `job_base_classes`). The discoverer reads the `#perform` method's parameter list
+# to compute arity.
 
 class ApplicationJob
-  # Stand-in base class so `ruby app/jobs/welcome_email_job.rb`
-  # parses standalone (without ActiveJob loaded). rigor-activejob
-  # doesn't care whether the class is declared here or anywhere
-  # else — it only matches by name against `job_base_classes`.
+  # Stand-in base class so `ruby app/jobs/welcome_email_job.rb` parses standalone (without ActiveJob
+  # loaded). rigor-activejob doesn't care whether the class is declared here or anywhere else — it
+  # only matches by name against `job_base_classes`.
   def self.perform_later(*); end
   def self.perform_now(*); end
 end
 
 class WelcomeEmailJob < ApplicationJob
   def perform(user_id, locale = "en")
-    # Body is not analysed by rigor-activejob — only the
-    # signature.
+    # Body is not analysed by rigor-activejob — only the signature.
     [user_id, locale]
   end
 end
 
 class ReportJob < ApplicationJob
   def perform(*report_ids)
-    # `*report_ids` makes the upper bound unbounded
-    # (`0+` arity). Calling `ReportJob.perform_later`
+    # `*report_ids` makes the upper bound unbounded (`0+` arity). Calling `ReportJob.perform_later`
     # with no arguments is OK.
     report_ids
   end

--- a/plugins/rigor-activejob/demo/demo.rb
+++ b/plugins/rigor-activejob/demo/demo.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-# Demo: rigor-activejob recognises every `Job.perform_later`
-# / `.perform_now` / `.perform` call and validates arity
-# against the discovered `#perform`. Run with `bundle exec
-# rigor check` from this directory.
+# Demo: rigor-activejob recognises every `Job.perform_later` / `.perform_now` / `.perform` call and
+# validates arity against the discovered `#perform`. Run with `bundle exec rigor check` from this
+# directory.
 
-# `WelcomeEmailJob#perform(user_id, locale = "en")` →
-# arity 1..2.
+# `WelcomeEmailJob#perform(user_id, locale = "en")` → arity 1..2.
 WelcomeEmailJob.perform_later(123)
 WelcomeEmailJob.perform_later(123, "ja")
 WelcomeEmailJob.perform_now(123)

--- a/plugins/rigor-activejob/demo/errors_demo.rb
+++ b/plugins/rigor-activejob/demo/errors_demo.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-# DO NOT run via `ruby errors_demo.rb` — analyse with
-# `bundle exec rigor check` to see rigor-activejob's
-# diagnostics.
+# DO NOT run via `ruby errors_demo.rb` — analyse with `bundle exec rigor check` to see
+# rigor-activejob's diagnostics.
 
-# `WelcomeEmailJob#perform(user_id, locale = "en")` →
-# arity 1..2. These call sites are wrong:
+# `WelcomeEmailJob#perform(user_id, locale = "en")` → arity 1..2. These call sites are wrong:
 
 # Missing required user_id:
 #   plugin.activejob.wrong-arity

--- a/plugins/rigor-activejob/lib/rigor/plugin/activejob.rb
+++ b/plugins/rigor-activejob/lib/rigor/plugin/activejob.rb
@@ -8,14 +8,12 @@ require_relative "activejob/analyzer"
 
 module Rigor
   module Plugin
-    # rigor-activejob — validates `Job.perform_later(...)` /
-    # `.perform_now(...)` / `.perform(...)` argument arity
-    # against the discovered `#perform` definitions.
+    # rigor-activejob — validates `Job.perform_later(...)` / `.perform_now(...)` / `.perform(...)`
+    # argument arity against the discovered `#perform` definitions.
     #
     # Tier 1D of the [Rails plugins roadmap](../../../../docs/design/20260508-rails-plugins-roadmap.md).
-    # Statically discovers ActiveJob subclasses by walking
-    # the configured `job_search_paths` and parsing each
-    # file with Prism — no `active_job` runtime dependency.
+    # Statically discovers ActiveJob subclasses by walking the configured `job_search_paths` and
+    # parsing each file with Prism — no `active_job` runtime dependency.
     #
     # ## Configuration
     #
@@ -27,16 +25,12 @@ module Rigor
     #
     # ## Limitations (v0.1.0)
     #
-    # - Direct-superclass match only. `class WelcomeJob <
-    #   BaseJob` where `BaseJob < ApplicationJob` is NOT
-    #   discovered. Add `BaseJob` to `job_base_classes` if
-    #   needed.
-    # - The `#perform` arity is read from the syntactic
-    #   parameter list. Methods built via `define_method`
-    #   are out of scope.
-    # - Required keyword arguments are recognised but not
-    #   validated at the call site (positional arity only
-    #   for v0.1.0).
+    # - Direct-superclass match only. `class WelcomeJob < BaseJob` where `BaseJob < ApplicationJob` is
+    #   NOT discovered. Add `BaseJob` to `job_base_classes` if needed.
+    # - The `#perform` arity is read from the syntactic parameter list. Methods built via
+    #   `define_method` are out of scope.
+    # - Required keyword arguments are recognised but not validated at the call site (positional arity
+    #   only for v0.1.0).
     class Activejob < Rigor::Plugin::Base
       manifest(
         id: "activejob",
@@ -48,11 +42,10 @@ module Rigor
         }
       )
 
-      # Cached: discovered job index. `watch:` (ADR-60 WD3) covers
-      # every `.rb` under `job_search_paths` so the cache invalidates
-      # when a job is added, removed, or edited; the discoverer's
-      # in-block `IoBoundary` reads are captured into the record-and-
-      # validate dependency descriptor after the block runs.
+      # Cached: discovered job index. `watch:` (ADR-60 WD3) covers every `.rb` under `job_search_paths`
+      # so the cache invalidates when a job is added, removed, or edited; the discoverer's in-block
+      # `IoBoundary` reads are captured into the record-and-validate dependency descriptor after the
+      # block runs.
       producer :job_index, watch: -> { [[@job_search_paths, "**/*.rb"]] } do |_params|
         JobDiscoverer.new(
           io_boundary: io_boundary,
@@ -66,9 +59,8 @@ module Rigor
         @job_base_classes = Array(config.fetch("job_base_classes")).map(&:to_s)
       end
 
-      # File-level only: the load-error emission. Per-call arity
-      # validation runs over the engine-owned walk via the node_rule
-      # below (ADR-37). The job index is lazily loaded + memoised by
+      # File-level only: the load-error emission. Per-call arity validation runs over the engine-owned
+      # walk via the node_rule below (ADR-37). The job index is lazily loaded + memoised by
       # `producer_value`, shared by both surfaces.
       def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
         index = producer_value(:job_index)

--- a/plugins/rigor-activejob/lib/rigor/plugin/activejob/analyzer.rb
+++ b/plugins/rigor-activejob/lib/rigor/plugin/activejob/analyzer.rb
@@ -5,34 +5,26 @@ require "prism"
 module Rigor
   module Plugin
     class Activejob < Rigor::Plugin::Base
-      # Walks a parsed file's AST looking for
-      # `<JobClass>.perform_later(...)` /
-      # `.perform_now(...)` / `.perform(...)` calls and
-      # validates each against the {JobIndex}.
+      # Walks a parsed file's AST looking for `<JobClass>.perform_later(...)` / `.perform_now(...)` /
+      # `.perform(...)` calls and validates each against the {JobIndex}.
       #
-      # The plugin recognises a call as job-shaped when the
-      # receiver is a `ConstantReadNode` / `ConstantPathNode`
-      # whose resolved name appears in the index, and the
-      # method name is one of the three ActiveJob entry
-      # points.
+      # The plugin recognises a call as job-shaped when the receiver is a `ConstantReadNode` /
+      # `ConstantPathNode` whose resolved name appears in the index, and the method name is one of the
+      # three ActiveJob entry points.
       module Analyzer
-        # Methods that delegate to the job's `#perform`. All
-        # three accept the same argument shape — `perform_later`
-        # is the most common (queues for later execution),
-        # `perform_now` runs synchronously, and `perform` is
-        # the bare execution path.
+        # Methods that delegate to the job's `#perform`. All three accept the same argument shape —
+        # `perform_later` is the most common (queues for later execution), `perform_now` runs
+        # synchronously, and `perform` is the bare execution path.
         ENTRY_METHODS = %i[perform_later perform_now perform].freeze
 
-        # One job-call observation. Carries no path/location — the
-        # caller (the `node_rule` block) positions it via
-        # `Plugin::Base#diagnostic`.
+        # One job-call observation. Carries no path/location — the caller (the `node_rule` block)
+        # positions it via `Plugin::Base#diagnostic`.
         Violation = Struct.new(:rule, :severity, :message, keyword_init: true)
 
         module_function
 
-        # The job-call violations for a single call node (0..2), or `[]`
-        # when the node is not a `<Job>.perform_*` entry call on a known
-        # job. ADR-37: the engine owns the walk.
+        # The job-call violations for a single call node (0..2), or `[]` when the node is not a
+        # `<Job>.perform_*` entry call on a known job. ADR-37: the engine owns the walk.
         #
         # @param call_node [Prism::Node]
         # @param job_index [JobIndex]
@@ -76,8 +68,7 @@ module Rigor
           )
         end
 
-        # Renders a constant-path receiver as a String.
-        # Mirrors the helpers in rigor-activerecord /
+        # Renders a constant-path receiver as a String. Mirrors the helpers in rigor-activerecord /
         # rigor-rails-routes for parity.
         def constant_receiver_name(node)
           case node

--- a/plugins/rigor-activejob/lib/rigor/plugin/activejob/job_discoverer.rb
+++ b/plugins/rigor-activejob/lib/rigor/plugin/activejob/job_discoverer.rb
@@ -7,25 +7,19 @@ require_relative "job_index"
 module Rigor
   module Plugin
     class Activejob < Rigor::Plugin::Base
-      # Walks the configured job-search paths via the plugin's
-      # `IoBoundary`, parses each `.rb` file with Prism, and
-      # collects classes whose immediate superclass is one of
-      # the configured base classes. For each discovered class,
-      # the discoverer also reads the `#perform` method's
-      # parameter list and computes the arity envelope.
+      # Walks the configured job-search paths via the plugin's `IoBoundary`, parses each `.rb` file with
+      # Prism, and collects classes whose immediate superclass is one of the configured base classes.
+      # For each discovered class, the discoverer also reads the `#perform` method's parameter list and
+      # computes the arity envelope.
       #
       # Limitations (intentional for v0.1.0):
       #
-      # - Only direct-superclass matches. `class WelcomeJob <
-      #   BaseJob` where `BaseJob < ApplicationJob` is NOT
-      #   discovered. List `BaseJob` in `job_base_classes`
-      #   if needed.
-      # - The qualified class name is the lexical path
-      #   (`Admin::WelcomeJob` for a class declared inside
+      # - Only direct-superclass matches. `class WelcomeJob < BaseJob` where `BaseJob < ApplicationJob`
+      #   is NOT discovered. List `BaseJob` in `job_base_classes` if needed.
+      # - The qualified class name is the lexical path (`Admin::WelcomeJob` for a class declared inside
       #   `module Admin`).
-      # - The `#perform` arity is read from the syntactic
-      #   parameter list. Methods built via `define_method`
-      #   are out of scope.
+      # - The `#perform` arity is read from the syntactic parameter list. Methods built via
+      #   `define_method` are out of scope.
       class JobDiscoverer
         def initialize(io_boundary:, search_paths:, base_classes:)
           @io_boundary = io_boundary
@@ -119,9 +113,8 @@ module Rigor
           end
         end
 
-        # Returns the `def perform(...)` node from a class
-        # body, or `nil` when the class doesn't override
-        # `#perform`. Only matches instance-side `def perform`.
+        # Returns the `def perform(...)` node from a class body, or `nil` when the class doesn't
+        # override `#perform`. Only matches instance-side `def perform`.
         def lookup_perform_def(body)
           return nil if body.nil?
 
@@ -134,13 +127,10 @@ module Rigor
           nil
         end
 
-        # Builds a JobIndex::Entry from the discovered class's
-        # `#perform` def. When the class doesn't override
-        # `#perform`, we record an "any-arity" entry — Active
-        # Job's default `#perform` is abstract; calling
-        # `perform_later` on a job that didn't override it is
-        # itself a bug, but it's the user's bug, not the
-        # plugin's call to flag without runtime context.
+        # Builds a JobIndex::Entry from the discovered class's `#perform` def. When the class doesn't
+        # override `#perform`, we record an "any-arity" entry — Active Job's default `#perform` is
+        # abstract; calling `perform_later` on a job that didn't override it is itself a bug, but it's
+        # the user's bug, not the plugin's call to flag without runtime context.
         def build_entry(class_name, perform_def)
           if perform_def.nil?
             return JobIndex::Entry.new(

--- a/plugins/rigor-activejob/lib/rigor/plugin/activejob/job_index.rb
+++ b/plugins/rigor-activejob/lib/rigor/plugin/activejob/job_index.rb
@@ -3,22 +3,17 @@
 module Rigor
   module Plugin
     class Activejob < Rigor::Plugin::Base
-      # Frozen catalogue of discovered ActiveJob subclasses
-      # keyed by qualified class name. Each entry holds the
-      # `#perform` method's arity envelope so the analyzer can
-      # validate `Job.perform_later(...)` call sites.
+      # Frozen catalogue of discovered ActiveJob subclasses keyed by qualified class name. Each entry
+      # holds the `#perform` method's arity envelope so the analyzer can validate
+      # `Job.perform_later(...)` call sites.
       #
-      # `min_arity` / `max_arity` form a closed range
-      # (`Float::INFINITY` for the upper bound when `*args`
-      # is present). `keyword_required` lists any required
-      # keyword arguments — Active Job supports keyword args
-      # but they're rare in user code, so the analyzer
-      # validates positional arity only (keyword arity
-      # validation is deferred).
+      # `min_arity` / `max_arity` form a closed range (`Float::INFINITY` for the upper bound when
+      # `*args` is present). `keyword_required` lists any required keyword arguments — Active Job
+      # supports keyword args but they're rare in user code, so the analyzer validates positional arity
+      # only (keyword arity validation is deferred).
       class JobIndex
         Entry = Data.define(:class_name, :min_arity, :max_arity, :keyword_required) do
-          # Flexible-friendly textual form of the arity for
-          # error messages: `1`, `1..2`, `2+`.
+          # Flexible-friendly textual form of the arity for error messages: `1`, `1..2`, `2+`.
           def arity_label
             return "#{min_arity}+" if max_arity == Float::INFINITY
             return min_arity.to_s if min_arity == max_arity

--- a/plugins/rigor-activerecord/demo/demo.rb
+++ b/plugins/rigor-activerecord/demo/demo.rb
@@ -9,11 +9,9 @@ require_relative "app/models/comment"
 #
 #   RUBYLIB=$PWD/../lib bundle exec rigor check
 #
-# rigor-activerecord reads `db/schema.rb` once (via
-# Plugin::IoBoundary), discovers the AR models under
-# `app/models/`, builds a model index, and validates each
-# `Model.find` / `.find_by` / `.where` call against the
-# resolved table's columns.
+# rigor-activerecord reads `db/schema.rb` once (via Plugin::IoBoundary), discovers the AR models under
+# `app/models/`, builds a model index, and validates each `Model.find` / `.find_by` / `.where` call
+# against the resolved table's columns.
 
 # ---- Recognised calls ----
 

--- a/plugins/rigor-activerecord/demo/errors_demo.rb
+++ b/plugins/rigor-activerecord/demo/errors_demo.rb
@@ -4,10 +4,9 @@ require_relative "lib/runtime"
 require_relative "app/models/user"
 require_relative "app/models/post"
 
-# Intentionally ill-typed file — demonstrates the diagnostics
-# rigor-activerecord emits for unknown columns and arity
-# mistakes. DO NOT run via `ruby errors_demo.rb` — the runtime
-# stubs accept anything; rigor check is what catches these.
+# Intentionally ill-typed file — demonstrates the diagnostics rigor-activerecord emits for unknown
+# columns and arity mistakes. DO NOT run via `ruby errors_demo.rb` — the runtime stubs accept anything;
+# rigor check is what catches these.
 
 # Unknown column with a close did-you-mean suggestion.
 User.where(emial: "alice@example.com")

--- a/plugins/rigor-activerecord/demo/lib/runtime.rb
+++ b/plugins/rigor-activerecord/demo/lib/runtime.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-# Stand-in runtime so the demo files run under MRI without
-# requiring Rails. Real Rails apps would `require "active_record"`
-# instead. The plugin analyses the source — it does NOT need
-# ActiveRecord loaded at lint time.
+# Stand-in runtime so the demo files run under MRI without requiring Rails. Real Rails apps would
+# `require "active_record"` instead. The plugin analyses the source — it does NOT need ActiveRecord
+# loaded at lint time.
 
 class ApplicationRecord
   def self.find(*) = new

--- a/plugins/rigor-activerecord/lib/rigor-activerecord.rb
+++ b/plugins/rigor-activerecord/lib/rigor-activerecord.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-activerecord` under `plugins:`. The
-# loader expects this `require` to side-effect a call to
-# `Rigor::Plugin.register`, which the body of
-# `lib/rigor/plugin/activerecord.rb` performs at load time.
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists `rigor-activerecord` under
+# `plugins:`. The loader expects this `require` to side-effect a call to `Rigor::Plugin.register`, which
+# the body of `lib/rigor/plugin/activerecord.rb` performs at load time.
 require_relative "rigor/plugin/activerecord"

--- a/plugins/rigor-activerecord/lib/rigor/plugin/activerecord.rb
+++ b/plugins/rigor-activerecord/lib/rigor/plugin/activerecord.rb
@@ -10,34 +10,26 @@ require_relative "activerecord/analyzer"
 
 module Rigor
   module Plugin
-    # rigor-activerecord — types ActiveRecord finder + relation
-    # calls against the project's `db/schema.rb` and discovered
-    # AR model classes.
+    # rigor-activerecord — types ActiveRecord finder + relation calls against the project's `db/schema.rb`
+    # and discovered AR model classes.
     #
     # ## Architecture
     #
     # Two cached producers per plugin run:
     #
-    # 1. `:schema_table` reads `db/schema.rb` via the `IoBoundary`
-    #    and parses it through {SchemaParser} into a
-    #    {SchemaTable} mapping `table_name → { column_name →
-    #    Column }`.
-    # 2. `:model_index` walks every `.rb` file under the
-    #    configured `model_search_paths`, finds class declarations
-    #    whose direct superclass is in `model_base_classes`, and
-    #    composes them with the schema table into a {ModelIndex}.
+    # 1. `:schema_table` reads `db/schema.rb` via the `IoBoundary` and parses it through {SchemaParser} into
+    #    a {SchemaTable} mapping `table_name → { column_name → Column }`.
+    # 2. `:model_index` walks every `.rb` file under the configured `model_search_paths`, finds class
+    #    declarations whose direct superclass is in `model_base_classes`, and composes them with the schema
+    #    table into a {ModelIndex}.
     #
-    # Both producers ride `Plugin::Base#cache_for` (ADR-60 WD3
-    # record-and-validate): each producer's in-block boundary reads
-    # are captured into its dependency descriptor after the block
-    # runs, and `model_index`'s `watch:` covers model-file additions,
-    # so editing `db/schema.rb`, editing any model, or adding a new
-    # model file invalidates exactly the right cache entry.
+    # Both producers ride `Plugin::Base#cache_for` (ADR-60 WD3 record-and-validate): each producer's
+    # in-block boundary reads are captured into its dependency descriptor after the block runs, and
+    # `model_index`'s `watch:` covers model-file additions, so editing `db/schema.rb`, editing any model, or
+    # adding a new model file invalidates exactly the right cache entry.
     #
-    # The per-file `#diagnostics_for_file` hook delegates to
-    # {Analyzer}, which walks Prism and emits diagnostics for
-    # `Model.find` / `Model.find_by` / `Model.where` calls
-    # against the index.
+    # The per-file `#diagnostics_for_file` hook delegates to {Analyzer}, which walks Prism and emits
+    # diagnostics for `Model.find` / `Model.find_by` / `Model.where` calls against the index.
     #
     # ## Configuration
     #
@@ -48,25 +40,19 @@ module Rigor
     #           model_search_paths: ["app/models"]
     #           model_base_classes: ["ApplicationRecord", "ActiveRecord::Base"]
     #
-    # All three keys default to the values shown above. The class
-    # name `Rigor::Plugin::Activerecord` (single capital R) is
-    # intentional — keeps the constant lookup distinct from
-    # `::ActiveRecord` even though the gem name is hyphenated.
+    # All three keys default to the values shown above. The class name `Rigor::Plugin::Activerecord` (single
+    # capital R) is intentional — keeps the constant lookup distinct from `::ActiveRecord` even though the
+    # gem name is hyphenated.
     #
-    # Note: this plugin is the seventh worked example. It does NOT
-    # require `active_record` at runtime — it only reads project
-    # source, the same way the other examples do. Rigor stays
-    # decoupled from Rails.
+    # Note: this plugin is the seventh worked example. It does NOT require `active_record` at runtime — it
+    # only reads project source, the same way the other examples do. Rigor stays decoupled from Rails.
     class Activerecord < Rigor::Plugin::Base
       manifest(
         id: "activerecord",
-        # Bumped 2026-05-28 — implicit-self class-side AR call
-        # resolution: `select(:uri).group(:uri)` inside a scope
-        # lambda body / class-method body now contributes
-        # `Relation[Model]` via `scope.self_type` instead of
-        # falling through to `Kernel#select` (the IO multiplexer,
-        # `Array[String]` return). Plus `:select` added to the
-        # relation-entry-point list.
+        # Bumped 2026-05-28 — implicit-self class-side AR call resolution: `select(:uri).group(:uri)` inside
+        # a scope lambda body / class-method body now contributes `Relation[Model]` via `scope.self_type`
+        # instead of falling through to `Kernel#select` (the IO multiplexer, `Array[String]` return). Plus
+        # `:select` added to the relation-entry-point list.
         version: "0.5.0",
         description: "Types ActiveRecord finders against the project's db/schema.rb and AR models.",
         config_schema: {
@@ -75,37 +61,30 @@ module Rigor
           "model_base_classes" => { kind: :array, default: %w[ApplicationRecord ActiveRecord::Base] }
         },
         produces: [:model_index],
-        # ADR-25 — the bundled `ActiveRecord::Relation` RBS that
-        # relation-typed call sites (`has_many` accessors,
-        # `Model.where`, scopes) dispatch against.
+        # ADR-25 — the bundled `ActiveRecord::Relation` RBS that relation-typed call sites (`has_many`
+        # accessors, `Model.where`, scopes) dispatch against.
         signature_paths: ["sig"],
-        # ADR-26 — `ActiveRecord::Relation` is an "open" receiver:
-        # it delegates an unbounded set of user-defined scopes /
-        # class methods to its model, so `call.undefined-method`
-        # must not fire for it. `CheckRules` reads this manifest
-        # field and skips the rule for the class.
+        # ADR-26 — `ActiveRecord::Relation` is an "open" receiver: it delegates an unbounded set of
+        # user-defined scopes / class methods to its model, so `call.undefined-method` must not fire for
+        # it. `CheckRules` reads this manifest field and skips the rule for the class.
         open_receivers: ["ActiveRecord::Relation"]
       )
 
-      # The class the bundled `sig/active_record/relation.rbs`
-      # describes; `dynamic_return` contributes
-      # `ActiveRecord::Relation[Model]` for relation-returning
-      # call sites (`has_many` accessors, `Model.where`, scopes).
+      # The class the bundled `sig/active_record/relation.rbs` describes; `dynamic_return` contributes
+      # `ActiveRecord::Relation[Model]` for relation-returning call sites (`has_many` accessors,
+      # `Model.where`, scopes).
       RELATION_CLASS_NAME = "ActiveRecord::Relation"
 
-      # Cached: parsed schema table. The producer reads `@schema_file`
-      # via `io_boundary.read_file` so the descriptor picks up the
-      # digest, then parses through {SchemaParser}.
+      # Cached: parsed schema table. The producer reads `@schema_file` via `io_boundary.read_file` so the
+      # descriptor picks up the digest, then parses through {SchemaParser}.
       producer :schema_table do |_params|
         contents = io_boundary.read_file(@schema_file)
         SchemaParser.parse(contents)
       end
 
-      # Cached: model index. Walks every model file, then composes
-      # the rows with the cached schema table. `watch:` (ADR-60 WD3)
-      # covers model-file additions; the discoverer's in-block reads
-      # are captured into the record-and-validate dependency
-      # descriptor after the block runs.
+      # Cached: model index. Walks every model file, then composes the rows with the cached schema table.
+      # `watch:` (ADR-60 WD3) covers model-file additions; the discoverer's in-block reads are captured
+      # into the record-and-validate dependency descriptor after the block runs.
       producer :model_index, watch: -> { [[@model_search_paths, "**/*.rb"]] } do |_params|
         rows = ModelDiscoverer.new(
           io_boundary: io_boundary,
@@ -125,15 +104,11 @@ module Rigor
         @load_errors = []
       end
 
-      # ADR-9 cross-plugin publication. Builds the model index
-      # eagerly during the per-run `prepare(services)` pass and
-      # publishes a flat Hash form to the shared fact store so
-      # downstream Tier-2 consumers (rigor-actionpack Phase 1
-      # strong-parameter validation, rigor-factorybot Phase 1
-      # (c) attribute → column cross-check, future plugins
-      # that need to know "what columns does class `User`
-      # expose?") can read it without coupling to this
-      # plugin's carrier classes.
+      # ADR-9 cross-plugin publication. Builds the model index eagerly during the per-run
+      # `prepare(services)` pass and publishes a flat Hash form to the shared fact store so downstream
+      # Tier-2 consumers (rigor-actionpack Phase 1 strong-parameter validation, rigor-factorybot Phase 1
+      # (c) attribute → column cross-check, future plugins that need to know "what columns does class
+      # `User` expose?") can read it without coupling to this plugin's carrier classes.
       #
       # The published shape:
       #
@@ -143,11 +118,9 @@ module Rigor
       #       ...
       #     }
       #
-      # Consumers do `services.fact_store.read(plugin_id:
-      # "activerecord", name: :model_index)` and look up by
-      # class name. Discovery failures (missing schema,
-      # unparseable models) leave the fact unpublished — the
-      # consumer's own degrade path runs (typically a no-op).
+      # Consumers do `services.fact_store.read(plugin_id: "activerecord", name: :model_index)` and look up
+      # by class name. Discovery failures (missing schema, unparseable models) leave the fact unpublished —
+      # the consumer's own degrade path runs (typically a no-op).
       def prepare(services)
         index = model_index
         return if index.nil? || index.empty?
@@ -162,12 +135,10 @@ module Rigor
       def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
         index = model_index
         if index.nil?
-          # Project-global error (missing `db/schema.rb`, parse
-          # failure, etc.) — emit once per run rather than once
-          # per analyzed file. On a Redmine-shape project that
-          # uses migrations only (no `schema.rb`), the old path
-          # produced 346 identical load-errors; on a Solidus
-          # monorepo (no top-level `schema.rb`), 999.
+          # Project-global error (missing `db/schema.rb`, parse failure, etc.) — emit once per run rather
+          # than once per analyzed file. On a Redmine-shape project that uses migrations only (no
+          # `schema.rb`), the old path produced 346 identical load-errors; on a Solidus monorepo (no
+          # top-level `schema.rb`), 999.
           return [] if @load_errors_emitted
 
           @load_errors_emitted = true
@@ -179,15 +150,11 @@ module Rigor
         Analyzer.new(path: path, model_index: index).analyze(root).diagnostics
       end
 
-      # Rails migration files (`db/migrate/<timestamp>_*.rb`)
-      # and post-migration files (`db/post_migrate/`) reference
-      # the EVOLVING schema at the time the migration was
-      # written — `User.where(admin: ...)` is valid when the
-      # migration ran on a schema that still had the `admin`
-      # column, even though the current `db/schema.rb` no
-      # longer carries it. Validating these files against the
-      # CURRENT schema is a category error; the column
-      # diagnostics MUST stay silent.
+      # Rails migration files (`db/migrate/<timestamp>_*.rb`) and post-migration files
+      # (`db/post_migrate/`) reference the EVOLVING schema at the time the migration was written —
+      # `User.where(admin: ...)` is valid when the migration ran on a schema that still had the `admin`
+      # column, even though the current `db/schema.rb` no longer carries it. Validating these files
+      # against the CURRENT schema is a category error; the column diagnostics MUST stay silent.
       MIGRATION_PATH_PATTERNS = [
         %r{(\A|/)db/migrate/},
         %r{(\A|/)db/post_migrate/}
@@ -201,48 +168,36 @@ module Rigor
         MIGRATION_PATH_PATTERNS.any? { |pattern| path_s.match?(pattern) }
       end
 
-      # The class-side finder / relation entry-point names
-      # `finder_return_type` recognises. Static half of the
-      # `dynamic_return` name gate; the run-time half comes from
-      # the model index (scopes, associations, columns).
+      # The class-side finder / relation entry-point names `finder_return_type` recognises. Static half of
+      # the `dynamic_return` name gate; the run-time half comes from the model index (scopes,
+      # associations, columns).
       FINDER_METHOD_NAMES = %i[find find_by! find_by where all order limit none select].freeze
       private_constant :FINDER_METHOD_NAMES
 
-      # Return-type contribution via the run-time `methods:` name
-      # gate (ADR-52 slice 5b). `Model.find(id)` narrows the call
-      # site's return type to `Nominal[Model]`, so chained calls
-      # (`User.find(1).name`) resolve through the analyzer's
-      # normal dispatch instead of the RBS-level untyped
-      # fall-back; scopes, association accessors, and column
-      # readers narrow per the paths below.
+      # Return-type contribution via the run-time `methods:` name gate (ADR-52 slice 5b). `Model.find(id)`
+      # narrows the call site's return type to `Nominal[Model]`, so chained calls (`User.find(1).name`)
+      # resolve through the analyzer's normal dispatch instead of the RBS-level untyped fall-back; scopes,
+      # association accessors, and column readers narrow per the paths below.
       #
-      # WHY a method-name gate and not `receivers:` — the ADR-52
-      # "rigor-activerecord blocker": a project model not in RBS
-      # types its constant as `Dynamic[top]`, so a receiver-type
-      # gate declines exactly the calls this plugin exists for. A
-      # *name* gate never reads the receiver type; the block keeps
-      # the plugin's own AST-constant / `self_type` / `type_of`
-      # resolution, so the Dynamic-constant case still reaches it
-      # (the same shape as rigor-sorbet's catalog path). The set —
-      # the static finder names ∪ every scope, association, and
-      # column name (plus `column?` predicate forms) the model
-      # index discovered — is exactly the union of names the four
-      # resolution paths below can return a type for, so gating on
-      # it is byte-identical to the old ungated hook. It is broad
-      # (`name`, `id`, …), but membership is one Set probe and the
-      # expensive block runs only on candidate hits.
+      # WHY a method-name gate and not `receivers:` — the ADR-52 "rigor-activerecord blocker": a project
+      # model not in RBS types its constant as `Dynamic[top]`, so a receiver-type gate declines exactly the
+      # calls this plugin exists for. A *name* gate never reads the receiver type; the block keeps the
+      # plugin's own AST-constant / `self_type` / `type_of` resolution, so the Dynamic-constant case still
+      # reaches it (the same shape as rigor-sorbet's catalog path). The set — the static finder names ∪
+      # every scope, association, and column name (plus `column?` predicate forms) the model index
+      # discovered — is exactly the union of names the four resolution paths below can return a type for,
+      # so gating on it is byte-identical to the old ungated hook. It is broad (`name`, `id`, …), but
+      # membership is one Set probe and the expensive block runs only on candidate hits.
       dynamic_return methods: -> { recognised_method_names } do |call_node, scope|
         contribution_return_type(call_node, scope)
       end
 
       private
 
-      # The run-time name gate: finders ∪ scopes ∪ associations ∪
-      # column readers (+ `?` predicates). Resolved lazily on first
-      # dispatch (after `#prepare` built the index), memoised by the
-      # engine. Returns [] when discovery found nothing — the gate
-      # then declines every call, matching the old hook's
-      # `index.nil? || index.empty?` early return.
+      # The run-time name gate: finders ∪ scopes ∪ associations ∪ column readers (+ `?` predicates).
+      # Resolved lazily on first dispatch (after `#prepare` built the index), memoised by the engine.
+      # Returns [] when discovery found nothing — the gate then declines every call, matching the old
+      # hook's `index.nil? || index.empty?` early return.
       def recognised_method_names
         index = model_index
         return [] if index.nil? || index.empty?
@@ -259,8 +214,8 @@ module Rigor
         names
       end
 
-      # Resolution body for `dynamic_return` — same four-path
-      # order, returning the bare type the contract expects.
+      # Resolution body for `dynamic_return` — same four-path order, returning the bare type the contract
+      # expects.
       def contribution_return_type(call_node, scope)
         return nil unless call_node.is_a?(Prism::CallNode)
 
@@ -287,24 +242,19 @@ module Rigor
           class_scope_return_type(call_node, entry)
       end
 
-      # Implicit-self class-side call: `select(:uri)` /
-      # `where(active: true)` inside a `def self.<method>` body,
-      # a class body, or a scope lambda body (`scope :x, -> { ... }`).
-      # The surrounding `self_type` is `Singleton[Model]` in all
-      # three cases, so the same finder / scope / relation entry-
-      # point resolution that handles `Model.where(...)` applies.
+      # Implicit-self class-side call: `select(:uri)` / `where(active: true)` inside a `def
+      # self.<method>` body, a class body, or a scope lambda body (`scope :x, -> { ... }`). The
+      # surrounding `self_type` is `Singleton[Model]` in all three cases, so the same finder / scope /
+      # relation entry-point resolution that handles `Model.where(...)` applies.
       #
-      # Without this, `select(:uri)` inside a class body falls
-      # through to RBS dispatch on `Singleton[Account]`, which
-      # finds `Kernel#select` (the IO multiplexer) at
-      # `core/kernel.rbs` — its `Array[String]` return masks the
-      # AR class-side `select`'s relation return type, so the
-      # canonical scope-body idiom
+      # Without this, `select(:uri)` inside a class body falls through to RBS dispatch on
+      # `Singleton[Account]`, which finds `Kernel#select` (the IO multiplexer) at `core/kernel.rbs` — its
+      # `Array[String]` return masks the AR class-side `select`'s relation return type, so the canonical
+      # scope-body idiom
       #
       #   scope :duplicate_uris, -> { select(:uri).group(:uri) }
       #
-      # types `select(:uri)` as `Array[String]` and the chained
-      # `.group` as `undefined-method`.
+      # types `select(:uri)` as `Array[String]` and the chained `.group` as `undefined-method`.
       def implicit_self_class_call_return_type(call_node, scope, index)
         return nil if scope.nil?
 
@@ -318,12 +268,10 @@ module Rigor
           class_scope_return_type(call_node, entry)
       end
 
-      # Class-side finders + the class-side relation entry points.
-      # `find` / `find_by!` return the model; `find_by` adds the
-      # `nil` arm; `where` / `all` / `order` / `limit` / `none`
-      # open a relation. The relation then carries its element
-      # type through any further chained query method via the
-      # bundled `ActiveRecord::Relation` RBS.
+      # Class-side finders + the class-side relation entry points. `find` / `find_by!` return the model;
+      # `find_by` adds the `nil` arm; `where` / `all` / `order` / `limit` / `none` open a relation. The
+      # relation then carries its element type through any further chained query method via the bundled
+      # `ActiveRecord::Relation` RBS.
       def finder_return_type(call_node, entry)
         case call_node.name
         when :find
@@ -331,8 +279,8 @@ module Rigor
 
           Rigor::Type::Combinator.nominal_of(entry.class_name)
         when :find_by!
-          # The bang variant raises `RecordNotFound` instead of
-          # returning `nil`, so the result is non-nullable.
+          # The bang variant raises `RecordNotFound` instead of returning `nil`, so the result is
+          # non-nullable.
           Rigor::Type::Combinator.nominal_of(entry.class_name)
         when :find_by
           Rigor::Type::Combinator.union(
@@ -341,31 +289,26 @@ module Rigor
           )
         when :where, :all, :order, :limit, :none, :select
           # `:select` was added to close Mastodon's
-          # `scope :duplicate_uris, -> { select(:uri).group(:uri).having(...) }`
-          # shape: the implicit-self `select(:uri)` inside the
-          # scope lambda body had been resolving to `Kernel#select`
-          # (IO multiplexer, return `Array[String]`), masking the
-          # AR class-side relation entry point. The rest of the
-          # query DSL chains through the bundled `ActiveRecord::Relation`
-          # RBS once a relation is open.
+          # `scope :duplicate_uris, -> { select(:uri).group(:uri).having(...) }` shape: the implicit-self
+          # `select(:uri)` inside the scope lambda body had been resolving to `Kernel#select` (IO
+          # multiplexer, return `Array[String]`), masking the AR class-side relation entry point. The rest
+          # of the query DSL chains through the bundled `ActiveRecord::Relation` RBS once a relation is
+          # open.
           relation_of(entry.class_name)
         end
       end
 
-      # `Post.published` / `Post.recent(5)` — a user-declared
-      # `scope` returns a relation of the model regardless of the
-      # arguments it takes.
+      # `Post.published` / `Post.recent(5)` — a user-declared `scope` returns a relation of the model
+      # regardless of the arguments it takes.
       def class_scope_return_type(call_node, entry)
         return nil unless entry.scope?(call_node.name)
 
         relation_of(entry.class_name)
       end
 
-      # `ActiveRecord::Relation[Model]` — the type the bundled
-      # `sig/active_record/relation.rbs` describes. The class is
-      # declared `open_receivers` in the manifest, so a chained
-      # scope call the bundled RBS cannot enumerate does not
-      # surface as `call.undefined-method` (ADR-26).
+      # `ActiveRecord::Relation[Model]` — the type the bundled `sig/active_record/relation.rbs` describes.
+      # The class is declared `open_receivers` in the manifest, so a chained scope call the bundled RBS
+      # cannot enumerate does not surface as `call.undefined-method` (ADR-26).
       def relation_of(model_class_name)
         Rigor::Type::Combinator.nominal_of(
           RELATION_CLASS_NAME,
@@ -373,24 +316,17 @@ module Rigor
         )
       end
 
-      # A scope invoked on an already-typed relation
-      # (`User.where(active: true).published`) keeps the relation
-      # type through the chain. The bundled `ActiveRecord::Relation`
-      # RBS cannot enumerate user-defined scopes, so without this
-      # the chain would lose its element type after the first
-      # scope call. Non-scope methods decline — the RBS tier
-      # resolves `where` / `order` / `each` / `first` precisely.
-      # Scopes may take arguments (`relation.recent(5)`), so —
-      # unlike `instance_call_return_type` — argument calls are
-      # not skipped.
+      # A scope invoked on an already-typed relation (`User.where(active: true).published`) keeps the
+      # relation type through the chain. The bundled `ActiveRecord::Relation` RBS cannot enumerate
+      # user-defined scopes, so without this the chain would lose its element type after the first scope
+      # call. Non-scope methods decline — the RBS tier resolves `where` / `order` / `each` / `first`
+      # precisely. Scopes may take arguments (`relation.recent(5)`), so — unlike `instance_call_return_type`
+      # — argument calls are not skipped.
       #
-      # The cheap `scope_name?` pre-check is load-bearing: it
-      # gates the `scope.type_of(receiver)` call so the receiver
-      # type is computed ONLY when the method name could be a
-      # scope. `type_of` on a call receiver re-enters dispatch,
-      # and calling it for every call node in a long method chain
-      # is pathologically expensive — the pre-check keeps the
-      # cost off the hot path.
+      # The cheap `scope_name?` pre-check is load-bearing: it gates the `scope.type_of(receiver)` call so
+      # the receiver type is computed ONLY when the method name could be a scope. `type_of` on a call
+      # receiver re-enters dispatch, and calling it for every call node in a long method chain is
+      # pathologically expensive — the pre-check keeps the cost off the hot path.
       def relation_call_return_type(call_node, scope, index)
         return nil if call_node.receiver.nil?
         return nil unless scope_name?(call_node.name, index)
@@ -405,16 +341,15 @@ module Rigor
         relation_of(model_name)
       end
 
-      # Whether `name` is a declared `scope` on ANY model in the
-      # index. A run-lifetime memoised Set so the per-call check
-      # in `relation_call_return_type` stays O(1).
+      # Whether `name` is a declared `scope` on ANY model in the index. A run-lifetime memoised Set so the
+      # per-call check in `relation_call_return_type` stays O(1).
       def scope_name?(name, index)
         @all_scope_names ||= index.entries.each_value.flat_map(&:scopes).to_set
         @all_scope_names.include?(name.to_s)
       end
 
-      # When `type` is `ActiveRecord::Relation[Nominal[Model]]`,
-      # returns the model class name; nil for any other type.
+      # When `type` is `ActiveRecord::Relation[Nominal[Model]]`, returns the model class name; nil for
+      # any other type.
       def relation_element_class_name(type)
         return nil unless type.is_a?(Rigor::Type::Nominal)
         return nil unless type.class_name == RELATION_CLASS_NAME
@@ -423,13 +358,10 @@ module Rigor
         element.class_name if element.is_a?(Rigor::Type::Nominal)
       end
 
-      # Instance-side navigation: when the call's receiver
-      # resolves to `Nominal[Model]` and the method name matches
-      # a discovered association OR a table column, the call site
-      # gets a precise return type. Calls with arguments are
-      # skipped — accessor / association calls take no args, and
-      # argument forms (`user.posts(limit: 10)`, `user.name = x`)
-      # route through Rails APIs this slice does not model.
+      # Instance-side navigation: when the call's receiver resolves to `Nominal[Model]` and the method name
+      # matches a discovered association OR a table column, the call site gets a precise return type.
+      # Calls with arguments are skipped — accessor / association calls take no args, and argument forms
+      # (`user.posts(limit: 10)`, `user.name = x`) route through Rails APIs this slice does not model.
       def instance_call_return_type(call_node, scope, index)
         return nil unless call_node.arguments.nil?
 
@@ -444,16 +376,12 @@ module Rigor
           column_return_type(entry, call_node.name)
       end
 
-      # The return type for an association accessor. A `belongs_to`
-      # / `has_one` singular association narrows to the target
-      # model — `belongs_to` is required (non-`nil`) by default
-      # since Rails 5 so it is `Nominal[Target]`, while `has_one`
-      # (and an `optional: true` / `required: false` `belongs_to`)
-      # adds the `nil` arm. A `has_many` / `has_and_belongs_to_many`
-      # collection narrows to `ActiveRecord::Relation[Target]` so
-      # chained query / iteration calls resolve. A polymorphic
-      # association has no single static target and declines
-      # rather than inventing a wrong type.
+      # The return type for an association accessor. A `belongs_to` / `has_one` singular association
+      # narrows to the target model — `belongs_to` is required (non-`nil`) by default since Rails 5 so it
+      # is `Nominal[Target]`, while `has_one` (and an `optional: true` / `required: false` `belongs_to`)
+      # adds the `nil` arm. A `has_many` / `has_and_belongs_to_many` collection narrows to
+      # `ActiveRecord::Relation[Target]` so chained query / iteration calls resolve. A polymorphic
+      # association has no single static target and declines rather than inventing a wrong type.
       def association_return_type(entry, method_name)
         association = entry.association(method_name)
         return nil if association.nil?
@@ -470,19 +398,14 @@ module Rigor
         end
       end
 
-      # Instance-side column access. `user.name` on a
-      # `Nominal[User]` receiver narrows to the column's value
-      # type; `user.name?` (the ActiveRecord-generated predicate)
-      # narrows to `bool`.
+      # Instance-side column access. `user.name` on a `Nominal[User]` receiver narrows to the column's
+      # value type; `user.name?` (the ActiveRecord-generated predicate) narrows to `bool`.
       #
-      # The contributed type is deliberately NON-nullable even
-      # though the DB column may permit `NULL`: Rails code calls
-      # column accessors directly (`user.email.downcase`) as a
-      # matter of course, and contributing `T | nil` would light
-      # up that idiom with `possible-nil-receiver` across an
-      # entire codebase. Under-reporting a nil column is a false
-      # negative; over-reporting it is a false positive — and the
-      # project ranks the latter as the worse failure.
+      # The contributed type is deliberately NON-nullable even though the DB column may permit `NULL`:
+      # Rails code calls column accessors directly (`user.email.downcase`) as a matter of course, and
+      # contributing `T | nil` would light up that idiom with `possible-nil-receiver` across an entire
+      # codebase. Under-reporting a nil column is a false negative; over-reporting it is a false positive
+      # — and the project ranks the latter as the worse failure.
       def column_return_type(entry, method_name)
         name = method_name.to_s
         predicate = name.end_with?("?")
@@ -498,12 +421,10 @@ module Rigor
         column.array? ? Rigor::Type::Combinator.nominal_of("Array", type_args: [inner]) : inner
       end
 
-      # Maps a `SchemaTable::Column#ruby_type` string to a Rigor
-      # type. `"Object"` (json / jsonb / unrecognised column
-      # types) declines — `Nominal[Object]` would be NARROWER
-      # than the RBS-erased envelope and could surface false
-      # `call.undefined-method` on a value whose real shape the
-      # plugin cannot model.
+      # Maps a `SchemaTable::Column#ruby_type` string to a Rigor type. `"Object"` (json / jsonb /
+      # unrecognised column types) declines — `Nominal[Object]` would be NARROWER than the RBS-erased
+      # envelope and could surface false `call.undefined-method` on a value whose real shape the plugin
+      # cannot model.
       def ruby_type_to_type(ruby_type)
         case ruby_type
         when "bool" then bool_type
@@ -546,12 +467,9 @@ module Rigor
         node.arguments.arguments.size
       end
 
-      # Marshal-clean Hash form for the cross-plugin fact
-      # store. Consumers (rigor-actionpack Phase 1,
-      # rigor-factorybot Phase 1 (c), ...) get a flat
-      # `class_name → { table:, columns: }` map without
-      # depending on this plugin's `ModelIndex` /
-      # `SchemaTable::Column` carrier classes.
+      # Marshal-clean Hash form for the cross-plugin fact store. Consumers (rigor-actionpack Phase 1,
+      # rigor-factorybot Phase 1 (c), ...) get a flat `class_name → { table:, columns: }` map without
+      # depending on this plugin's `ModelIndex` / `SchemaTable::Column` carrier classes.
       def index_to_published_hash(index)
         index.entries.transform_values do |entry|
           {
@@ -573,11 +491,9 @@ module Rigor
         table = schema_table_or_nil
         return nil if table.nil?
 
-        # ADR-60 WD3 record-and-validate: the producer's own in-block
-        # `ModelDiscoverer` reads are captured into the dependency
-        # descriptor after the block runs, and the producer's `watch:`
-        # covers model-file additions — so no priming walk is needed
-        # (it used to run the discover twice).
+        # ADR-60 WD3 record-and-validate: the producer's own in-block `ModelDiscoverer` reads are
+        # captured into the dependency descriptor after the block runs, and the producer's `watch:` covers
+        # model-file additions — so no priming walk is needed (it used to run the discover twice).
         @model_index = cache_for(:model_index, params: {}).call
       rescue StandardError => e
         @load_errors << "model index build failed: #{e.class}: #{e.message}"
@@ -586,20 +502,17 @@ module Rigor
 
       def schema_table_or_nil
         return @schema_table if @schema_table
-        # Memoize the *failure*, not just the success: `model_index`
-        # (and thus this method) is invoked per AR call site, so a
-        # missing / unreadable schema file would otherwise re-attempt
-        # the read and append a fresh interpolated error string to
-        # `@load_errors` on every call. On a large Rails app that grew
-        # `@load_errors` to millions of retained strings (measured: 4.2 M
-        # strings / ~1.5 GB on Redmine). One attempt is enough.
+        # Memoize the *failure*, not just the success: `model_index` (and thus this method) is invoked per
+        # AR call site, so a missing / unreadable schema file would otherwise re-attempt the read and
+        # append a fresh interpolated error string to `@load_errors` on every call. On a large Rails app
+        # that grew `@load_errors` to millions of retained strings (measured: 4.2 M strings / ~1.5 GB on
+        # Redmine). One attempt is enough.
         return nil if @schema_load_attempted
 
         @schema_load_attempted = true
-        # ADR-60 WD3 record-and-validate: the producer reads
-        # `@schema_file` in-block, and that read is captured into the
-        # dependency descriptor after the block runs — so no priming
-        # read is needed here.
+        # ADR-60 WD3 record-and-validate: the producer reads `@schema_file` in-block, and that read is
+        # captured into the dependency descriptor after the block runs — so no priming read is needed
+        # here.
         @schema_table = cache_for(:schema_table, params: {}).call
       rescue Plugin::AccessDeniedError => e
         @load_errors << "rigor-activerecord: #{e.message}"

--- a/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/analyzer.rb
+++ b/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/analyzer.rb
@@ -5,9 +5,8 @@ require "prism"
 module Rigor
   module Plugin
     class Activerecord < Rigor::Plugin::Base
-      # Per-file AST walker. For each `Model.find(...)` /
-      # `Model.find_by(...)` / `Model.where(...)` call where
-      # `Model` is a name in the {ModelIndex}, emits diagnostics:
+      # Per-file AST walker. For each `Model.find(...)` / `Model.find_by(...)` / `Model.where(...)` call
+      # where `Model` is a name in the {ModelIndex}, emits diagnostics:
       #
       # | Method | Recognised arg shape | Validation |
       # | --- | --- | --- |
@@ -16,17 +15,13 @@ module Rigor
       # | `Model.where(col: v, ...)` | keyword args | each key must be a column |
       # | `Model.where(string)` | String literal | parser-side; not validated |
       #
-      # Successful matches surface as `:info` diagnostics naming
-      # the resolved table; unknown columns surface as `:error`.
-      # Calls whose receiver is not a model in the index, and
-      # calls with non-keyword arguments to `where` / `find_by`,
-      # stay silent.
+      # Successful matches surface as `:info` diagnostics naming the resolved table; unknown columns
+      # surface as `:error`. Calls whose receiver is not a model in the index, and calls with
+      # non-keyword arguments to `where` / `find_by`, stay silent.
       class Analyzer
-        # Methods that take a column → value Hash and need each key
-        # validated against the receiver's column set. The bang
-        # variants (`find_by!` raises instead of returning nil;
-        # `find_or_create_by!` raises on a validation failure) and
-        # `create_or_find_by` / `create_or_find_by!` take the
+        # Methods that take a column → value Hash and need each key validated against the receiver's
+        # column set. The bang variants (`find_by!` raises instead of returning nil; `find_or_create_by!`
+        # raises on a validation failure) and `create_or_find_by` / `create_or_find_by!` take the
         # identical column-hash argument shape.
         COLUMN_HASH_METHODS = %i[
           where
@@ -88,14 +83,11 @@ module Rigor
           keyword_pairs = keyword_argument_pairs(node)
           return push_recognised(node, entry) if keyword_pairs.empty?
 
-          # Models with no schema-side columns are virtual — backed
-          # by a database VIEW (Mastodon's `Instance` model wraps a
-          # SQL view that isn't in `db/schema.rb`), seeded from an
-          # external source, or otherwise opaque to our schema
-          # parser. Without a column set we cannot meaningfully
-          # check query keys; surface the call as recognised and
-          # skip column validation entirely rather than firing a
-          # false `unknown-column` against every key.
+          # Models with no schema-side columns are virtual — backed by a database VIEW (Mastodon's
+          # `Instance` model wraps a SQL view that isn't in `db/schema.rb`), seeded from an external
+          # source, or otherwise opaque to our schema parser. Without a column set we cannot meaningfully
+          # check query keys; surface the call as recognised and skip column validation entirely rather
+          # than firing a false `unknown-column` against every key.
           return push_recognised(node, entry, keyword_pairs.map { |p| p[:key] }) if entry.column_names.empty?
 
           unknown = keyword_pairs.reject { |pair| valid_query_key?(entry, pair[:key]) }
@@ -114,23 +106,20 @@ module Rigor
           end
         end
 
-        # ActiveRecord's `where` / `find_by` / `find_or_initialize_by`
-        # accept either a column name *or* a singular association
-        # name (belongs_to / has_one). The latter resolves to the
-        # association's FK column behind the scenes:
+        # ActiveRecord's `where` / `find_by` / `find_or_initialize_by` accept either a column name *or* a
+        # singular association name (belongs_to / has_one). The latter resolves to the association's FK
+        # column behind the scenes:
         #
         #   AccountPin.find_by(account: x)
         #   # → SELECT … WHERE account_id = x.id
         #
-        # Without this allowance, every `find_by(<assoc>:)` call
-        # surfaces as an `unknown-column` false positive — Mastodon
-        # saw ~100 such hits across the API controllers, all of
-        # which were the canonical Rails idiom rather than typos.
+        # Without this allowance, every `find_by(<assoc>:)` call surfaces as an `unknown-column` false
+        # positive — Mastodon saw ~100 such hits across the API controllers, all of which were the
+        # canonical Rails idiom rather than typos.
         #
-        # `alias_attribute` names resolve to their target before
-        # the column / association check — querying by an aliased
-        # attribute is a valid Rails idiom and must not surface as
-        # an `unknown-column`.
+        # `alias_attribute` names resolve to their target before the column / association check —
+        # querying by an aliased attribute is a valid Rails idiom and must not surface as an
+        # `unknown-column`.
         def valid_query_key?(entry, key)
           key = entry.resolve_alias(key) if entry.alias?(key)
 
@@ -140,13 +129,10 @@ module Rigor
           assoc && assoc[:kind] == :singular
         end
 
-        # When the column is an enum-bearing column AND the
-        # passed value is a Symbol literal, the value MUST be
-        # one of the declared enum values. Non-Symbol values
-        # (variables, expressions) decline so dynamic call
-        # sites stay silent. Sequences (`status: [:active,
-        # :archived]`) are intentionally NOT walked here —
-        # the relation-shape check belongs in a future track.
+        # When the column is an enum-bearing column AND the passed value is a Symbol literal, the value
+        # MUST be one of the declared enum values. Non-Symbol values (variables, expressions) decline so
+        # dynamic call sites stay silent. Sequences (`status: [:active, :archived]`) are intentionally NOT
+        # walked here — the relation-shape check belongs in a future track.
         def validate_enum_value(node, entry, pair)
           return unless entry.enum?(pair[:key])
           return unless pair[:value].is_a?(Prism::SymbolNode)
@@ -199,13 +185,10 @@ module Rigor
           node.arguments.arguments.size
         end
 
-        # Returns the symbol-keyed pairs of any KeywordHashNode
-        # argument as `{ key:, value: }` rows. Plain hash-literal
-        # arguments (`Model.where({a: 1})`) are NOT walked —
-        # Rails accepts both, but the keyword form is the
-        # idiomatic one. The `value` Prism node is preserved so
-        # the enum check downstream can recognise Symbol
-        # literals without re-walking the call.
+        # Returns the symbol-keyed pairs of any KeywordHashNode argument as `{ key:, value: }` rows. Plain
+        # hash-literal arguments (`Model.where({a: 1})`) are NOT walked — Rails accepts both, but the
+        # keyword form is the idiomatic one. The `value` Prism node is preserved so the enum check
+        # downstream can recognise Symbol literals without re-walking the call.
         def keyword_argument_pairs(node)
           return [] if node.arguments.nil?
 

--- a/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/model_discoverer.rb
+++ b/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/model_discoverer.rb
@@ -6,20 +6,15 @@ require "rigor/source/literals"
 module Rigor
   module Plugin
     class Activerecord < Rigor::Plugin::Base
-      # Walks the configured model search paths via the plugin's
-      # `IoBoundary`, parses each `.rb` file with Prism, and
-      # collects class declarations that resolve to ActiveRecord
-      # models.
+      # Walks the configured model search paths via the plugin's `IoBoundary`, parses each `.rb` file with
+      # Prism, and collects class declarations that resolve to ActiveRecord models.
       #
-      # Discovery is a two-step pass. First every class declaration
-      # is captured as a *candidate* (its name, its superclass
-      # name, and its DSL metadata). Then a fixpoint marks a
-      # candidate as a model when its superclass is a configured
-      # base class OR (transitively) the class name of another
-      # model — this is what makes single-table-inheritance
-      # subclasses (`class Admin < User`) discoverable. Each STI
-      # child carries an `sti_parent:` pointer the {ModelIndex}
-      # uses to inherit the root model's table and DSL surface.
+      # Discovery is a two-step pass. First every class declaration is captured as a *candidate* (its
+      # name, its superclass name, and its DSL metadata). Then a fixpoint marks a candidate as a model
+      # when its superclass is a configured base class OR (transitively) the class name of another model
+      # — this is what makes single-table-inheritance subclasses (`class Admin < User`) discoverable.
+      # Each STI child carries an `sti_parent:` pointer the {ModelIndex} uses to inherit the root model's
+      # table and DSL surface.
       #
       # Returns rows the {ModelIndex} consumes:
       #
@@ -28,21 +23,16 @@ module Rigor
       #
       # Limitations (intentional for v0.1.0 of the plugin):
       #
-      # - `self.table_name = "..."` recognised only when the RHS
-      #   is a String literal. Computed names
+      # - `self.table_name = "..."` recognised only when the RHS is a String literal. Computed names
       #   (`self.table_name = "#{tenant}_users"`) are skipped.
-      # - Modules (`class Admin::User < ApplicationRecord`) are
-      #   recognised; the resulting class name is the lexical
-      #   path (`Admin::User`).
-      # - The STI fixpoint matches a superclass name against model
-      #   class names tolerating a leading `::`; richer constant
-      #   resolution (relative namespacing) is not modelled.
+      # - Modules (`class Admin::User < ApplicationRecord`) are recognised; the resulting class name is
+      #   the lexical path (`Admin::User`).
+      # - The STI fixpoint matches a superclass name against model class names tolerating a leading `::`;
+      #   richer constant resolution (relative namespacing) is not modelled.
       class ModelDiscoverer
         # @param io_boundary [Rigor::Plugin::IoBoundary]
-        # @param search_paths [Array<String>] absolute or
-        #   project-relative paths.
-        # @param base_classes [Array<String>] superclass names that
-        #   identify a class as an AR model.
+        # @param search_paths [Array<String>] absolute or project-relative paths.
+        # @param base_classes [Array<String>] superclass names that identify a class as an AR model.
         def initialize(io_boundary:, search_paths:, base_classes:)
           @io_boundary = io_boundary
           @search_paths = search_paths
@@ -64,17 +54,13 @@ module Rigor
 
         private
 
-        # Fixpoint over the captured class candidates: a candidate
-        # is a model when its superclass is a configured base
-        # class, or — transitively — the class name of an
-        # already-known model. The second arm is what discovers
-        # STI subclasses; the matched parent name is stamped onto
-        # the row as `sti_parent:` so the {ModelIndex} can inherit
-        # the root model's table and association surface.
+        # Fixpoint over the captured class candidates: a candidate is a model when its superclass is a
+        # configured base class, or — transitively — the class name of an already-known model. The
+        # second arm is what discovers STI subclasses; the matched parent name is stamped onto the row as
+        # `sti_parent:` so the {ModelIndex} can inherit the root model's table and association surface.
         #
-        # Non-model classes (POROs, service objects that happen to
-        # live under `app/models/`) never enter `model_names` and
-        # are dropped.
+        # Non-model classes (POROs, service objects that happen to live under `app/models/`) never enter
+        # `model_names` and are dropped.
         def resolve_models(candidates)
           model_names = {}
           sti_parent = {}
@@ -108,9 +94,8 @@ module Rigor
           end
         end
 
-        # Resolves a superclass NAME against the set of known
-        # model class names, tolerating a leading `::`. Returns
-        # the matched model class name, or nil.
+        # Resolves a superclass NAME against the set of known model class names, tolerating a leading
+        # `::`. Returns the matched model class name, or nil.
         def model_match(superclass_name, model_names)
           return superclass_name if model_names.key?(superclass_name)
 
@@ -146,11 +131,9 @@ module Rigor
           end
         end
 
-        # Captures EVERY class declaration as a candidate — the
-        # `resolve_models` fixpoint decides afterwards which ones
-        # are models. The DSL metadata is extracted eagerly; for a
-        # non-model class it is simply discarded when the candidate
-        # is dropped.
+        # Captures EVERY class declaration as a candidate — the `resolve_models` fixpoint decides
+        # afterwards which ones are models. The DSL metadata is extracted eagerly; for a non-model class
+        # it is simply discarded when the candidate is dropped.
         def visit_class(node, lexical_path, &)
           class_local_name = constant_path_name(node.constant_path)
           return if class_local_name.nil?
@@ -183,8 +166,7 @@ module Rigor
           walk_for_classes(node.body, inner_path, &) if node.body
         end
 
-        # Renders a constant-path node (`Admin::User`,
-        # `::ApplicationRecord`) as a String. Returns nil for
+        # Renders a constant-path node (`Admin::User`, `::ApplicationRecord`) as a String. Returns nil for
         # shapes the discoverer chooses not to handle.
         def constant_path_name(node)
           return nil if node.nil?
@@ -208,9 +190,8 @@ module Rigor
           end
         end
 
-        # Looks for `self.table_name = "..."` at the top level of
-        # the class body. Returns the literal String when found,
-        # nil otherwise.
+        # Looks for `self.table_name = "..."` at the top level of the class body. Returns the literal
+        # String when found, nil otherwise.
         def lookup_table_name_override(body)
           return nil if body.nil?
 
@@ -224,19 +205,14 @@ module Rigor
           nil
         end
 
-        # Recognised single-instance and collection association
-        # DSL methods. The kind drives the eventual return-type
-        # contribution: singular associations narrow to
-        # `Nominal[Target] | nil`, plural ones narrow to
-        # `ActiveRecord::Relation[Target]`.
+        # Recognised single-instance and collection association DSL methods. The kind drives the eventual
+        # return-type contribution: singular associations narrow to `Nominal[Target] | nil`, plural ones
+        # narrow to `ActiveRecord::Relation[Target]`.
         #
-        # `composed_of` value-object aggregations and
-        # `delegated_type` roles are folded in here too — both
-        # accept the association name as a `where` / `find_by`
-        # query key, so omitting them turns every such query into
-        # a false `unknown-column`. `composed_of` resolves to its
-        # value class (a real target); `delegated_type` is
-        # polymorphic (no single target).
+        # `composed_of` value-object aggregations and `delegated_type` roles are folded in here too — both
+        # accept the association name as a `where` / `find_by` query key, so omitting them turns every
+        # such query into a false `unknown-column`. `composed_of` resolves to its value class (a real
+        # target); `delegated_type` is polymorphic (no single target).
         ASSOCIATION_METHODS = {
           belongs_to: :singular,
           has_one: :singular,
@@ -247,28 +223,21 @@ module Rigor
         }.freeze
         private_constant :ASSOCIATION_METHODS
 
-        # Association DSL methods that are ALWAYS polymorphic —
-        # the accessor has no single static target class.
-        # `belongs_to` / `has_one` become polymorphic only with
-        # an explicit `polymorphic: true` option.
+        # Association DSL methods that are ALWAYS polymorphic — the accessor has no single static target
+        # class. `belongs_to` / `has_one` become polymorphic only with an explicit `polymorphic: true`
+        # option.
         POLYMORPHIC_BY_DEFAULT = %i[delegated_type].freeze
         private_constant :POLYMORPHIC_BY_DEFAULT
 
-        # Class-body declaration calls — the top-level `CallNode`s
-        # PLUS those nested inside a `with_options(...) do … end`
-        # block. `with_options` is Rails' idiom for sharing
-        # options across a group of `belongs_to` / `validates` /
-        # etc. declarations; without descending into it every
-        # association / enum / validation declared inside is
-        # invisible to the discoverer, turning `where(<assoc>:
-        # ...)` into a false `unknown-column`. Nested
-        # `with_options` blocks recurse.
+        # Class-body declaration calls — the top-level `CallNode`s PLUS those nested inside a
+        # `with_options(...) do … end` block. `with_options` is Rails' idiom for sharing options across a
+        # group of `belongs_to` / `validates` / etc. declarations; without descending into it every
+        # association / enum / validation declared inside is invisible to the discoverer, turning
+        # `where(<assoc>: ...)` into a false `unknown-column`. Nested `with_options` blocks recurse.
         #
-        # The options the `with_options` call itself carries (e.g.
-        # `with_options class_name: 'Account'`) are NOT merged into
-        # the nested calls — discovering the declaration name is
-        # what clears the false positive; the merged-option target
-        # precision is a separate refinement.
+        # The options the `with_options` call itself carries (e.g. `with_options class_name: 'Account'`)
+        # are NOT merged into the nested calls — discovering the declaration name is what clears the
+        # false positive; the merged-option target precision is a separate refinement.
         def declaration_calls(body)
           return [] if body.nil?
 
@@ -283,17 +252,13 @@ module Rigor
           end
         end
 
-        # Walks the class body for association DSL calls and
-        # returns a list of rows shaped:
+        # Walks the class body for association DSL calls and returns a list of rows shaped:
         #
         #     { name: "user", kind: :singular, target: "User" }
         #
-        # The `target` is resolved from an explicit
-        # `class_name: "Foo"` option when supplied, otherwise
-        # inferred from the association name via
-        # {Inflector.classify}. Calls whose first arg is not a
-        # Symbol literal (or whose `class_name:` is a non-literal
-        # expression) decline rather than guess.
+        # The `target` is resolved from an explicit `class_name: "Foo"` option when supplied, otherwise
+        # inferred from the association name via {Inflector.classify}. Calls whose first arg is not a
+        # Symbol literal (or whose `class_name:` is a non-literal expression) decline rather than guess.
         def lookup_associations(body)
           return [] if body.nil?
 
@@ -319,10 +284,8 @@ module Rigor
           polymorphic = POLYMORPHIC_BY_DEFAULT.include?(node.name) ||
                         association_option(args, "polymorphic") == true
 
-          # A polymorphic association has no single static target
-          # class — `target` is nil and the flow contribution
-          # declines to narrow rather than inventing a wrong
-          # `Nominal[<classified-name>]`.
+          # A polymorphic association has no single static target class — `target` is nil and the flow
+          # contribution declines to narrow rather than inventing a wrong `Nominal[<classified-name>]`.
           if polymorphic
             target = nil
           else
@@ -334,15 +297,12 @@ module Rigor
             nullable: association_nullable?(node.name, args) }
         end
 
-        # Whether a `:singular` association's accessor can return
-        # `nil`. `has_one` genuinely can (no associated record →
-        # `nil`). `belongs_to` is **required (non-`nil`) by default
-        # since Rails 5** (`belongs_to_required_by_default`); it
-        # becomes nullable only when the call passes `optional: true`
-        # or `required: false`. `composed_of` is non-nullable
-        # unless `allow_nil: true`. `delegated_type` roles are
-        # required. A non-literal option value declines to the
-        # default rather than guessing.
+        # Whether a `:singular` association's accessor can return `nil`. `has_one` genuinely can (no
+        # associated record → `nil`). `belongs_to` is **required (non-`nil`) by default since Rails 5**
+        # (`belongs_to_required_by_default`); it becomes nullable only when the call passes
+        # `optional: true` or `required: false`. `composed_of` is non-nullable unless `allow_nil: true`.
+        # `delegated_type` roles are required. A non-literal option value declines to the default rather
+        # than guessing.
         def association_nullable?(method_name, args)
           case method_name
           when :has_one
@@ -357,9 +317,8 @@ module Rigor
           end
         end
 
-        # Reads a literal boolean association option (`optional:` /
-        # `required:`). Returns `true` / `false` for a literal, or
-        # `nil` when the key is absent or its value is non-literal.
+        # Reads a literal boolean association option (`optional:` / `required:`). Returns `true` / `false`
+        # for a literal, or `nil` when the key is absent or its value is non-literal.
         def association_option(args, key)
           args.each do |arg|
             next unless arg.is_a?(Prism::KeywordHashNode)
@@ -388,10 +347,9 @@ module Rigor
           nil
         end
 
-        # `enum status: { active: 0, archived: 1 }` (Rails ≤6)
-        # and `enum :status, [:active, :archived]` (Rails 7+).
-        # Returns `Hash<column_name => Array<Symbol>>`.
-        # Non-literal forms decline rather than guess.
+        # `enum status: { active: 0, archived: 1 }` (Rails ≤6) and `enum :status, [:active, :archived]`
+        # (Rails 7+). Returns `Hash<column_name => Array<Symbol>>`. Non-literal forms decline rather than
+        # guess.
         def lookup_enums(body)
           return {} if body.nil?
 
@@ -445,10 +403,9 @@ module Rigor
           end
         end
 
-        # `scope :active, -> { ... }`. Records the scope name
-        # only (the body is intentionally NOT introspected —
-        # the caller contributes `ActiveRecord::Relation[Model]`
-        # based on the name alone via `class_scope_return_type`).
+        # `scope :active, -> { ... }`. Records the scope name only (the body is intentionally NOT
+        # introspected — the caller contributes `ActiveRecord::Relation[Model]` based on the name alone
+        # via `class_scope_return_type`).
         def lookup_scopes(body)
           return [] if body.nil?
 
@@ -468,11 +425,9 @@ module Rigor
           scopes.freeze
         end
 
-        # `validates :name, presence: true, length: { maximum: 100 }`.
-        # Records the attribute name (the validator option set
-        # is ignored — the value here is the diagnostic
-        # `validates :unknown_attr` surfacing when the attribute
-        # isn't a column on the table).
+        # `validates :name, presence: true, length: { maximum: 100 }`. Records the attribute name (the
+        # validator option set is ignored — the value here is the diagnostic `validates :unknown_attr`
+        # surfacing when the attribute isn't a column on the table).
         def lookup_validations(body)
           return [] if body.nil?
 
@@ -487,10 +442,9 @@ module Rigor
           attrs.uniq.freeze
         end
 
-        # `before_save :foo`, `after_create :bar`, etc. Records
-        # the referenced method name (a Symbol literal). The
-        # diagnostic value is "did you forget to `def` this?".
-        # Block callbacks (`before_save { ... }`) decline.
+        # `before_save :foo`, `after_create :bar`, etc. Records the referenced method name (a Symbol
+        # literal). The diagnostic value is "did you forget to `def` this?". Block callbacks
+        # (`before_save { ... }`) decline.
         CALLBACK_METHODS = %i[
           before_validation after_validation
           before_save after_save around_save
@@ -517,12 +471,10 @@ module Rigor
           targets.freeze
         end
 
-        # `alias_attribute :new_name, :old_name`. Records the
-        # mapping so the analyzer accepts the alias as a query
-        # key — without it every `where(<alias>: ...)` /
-        # `find_by(<alias>: ...)` call surfaces as a false
-        # `unknown-column`. Returns `Hash<alias => target>`;
-        # non-Symbol-literal forms decline rather than guess.
+        # `alias_attribute :new_name, :old_name`. Records the mapping so the analyzer accepts the alias
+        # as a query key — without it every `where(<alias>: ...)` / `find_by(<alias>: ...)` call surfaces
+        # as a false `unknown-column`. Returns `Hash<alias => target>`; non-Symbol-literal forms decline
+        # rather than guess.
         def lookup_aliases(body)
           return {} if body.nil?
 
@@ -543,10 +495,8 @@ module Rigor
           aliases.freeze
         end
 
-        # Collects every Symbol-literal positional argument
-        # from a CallNode. Used by both `lookup_validations`
-        # and `lookup_callbacks` to extract the attribute /
-        # method name list.
+        # Collects every Symbol-literal positional argument from a CallNode. Used by both
+        # `lookup_validations` and `lookup_callbacks` to extract the attribute / method name list.
         def symbol_args(node)
           args = node.arguments&.arguments
           return [] if args.nil?

--- a/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/model_index.rb
+++ b/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/model_index.rb
@@ -3,44 +3,32 @@
 module Rigor
   module Plugin
     class Activerecord < Rigor::Plugin::Base
-      # Maps a discovered ActiveRecord model class name to its
-      # resolved table name and the column set the schema attaches
-      # to that table. Marshal-clean; the cache producer round-
-      # trips it through the standard pair.
+      # Maps a discovered ActiveRecord model class name to its resolved table name and the column set the
+      # schema attaches to that table. Marshal-clean; the cache producer round-trips it through the
+      # standard pair.
       #
       # Construction is two-phase by design:
-      # 1. {ModelDiscoverer} walks the project source for model
-      #    class declarations (direct base-class children plus
-      #    transitive STI subclasses) and yields a row per model.
-      # 2. The plugin combines those rows with the parsed
-      #    {SchemaTable} to produce this index.
+      # 1. {ModelDiscoverer} walks the project source for model class declarations (direct base-class
+      #    children plus transitive STI subclasses) and yields a row per model.
+      # 2. The plugin combines those rows with the parsed {SchemaTable} to produce this index.
       #
-      # `table_name_override` is non-nil when the source contained
-      # `self.table_name = "..."`. When nil, the table name
-      # derives from {Inflector.tableize}.
+      # `table_name_override` is non-nil when the source contained `self.table_name = "..."`. When nil,
+      # the table name derives from {Inflector.tableize}.
       #
-      # Single-table-inheritance subclasses (`class Admin < User`)
-      # carry an `sti_parent:` pointer; their {Entry} resolves its
-      # table from the root model and inherits the chain's
-      # declared associations / enums / aliases / scopes /
-      # validations / callbacks.
+      # Single-table-inheritance subclasses (`class Admin < User`) carry an `sti_parent:` pointer; their
+      # {Entry} resolves its table from the root model and inherits the chain's declared associations /
+      # enums / aliases / scopes / validations / callbacks.
       class ModelIndex
-        # `associations` is a frozen `Array<Hash>` where each
-        # row carries `{ name:, kind:, target:, nullable: }`:
+        # `associations` is a frozen `Array<Hash>` where each row carries `{ name:, kind:, target:,
+        # nullable: }`:
         #
-        # - `name`   — String, the association method name as
-        #              the user invokes it (`"posts"`).
-        # - `kind`   — `:singular` (`belongs_to` / `has_one`)
-        #              or `:collection` (`has_many`).
-        # - `target` — String, the target class name resolved
-        #              either from an explicit `class_name:`
+        # - `name`   — String, the association method name as the user invokes it (`"posts"`).
+        # - `kind`   — `:singular` (`belongs_to` / `has_one`) or `:collection` (`has_many`).
+        # - `target` — String, the target class name resolved either from an explicit `class_name:`
         #              option or via {Inflector.classify}.
-        # - `nullable` — Boolean; whether a `:singular` accessor
-        #              can return `nil`. `has_one` → `true`;
-        #              `belongs_to` → `false` (required by default
-        #              since Rails 5) unless `optional: true` /
-        #              `required: false`. Meaningless for
-        #              `:collection` rows.
+        # - `nullable` — Boolean; whether a `:singular` accessor can return `nil`. `has_one` → `true`;
+        #              `belongs_to` → `false` (required by default since Rails 5) unless `optional: true`
+        #              / `required: false`. Meaningless for `:collection` rows.
         Entry = Struct.new(:class_name, :table_name, :columns, :associations,
                            :enums, :scopes, :validations, :callbacks, :aliases,
                            keyword_init: true) do
@@ -71,8 +59,7 @@ module Rigor
           # `scopes` is `Array<scope_name>`.
           def scope?(name) = scopes.include?(name.to_s)
 
-          # `validations` is `Array<attribute_name>` covering
-          # both `validates :name, ...` and the
+          # `validations` is `Array<attribute_name>` covering both `validates :name, ...` and the
           # `validates_*_of :name, ...` shorthand families.
           def validation?(name) = validations.include?(name.to_s)
           def validated_attributes = validations
@@ -80,8 +67,8 @@ module Rigor
           # `callbacks` is `Array<{ name:, callback: }>`.
           def callback_targets = callbacks.map { |c| c[:name] }
 
-          # `aliases` is `Hash<alias_name => target_attribute>`
-          # populated from `alias_attribute` declarations.
+          # `aliases` is `Hash<alias_name => target_attribute>` populated from `alias_attribute`
+          # declarations.
           def alias?(name) = aliases.key?(name.to_s)
           def resolve_alias(name) = aliases[name.to_s]
         end
@@ -106,17 +93,14 @@ module Rigor
 
           entries = model_rows.each_with_object({}) do |row, acc|
             class_name = row.fetch(:class_name)
-            # The STI ancestry chain, root → self. For a plain
-            # (non-STI) model this is just `[row]`.
+            # The STI ancestry chain, root → self. For a plain (non-STI) model this is just `[row]`.
             chain = sti_chain(row, rows_by_name)
             table_name = sti_table_name(chain)
             columns = schema_table.columns_for(table_name) || []
 
-            # STI children inherit their ancestors' declared
-            # associations / enums / aliases / scopes /
-            # validations / callbacks. Without the merge a
-            # `where(<parent-association>: ...)` on the child
-            # would surface as a false `unknown-column`.
+            # STI children inherit their ancestors' declared associations / enums / aliases / scopes /
+            # validations / callbacks. Without the merge a `where(<parent-association>: ...)` on the
+            # child would surface as a false `unknown-column`.
             acc[class_name] = Entry.new(
               class_name: class_name,
               table_name: table_name,
@@ -132,8 +116,8 @@ module Rigor
           new(entries.freeze)
         end
 
-        # The STI ancestry chain for a row, ordered root → self.
-        # Walks `sti_parent` pointers, guarding against a cycle.
+        # The STI ancestry chain for a row, ordered root → self. Walks `sti_parent` pointers, guarding
+        # against a cycle.
         def self.sti_chain(row, rows_by_name, seen = [])
           class_name = row.fetch(:class_name)
           parent_name = row[:sti_parent]
@@ -145,9 +129,8 @@ module Rigor
           sti_chain(parent, rows_by_name, seen + [class_name]) + [row]
         end
 
-        # The effective table name for an STI chain: the nearest
-        # explicit `self.table_name =` override walking leaf →
-        # root, else the name inflected from the root class.
+        # The effective table name for an STI chain: the nearest explicit `self.table_name =` override
+        # walking leaf → root, else the name inflected from the root class.
         def self.sti_table_name(chain)
           chain.reverse_each do |row|
             override = row[:table_name_override]
@@ -156,18 +139,16 @@ module Rigor
           Rigor::Plugin::Inflector.tableize(strip_leading_namespace(chain.first.fetch(:class_name)))
         end
 
-        # Dedups association-style rows by `:name`, keeping the
-        # LAST occurrence so a child redeclaration overrides the
-        # inherited ancestor row.
+        # Dedups association-style rows by `:name`, keeping the LAST occurrence so a child redeclaration
+        # overrides the inherited ancestor row.
         def self.merge_named_rows(rows)
           seen = {}
           rows.each { |row| seen[row[:name]] = row }
           seen.values.map(&:freeze).freeze
         end
 
-        # `Hash<column => Array<value>>` merged across the STI
-        # chain; a child redeclaration of the same enum column
-        # overrides the ancestor's value list.
+        # `Hash<column => Array<value>>` merged across the STI chain; a child redeclaration of the same
+        # enum column overrides the ancestor's value list.
         def self.merge_enums(chain)
           chain.each_with_object({}) do |row, acc|
             (row[:enums] || {}).each { |col, values| acc[col] = Array(values).map(&:freeze).freeze }
@@ -181,10 +162,8 @@ module Rigor
           end.freeze
         end
 
-        # `::User` → `User`. The discoverer might prefix with
-        # `::` for top-level constants depending on how it
-        # resolved the path; the table-name derivation uses the
-        # short form regardless.
+        # `::User` → `User`. The discoverer might prefix with `::` for top-level constants depending on
+        # how it resolved the path; the table-name derivation uses the short form regardless.
         def self.strip_leading_namespace(name)
           name.start_with?("::") ? name[2..] : name
         end

--- a/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/schema_parser.rb
+++ b/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/schema_parser.rb
@@ -21,30 +21,23 @@ module Rigor
       #     end
       #   end
       #
-      # `t.references "x"` becomes an `x_id` integer column
-      # (foreign-key indices and constraints are ignored — only the
-      # column shape matters for type inference); add a `polymorphic:
-      # true` option and an `x_type` string column is emitted too.
-      # `t.timestamps` adds `created_at` and `updated_at` datetime
-      # columns. `t.column "x", :type` is the generic column form.
-      # Any other `t.<method> "name"` call is treated as a column
-      # whose type symbol is the method name — unknown types degrade
-      # to `Object` per `SchemaTable.ruby_type_for` rather than being
-      # dropped. Only the structural calls in {NON_COLUMN_METHODS}
-      # (indexes, constraints, foreign keys) are skipped.
+      # `t.references "x"` becomes an `x_id` integer column (foreign-key indices and constraints are
+      # ignored — only the column shape matters for type inference); add a `polymorphic: true` option and
+      # an `x_type` string column is emitted too. `t.timestamps` adds `created_at` and `updated_at`
+      # datetime columns. `t.column "x", :type` is the generic column form. Any other `t.<method> "name"`
+      # call is treated as a column whose type symbol is the method name — unknown types degrade to
+      # `Object` per `SchemaTable.ruby_type_for` rather than being dropped. Only the structural calls in
+      # {NON_COLUMN_METHODS} (indexes, constraints, foreign keys) are skipped.
       #
-      # Designed for the Prism interpretation pattern from
-      # rigor-lisp-eval — recursive descent on the AST, no eval.
+      # Designed for the Prism interpretation pattern from rigor-lisp-eval — recursive descent on the AST,
+      # no eval.
       class SchemaParser
         TIMESTAMPS_COLUMNS = %w[created_at updated_at].freeze
 
-        # Structural `t.<method>` calls inside a `create_table`
-        # block that declare indexes / constraints rather than
-        # columns. Everything NOT in this set that carries a
-        # literal column name is treated as a column declaration
-        # so a real column is never silently dropped — a dropped
-        # column turns every query against it into a false
-        # `unknown-column` diagnostic.
+        # Structural `t.<method>` calls inside a `create_table` block that declare indexes / constraints
+        # rather than columns. Everything NOT in this set that carries a literal column name is treated as
+        # a column declaration so a real column is never silently dropped — a dropped column turns every
+        # query against it into a false `unknown-column` diagnostic.
         NON_COLUMN_METHODS = %i[
           index check_constraint exclusion_constraint
           unique_constraint foreign_key primary_keys
@@ -114,10 +107,9 @@ module Rigor
           false
         end
 
-        # Walks the block body collecting `t.<method>(...)` calls.
-        # Skips nested blocks (e.g. inside `if`-conditioned columns)
-        # only at the top level — for richer schema constructs the
-        # parser falls back silently.
+        # Walks the block body collecting `t.<method>(...)` calls. Skips nested blocks (e.g. inside
+        # `if`-conditioned columns) only at the top level — for richer schema constructs the parser falls
+        # back silently.
         def collect_column_calls(node, &)
           return if node.nil?
 
@@ -139,13 +131,11 @@ module Rigor
           when :column
             parse_generic_column(call_node)
           else
-            # Structural DSL call (index / constraint / FK) —
-            # not a column.
+            # Structural DSL call (index / constraint / FK) — not a column.
             return nil if NON_COLUMN_METHODS.include?(method)
 
-            # Any other `t.<method> "name"` is a column. The
-            # method name is the type symbol; unknown types
-            # degrade to `Object` rather than dropping the column.
+            # Any other `t.<method> "name"` is a column. The method name is the type symbol; unknown
+            # types degrade to `Object` rather than dropping the column.
             parse_typed_column(method, call_node)
           end
         end
@@ -162,11 +152,9 @@ module Rigor
           )
         end
 
-        # `t.references "x"` adds an `x_id` integer column.
-        # `t.references "x", polymorphic: true` additionally adds
-        # an `x_type` string column — without it every
-        # `where(x_type: ...)` on the polymorphic owner surfaces
-        # as a false `unknown-column`.
+        # `t.references "x"` adds an `x_id` integer column. `t.references "x", polymorphic: true`
+        # additionally adds an `x_type` string column — without it every `where(x_type: ...)` on the
+        # polymorphic owner surfaces as a false `unknown-column`.
         def parse_references_column(call_node)
           name = string_argument(call_node, 0)
           return nil if name.nil?
@@ -184,10 +172,9 @@ module Rigor
           keyword_true?(call_node, :polymorphic)
         end
 
-        # Returns true iff `call_node` has a `name: true` keyword
-        # argument. Used to detect schema modifiers like
-        # `t.bigint "status_ids", array: true` (Postgres array
-        # column) and `t.references "x", polymorphic: true`.
+        # Returns true iff `call_node` has a `name: true` keyword argument. Used to detect schema
+        # modifiers like `t.bigint "status_ids", array: true` (Postgres array column) and `t.references
+        # "x", polymorphic: true`.
         def keyword_true?(call_node, name)
           return false if call_node.arguments.nil?
 
@@ -204,9 +191,8 @@ module Rigor
           false
         end
 
-        # `t.column "name", "type"` / `t.column "name", :type` —
-        # the explicit generic column form. The type lives in the
-        # second argument; an absent type degrades to `:string`.
+        # `t.column "name", "type"` / `t.column "name", :type` — the explicit generic column form. The
+        # type lives in the second argument; an absent type degrades to `:string`.
         def parse_generic_column(call_node)
           name = string_argument(call_node, 0)
           return nil if name.nil?

--- a/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/schema_table.rb
+++ b/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/schema_table.rb
@@ -3,18 +3,15 @@
 module Rigor
   module Plugin
     class Activerecord < Rigor::Plugin::Base
-      # Parsed `db/schema.rb`. Maps each table name to its column
-      # set; each column carries its declared type. Marshal-clean
-      # by construction so the cache producer can round-trip it
-      # without a custom serialize / deserialize pair.
+      # Parsed `db/schema.rb`. Maps each table name to its column set; each column carries its declared
+      # type. Marshal-clean by construction so the cache producer can round-trip it without a custom
+      # serialize / deserialize pair.
       #
-      # The mapping from Rails column types to Ruby class names is
-      # deliberately conservative — `:string`/`:text` → `String`,
-      # `:integer`/`:bigint` → `Integer`, `:boolean` → `bool`,
-      # `:datetime`/`:timestamp` → `Time`, `:date` → `Date`,
-      # `:decimal`/`:float` → `Float`. Exotic types (json, jsonb,
-      # ltree, hstore, custom) fall back to `Object` so the
-      # plugin stays silent rather than guessing.
+      # The mapping from Rails column types to Ruby class names is deliberately conservative —
+      # `:string`/`:text` → `String`, `:integer`/`:bigint` → `Integer`, `:boolean` → `bool`,
+      # `:datetime`/`:timestamp` → `Time`, `:date` → `Date`, `:decimal`/`:float` → `Float`. Exotic types
+      # (json, jsonb, ltree, hstore, custom) fall back to `Object` so the plugin stays silent rather than
+      # guessing.
       class SchemaTable
         Column = Struct.new(:name, :type, :ruby_type, :array, keyword_init: true) do
           def to_h = { name: name, type: type, ruby_type: ruby_type, array: array }
@@ -40,21 +37,17 @@ module Rigor
           binary: "String",
           json: "Object",
           jsonb: "Object",
-          # PostgreSQL-flavoured string-ish column types Rails
-          # schemas commonly carry. `uuid` / `citext` / `inet`
-          # all behave as `String` for query purposes; mapping
-          # them here keeps the column out of the "unknown type
-          # → dropped column → false unknown-column" path.
+          # PostgreSQL-flavoured string-ish column types Rails schemas commonly carry. `uuid` / `citext` /
+          # `inet` all behave as `String` for query purposes; mapping them here keeps the column out of
+          # the "unknown type → dropped column → false unknown-column" path.
           uuid: "String",
           citext: "String",
           inet: "String"
         }.freeze
 
-        # Implicit columns that every Rails table has unless the
-        # schema explicitly opts out. The plugin assumes these
-        # exist; users who run `create_table id: false` get no
-        # implicit `id` column from the parser, but most apps
-        # never disable it.
+        # Implicit columns that every Rails table has unless the schema explicitly opts out. The plugin
+        # assumes these exist; users who run `create_table id: false` get no implicit `id` column from
+        # the parser, but most apps never disable it.
         IMPLICIT_COLUMNS = [
           Column.new(name: "id", type: :integer, ruby_type: "Integer").freeze
         ].freeze
@@ -86,9 +79,8 @@ module Rigor
 
         def table_names = tables.keys
 
-        # Maps a Rails column type symbol to its Ruby class name.
-        # Returns "Object" for unknown types — the analyzer treats
-        # that as "do not narrow" (silent on unknowns).
+        # Maps a Rails column type symbol to its Ruby class name. Returns "Object" for unknown types —
+        # the analyzer treats that as "do not narrow" (silent on unknowns).
         def self.ruby_type_for(column_type)
           RUBY_TYPE_MAPPING.fetch(column_type.to_sym, "Object")
         end

--- a/plugins/rigor-activestorage/lib/rigor-activestorage.rb
+++ b/plugins/rigor-activestorage/lib/rigor-activestorage.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Entry point matching the `rigor-<id>` gem-name convention.
-# The Plugin::Loader's `require_gem!` step calls
-# `require "rigor-activestorage"`, and this file loads the
-# plugin's actual implementation under the `rigor/plugin/`
-# namespace so the require / register pair fires.
+# Entry point matching the `rigor-<id>` gem-name convention. The Plugin::Loader's `require_gem!` step
+# calls `require "rigor-activestorage"`, and this file loads the plugin's actual implementation under
+# the `rigor/plugin/` namespace so the require / register pair fires.
 require "rigor/plugin/activestorage"

--- a/plugins/rigor-activestorage/lib/rigor/plugin/activestorage.rb
+++ b/plugins/rigor-activestorage/lib/rigor/plugin/activestorage.rb
@@ -8,26 +8,18 @@ require_relative "activestorage/analyzer"
 
 module Rigor
   module Plugin
-    # rigor-activestorage — recognises `has_one_attached` /
-    # `has_many_attached` macros on ActiveRecord models and
-    # contributes attachment accessor return types so chained
-    # calls (`user.avatar.attached?`) route through Rigor's
-    # normal dispatch.
+    # rigor-activestorage — recognises `has_one_attached` / `has_many_attached` macros on ActiveRecord
+    # models and contributes attachment accessor return types so chained calls (`user.avatar.attached?`)
+    # route through Rigor's normal dispatch.
     #
     # ## Architecture
     #
-    # One discovery pass per run reads the configured AR model
-    # paths (default `app/models/`) via the plugin's
-    # `IoBoundary`, walks each `.rb` file with Prism, and
-    # collects `has_one_attached :avatar` /
-    # `has_many_attached :photos` macros into an
-    # {AttachmentIndex} keyed by class name. The walker is
-    # stand-alone (mirrors `rigor-activerecord`'s
-    # `ModelDiscoverer`) so the plugin works even when
-    # `rigor-activerecord` is not loaded; when it IS loaded,
-    # the published `:model_index` fact (ADR-9 cross-plugin
-    # API) drives the same class set so the two plugins agree
-    # on what counts as a model.
+    # One discovery pass per run reads the configured AR model paths (default `app/models/`) via the
+    # plugin's `IoBoundary`, walks each `.rb` file with Prism, and collects `has_one_attached :avatar` /
+    # `has_many_attached :photos` macros into an {AttachmentIndex} keyed by class name. The walker is
+    # stand-alone (mirrors `rigor-activerecord`'s `ModelDiscoverer`) so the plugin works even when
+    # `rigor-activerecord` is not loaded; when it IS loaded, the published `:model_index` fact (ADR-9
+    # cross-plugin API) drives the same class set so the two plugins agree on what counts as a model.
     #
     # ## Configuration
     #
@@ -39,9 +31,8 @@ module Rigor
     #
     # `model_search_paths` defaults to `["app/models"]`.
     #
-    # The class name `Rigor::Plugin::Activestorage` (single
-    # capital A) matches the constant-distinguishing convention
-    # used by `rigor-activerecord`.
+    # The class name `Rigor::Plugin::Activestorage` (single capital A) matches the constant-distinguishing
+    # convention used by `rigor-activerecord`.
     class Activestorage < Rigor::Plugin::Base
       manifest(
         id: "activestorage",
@@ -53,11 +44,9 @@ module Rigor
         consumes: [{ plugin_id: "activerecord", name: :model_index, optional: true }]
       )
 
-      # Cached: attachment index. Walks every `.rb` file under
-      # `model_search_paths` for `has_*_attached` macros. `watch:`
-      # (ADR-60 WD3) covers model-file additions; the discoverer's
-      # in-block reads are captured into the record-and-validate
-      # dependency descriptor after the block runs.
+      # Cached: attachment index. Walks every `.rb` file under `model_search_paths` for `has_*_attached`
+      # macros. `watch:` (ADR-60 WD3) covers model-file additions; the discoverer's in-block reads are
+      # captured into the record-and-validate dependency descriptor after the block runs.
       producer :attachment_index, watch: -> { [[@model_search_paths, "**/*.rb"]] } do |_params|
         rows = AttachmentDiscoverer.new(
           io_boundary: io_boundary,
@@ -80,18 +69,12 @@ module Rigor
         Analyzer.new(path: path, attachment_index: index).analyze(root).diagnostics
       end
 
-      # Return-type contribution: when the receiver is
-      # `Nominal[Model]` and the method matches a discovered
-      # attachment, narrows to
-      # `Nominal[ActiveStorage::Attached::One]` (singular) or
-      # `Nominal[ActiveStorage::Attached::Many]` (collection)
-      # via a `dynamic_return` rule keyed on the live set of
-      # model class names from the attachment index.
-      # The chained call (`.attached?`, `.purge`, `.url`)
-      # then resolves through ActiveStorage's RBS surface.
-      # Attachment setters (`user.avatar=`) decline — they
-      # take side-effecting argument types that the RBS
-      # surface already covers.
+      # Return-type contribution: when the receiver is `Nominal[Model]` and the method matches a
+      # discovered attachment, narrows to `Nominal[ActiveStorage::Attached::One]` (singular) or
+      # `Nominal[ActiveStorage::Attached::Many]` (collection) via a `dynamic_return` rule keyed on the
+      # live set of model class names from the attachment index. The chained call (`.attached?`, `.purge`,
+      # `.url`) then resolves through ActiveStorage's RBS surface. Attachment setters (`user.avatar=`)
+      # decline — they take side-effecting argument types that the RBS surface already covers.
       dynamic_return receivers: -> { attachment_index&.class_names || [] } do |call_node, scope|
         next nil unless call_node.is_a?(Prism::CallNode)
         next nil if call_node.receiver.nil?
@@ -129,10 +112,9 @@ module Rigor
       def attachment_index
         return @attachment_index if @attachment_index
 
-        # ADR-60 WD3 record-and-validate: the producer's in-block
-        # `AttachmentDiscoverer` reads are captured into the
-        # dependency descriptor after the block runs, and the
-        # producer's `watch:` covers model-file additions.
+        # ADR-60 WD3 record-and-validate: the producer's in-block `AttachmentDiscoverer` reads are
+        # captured into the dependency descriptor after the block runs, and the producer's `watch:`
+        # covers model-file additions.
         @attachment_index = cache_for(:attachment_index, params: {}).call
       rescue Plugin::AccessDeniedError => e
         @load_errors << "rigor-activestorage: #{e.message}"

--- a/plugins/rigor-activestorage/lib/rigor/plugin/activestorage/analyzer.rb
+++ b/plugins/rigor-activestorage/lib/rigor/plugin/activestorage/analyzer.rb
@@ -5,17 +5,13 @@ require "prism"
 module Rigor
   module Plugin
     class Activestorage < Rigor::Plugin::Base
-      # Per-file walker. Emits one `:info` `attachment-call`
-      # diagnostic per recognised attachment access on a
-      # known AR class. The diagnostic surfaces what the
-      # plugin recognised so users can verify the model →
-      # attachment mapping the plugin sees.
+      # Per-file walker. Emits one `:info` `attachment-call` diagnostic per recognised attachment access
+      # on a known AR class. The diagnostic surfaces what the plugin recognised so users can verify the
+      # model → attachment mapping the plugin sees.
       #
-      # No `:error` diagnostics here — the `dynamic_return`
-      # return-type narrowing carries the type-checking value.
-      # An `unknown-attachment` rule (similar to
-      # `rigor-activerecord`'s `unknown-column`) is deferred:
-      # it requires a coupled receiver-class narrowing pass.
+      # No `:error` diagnostics here — the `dynamic_return` return-type narrowing carries the
+      # type-checking value. An `unknown-attachment` rule (similar to `rigor-activerecord`'s
+      # `unknown-column`) is deferred: it requires a coupled receiver-class narrowing pass.
       class Analyzer
         attr_reader :diagnostics
 
@@ -47,10 +43,8 @@ module Rigor
                         @attachment_index.attachments_for("::#{owner}")
           return if attachments.nil?
 
-          # Only flag when the method matches a known
-          # attachment name (the `dynamic_return` rule
-          # provides the narrowing; the diagnostic just
-          # confirms the recognition).
+          # Only flag when the method matches a known attachment name (the `dynamic_return` rule provides
+          # the narrowing; the diagnostic just confirms the recognition).
           attachment = attachments.find { |a| a[:name] == node.name.to_s }
           return if attachment.nil?
 

--- a/plugins/rigor-activestorage/lib/rigor/plugin/activestorage/attachment_discoverer.rb
+++ b/plugins/rigor-activestorage/lib/rigor/plugin/activestorage/attachment_discoverer.rb
@@ -6,10 +6,8 @@ require "rigor/source/literals"
 module Rigor
   module Plugin
     class Activestorage < Rigor::Plugin::Base
-      # Walks the configured model search paths via the plugin's
-      # `IoBoundary`, parses each `.rb` file with Prism, and
-      # collects `has_one_attached` / `has_many_attached`
-      # declarations.
+      # Walks the configured model search paths via the plugin's `IoBoundary`, parses each `.rb` file
+      # with Prism, and collects `has_one_attached` / `has_many_attached` declarations.
       #
       # Returns rows the {AttachmentIndex} consumes:
       #
@@ -19,17 +17,13 @@ module Rigor
       #
       # Limitations (intentional for v0.1.0 of the plugin):
       #
-      # - The walker matches any class declaration that
-      #   contains a `has_*_attached` call. Whether the class
-      #   IS an ActiveRecord model is not verified here —
-      #   `rigor-activerecord` provides that check via its
-      #   own model index. The analyser is intentionally
-      #   lenient so the plugin runs standalone in projects
-      #   that haven't loaded `rigor-activerecord` yet.
-      # - Only Symbol-literal attachment names are recognised.
-      #   `has_one_attached(args)` or computed names decline.
-      # - Modules (`class Admin::User`) are recognised; the
-      #   resulting class name is the lexical path
+      # - The walker matches any class declaration that contains a `has_*_attached` call. Whether the
+      #   class IS an ActiveRecord model is not verified here — `rigor-activerecord` provides that check
+      #   via its own model index. The analyser is intentionally lenient so the plugin runs standalone in
+      #   projects that haven't loaded `rigor-activerecord` yet.
+      # - Only Symbol-literal attachment names are recognised. `has_one_attached(args)` or computed names
+      #   decline.
+      # - Modules (`class Admin::User`) are recognised; the resulting class name is the lexical path
       #   (`Admin::User`).
       class AttachmentDiscoverer
         ATTACHMENT_METHODS = {

--- a/plugins/rigor-activestorage/lib/rigor/plugin/activestorage/attachment_index.rb
+++ b/plugins/rigor-activestorage/lib/rigor/plugin/activestorage/attachment_index.rb
@@ -3,16 +3,13 @@
 module Rigor
   module Plugin
     class Activestorage < Rigor::Plugin::Base
-      # Maps a discovered class name to the list of attachment
-      # rows declared on it. Marshal-clean so the cache producer
-      # round-trips it through the standard pair.
+      # Maps a discovered class name to the list of attachment rows declared on it. Marshal-clean so the
+      # cache producer round-trips it through the standard pair.
       #
       # Each row is `{ name:, kind: }`:
       #
-      # - `name` — String, the attachment method name as the
-      #            user invokes it (`"avatar"`).
-      # - `kind` — `:singular` (`has_one_attached`) or
-      #            `:collection` (`has_many_attached`).
+      # - `name` — String, the attachment method name as the user invokes it (`"avatar"`).
+      # - `kind` — `:singular` (`has_one_attached`) or `:collection` (`has_many_attached`).
       class AttachmentIndex
         attr_reader :entries
 

--- a/plugins/rigor-activesupport-core-ext/demo/demo.rb
+++ b/plugins/rigor-activesupport-core-ext/demo/demo.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-# Demo: every method in this file is an ActiveSupport core_ext
-# extension. Without `rigor-activesupport-core-ext` activated
-# under `.rigor.yml`'s `plugins:`, every line emits a
-# `call.undefined-method` diagnostic. With the plugin in scope,
-# they all type-check cleanly.
+# Demo: every method in this file is an ActiveSupport core_ext extension. Without
+# `rigor-activesupport-core-ext` activated under `.rigor.yml`'s `plugins:`, every line emits a
+# `call.undefined-method` diagnostic. With the plugin in scope, they all type-check cleanly.
 
 # Duration multipliers (Integer / Float)
 5.minutes

--- a/plugins/rigor-activesupport-core-ext/lib/rigor-activesupport-core-ext.rb
+++ b/plugins/rigor-activesupport-core-ext/lib/rigor-activesupport-core-ext.rb
@@ -1,20 +1,17 @@
 # frozen_string_literal: true
 
-# rigor-activesupport-core-ext — a community-maintained RBS bundle
-# for the most-frequently-flagged ActiveSupport core extensions.
+# rigor-activesupport-core-ext — a community-maintained RBS bundle for the most-frequently-flagged
+# ActiveSupport core extensions.
 #
-# Per ADR-25 this gem is a pure RBS-bundle *plugin*: it ships a
-# `sig/` directory and a trivial `Rigor::Plugin::Base` subclass
-# whose manifest declares `signature_paths: ["sig"]`. Activate it
-# by listing the gem under `.rigor.yml`'s `plugins:` — Rigor
-# resolves and loads the bundled `sig/` automatically, with no
-# hand-written path:
+# Per ADR-25 this gem is a pure RBS-bundle *plugin*: it ships a `sig/` directory and a trivial
+# `Rigor::Plugin::Base` subclass whose manifest declares `signature_paths: ["sig"]`. Activate it by
+# listing the gem under `.rigor.yml`'s `plugins:` — Rigor resolves and loads the bundled `sig/`
+# automatically, with no hand-written path:
 #
 #     # .rigor.yml
 #     plugins:
 #       - rigor-activesupport-core-ext
 #
-# Coverage scope and rationale: see `README.md` in this directory
-# and `docs/notes/20260515-real-world-rails-survey.md` for the
-# survey that established the selector ranking.
+# Coverage scope and rationale: see `README.md` in this directory and
+# `docs/notes/20260515-real-world-rails-survey.md` for the survey that established the selector ranking.
 require_relative "rigor/plugin/activesupport_core_ext"

--- a/plugins/rigor-activesupport-core-ext/lib/rigor/plugin/activesupport_core_ext.rb
+++ b/plugins/rigor-activesupport-core-ext/lib/rigor/plugin/activesupport_core_ext.rb
@@ -4,14 +4,11 @@ require "rigor/plugin"
 
 module Rigor
   module Plugin
-    # ADR-25 — a pure RBS-bundle plugin. It ships NO analyzer code:
-    # no `diagnostics_for_file`, no `dynamic_return`. Its
-    # whole contribution is the manifest's `signature_paths: ["sig"]`,
-    # which declares the bundled ActiveSupport `core_ext` RBS
-    # directory. `Plugin::Loader` resolves that directory against
-    # this gem's root and `Environment.for_project` merges it into
-    # the RBS environment, so the ActiveSupport core-extension
-    # selectors (`3.days`, `"x".squish`, `Time.current`, …) resolve.
+    # ADR-25 — a pure RBS-bundle plugin. It ships NO analyzer code: no `diagnostics_for_file`, no
+    # `dynamic_return`. Its whole contribution is the manifest's `signature_paths: ["sig"]`, which
+    # declares the bundled ActiveSupport `core_ext` RBS directory. `Plugin::Loader` resolves that
+    # directory against this gem's root and `Environment.for_project` merges it into the RBS environment,
+    # so the ActiveSupport core-extension selectors (`3.days`, `"x".squish`, `Time.current`, …) resolve.
     #
     # Activate it like any plugin — no path, no vendoring:
     #
@@ -23,8 +20,7 @@ module Rigor
     class ActivesupportCoreExt < Rigor::Plugin::Base
       manifest(
         id: "activesupport-core-ext",
-        # Bumped 2026-05-28 — added Date#midnight /
-        # at_midnight / beginning_of_day / end_of_day (Rails
+        # Bumped 2026-05-28 — added Date#midnight / at_midnight / beginning_of_day / end_of_day (Rails
         # aliases that return Time, not Date).
         version: "0.2.0",
         description: "RBS bundle for the most-frequently-flagged ActiveSupport core_ext extensions.",

--- a/plugins/rigor-devise/demo/consumer.rb
+++ b/plugins/rigor-devise/demo/consumer.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-# Cross-file dispatch through the synthesised methods Tier B
-# emits from the `devise :*` calls in demo.rb. Without the plugin
-# these would all fall through to `call.undefined-method` (or
-# Dynamic[T] at best via the user-class fallback tier).
+# Cross-file dispatch through the synthesised methods Tier B emits from the `devise :*` calls in
+# demo.rb. Without the plugin these would all fall through to `call.undefined-method` (or Dynamic[T] at
+# best via the user-class fallback tier).
 #
-# Slice 3 floor (WD13): the synthesised readers return Dynamic[T];
-# precise return-type promotion is the slice-6 ceiling. The
-# substrate's job here is making sure the methods resolve at all.
+# Slice 3 floor (WD13): the synthesised readers return Dynamic[T]; precise return-type promotion is the
+# slice-6 ceiling. The substrate's job here is making sure the methods resolve at all.
 
 def authenticate(user, password)
   return :no_password unless user.valid_password?(password)

--- a/plugins/rigor-devise/demo/demo.rb
+++ b/plugins/rigor-devise/demo/demo.rb
@@ -4,20 +4,15 @@
 #
 #   RUBYLIB=$PWD/../lib bundle exec rigor check
 #
-# The .rigor.yml in this directory enables the plugin and points
-# signature_paths at the local sig/ stub for ActiveRecord +
-# Devise::Models::*. With Tier B active, the substrate's pre-pass
-# walks `class User < ApplicationRecord; devise :database_authenticatable,
-# :recoverable; end` and synthesises one SyntheticMethod per
-# (User, included module instance method) pair into the
-# SyntheticMethodIndex.
+# The .rigor.yml in this directory enables the plugin and points signature_paths at the local sig/ stub
+# for ActiveRecord + Devise::Models::*. With Tier B active, the substrate's pre-pass walks `class User <
+# ApplicationRecord; devise :database_authenticatable, :recoverable; end` and synthesises one
+# SyntheticMethod per (User, included module instance method) pair into the SyntheticMethodIndex.
 #
-# Slice 3 floor (WD13): the synthetic methods return `Dynamic[T]`
-# at dispatch — i.e. `user.valid_password?(...)` resolves through
-# the synthetic-method tier and does NOT raise call.undefined-method,
-# but its return type is Dynamic[T] rather than `bool`. Precision
-# promotion (using the module's authored RBS return) is slice-6
-# ceiling work.
+# Slice 3 floor (WD13): the synthetic methods return `Dynamic[T]` at dispatch — i.e.
+# `user.valid_password?(...)` resolves through the synthetic-method tier and does NOT raise
+# call.undefined-method, but its return type is Dynamic[T] rather than `bool`. Precision promotion
+# (using the module's authored RBS return) is slice-6 ceiling work.
 
 class ApplicationRecord # rubocop:disable Lint/EmptyClass
 end

--- a/plugins/rigor-devise/lib/rigor-devise.rb
+++ b/plugins/rigor-devise/lib/rigor-devise.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-devise` under `plugins:`. The loader
-# expects this `require` to side-effect a call to
-# `Rigor::Plugin.register`, which the body of
-# `lib/rigor/plugin/devise.rb` performs at load time.
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists `rigor-devise` under
+# `plugins:`. The loader expects this `require` to side-effect a call to `Rigor::Plugin.register`,
+# which the body of `lib/rigor/plugin/devise.rb` performs at load time.
 require_relative "rigor/plugin/devise"

--- a/plugins/rigor-devise/lib/rigor/plugin/devise.rb
+++ b/plugins/rigor-devise/lib/rigor/plugin/devise.rb
@@ -4,26 +4,21 @@ require "rigor/plugin"
 
 module Rigor
   module Plugin
-    # ADR-16 Tier B worked plugin: recognises Devise's model-side
-    # `devise :strategy_a, :strategy_b` DSL on `ActiveRecord::Base`
-    # subclasses and explodes each strategy's module RBS into the
-    # calling class.
+    # ADR-16 Tier B worked plugin: recognises Devise's model-side `devise :strategy_a, :strategy_b` DSL on
+    # `ActiveRecord::Base` subclasses and explodes each strategy's module RBS into the calling class.
     #
-    # Per the per-library survey (§ Devise), Devise's `devise(*modules)`
-    # at `lib/devise/models.rb:79-112` is a **table-driven include
-    # sequence**: each Symbol argument resolves through
-    # `Devise::Models.const_get(m.to_s.classify)` to a concrete
-    # `Devise::Models::*` module, which is then mixed into the
-    # calling class. The substrate replays the same shape
-    # statically — the manifest's `modules_by_symbol:` mirrors
-    # Devise's `lib/devise/modules.rb` and the pre-pass scanner
-    # synthesises one SyntheticMethod per (calling class, included
-    # module instance method) pair into the SyntheticMethodIndex.
+    # Per the per-library survey (§ Devise), Devise's `devise(*modules)` at `lib/devise/models.rb:79-112`
+    # is a **table-driven include sequence**: each Symbol argument resolves through
+    # `Devise::Models.const_get(m.to_s.classify)` to a concrete `Devise::Models::*` module, which is then
+    # mixed into the calling class. The substrate replays the same shape statically — the manifest's
+    # `modules_by_symbol:` mirrors Devise's `lib/devise/modules.rb` and the pre-pass scanner synthesises
+    # one SyntheticMethod per (calling class, included module instance method) pair into the
+    # SyntheticMethodIndex.
     #
     # ## Reach
     #
-    # The full set of strategies Devise registers via
-    # `Devise.add_module` at gem load (per `lib/devise/modules.rb`):
+    # The full set of strategies Devise registers via `Devise.add_module` at gem load (per
+    # `lib/devise/modules.rb`):
     #
     # - `:database_authenticatable` — password + email auth core
     # - `:recoverable` — password-reset flow
@@ -37,41 +32,31 @@ module Rigor
     # - `:omniauthable` — OmniAuth providers
     # - `:authenticatable` — always-included base module
     #
-    # The substrate's pre-pass scanner consults each module's RBS
-    # via `Environment::RbsLoader#instance_definition` to enumerate
-    # method names. A user project providing real Devise via
-    # Bundler will see methods like `valid_password?`,
-    # `send_reset_password_instructions`, etc. resolve through the
-    # synthetic-method tier without `call.undefined-method`.
+    # The substrate's pre-pass scanner consults each module's RBS via `Environment::RbsLoader#instance_definition`
+    # to enumerate method names. A user project providing real Devise via Bundler will see methods like
+    # `valid_password?`, `send_reset_password_instructions`, etc. resolve through the synthetic-method
+    # tier without `call.undefined-method`.
     #
     # ## Precision tier
     #
-    # The scanner records `origin_module:` in each synthetic
-    # method's provenance. The dispatcher's slice-6a TierB path
-    # (`promote_via_origin_module`) redispatches on
-    # `Nominal[origin_module]` via `RbsDispatch`, so Devise's
-    # authored RBS return types win: `valid_password?` returns
-    # `bool`, not `Dynamic[T]`. Unknown return types degrade
-    # gracefully to `Dynamic[T]`.
+    # The scanner records `origin_module:` in each synthetic method's provenance. The dispatcher's
+    # slice-6a TierB path (`promote_via_origin_module`) redispatches on `Nominal[origin_module]` via
+    # `RbsDispatch`, so Devise's authored RBS return types win: `valid_password?` returns `bool`, not
+    # `Dynamic[T]`. Unknown return types degrade gracefully to `Dynamic[T]`.
     #
     # ## Scope
     #
-    # - Recognises model-side `devise :a, :b` on any AR::Base
-    #   subclass; trait symbol set mirrors `lib/devise/modules.rb`.
-    # - `Devise::Models::Authenticatable` is always_included
-    #   (matches Devise's `with_options model: true`).
-    # - Unknown trait symbols silently skipped (per slice-3
-    #   design judgment (2)). User initializers that call
-    #   `Devise.add_module :my_strategy, ...` are NOT seen — that
-    #   path requires a separate scanner for `config/initializers/`
-    #   and is deferred.
-    # - Controller-side helpers (`current_user`, `authenticate_user!`,
-    #   etc.) are Tier C work, NOT Tier B; deferred to a future
-    #   slice that consumes ADR-9 fact-store entries from a
-    #   `rigor-rails-routes`-style walker.
-    # - Per-strategy `ClassMethods` extend (Devise's `extend
-    #   Mod::ClassMethods` pattern) is NOT yet wired — slice 3
-    #   covers instance methods only per WD13 floor.
+    # - Recognises model-side `devise :a, :b` on any AR::Base subclass; trait symbol set mirrors
+    #   `lib/devise/modules.rb`.
+    # - `Devise::Models::Authenticatable` is always_included (matches Devise's `with_options model: true`).
+    # - Unknown trait symbols silently skipped (per slice-3 design judgment (2)). User initializers that
+    #   call `Devise.add_module :my_strategy, ...` are NOT seen — that path requires a separate scanner
+    #   for `config/initializers/` and is deferred.
+    # - Controller-side helpers (`current_user`, `authenticate_user!`, etc.) are Tier C work, NOT Tier B;
+    #   deferred to a future slice that consumes ADR-9 fact-store entries from a `rigor-rails-routes`-style
+    #   walker.
+    # - Per-strategy `ClassMethods` extend (Devise's `extend Mod::ClassMethods` pattern) is NOT yet wired
+    #   — slice 3 covers instance methods only per WD13 floor.
     class Devise < Rigor::Plugin::Base
       manifest(
         id: "devise",

--- a/plugins/rigor-dry-schema/demo/demo.rb
+++ b/plugins/rigor-dry-schema/demo/demo.rb
@@ -5,17 +5,14 @@
 #   cp .rigor.dist.yml .rigor.yml
 #   RUBYLIB=$PWD/../lib:$PWD/../../rigor-dry-types/lib bundle exec rigor check
 #
-# The canonical dry-schema declarations. With the plugin
-# enabled, rigor's prepare(services) hook scans this file, sees
-# the `Dry::Schema.Params { ... }` / `Dry::Schema.JSON { ... }`
-# assignments, and publishes the `:dry_schema_table` fact
-# mapping each schema constant to its `{required: {...},
+# The canonical dry-schema declarations. With the plugin enabled, rigor's prepare(services) hook scans
+# this file, sees the `Dry::Schema.Params { ... }` / `Dry::Schema.JSON { ... }` assignments, and
+# publishes the `:dry_schema_table` fact mapping each schema constant to its `{required: {...},
 # optional: {...}}` typed-key shape.
 #
-# At slice 1 the observable change is fact-publication only;
-# the downstream uplift (typed `Contract#call → Result.to_h`
-# returns through rigor-dry-validation) lands in a later slice
-# per docs/design/20260517-dry-validation-slicing.md.
+# At slice 1 the observable change is fact-publication only; the downstream uplift (typed `Contract#call
+# → Result.to_h` returns through rigor-dry-validation) lands in a later slice per
+# docs/design/20260517-dry-validation-slicing.md.
 
 module Types
   include Dry.Types()

--- a/plugins/rigor-dry-schema/lib/rigor-dry-schema.rb
+++ b/plugins/rigor-dry-schema/lib/rigor-dry-schema.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-dry-schema` under `plugins:`. The
-# loader expects this `require` to side-effect a call to
-# `Rigor::Plugin.register`, which the body of
-# `lib/rigor/plugin/dry_schema.rb` performs at load time.
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists `rigor-dry-schema` under
+# `plugins:`. The loader expects this `require` to side-effect a call to `Rigor::Plugin.register`,
+# which the body of `lib/rigor/plugin/dry_schema.rb` performs at load time.
 require_relative "rigor/plugin/dry_schema"

--- a/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema.rb
+++ b/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema.rb
@@ -10,7 +10,8 @@ module Rigor
   module Plugin
     # rigor-dry-schema — Tier A per
     # [ADR-12](../../../../../docs/adr/12-dry-rb-packaging.md) and the
-    # slicing plan in [docs/design/20260517-dry-validation-slicing.md](../../../../../docs/design/20260517-dry-validation-slicing.md).
+    # slicing plan in
+    # [docs/design/20260517-dry-validation-slicing.md](../../../../../docs/design/20260517-dry-validation-slicing.md).
     #
     # Recognises the canonical dry-schema declaration shapes:
     #
@@ -28,51 +29,42 @@ module Rigor
     #       required(:foo).value(:string)
     #     end
     #
-    # and publishes the resulting
-    # `{schema_const_fqn => {required: {key => underlying_class}, optional: {…}}}`
-    # table as the `:dry_schema_table` cross-plugin fact (ADR-9).
-    # Downstream `rigor-dry-validation` consumes the fact for
-    # per-Contract typed-payload synthesis.
+    # and publishes the resulting `{schema_const_fqn => {required: {key => underlying_class}, optional:
+    # {…}}}` table as the `:dry_schema_table` cross-plugin fact (ADR-9). Downstream `rigor-dry-validation`
+    # consumes the fact for per-Contract typed-payload synthesis.
     #
     # ## Predicate type recognition
     #
-    # Each `required(:key).<predicate>(<arg>)` row maps the predicate
-    # argument to an underlying Ruby class via the dry-schema
-    # canonical-type vocabulary:
+    # Each `required(:key).<predicate>(<arg>)` row maps the predicate argument to an underlying Ruby
+    # class via the dry-schema canonical-type vocabulary:
     #
-    # - `:string` / `:integer` / `:float` / `:decimal` / `:symbol` /
-    #   `:bool` / `:nil` / `:date` / `:date_time` / `:time` / `:hash`
-    #   / `:array` map to their underlying class.
-    # - The four predicate verbs `filled` / `value` / `maybe` /
-    #   `each` are accepted on the same row; their semantic
-    #   difference (whether the value is nullable or coerced) does
-    #   not change the underlying class for Rigor's purposes.
-    # - References to dry-types aliases (`value(Types::Email)`,
-    #   `filled(Types::String)`) resolve through the
-    #   `:dry_type_aliases` ADR-9 fact published by `rigor-dry-types`
-    #   when that plugin is loaded; without it the row degrades to
-    #   "no type contribution from this key".
+    # - `:string` / `:integer` / `:float` / `:decimal` / `:symbol` / `:bool` / `:nil` / `:date` /
+    #   `:date_time` / `:time` / `:hash` / `:array` map to their underlying class.
+    # - The four predicate verbs `filled` / `value` / `maybe` / `each` are accepted on the same row; their
+    #   semantic difference (whether the value is nullable or coerced) does not change the underlying
+    #   class for Rigor's purposes.
+    # - References to dry-types aliases (`value(Types::Email)`, `filled(Types::String)`) resolve through
+    #   the `:dry_type_aliases` ADR-9 fact published by `rigor-dry-types` when that plugin is loaded;
+    #   without it the row degrades to "no type contribution from this key".
     #
     # ## Floor / ceiling (slice 1)
     #
     # Slice 1 ships the **floor**:
     #
-    # - Top-level `Foo = Dry::Schema.{Params,JSON,define} { ... }`
-    #   assignments. Class-level constants (`class Bar; SCHEMA =
-    #   Dry::Schema.Params { ... }; end`) work too — the walker
-    #   prefixes the enclosing constant chain.
-    # - `required(:key).<predicate>(:type_symbol_or_constant)` rows
-    #   for the canonical-type vocabulary above.
+    # - Top-level `Foo = Dry::Schema.{Params,JSON,define} { ... }` assignments. Class-level constants
+    #   (`class Bar; SCHEMA = Dry::Schema.Params { ... }; end`) work too — the walker prefixes the
+    #   enclosing constant chain.
+    # - `required(:key).<predicate>(:type_symbol_or_constant)` rows for the canonical-type vocabulary
+    #   above.
     # - Publishes the table; no user-facing diagnostics yet.
     #
     # The **ceiling** (slice 2+):
     #
-    # - Synthesise typed `result.to_h` returns from each schema
-    #   via ADR-16 Tier C heredoc-template substrate.
+    # - Synthesise typed `result.to_h` returns from each schema via ADR-16 Tier C heredoc-template
+    #   substrate.
     # - Nested schemas (`schema(do ... end)` inside another row).
     # - `predicates(:size?)` / `each { ... }` recursion.
-    # - Per-row `dry-schema.unknown-predicate` /
-    #   `dry-schema.unknown-type` `:info` diagnostics when a
+    # - Per-row `dry-schema.unknown-predicate` / `dry-schema.unknown-type` `:info` diagnostics when a
     #   row's predicate or type symbol isn't recognised.
     class DrySchema < Rigor::Plugin::Base
       manifest(
@@ -84,10 +76,9 @@ module Rigor
         consumes: [{ plugin_id: "dry-types", name: :dry_type_aliases, optional: true }]
       )
 
-      # Walks every project file once during `prepare(services)` to
-      # build the schema table, then publishes via the ADR-9 fact
-      # store. Mirrors the rigor-dry-types `#prepare` shape — the
-      # walk is bounded by `paths:`, parse errors degrade silently.
+      # Walks every project file once during `prepare(services)` to build the schema table, then publishes
+      # via the ADR-9 fact store. Mirrors the rigor-dry-types `#prepare` shape — the walk is bounded by
+      # `paths:`, parse errors degrade silently.
       def prepare(services)
         type_aliases = services.fact_store.read(plugin_id: "dry-types", name: :dry_type_aliases) || {}
         table = SchemaScanner.scan(paths: scannable_paths(services), type_aliases: type_aliases)

--- a/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema/schema_scanner.rb
+++ b/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema/schema_scanner.rb
@@ -6,16 +6,13 @@ require "rigor/source/literals"
 module Rigor
   module Plugin
     class DrySchema < Rigor::Plugin::Base
-      # Walks project source for `Foo = Dry::Schema.{Params,JSON,define}
-      # { ... }` shapes and emits a
-      # `{schema_const_fqn => {required: {key => underlying_class}, optional: {…}}}`
-      # table covering each schema's typed-key surface.
+      # Walks project source for `Foo = Dry::Schema.{Params,JSON,define} { ... }` shapes and emits a
+      # `{schema_const_fqn => {required: {key => underlying_class}, optional: {…}}}` table covering each
+      # schema's typed-key surface.
       module SchemaScanner
-        # The dry-schema canonical-type symbols accepted as
-        # predicate arguments. Maps each to the underlying Ruby
-        # class name (the same vocabulary `rigor-dry-types`
-        # uses for `CANONICAL_ALIASES`, intersected with what
-        # dry-schema's predicate engine accepts).
+        # The dry-schema canonical-type symbols accepted as predicate arguments. Maps each to the
+        # underlying Ruby class name (the same vocabulary `rigor-dry-types` uses for `CANONICAL_ALIASES`,
+        # intersected with what dry-schema's predicate engine accepts).
         CANONICAL_TYPES = {
           string: "String",
           integer: "Integer",
@@ -30,12 +27,10 @@ module Rigor
           array: "Array"
         }.tap { |h| h[:nil] = "NilClass" }.freeze
 
-        # The dry-schema predicate verbs that accept a type
-        # argument. Each verb has a slightly different runtime
-        # semantic (`filled` = present + non-empty; `value` =
-        # present; `maybe` = present-or-nil; `each` = collection
-        # element type) but for Rigor's purposes they all
-        # contribute the same underlying class for the key.
+        # The dry-schema predicate verbs that accept a type argument. Each verb has a slightly different
+        # runtime semantic (`filled` = present + non-empty; `value` = present; `maybe` = present-or-nil;
+        # `each` = collection element type) but for Rigor's purposes they all contribute the same
+        # underlying class for the key.
         TYPE_BEARING_PREDICATES = %i[filled value maybe each].to_set.freeze
         private_constant :TYPE_BEARING_PREDICATES
 
@@ -45,17 +40,12 @@ module Rigor
 
         module_function
 
-        # @param paths [Array<String>] absolute paths to `.rb`
-        #   files the project's `paths:` resolves to.
-        # @param type_aliases [Hash{String => String}] the
-        #   ADR-9 `:dry_type_aliases` fact published by
-        #   `rigor-dry-types` when loaded. Used to resolve
-        #   `value(Types::Email)` references to their
-        #   underlying class. Empty when the plugin isn't
-        #   loaded.
-        # @return [Hash{String => Hash{Symbol => Hash{Symbol => String}}}]
-        #   frozen per-schema typed-key table. Empty when no
-        #   recognisable schema declaration is found.
+        # @param paths [Array<String>] absolute paths to `.rb` files the project's `paths:` resolves to.
+        # @param type_aliases [Hash{String => String}] the ADR-9 `:dry_type_aliases` fact published by
+        #   `rigor-dry-types` when loaded. Used to resolve `value(Types::Email)` references to their
+        #   underlying class. Empty when the plugin isn't loaded.
+        # @return [Hash{String => Hash{Symbol => Hash{Symbol => String}}}] frozen per-schema typed-key
+        #   table. Empty when no recognisable schema declaration is found.
         def scan(paths:, type_aliases: {})
           table = {}
           paths.each do |path|
@@ -77,11 +67,9 @@ module Rigor
         end
         private_class_method :scan_file
 
-        # Walks the AST collecting `<Const> = Dry::Schema.X { ... }`
-        # assignments at any nesting level. Tracks the enclosing
-        # constant chain so a class-level `class Foo; SCHEMA =
-        # Dry::Schema.Params { ... }; end` registers as
-        # `"Foo::SCHEMA"`.
+        # Walks the AST collecting `<Const> = Dry::Schema.X { ... }` assignments at any nesting level.
+        # Tracks the enclosing constant chain so a class-level `class Foo; SCHEMA = Dry::Schema.Params
+        # { ... }; end` registers as `"Foo::SCHEMA"`.
         def collect_schemas(node, qualified_prefix, type_aliases)
           return {} if node.nil?
 
@@ -119,8 +107,7 @@ module Rigor
         end
         private_class_method :collect_schema_assignment
 
-        # Matches `Dry::Schema.Params { ... }` /
-        # `Dry::Schema.JSON { ... }` / `Dry::Schema.define { ... }`.
+        # Matches `Dry::Schema.Params { ... }` / `Dry::Schema.JSON { ... }` / `Dry::Schema.define { ... }`.
         def schema_entry_call?(node)
           return false unless node.is_a?(Prism::CallNode)
           return false unless SCHEMA_ENTRY_NAMES.include?(node.name)
@@ -147,10 +134,9 @@ module Rigor
         end
         private_class_method :collect_schema_shape
 
-        # Walks every top-level `required(:key).<predicate>(...)` /
-        # `optional(:key).<predicate>(...)` chain in the block
-        # body. The block's body is either a `Prism::StatementsNode`
-        # (multi-statement) or a single expression node.
+        # Walks every top-level `required(:key).<predicate>(...)` / `optional(:key).<predicate>(...)`
+        # chain in the block body. The block's body is either a `Prism::StatementsNode` (multi-statement)
+        # or a single expression node.
         def walk_block_body(block_node, &)
           body = block_node.body
           return if body.nil?
@@ -160,13 +146,10 @@ module Rigor
         end
         private_class_method :walk_block_body
 
-        # `required(:key).filled(:string)` parses as a CallNode
-        # whose receiver is the `required(:key)` call. Walk the
-        # chain inward looking for the type-bearing predicate at
-        # the head; the key sits on the chain's tail. The
-        # `each(<Type>)` predicate yields a list-of-element
-        # type info (`{type: <T>, list: true}`); other type-bearing
-        # predicates (`filled`/`value`/`maybe`) yield scalar info
+        # `required(:key).filled(:string)` parses as a CallNode whose receiver is the `required(:key)`
+        # call. Walk the chain inward looking for the type-bearing predicate at the head; the key sits on
+        # the chain's tail. The `each(<Type>)` predicate yields a list-of-element type info (`{type: <T>,
+        # list: true}`); other type-bearing predicates (`filled`/`value`/`maybe`) yield scalar info
         # (`{type: <T>, list: false}`).
         def visit_chain(node, &block)
           return unless node.is_a?(Prism::CallNode)
@@ -179,11 +162,9 @@ module Rigor
         end
         private_class_method :visit_chain
 
-        # `required(:key).filled(:string).value(...)...` — the
-        # OUTERMOST call's receiver chain ends in the
-        # `required(:key)` / `optional(:key)` call. Recurse on
-        # `node.receiver` until we hit the `required` /
-        # `optional` call, recording the key + kind.
+        # `required(:key).filled(:string).value(...)...` — the OUTERMOST call's receiver chain ends in
+        # the `required(:key)` / `optional(:key)` call. Recurse on `node.receiver` until we hit the
+        # `required` / `optional` call, recording the key + kind.
         def extract_key_and_kind(node)
           current = node
           while current.is_a?(Prism::CallNode)
@@ -199,11 +180,9 @@ module Rigor
         end
         private_class_method :extract_key_and_kind
 
-        # Walks the call chain finding the first type-bearing
-        # predicate (`filled` / `value` / `maybe` / `each`) and
-        # extracts its argument type. Returns a `{type:, list:}`
-        # tuple (`each` is the only verb that produces a list)
-        # or nil when no recognisable type sits on the chain.
+        # Walks the call chain finding the first type-bearing predicate (`filled` / `value` / `maybe` /
+        # `each`) and extracts its argument type. Returns a `{type:, list:}` tuple (`each` is the only
+        # verb that produces a list) or nil when no recognisable type sits on the chain.
         def walk_predicate_chain(node)
           current = node
           while current.is_a?(Prism::CallNode)
@@ -217,12 +196,10 @@ module Rigor
         end
         private_class_method :walk_predicate_chain
 
-        # Reads the first positional argument of a `filled(:string)`
-        # / `value(:integer)` / `maybe(Types::Email)` call. Returns
-        # either the canonical-type-symbol's underlying class
-        # ("String" / "Integer" / …), or the constant's qualified
-        # name for downstream type-alias resolution. Returns nil
-        # for anything else.
+        # Reads the first positional argument of a `filled(:string)` / `value(:integer)` /
+        # `maybe(Types::Email)` call. Returns either the canonical-type-symbol's underlying class
+        # ("String" / "Integer" / …), or the constant's qualified name for downstream type-alias
+        # resolution. Returns nil for anything else.
         def extract_type_from_predicate(call_node)
           arg = call_node.arguments&.arguments&.first
           case arg
@@ -236,12 +213,10 @@ module Rigor
         end
         private_class_method :extract_type_from_predicate
 
-        # In-place: any value's `type:` slot in `bucket` that
-        # doesn't already match a canonical class (e.g.
-        # `"Types::Email"`) gets resolved through the
-        # type_aliases fact. Unresolvable values drop from the
-        # bucket (no fact contribution rather than misleading
-        # data). The `list:` slot rides along unchanged.
+        # In-place: any value's `type:` slot in `bucket` that doesn't already match a canonical class
+        # (e.g. `"Types::Email"`) gets resolved through the type_aliases fact. Unresolvable values drop
+        # from the bucket (no fact contribution rather than misleading data). The `list:` slot rides along
+        # unchanged.
         def remap_aliases!(bucket, type_aliases)
           canonical_set = CANONICAL_TYPES.values.to_set
           bucket.each_pair.to_a.each do |key, info|
@@ -258,9 +233,8 @@ module Rigor
         end
         private_class_method :remap_aliases!
 
-        # Constant-path serialiser: `Dry::Schema` -> "Dry::Schema",
-        # bare `Foo` -> "Foo". Returns nil for shapes Prism
-        # doesn't expose as ConstantRead/PathNode.
+        # Constant-path serialiser: `Dry::Schema` -> "Dry::Schema", bare `Foo` -> "Foo". Returns nil for
+        # shapes Prism doesn't expose as ConstantRead/PathNode.
         def constant_name_for(node)
           return nil if node.nil?
 

--- a/plugins/rigor-dry-struct/demo/consumer.rb
+++ b/plugins/rigor-dry-struct/demo/consumer.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-# Cross-file dispatch through the synthetic methods the substrate
-# emits for the structs in demo.rb. Without the plugin these
-# would fall through to `call.undefined-method` (or `Dynamic[T]`
-# at best via the user-class fallback tier).
+# Cross-file dispatch through the synthetic methods the substrate emits for the structs in demo.rb.
+# Without the plugin these would fall through to `call.undefined-method` (or `Dynamic[T]` at best via
+# the user-class fallback tier).
 #
-# Slice 2c floor (WD13): the synthetic readers return `Dynamic[T]`;
-# precise return-type promotion (so `address.city` returns `String`
-# from the `Types::String` declaration) is the ceiling, deferred
-# to a later slice routing through ADR-13's resolver chain.
+# Slice 2c floor (WD13): the synthetic readers return `Dynamic[T]`; precise return-type promotion (so
+# `address.city` returns `String` from the `Types::String` declaration) is the ceiling, deferred to a
+# later slice routing through ADR-13's resolver chain.
 
 def greet_address(address)
   "#{address.city}, #{address.country}"

--- a/plugins/rigor-dry-struct/demo/demo.rb
+++ b/plugins/rigor-dry-struct/demo/demo.rb
@@ -4,19 +4,15 @@
 #
 #   RUBYLIB=$PWD/../lib bundle exec rigor check
 #
-# The .rigor.yml in this directory enables the plugin and points
-# signature_paths at the local sig/ stub for Dry::Struct. With
-# Tier C active, the pre-pass synthesises `Address#city`,
-# `Address#country`, `User#name`, `User#email`, and `User#admin`
-# as instance readers. The `consumer.rb` file then dispatches
-# `address.city` / `user.name` / etc. through the substrate's
-# SyntheticMethodIndex below RBS dispatch (per WD13 — Dynamic[T]
-# returns at the floor; precise return-type promotion is deferred
-# to a later slice).
+# The .rigor.yml in this directory enables the plugin and points signature_paths at the local sig/ stub
+# for Dry::Struct. With Tier C active, the pre-pass synthesises `Address#city`, `Address#country`,
+# `User#name`, `User#email`, and `User#admin` as instance readers. The `consumer.rb` file then dispatches
+# `address.city` / `user.name` / etc. through the substrate's SyntheticMethodIndex below RBS dispatch
+# (per WD13 — Dynamic[T] returns at the floor; precise return-type promotion is deferred to a later
+# slice).
 #
-# Without the plugin the bare reader calls in `consumer.rb` would
-# fall through to `call.undefined-method` (or `Dynamic[T]` via
-# the user-class fallback tier).
+# Without the plugin the bare reader calls in `consumer.rb` would fall through to
+# `call.undefined-method` (or `Dynamic[T]` via the user-class fallback tier).
 
 class Address < Dry::Struct
   attribute :city, Types::String

--- a/plugins/rigor-dry-struct/demo/types.rb
+++ b/plugins/rigor-dry-struct/demo/types.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
-# The canonical dry-types alias-module declaration. With
-# `rigor-dry-types` loaded, this file's scan publishes
-# `Types::String` -> "String", `Types::Bool` -> "TrueClass",
-# etc. as the `:dry_type_aliases` cross-plugin fact. The
-# `rigor-dry-struct` plugin (also loaded) consumes that fact
-# through ADR-18's `returns_from_arg:` so each
-# `attribute :name, Types::String` line synthesises a reader
-# returning `Nominal[String]` instead of `Dynamic[Top]`.
+# The canonical dry-types alias-module declaration. With `rigor-dry-types` loaded, this file's scan
+# publishes `Types::String` -> "String", `Types::Bool` -> "TrueClass", etc. as the `:dry_type_aliases`
+# cross-plugin fact. The `rigor-dry-struct` plugin (also loaded) consumes that fact through ADR-18's
+# `returns_from_arg:` so each `attribute :name, Types::String` line synthesises a reader returning
+# `Nominal[String]` instead of `Dynamic[Top]`.
 
 module Types
   include Dry.Types()

--- a/plugins/rigor-dry-struct/lib/rigor-dry-struct.rb
+++ b/plugins/rigor-dry-struct/lib/rigor-dry-struct.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-dry-struct` under `plugins:`. The
-# loader expects this `require` to side-effect a call to
-# `Rigor::Plugin.register`, which the body of
-# `lib/rigor/plugin/dry_struct.rb` performs at load time.
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists `rigor-dry-struct` under
+# `plugins:`. The loader expects this `require` to side-effect a call to `Rigor::Plugin.register`,
+# which the body of `lib/rigor/plugin/dry_struct.rb` performs at load time.
 require_relative "rigor/plugin/dry_struct"

--- a/plugins/rigor-dry-struct/lib/rigor/plugin/dry_struct.rb
+++ b/plugins/rigor-dry-struct/lib/rigor/plugin/dry_struct.rb
@@ -4,16 +4,13 @@ require "rigor/plugin"
 
 module Rigor
   module Plugin
-    # ADR-16 Tier C worked plugin: recognises dry-struct's class-
-    # level `attribute :name, T` DSL and synthesises a reader on
-    # the enclosing `Dry::Struct` subclass.
+    # ADR-16 Tier C worked plugin: recognises dry-struct's class-level `attribute :name, T` DSL and
+    # synthesises a reader on the enclosing `Dry::Struct` subclass.
     #
-    # dry-struct's `Dry::Struct::ClassInterface#attribute` (per the
-    # per-library survey, `lib/dry/struct/class_interface.rb:86-88`
-    # in the upstream gem) is the textbook Tier C target — a
-    # class-level DSL call enumerates a literal Symbol argument, and
-    # `class_interface.rb:452-464` `class_eval`s a heredoc
-    # interpolating that Symbol into a getter:
+    # dry-struct's `Dry::Struct::ClassInterface#attribute` (per the per-library survey,
+    # `lib/dry/struct/class_interface.rb:86-88` in the upstream gem) is the textbook Tier C target — a
+    # class-level DSL call enumerates a literal Symbol argument, and `class_interface.rb:452-464`
+    # `class_eval`s a heredoc interpolating that Symbol into a getter:
     #
     #     class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
     #       def #{key}                       # def city
@@ -21,44 +18,36 @@ module Rigor
     #       end
     #     RUBY
     #
-    # The substrate replays the same contract statically. For
-    # source like:
+    # The substrate replays the same contract statically. For source like:
     #
     #     class Address < Dry::Struct
     #       attribute :city, Types::String
     #       attribute :country, Types::String
     #     end
     #
-    # the pre-pass scans the file, sees `attribute :city, ...`, and
-    # synthesises `Address#city` as a SyntheticMethod the dispatcher
-    # surfaces below RBS dispatch. Bare `address.city` calls in
-    # other files then dispatch through the synthetic record rather
-    # than falling through to `call.undefined-method`.
+    # the pre-pass scans the file, sees `attribute :city, ...`, and synthesises `Address#city` as a
+    # SyntheticMethod the dispatcher surfaces below RBS dispatch. Bare `address.city` calls in other
+    # files then dispatch through the synthetic record rather than falling through to
+    # `call.undefined-method`.
     #
     # ## Precision model (ADR-16 WD13 + ADR-18)
     #
-    # The synthetic reader's return type is resolved via ADR-18's
-    # `returns_from_arg:` fact lookup: the call-site's second argument
-    # (`Types::String` etc.) is looked up through the `:dry_type_aliases`
-    # fact published by `rigor-dry-types`, yielding `Nominal[String]`
-    # for common cases. When the lookup misses (e.g. inline method-chain
-    # argument whose chain-head isn't currently extracted), the row
+    # The synthetic reader's return type is resolved via ADR-18's `returns_from_arg:` fact lookup: the
+    # call-site's second argument (`Types::String` etc.) is looked up through the `:dry_type_aliases`
+    # fact published by `rigor-dry-types`, yielding `Nominal[String]` for common cases. When the lookup
+    # misses (e.g. inline method-chain argument whose chain-head isn't currently extracted), the row
     # falls back to `Dynamic[Top]` silently.
     #
     # ## Scope (slice 2c minimum)
     #
     # - Recognises `attribute :name, T` at class body top level.
-    # - Recognises `attribute? :name, T` via a separate template
-    #   entry (omittable attribute; same reader name, `?` stripped).
-    # - Synthesises **only the reader** — the other survey-listed
-    #   emit rows (`schema` key, `to_h` row, `[:key]` access, `.new`
-    #   kwarg) are not yet wired by the substrate (they require
-    #   either RBS-level shape synthesis or additional substrate
-    #   primitives). Slice 2c stops at the reader.
-    # - Nested-block form (`attribute :details do ... end` minting
-    #   `Address::Details`) is out of scope for slice 2c; that
-    #   pattern needs Tier A + Tier C composition + const_set
-    #   emission. Deferred.
+    # - Recognises `attribute? :name, T` via a separate template entry (omittable attribute; same reader
+    #   name, `?` stripped).
+    # - Synthesises **only the reader** — the other survey-listed emit rows (`schema` key, `to_h` row,
+    #   `[:key]` access, `.new` kwarg) are not yet wired by the substrate (they require either RBS-level
+    #   shape synthesis or additional substrate primitives). Slice 2c stops at the reader.
+    # - Nested-block form (`attribute :details do ... end` minting `Address::Details`) is out of scope
+    #   for slice 2c; that pattern needs Tier A + Tier C composition + const_set emission. Deferred.
     class DryStruct < Rigor::Plugin::Base
       manifest(
         id: "dry-struct",
@@ -66,26 +55,20 @@ module Rigor
         description: "Recognises dry-struct `attribute :name, T` DSL via ADR-16 Tier C; " \
                      "promotes the reader's return type through ADR-18's `returns_from_arg:` " \
                      "by consuming `rigor-dry-types`'s `:dry_type_aliases` fact.",
-        # ADR-9 consumption — the precision-promotion path
-        # below uses `:dry_type_aliases` published by
-        # `rigor-dry-types`. The fact is optional: when the
-        # `rigor-dry-types` plugin isn't loaded, the
-        # `returns_from_arg:` lookup misses and the synthetic
-        # readers fall back to `Dynamic[Top]` (the pre-ADR-18
-        # floor).
+        # ADR-9 consumption — the precision-promotion path below uses `:dry_type_aliases` published by
+        # `rigor-dry-types`. The fact is optional: when the `rigor-dry-types` plugin isn't loaded, the
+        # `returns_from_arg:` lookup misses and the synthetic readers fall back to `Dynamic[Top]` (the
+        # pre-ADR-18 floor).
         consumes: [{ plugin_id: "dry-types", name: :dry_type_aliases, optional: true }],
         heredoc_templates: [
           Rigor::Plugin::Macro::HeredocTemplate.new(
             receiver_constraint: "Dry::Struct",
             method_name: :attribute,
             symbol_arg_position: 0,
-            # ADR-18 — the synthetic reader's return type comes
-            # from the call site's second argument
-            # (`Types::String` etc.), resolved through the
-            # `:dry_type_aliases` fact. When the lookup misses
-            # (e.g. inline `attribute :tag, Types::String.constrained(...)`,
-            # whose receiver chain head isn't currently
-            # extracted), the row falls back to Dynamic[Top].
+            # ADR-18 — the synthetic reader's return type comes from the call site's second argument
+            # (`Types::String` etc.), resolved through the `:dry_type_aliases` fact. When the lookup
+            # misses (e.g. inline `attribute :tag, Types::String.constrained(...)`, whose receiver chain
+            # head isn't currently extracted), the row falls back to Dynamic[Top].
             emit: [{
               name: "\#{name}",
               returns_from_arg: {

--- a/plugins/rigor-dry-types/demo/demo.rb
+++ b/plugins/rigor-dry-types/demo/demo.rb
@@ -5,17 +5,13 @@
 #   cp .rigor.dist.yml .rigor.yml
 #   RUBYLIB=$PWD/../lib bundle exec rigor check
 #
-# The canonical dry-types alias-module declaration. With the
-# plugin enabled, rigor's prepare(services) hook scans this
-# file, sees `include Dry.Types()` inside `module Types`, and
-# publishes the `:dry_type_aliases` fact mapping
-# `Types::String` → `String`, `Types::Integer` → `Integer`,
-# etc.
+# The canonical dry-types alias-module declaration. With the plugin enabled, rigor's prepare(services)
+# hook scans this file, sees `include Dry.Types()` inside `module Types`, and publishes the
+# `:dry_type_aliases` fact mapping `Types::String` → `String`, `Types::Integer` → `Integer`, etc.
 #
-# At slice 1 the observable change is fact-publication only;
-# the downstream uplift (e.g., promoting `rigor-dry-struct`
-# reader returns from Dynamic[T] to Nominal[String]) lands in
-# a later slice that wires the fact through the dispatcher.
+# At slice 1 the observable change is fact-publication only; the downstream uplift (e.g., promoting
+# `rigor-dry-struct` reader returns from Dynamic[T] to Nominal[String]) lands in a later slice that wires
+# the fact through the dispatcher.
 
 module Types
   include Dry.Types()

--- a/plugins/rigor-dry-types/lib/rigor-dry-types.rb
+++ b/plugins/rigor-dry-types/lib/rigor-dry-types.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-dry-types` under `plugins:`. The
-# loader expects this `require` to side-effect a call to
-# `Rigor::Plugin.register`, which the body of
-# `lib/rigor/plugin/dry_types.rb` performs at load time.
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists `rigor-dry-types` under
+# `plugins:`. The loader expects this `require` to side-effect a call to `Rigor::Plugin.register`,
+# which the body of `lib/rigor/plugin/dry_types.rb` performs at load time.
 require_relative "rigor/plugin/dry_types"

--- a/plugins/rigor-dry-types/lib/rigor/plugin/dry_types.rb
+++ b/plugins/rigor-dry-types/lib/rigor/plugin/dry_types.rb
@@ -17,56 +17,44 @@ module Rigor
     #       include Dry.Types()
     #     end
     #
-    # and publishes the resulting `{aliased_name => underlying_class}`
-    # table as the `:dry_type_aliases` cross-plugin fact (ADR-9).
-    # Other dry-rb adapter plugins consume this fact:
+    # and publishes the resulting `{aliased_name => underlying_class}` table as the `:dry_type_aliases`
+    # cross-plugin fact (ADR-9). Other dry-rb adapter plugins consume this fact:
     #
-    # - `rigor-dry-struct` reads it so `attribute :city, Types::String`
-    #   promotes `address.city` from `Dynamic[Top]` to `Nominal[String]`
-    #   via ADR-18's `returns_from_arg:` fact lookup.
-    # - `rigor-dry-validation` / `rigor-dry-schema` read it for
-    #   per-key type recognition in `schema { … }` / `params { … }`
-    #   blocks (separate plugin slice).
+    # - `rigor-dry-struct` reads it so `attribute :city, Types::String` promotes `address.city` from
+    #   `Dynamic[Top]` to `Nominal[String]` via ADR-18's `returns_from_arg:` fact lookup.
+    # - `rigor-dry-validation` / `rigor-dry-schema` read it for per-key type recognition in `schema { … }`
+    #   / `params { … }` blocks (separate plugin slice).
     #
     # ## Floor / ceiling (slice 1)
     #
     # Slice 1 ships the **floor**:
     #
-    # - Recognises `module X; include Dry.Types(); end` for any
-    #   constant module name `X` (commonly `Types`, sometimes
-    #   `MyTypes` / `AppTypes`).
-    # - Maps the **basic** dry-types constants: `String`, `Integer`,
-    #   `Float`, `Decimal`, `Symbol`, `Bool`, `True`, `False`, `Nil`,
-    #   `Date`, `DateTime`, `Time`, `Hash`, `Array`, `Any`.
-    # - Publishes the table as `{ "<Module>::<Alias>" =>
-    #   "<UnderlyingClass>" }` so consumers can match on the
-    #   qualified constant name they see in source.
+    # - Recognises `module X; include Dry.Types(); end` for any constant module name `X` (commonly
+    #   `Types`, sometimes `MyTypes` / `AppTypes`).
+    # - Maps the **basic** dry-types constants: `String`, `Integer`, `Float`, `Decimal`, `Symbol`, `Bool`,
+    #   `True`, `False`, `Nil`, `Date`, `DateTime`, `Time`, `Hash`, `Array`, `Any`.
+    # - Publishes the table as `{ "<Module>::<Alias>" => "<UnderlyingClass>" }` so consumers can match on
+    #   the qualified constant name they see in source.
     #
     # Implemented beyond the floor:
     #
-    # - Nested-namespace aliases (`Types::Coercible::Integer`,
-    #   `Types::Strict::Symbol`, `Types::Params::Bool`,
-    #   `Types::JSON::Date`) — the four coercion categories each
-    #   map to the same underlying class as their canonical shortcut.
-    # - User-authored compositions (`Email = Types::String.constrained(...)`,
-    #   transitive resolution through composition chains) — the alias
-    #   surface extends beyond the 15 canonical names.
+    # - Nested-namespace aliases (`Types::Coercible::Integer`, `Types::Strict::Symbol`,
+    #   `Types::Params::Bool`, `Types::JSON::Date`) — the four coercion categories each map to the same
+    #   underlying class as their canonical shortcut.
+    # - User-authored compositions (`Email = Types::String.constrained(...)`, transitive resolution
+    #   through composition chains) — the alias surface extends beyond the 15 canonical names.
     #
     # Deferred:
     #
-    # - `dry-types.unknown-alias` / `dry-types.alias-shadow`
-    #   diagnostics when downstream code references a name that
-    #   wasn't published.
+    # - `dry-types.unknown-alias` / `dry-types.alias-shadow` diagnostics when downstream code references
+    #   a name that wasn't published.
     #
     # ## Why no `diagnostics_for_file` at the floor?
     #
-    # The plugin's user-visible value at slice 1 is the published
-    # fact — every downstream uplift (precision promotion in
-    # `address.city`, schema-key recognition in `rigor-dry-validation`)
-    # consumes the fact rather than the plugin itself emitting
-    # diagnostics. The diagnostics surface lands when the
-    # `dry-types.*` rule family becomes load-bearing for
-    # demand-driven cases.
+    # The plugin's user-visible value at slice 1 is the published fact — every downstream uplift
+    # (precision promotion in `address.city`, schema-key recognition in `rigor-dry-validation`) consumes
+    # the fact rather than the plugin itself emitting diagnostics. The diagnostics surface lands when the
+    # `dry-types.*` rule family becomes load-bearing for demand-driven cases.
     class DryTypes < Rigor::Plugin::Base
       manifest(
         id: "dry-types",
@@ -75,12 +63,9 @@ module Rigor
         produces: [:dry_type_aliases]
       )
 
-      # Walks every project file once during `prepare(services)` to
-      # build the alias table, then publishes via the ADR-9 fact
-      # store. The walk is bounded by the configured `paths:`
-      # surface; each file's parse error degrades to "no
-      # contribution" without polluting the user-visible
-      # diagnostic stream.
+      # Walks every project file once during `prepare(services)` to build the alias table, then publishes
+      # via the ADR-9 fact store. The walk is bounded by the configured `paths:` surface; each file's
+      # parse error degrades to "no contribution" without polluting the user-visible diagnostic stream.
       def prepare(services)
         aliases = AliasScanner.scan(paths: scannable_paths(services))
         return if aliases.empty?
@@ -98,11 +83,9 @@ module Rigor
 
       private
 
-      # Resolves the project's `paths:` to a flat list of `.rb`
-      # files the scanner walks. Mirrors `Analysis::Runner`'s
-      # `expand_paths` floor; we don't need the runner's full
-      # exclude/sort surface because the alias table is a
-      # union — any duplicate scan is a no-op.
+      # Resolves the project's `paths:` to a flat list of `.rb` files the scanner walks. Mirrors
+      # `Analysis::Runner`'s `expand_paths` floor; we don't need the runner's full exclude/sort surface
+      # because the alias table is a union — any duplicate scan is a no-op.
       def scannable_paths(services)
         @scannable_paths ||= services.configuration.paths.flat_map do |entry|
           if File.directory?(entry)

--- a/plugins/rigor-dry-types/lib/rigor/plugin/dry_types/alias_scanner.rb
+++ b/plugins/rigor-dry-types/lib/rigor/plugin/dry_types/alias_scanner.rb
@@ -5,15 +5,12 @@ require "prism"
 module Rigor
   module Plugin
     class DryTypes < Rigor::Plugin::Base
-      # Walks project source for `module X; include Dry.Types(); end`
-      # shapes and emits a `{ "<X>::<Alias>" => "<UnderlyingClass>" }`
-      # alias table covering the dry-types canonical-shortcut names.
-      # See {DryTypes} module-docstring for the floor / ceiling
-      # scoping.
+      # Walks project source for `module X; include Dry.Types(); end` shapes and emits a
+      # `{ "<X>::<Alias>" => "<UnderlyingClass>" }` alias table covering the dry-types canonical-shortcut
+      # names. See {DryTypes} module-docstring for the floor / ceiling scoping.
       module AliasScanner
-        # The canonical-shortcut names dry-types exposes through
-        # `include Dry.Types()`. Mirrors `Dry::Types.type_keys`
-        # from the upstream gem.
+        # The canonical-shortcut names dry-types exposes through `include Dry.Types()`. Mirrors
+        # `Dry::Types.type_keys` from the upstream gem.
         CANONICAL_ALIASES = {
           "String" => "String",
           "Integer" => "Integer",
@@ -32,29 +29,21 @@ module Rigor
           "Any" => "Object"
         }.freeze
 
-        # Slice 2 — nested-category aliases. dry-types installs
-        # four parallel coercion categories: `Coercible::*`
-        # (everything-to-target coercion), `Strict::*` (no
-        # coercion; raise if mismatch), `Params::*` (HTTP /
-        # query-string-style coercion, used by Hanami / Roda /
-        # dry-web in request handling), `JSON::*` (JSON-shape
-        # coercion). Each category exposes the same set of names
-        # as the canonical shortcuts above, plus a few additions
-        # that are category-specific (`Params::Nil`,
-        # `JSON::Symbol`). For Rigor's purposes the underlying
-        # class is the same regardless of category — coercion
-        # semantics are a runtime concern. We register every
-        # `<module>::<Category>::<Name>` mapping the upstream gem
-        # publishes so call-site references work uniformly.
+        # Slice 2 — nested-category aliases. dry-types installs four parallel coercion categories:
+        # `Coercible::*` (everything-to-target coercion), `Strict::*` (no coercion; raise if mismatch),
+        # `Params::*` (HTTP / query-string-style coercion, used by Hanami / Roda / dry-web in request
+        # handling), `JSON::*` (JSON-shape coercion). Each category exposes the same set of names as the
+        # canonical shortcuts above, plus a few additions that are category-specific (`Params::Nil`,
+        # `JSON::Symbol`). For Rigor's purposes the underlying class is the same regardless of category —
+        # coercion semantics are a runtime concern. We register every `<module>::<Category>::<Name>`
+        # mapping the upstream gem publishes so call-site references work uniformly.
         NESTED_CATEGORIES = %w[Coercible Strict Params JSON].freeze
         private_constant :NESTED_CATEGORIES
 
         module_function
 
-        # @param paths [Array<String>] absolute paths to `.rb`
-        #   files the project's `paths:` resolves to.
-        # @return [Hash{String => String}] frozen
-        #   `{aliased_name => underlying_class_name}` map. Empty
+        # @param paths [Array<String>] absolute paths to `.rb` files the project's `paths:` resolves to.
+        # @return [Hash{String => String}] frozen `{aliased_name => underlying_class_name}` map. Empty
         #   when no `include Dry.Types()` declaration is found.
         def scan(paths:)
           results = paths.flat_map { |path| scan_file(path) }
@@ -64,16 +53,16 @@ module Rigor
           base = canonical_table(modules)
           results.each do |result|
             result[:compositions].each do |const_name, underlying|
-              # Each result's compositions are scoped under that
-              # result's enclosing module (`Types::Email`, etc.).
+              # Each result's compositions are scoped under that result's enclosing module
+              # (`Types::Email`, etc.).
               base["#{result[:module_name]}::#{const_name}"] ||= underlying
             end
           end
           base.freeze
         end
 
-        # Populates the canonical-shortcut + nested-category
-        # table (15 + 15 × 4 = 75 entries per alias module).
+        # Populates the canonical-shortcut + nested-category table (15 + 15 × 4 = 75 entries per alias
+        # module).
         def canonical_table(modules)
           modules.each_with_object({}) do |module_name, acc|
             CANONICAL_ALIASES.each do |alias_name, underlying|
@@ -96,22 +85,18 @@ module Rigor
             { module_name: module_info[:module_name], compositions: compositions }
           end
         rescue StandardError
-          # Missing-file / parse failures degrade to "no
-          # contribution from this file"; the plugin's
-          # user-visible surface is the published fact, and
-          # dropping unparseable files keeps the fact stable.
+          # Missing-file / parse failures degrade to "no contribution from this file"; the plugin's
+          # user-visible surface is the published fact, and dropping unparseable files keeps the fact
+          # stable.
           []
         end
         private_class_method :scan_file
 
-        # Walks a Prism AST collecting alias-module info:
-        # `{module_name:, body:}` for every `module X; include
-        # Dry.Types(); …end` shape. Tracks the enclosing module
-        # chain so a nested `module App; module Types; include
-        # Dry.Types(); end; end` publishes `"App::Types"` as the
-        # alias scope. The `body:` field is the
-        # `Prism::StatementsNode` (or nil) we re-walk later for
-        # user-authored compositions (slice 3).
+        # Walks a Prism AST collecting alias-module info: `{module_name:, body:}` for every `module X;
+        # include Dry.Types(); …end` shape. Tracks the enclosing module chain so a nested `module App;
+        # module Types; include Dry.Types(); end; end` publishes `"App::Types"` as the alias scope. The
+        # `body:` field is the `Prism::StatementsNode` (or nil) we re-walk later for user-authored
+        # compositions (slice 3).
         def collect_alias_modules(node, qualified_prefix)
           return [] unless node.is_a?(Prism::Node)
 
@@ -127,9 +112,8 @@ module Rigor
                       end
             current + children
           when Prism::ClassNode
-            # Module-level declarations win; we don't recurse into
-            # class bodies for `include Dry.Types()` because the
-            # canonical pattern is module-level.
+            # Module-level declarations win; we don't recurse into class bodies for `include
+            # Dry.Types()` because the canonical pattern is module-level.
             []
           else
             node.compact_child_nodes.flat_map { |c| collect_alias_modules(c, qualified_prefix) }
@@ -137,31 +121,20 @@ module Rigor
         end
         private_class_method :collect_alias_modules
 
-        # Slice 3 — user-authored composition recognition.
-        # Walks the alias-module body for `Email =
-        # String.constrained(...)` shapes. Each
-        # `ConstantWriteNode` whose RHS is a method chain
-        # rooted on a canonical-shortcut name (`String`,
-        # `Integer`, …) — or on a nested-category form
-        # (`Strict::String` etc.) — registers the LHS under
-        # the canonical head's underlying class. Unions
-        # (`String | Integer`) and intersections are skipped
-        # (no single underlying class).
+        # Slice 3 — user-authored composition recognition. Walks the alias-module body for `Email =
+        # String.constrained(...)` shapes. Each `ConstantWriteNode` whose RHS is a method chain rooted on
+        # a canonical-shortcut name (`String`, `Integer`, …) — or on a nested-category form
+        # (`Strict::String` etc.) — registers the LHS under the canonical head's underlying class. Unions
+        # (`String | Integer`) and intersections are skipped (no single underlying class).
         #
-        # Slice 4 — transitive composition resolution. After
-        # the direct (slice-3) pass collects compositions
-        # whose RHS root is canonical, a second pass walks the
-        # remaining `ConstantWriteNode`s for RHS shapes that
-        # resolve THROUGH an already-published composition —
-        # e.g. `ManagerEmail = Email` (bare reference) or
-        # `ManagerEmail = Email.constrained(min_size: 3)`
-        # (method chain rooted on a composition LHS). Cycle
-        # detection: `A = B; B = A` resolves neither (each
-        # LHS's resolution walk sees itself in the visited
-        # set and bails). Unknown references (`ManagerEmail =
-        # NotAComposition`) silently drop — the user is free
-        # to assign any constant to any other; the plugin only
-        # publishes facts when the underlying class is known.
+        # Slice 4 — transitive composition resolution. After the direct (slice-3) pass collects
+        # compositions whose RHS root is canonical, a second pass walks the remaining
+        # `ConstantWriteNode`s for RHS shapes that resolve THROUGH an already-published composition —
+        # e.g. `ManagerEmail = Email` (bare reference) or `ManagerEmail = Email.constrained(min_size: 3)`
+        # (method chain rooted on a composition LHS). Cycle detection: `A = B; B = A` resolves neither
+        # (each LHS's resolution walk sees itself in the visited set and bails). Unknown references
+        # (`ManagerEmail = NotAComposition`) silently drop — the user is free to assign any constant to
+        # any other; the plugin only publishes facts when the underlying class is known.
         def collect_compositions(body)
           return {} if body.nil?
 
@@ -188,14 +161,10 @@ module Rigor
         end
         private_class_method :collect_compositions
 
-        # Slice-4 helper. Returns the un-resolved RHS root
-        # constant name (not necessarily a CANONICAL_ALIASES
-        # entry) for transitive resolution. Mirrors
-        # {composition_head_canonical} but accepts any
-        # `ConstantReadNode` / `ConstantPathNode` tail rather
-        # than canonical-only. Declines on union / intersection
-        # operators for the same single-underlying-class
-        # reason.
+        # Slice-4 helper. Returns the un-resolved RHS root constant name (not necessarily a
+        # CANONICAL_ALIASES entry) for transitive resolution. Mirrors {composition_head_canonical} but
+        # accepts any `ConstantReadNode` / `ConstantPathNode` tail rather than canonical-only. Declines on
+        # union / intersection operators for the same single-underlying-class reason.
         def transitive_reference_name(node)
           case node
           when Prism::ConstantReadNode
@@ -211,14 +180,10 @@ module Rigor
         end
         private_class_method :transitive_reference_name
 
-        # Slice-4 helper. Resolves `lhs`'s RHS through the
-        # `direct` (slice-3) compositions table, chaining
-        # through `ref_edges` for transitive references.
-        # Returns the canonical underlying-class name (e.g.
-        # `"String"`) or nil when no chain ends at a direct
-        # composition. Cycles silently return nil — every step
-        # adds the current lhs to `visited` and bails on
-        # re-entry.
+        # Slice-4 helper. Resolves `lhs`'s RHS through the `direct` (slice-3) compositions table, chaining
+        # through `ref_edges` for transitive references. Returns the canonical underlying-class name
+        # (e.g. `"String"`) or nil when no chain ends at a direct composition. Cycles silently return nil
+        # — every step adds the current lhs to `visited` and bails on re-entry.
         def resolve_transitive_ref(lhs, direct, ref_edges, visited:)
           return nil if visited.include?(lhs)
 
@@ -231,25 +196,19 @@ module Rigor
         end
         private_class_method :resolve_transitive_ref
 
-        # Walks an RHS expression looking for the canonical
-        # shortcut name at the root of a method chain. Returns
-        # the canonical name (`"String"` etc.) or nil.
+        # Walks an RHS expression looking for the canonical shortcut name at the root of a method chain.
+        # Returns the canonical name (`"String"` etc.) or nil.
         #
         # Recognised shapes (recursively on `node.receiver`):
         #
-        # - Bare `String` / `Integer` — `Prism::ConstantReadNode`
-        #   whose name is in `CANONICAL_ALIASES`.
-        # - `Strict::String` / `Coercible::Integer` / etc. —
-        #   `Prism::ConstantPathNode` whose tail is in
+        # - Bare `String` / `Integer` — `Prism::ConstantReadNode` whose name is in `CANONICAL_ALIASES`.
+        # - `Strict::String` / `Coercible::Integer` / etc. — `Prism::ConstantPathNode` whose tail is in
         #   `CANONICAL_ALIASES`.
-        # - `String.constrained(...)` / `.optional` /
-        #   `.default(...)` / arbitrary single-arg method —
+        # - `String.constrained(...)` / `.optional` / `.default(...)` / arbitrary single-arg method —
         #   recurse on the receiver.
         #
-        # Declines on `String | Integer` (union, `:|`) and
-        # `String & Foo` (intersection, `:&`) so the alias
-        # table doesn't claim a single underlying class for
-        # a multi-class composition.
+        # Declines on `String | Integer` (union, `:|`) and `String & Foo` (intersection, `:&`) so the
+        # alias table doesn't claim a single underlying class for a multi-class composition.
         def composition_head_canonical(node)
           case node
           when Prism::ConstantReadNode
@@ -266,12 +225,10 @@ module Rigor
         end
         private_class_method :composition_head_canonical
 
-        # `include Dry.Types()` at the top of the module body is the
-        # canonical alias declaration. We accept the call anywhere
-        # in the body (some projects guard it with a `if defined?`
-        # check). The argument list must be empty (or a kwargs-only
-        # `default: :nominal` style accepted by upstream; we treat
-        # both as "alias-installing").
+        # `include Dry.Types()` at the top of the module body is the canonical alias declaration. We
+        # accept the call anywhere in the body (some projects guard it with a `if defined?` check). The
+        # argument list must be empty (or a kwargs-only `default: :nominal` style accepted by upstream;
+        # we treat both as "alias-installing").
         def contains_dry_types_include?(body)
           return false if body.nil?
 
@@ -295,10 +252,9 @@ module Rigor
         end
         private_class_method :tree_walk
 
-        # Matches `include Dry.Types()` (with or without kwargs).
-        # The receiver of the include call MUST be implicit
-        # (i.e., called on `self`), and the argument MUST be a
-        # method call on the `Dry` constant naming `Types`.
+        # Matches `include Dry.Types()` (with or without kwargs). The receiver of the include call MUST
+        # be implicit (i.e., called on `self`), and the argument MUST be a method call on the `Dry`
+        # constant naming `Types`.
         def include_call_targeting_dry_types?(node)
           return false unless node.is_a?(Prism::CallNode)
           return false unless node.name == :include && node.receiver.nil?
@@ -319,11 +275,9 @@ module Rigor
         end
         private_class_method :dry_types_call?
 
-        # Resolves a `Prism::ConstantPathNode` /
-        # `Prism::ConstantReadNode` chain to its dot-separated
-        # name (e.g. `"App::Types"`). Returns nil for the
-        # dynamic-prefix shape so the scanner treats those as
-        # opaque rather than guessing.
+        # Resolves a `Prism::ConstantPathNode` / `Prism::ConstantReadNode` chain to its dot-separated
+        # name (e.g. `"App::Types"`). Returns nil for the dynamic-prefix shape so the scanner treats
+        # those as opaque rather than guessing.
         def qualified_name_for(node)
           case node
           when Prism::ConstantReadNode then node.name.to_s

--- a/plugins/rigor-dry-validation/demo/demo.rb
+++ b/plugins/rigor-dry-validation/demo/demo.rb
@@ -5,17 +5,13 @@
 #   cp .rigor.dist.yml .rigor.yml
 #   RUBYLIB=$PWD/../lib bundle exec rigor check
 #
-# The canonical Dry::Validation::Contract subclass shapes:
-# fully-qualified and lexical-Dry-nested. With the plugin
-# enabled, rigor's `prepare(services)` hook scans this file,
-# sees both subclasses, and publishes the
-# `:dry_validation_contracts` fact = ["EmailContract",
-# "NewUserContract"].
+# The canonical Dry::Validation::Contract subclass shapes: fully-qualified and lexical-Dry-nested. With
+# the plugin enabled, rigor's `prepare(services)` hook scans this file, sees both subclasses, and
+# publishes the `:dry_validation_contracts` fact = ["EmailContract", "NewUserContract"].
 #
-# The shipped RBS overlay (sig/dry_validation.rbs, wired via
-# the `signature_paths:` config) types `contract.call(input)`
-# as returning `Dry::Validation::Result`, so the chained
-# `.success?` / `.to_h` queries below resolve cleanly.
+# The shipped RBS overlay (sig/dry_validation.rbs, wired via the `signature_paths:` config) types
+# `contract.call(input)` as returning `Dry::Validation::Result`, so the chained `.success?` / `.to_h`
+# queries below resolve cleanly.
 
 class NewUserContract < Dry::Validation::Contract
   params do
@@ -36,8 +32,8 @@ end
 #     end
 #   end
 #
-# Omitted from this demo so the file doesn't redefine the
-# `Dry::Validation::Contract` stub the RBS overlay also describes.
+# Omitted from this demo so the file doesn't redefine the `Dry::Validation::Contract` stub the RBS
+# overlay also describes.
 
 result = NewUserContract.new.call(email: "alice@example.com", age: 17)
 if result.success?

--- a/plugins/rigor-dry-validation/lib/rigor-dry-validation.rb
+++ b/plugins/rigor-dry-validation/lib/rigor-dry-validation.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-dry-validation` under `plugins:`.
-# Side-effects a `Rigor::Plugin.register` call via the
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists `rigor-dry-validation`
+# under `plugins:`. Side-effects a `Rigor::Plugin.register` call via the
 # `lib/rigor/plugin/dry_validation.rb` class body.
 require_relative "rigor/plugin/dry_validation"

--- a/plugins/rigor-dry-validation/lib/rigor/plugin/dry_validation.rb
+++ b/plugins/rigor-dry-validation/lib/rigor/plugin/dry_validation.rb
@@ -15,31 +15,23 @@ module Rigor
     #
     # Slice 1 floor:
     #
-    # - Walks the project for `class T < Dry::Validation::Contract`
-    #   subclasses and publishes the resulting set of contract
-    #   class FQNs as the `:dry_validation_contracts` ADR-9
-    #   cross-plugin fact.
-    # - Ships an RBS overlay (`sig/dry_validation.rbs`) typing
-    #   `Dry::Validation::Contract#call` (returns Result) and
-    #   `Dry::Validation::Result#{success?, failure?, to_h}`.
-    #   The manifest's `signature_paths: ["sig"]` auto-contributes
-    #   the overlay (ADR-25) — no project-side wiring needed.
+    # - Walks the project for `class T < Dry::Validation::Contract` subclasses and publishes the
+    #   resulting set of contract class FQNs as the `:dry_validation_contracts` ADR-9 cross-plugin fact.
+    # - Ships an RBS overlay (`sig/dry_validation.rbs`) typing `Dry::Validation::Contract#call` (returns
+    #   Result) and `Dry::Validation::Result#{success?, failure?, to_h}`. The manifest's
+    #   `signature_paths: ["sig"]` auto-contributes the overlay (ADR-25) — no project-side wiring needed.
     #
     # Slice 2 (deferred, per design note):
     #
-    # - Integrate with `:dry_schema_table` (published by
-    #   `rigor-dry-schema`) so the `params { ... }` block inside a
-    #   Contract contributes a typed `result.to_h` shape per the
-    #   schema. Until this lands, `result.to_h` types as
-    #   `Hash[Symbol, untyped]` (the generic RBS overlay shape).
+    # - Integrate with `:dry_schema_table` (published by `rigor-dry-schema`) so the `params { ... }`
+    #   block inside a Contract contributes a typed `result.to_h` shape per the schema. Until this lands,
+    #   `result.to_h` types as `Hash[Symbol, untyped]` (the generic RBS overlay shape).
     #
-    # Slice 3 (deferred): `json { ... }` adapter parity with
-    # `params { ... }`. Same shape as slice 2.
+    # Slice 3 (deferred): `json { ... }` adapter parity with `params { ... }`. Same shape as slice 2.
     #
-    # No ADR-3 amendment is needed for the validation surface
-    # itself; `Dry::Validation::Result` is a generic class, not a
-    # sum type (the `success?` / `failure?` predicates narrow via
-    # existing bool flow facts).
+    # No ADR-3 amendment is needed for the validation surface itself; `Dry::Validation::Result` is a
+    # generic class, not a sum type (the `success?` / `failure?` predicates narrow via existing bool flow
+    # facts).
     class DryValidation < Rigor::Plugin::Base
       manifest(
         id: "dry-validation",
@@ -47,9 +39,8 @@ module Rigor
         description: "Recognises `class T < Dry::Validation::Contract` subclasses and " \
                      "publishes the contract FQN set.",
         produces: [:dry_validation_contracts],
-        # Auto-contribute the bundled RBS overlay (Contract#call -> Result,
-        # Result#success?/#to_h/...) per ADR-25, so no project-side
-        # signature_paths wiring is needed.
+        # Auto-contribute the bundled RBS overlay (Contract#call -> Result, Result#success?/#to_h/...)
+        # per ADR-25, so no project-side signature_paths wiring is needed.
         signature_paths: ["sig"]
       )
 

--- a/plugins/rigor-dry-validation/lib/rigor/plugin/dry_validation/contract_scanner.rb
+++ b/plugins/rigor-dry-validation/lib/rigor/plugin/dry_validation/contract_scanner.rb
@@ -5,18 +5,15 @@ require "prism"
 module Rigor
   module Plugin
     class DryValidation < Rigor::Plugin::Base
-      # Walks project source for `class T < Dry::Validation::Contract`
-      # subclasses and returns the contract class FQN set.
+      # Walks project source for `class T < Dry::Validation::Contract` subclasses and returns the
+      # contract class FQN set.
       #
-      # Recognition tightness: the superclass match accepts EITHER
-      # the fully-qualified `Dry::Validation::Contract` (3-segment
-      # path) OR the lexical-nested `Validation::Contract`
-      # (2-segment path, when the class body lives inside
-      # `module Dry`). The bare `< Contract` form (1-segment)
-      # is NOT recognised — too ambiguous; users who deeply nest
-      # under `Dry::Validation` should use the explicit form.
-      # Unrelated `< MyApp::Validation::Contract` shapes with the
-      # same tail do NOT register.
+      # Recognition tightness: the superclass match accepts EITHER the fully-qualified
+      # `Dry::Validation::Contract` (3-segment path) OR the lexical-nested `Validation::Contract`
+      # (2-segment path, when the class body lives inside `module Dry`). The bare `< Contract` form
+      # (1-segment) is NOT recognised — too ambiguous; users who deeply nest under `Dry::Validation`
+      # should use the explicit form. Unrelated `< MyApp::Validation::Contract` shapes with the same tail
+      # do NOT register.
       module ContractScanner
         CONTRACT_FULL_PATH = %w[Dry Validation Contract].freeze
         CONTRACT_LEXICAL_DRY_PATH = %w[Validation Contract].freeze
@@ -24,10 +21,8 @@ module Rigor
 
         module_function
 
-        # @param paths [Array<String>] absolute paths to `.rb`
-        #   files the project's `paths:` resolves to.
-        # @return [Array<String>] frozen, sorted list of
-        #   recognized contract class FQNs (e.g.
+        # @param paths [Array<String>] absolute paths to `.rb` files the project's `paths:` resolves to.
+        # @return [Array<String>] frozen, sorted list of recognized contract class FQNs (e.g.
         #   `["App::NewUserContract", "Types::EmailContract"]`).
         def scan(paths:)
           contracts = []
@@ -77,11 +72,9 @@ module Rigor
         end
         private_class_method :collect_module_node
 
-        # Matches superclasses whose constant chain is EXACTLY
-        # `Dry::Validation::Contract` (full path) OR EXACTLY
-        # `Validation::Contract` (lexical-Dry path). Other shapes
-        # — including same-tail-but-different-root chains and
-        # the ambiguous bare `Contract` — do not match.
+        # Matches superclasses whose constant chain is EXACTLY `Dry::Validation::Contract` (full path) OR
+        # EXACTLY `Validation::Contract` (lexical-Dry path). Other shapes — including
+        # same-tail-but-different-root chains and the ambiguous bare `Contract` — do not match.
         def contract_subclass?(class_node)
           superclass = class_node.superclass
           return false if superclass.nil?

--- a/plugins/rigor-factorybot/demo/demo.rb
+++ b/plugins/rigor-factorybot/demo/demo.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-# Demo: rigor-factorybot recognises every entry method shape
-# in the FactoryBot family. Run with `bundle exec rigor check`
-# from this directory.
+# Demo: rigor-factorybot recognises every entry method shape in the FactoryBot family. Run with
+# `bundle exec rigor check` from this directory.
 
-# Stub so `ruby demo.rb` doesn't fail at runtime — the plugin
-# reads the call shape statically.
+# Stub so `ruby demo.rb` doesn't fail at runtime — the plugin reads the call shape statically.
 module FactoryBot
   def self.create(*, **) = nil
   def self.build(*, **) = nil

--- a/plugins/rigor-factorybot/demo/errors_demo.rb
+++ b/plugins/rigor-factorybot/demo/errors_demo.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Demo: each call here triggers an error path
-# rigor-factorybot Phase 1 (a) emits.
+# Demo: each call here triggers an error path rigor-factorybot Phase 1 (a) emits.
 
 module FactoryBot
   def self.create(*, **) = nil
@@ -14,6 +13,5 @@ FactoryBot.create(:usre)
 # `:user` is real but `:rol` is not — should suggest `:role`.
 FactoryBot.create(:user, name: "Alice", rol: "admin")
 
-# `:post` exists but `:headline` isn't an attribute — should
-# suggest `:title`.
+# `:post` exists but `:headline` isn't an attribute — should suggest `:title`.
 FactoryBot.build(:post, headline: "Hello")

--- a/plugins/rigor-factorybot/demo/spec/factories/users.rb
+++ b/plugins/rigor-factorybot/demo/spec/factories/users.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Sample factory file rigor-factorybot statically interprets.
-# The plugin reads the call shape; nothing here is executed.
+# Sample factory file rigor-factorybot statically interprets. The plugin reads the call shape; nothing
+# here is executed.
 
 FactoryBot.define do
   factory :user do

--- a/plugins/rigor-factorybot/lib/rigor/plugin/factorybot.rb
+++ b/plugins/rigor-factorybot/lib/rigor/plugin/factorybot.rb
@@ -8,17 +8,13 @@ require_relative "factorybot/factory_index"
 
 module Rigor
   module Plugin
-    # rigor-factorybot — validates `FactoryBot.create(:name,
-    # key: ...)` and the build / build_stubbed /
-    # attributes_for / *_list family against a per-run index
-    # built from `factory_search_paths`.
+    # rigor-factorybot — validates `FactoryBot.create(:name, key: ...)` and the build / build_stubbed /
+    # attributes_for / *_list family against a per-run index built from `factory_search_paths`.
     #
-    # Recognises factory NAMES + literal ATTRIBUTE KEYS in
-    # the call's keyword hash. The AR column cross-check uses
-    # the `rigor-activerecord` `:model_index` ADR-9 fact when
-    # that plugin is loaded (optional `consumes:`).
-    # Traits, sequences, parent / child factories, and dynamic
-    # factory names are deferred to follow-up slices.
+    # Recognises factory NAMES + literal ATTRIBUTE KEYS in the call's keyword hash. The AR column
+    # cross-check uses the `rigor-activerecord` `:model_index` ADR-9 fact when that plugin is loaded
+    # (optional `consumes:`). Traits, sequences, parent / child factories, and dynamic factory names are
+    # deferred to follow-up slices.
     #
     # ## Configuration
     #
@@ -33,43 +29,32 @@ module Rigor
     #
     # ## What it checks
     #
-    # - **Factory existence** — every entry call's first
-    #   positional Symbol / String literal is looked up in
-    #   the index. Missing factories emit `unknown-factory`
-    #   with a `DidYouMean` suggestion.
-    # - **Attribute key existence** — every literal-Symbol
-    #   keyword-argument key is matched against the factory's
-    #   declared attribute names. Missing keys emit
-    #   `unknown-attribute` with a `DidYouMean` suggestion.
-    # - **Trace** — recognised entry calls also emit a
-    #   `factory-call` info diagnostic listing the factory's
-    #   declared attribute set.
+    # - **Factory existence** — every entry call's first positional Symbol / String literal is looked up
+    #   in the index. Missing factories emit `unknown-factory` with a `DidYouMean` suggestion.
+    # - **Attribute key existence** — every literal-Symbol keyword-argument key is matched against the
+    #   factory's declared attribute names. Missing keys emit `unknown-attribute` with a `DidYouMean`
+    #   suggestion.
+    # - **Trace** — recognised entry calls also emit a `factory-call` info diagnostic listing the
+    #   factory's declared attribute set.
     #
     # ## Recognised entry methods
     #
-    # `FactoryBot.create`, `.build`, `.build_stubbed`,
-    # `.attributes_for`, `.create_list`, `.build_list`,
-    # `.build_stubbed_list`. The legacy `FactoryGirl` constant
-    # is recognised identically. Implicit-receiver calls
-    # (`create(:name)` inside an `include FactoryBot::Syntax::Methods`
-    # context) are NOT recognised — too many false positives on
-    # plain `create` calls outside test files; deferred until
-    # receiver-type inference can disambiguate.
+    # `FactoryBot.create`, `.build`, `.build_stubbed`, `.attributes_for`, `.create_list`, `.build_list`,
+    # `.build_stubbed_list`. The legacy `FactoryGirl` constant is recognised identically. Implicit-receiver
+    # calls (`create(:name)` inside an `include FactoryBot::Syntax::Methods` context) are NOT recognised —
+    # too many false positives on plain `create` calls outside test files; deferred until receiver-type
+    # inference can disambiguate.
     #
     # ## What's recognised inside `factory :name do ... end`
     #
-    # - `name { "Alice" }` — implicit attribute via
-    #   `method_missing` with a block (modern syntax).
-    # - `name "Alice"` — implicit attribute with a positional
-    #   argument (legacy syntax).
+    # - `name { "Alice" }` — implicit attribute via `method_missing` with a block (modern syntax).
+    # - `name "Alice"` — implicit attribute with a positional argument (legacy syntax).
     # - `add_attribute(:name) { "Alice" }` — explicit form.
     #
-    # Sequences (`sequence(:email) { ... }`), associations
-    # (`association :author`), traits (`trait :admin do ... end`),
-    # and parent / child relationships (`factory :admin,
-    # parent: :user do ... end`) are deferred to follow-up
-    # slices. Factories whose name is a non-literal expression
-    # (`factory FACTORY_NAME do ... end`) are silently skipped.
+    # Sequences (`sequence(:email) { ... }`), associations (`association :author`), traits (`trait :admin
+    # do ... end`), and parent / child relationships (`factory :admin, parent: :user do ... end`) are
+    # deferred to follow-up slices. Factories whose name is a non-literal expression (`factory
+    # FACTORY_NAME do ... end`) are silently skipped.
     class Factorybot < Rigor::Plugin::Base
       manifest(
         id: "factorybot",
@@ -96,18 +81,16 @@ module Rigor
         @factory_search_paths = Array(config.fetch("factory_search_paths")).map(&:to_s)
       end
 
-      # ADR-37 — per-call factory/attribute validation over the
-      # engine-owned walk. Each violation carries its own location
-      # (the call's message_loc, or the offending attribute key), so it
-      # is positioned via `diagnostic(node, location:)`. No file-level
-      # diagnostic remains, so there is no `diagnostics_for_file`.
+      # ADR-37 — per-call factory/attribute validation over the engine-owned walk. Each violation carries
+      # its own location (the call's message_loc, or the offending attribute key), so it is positioned
+      # via `diagnostic(node, location:)`. No file-level diagnostic remains, so there is no
+      # `diagnostics_for_file`.
       node_rule Prism::CallNode do |node, _scope, path|
         index = producer_value(:factory_index)
         next [] if index.nil? || index.empty?
 
-        # `:model_index` is rigor-activerecord's published fact (ADR-9);
-        # nil when that plugin isn't loaded, in which case the analyzer
-        # falls back to factory-attributes-only checking.
+        # `:model_index` is rigor-activerecord's published fact (ADR-9); nil when that plugin isn't
+        # loaded, in which case the analyzer falls back to factory-attributes-only checking.
         violations = Analyzer.violations_for(
           call_node: node, factory_index: index,
           model_index: read_fact(plugin_id: "activerecord", name: :model_index)

--- a/plugins/rigor-factorybot/lib/rigor/plugin/factorybot/analyzer.rb
+++ b/plugins/rigor-factorybot/lib/rigor/plugin/factorybot/analyzer.rb
@@ -7,34 +7,27 @@ require "rigor/source/literals"
 module Rigor
   module Plugin
     class Factorybot < Rigor::Plugin::Base
-      # Per-file walker — visits every `FactoryBot.<entry>(...)`
-      # call (and the `FactoryGirl` legacy alias) and validates
-      # the factory name + the keyword-argument attribute keys
-      # against the per-run {FactoryIndex}.
+      # Per-file walker — visits every `FactoryBot.<entry>(...)` call (and the `FactoryGirl` legacy alias)
+      # and validates the factory name + the keyword-argument attribute keys against the per-run
+      # {FactoryIndex}.
       #
-      # Recognised entry methods cover the canonical create /
-      # build / build_stubbed / attributes_for family; the same
-      # validation applies to every entry (the runtime semantics
-      # differ — one persists, one returns a hash — but the
-      # call-site shape is identical from the static check's
-      # perspective).
+      # Recognised entry methods cover the canonical create / build / build_stubbed / attributes_for
+      # family; the same validation applies to every entry (the runtime semantics differ — one persists,
+      # one returns a hash — but the call-site shape is identical from the static check's perspective).
       module Analyzer
         ENTRY_METHODS = %i[create build build_stubbed attributes_for create_list build_list build_stubbed_list].freeze
 
-        # One violation. Carries its own `location` because a single
-        # entry call yields diagnostics at different positions — the
-        # matcher/method name (`message_loc`) for factory-call /
-        # unknown-factory, and the attribute key node for
-        # unknown-attribute. The caller positions each via
-        # `Plugin::Base#diagnostic(node, location:)`.
+        # One violation. Carries its own `location` because a single entry call yields diagnostics at
+        # different positions — the matcher/method name (`message_loc`) for factory-call /
+        # unknown-factory, and the attribute key node for unknown-attribute. The caller positions each
+        # via `Plugin::Base#diagnostic(node, location:)`.
         Violation = Data.define(:location, :message, :severity, :rule)
 
         module_function
 
-        # The violations for a single entry call (`FactoryBot.create(...)`
-        # etc.), or `[]` when the node is not an entry call or its first
-        # argument is not a literal factory name. ADR-37: the engine owns
-        # the walk.
+        # The violations for a single entry call (`FactoryBot.create(...)` etc.), or `[]` when the node
+        # is not an entry call or its first argument is not a literal factory name. ADR-37: the engine
+        # owns the walk.
         #
         # @param call_node [Prism::Node]
         # @param factory_index [FactoryIndex]
@@ -80,20 +73,14 @@ module Rigor
             [factory_call_violation(call_node, factory_name, entry)]
         end
 
-        # The keyword-argument attribute keys come from the
-        # trailing `Prism::KeywordHashNode` (Ruby's
-        # `name: "value"` syntax). Each AssocNode whose key is
-        # a `Prism::SymbolNode` is treated as a literal
-        # attribute reference.
+        # The keyword-argument attribute keys come from the trailing `Prism::KeywordHashNode` (Ruby's
+        # `name: "value"` syntax). Each AssocNode whose key is a `Prism::SymbolNode` is treated as a
+        # literal attribute reference.
         #
-        # When `model_index` (the cross-plugin `:model_index`
-        # fact published by rigor-activerecord) is present,
-        # the effective accepted key set is the UNION of the
-        # factory's declared attributes plus the corresponding
-        # model's columns. FactoryBot's runtime accepts any AR
-        # attribute regardless of whether the factory declared
-        # it, so the cross-check broadens the acceptance
-        # accordingly.
+        # When `model_index` (the cross-plugin `:model_index` fact published by rigor-activerecord) is
+        # present, the effective accepted key set is the UNION of the factory's declared attributes plus
+        # the corresponding model's columns. FactoryBot's runtime accepts any AR attribute regardless of
+        # whether the factory declared it, so the cross-check broadens the acceptance accordingly.
         def unknown_attribute_violations(call_node, entry, model_index)
           accepted_keys, suggestion_dictionary = effective_keys(entry, model_index)
           attr_spell_checker = DidYouMean::SpellChecker.new(dictionary: suggestion_dictionary)
@@ -119,10 +106,8 @@ module Rigor
           [(factory_keys + model_columns).uniq.freeze, (factory_keys + model_columns).uniq.freeze]
         end
 
-        # Convention: `:user` → `User`, `:order_item` →
-        # `OrderItem`. Mirrors rigor-actionpack Phase 1's
-        # convention; namespaced models (`:admin_user` →
-        # `Admin::User`) are deferred.
+        # Convention: `:user` → `User`, `:order_item` → `OrderItem`. Mirrors rigor-actionpack Phase 1's
+        # convention; namespaced models (`:admin_user` → `Admin::User`) are deferred.
         def model_class_for(factory_name)
           factory_name.to_s.split("_").map(&:capitalize).join
         end

--- a/plugins/rigor-factorybot/lib/rigor/plugin/factorybot/factory_discoverer.rb
+++ b/plugins/rigor-factorybot/lib/rigor/plugin/factorybot/factory_discoverer.rb
@@ -8,13 +8,10 @@ require_relative "factory_index"
 module Rigor
   module Plugin
     class Factorybot < Rigor::Plugin::Base
-      # Walks `factory_search_paths` and parses each `.rb` file
-      # into a {FactoryIndex}. The search-path list contains
-      # both directory paths (recursively walked) and direct
-      # file paths (read once); the typical default
-      # `["spec/factories", "spec/factories.rb"]` covers both
-      # the multi-file convention RSpec uses today and the
-      # legacy single-file form.
+      # Walks `factory_search_paths` and parses each `.rb` file into a {FactoryIndex}. The search-path
+      # list contains both directory paths (recursively walked) and direct file paths (read once); the
+      # typical default `["spec/factories", "spec/factories.rb"]` covers both the multi-file convention
+      # RSpec uses today and the legacy single-file form.
       #
       # The walker recognises:
       #
@@ -22,21 +19,16 @@ module Rigor
       # - `factory "users" do ... end` — string form
       # - `factory :users, aliases: [:author] do ... end` — alias form
       #
-      # Inside a factory block, attribute declarations come in
-      # several shapes. Only literal-name forms are recognised
-      # (Symbol arg / String arg):
+      # Inside a factory block, attribute declarations come in several shapes. Only literal-name forms
+      # are recognised (Symbol arg / String arg):
       #
-      # - `name { "Alice" }` — implicit attribute via
-      #   `method_missing` with a block (FactoryBot's modern
+      # - `name { "Alice" }` — implicit attribute via `method_missing` with a block (FactoryBot's modern
       #   syntax)
-      # - `name "Alice"` — implicit attribute via
-      #   `method_missing` with a positional argument (legacy)
-      # - `add_attribute(:name) { "Alice" }` — the explicit
-      #   form
+      # - `name "Alice"` — implicit attribute via `method_missing` with a positional argument (legacy)
+      # - `add_attribute(:name) { "Alice" }` — the explicit form
       #
-      # Sequences (`sequence(:email) { ... }`), associations
-      # (`association :author`), traits, and parent / child
-      # relationships are deferred to later slices.
+      # Sequences (`sequence(:email) { ... }`), associations (`association :author`), traits, and parent
+      # / child relationships are deferred to later slices.
       class FactoryDiscoverer
         def initialize(io_boundary:, search_paths:)
           @io_boundary = io_boundary
@@ -83,12 +75,10 @@ module Rigor
           nil
         end
 
-        # Yields `(factory_name, [attribute_names])` for every
-        # `factory :name do ... end` call discovered in the
-        # subtree. The walker recurses into top-level wrapping
-        # blocks (`FactoryBot.define do ... end`) and into
-        # arbitrary container nodes so factories inside `module`
-        # / `class` blocks are still picked up.
+        # Yields `(factory_name, [attribute_names])` for every `factory :name do ... end` call
+        # discovered in the subtree. The walker recurses into top-level wrapping blocks
+        # (`FactoryBot.define do ... end`) and into arbitrary container nodes so factories inside
+        # `module` / `class` blocks are still picked up.
         def walk_for_factories(node, &)
           return unless node.is_a?(Prism::Node)
 
@@ -116,26 +106,20 @@ module Rigor
           Rigor::Source::Literals.symbol_or_string_name(call_node.arguments&.arguments&.first)
         end
 
-        # Resolves the model class name for the factory.
-        # Three sources, in priority order:
+        # Resolves the model class name for the factory. Three sources, in priority order:
         #
-        # 1. Explicit `class: <Const>` keyword arg —
-        #    ConstantReadNode / ConstantPathNode value.
-        # 2. Explicit `class: "<name>"` keyword arg — String
-        #    value (supports `"Admin::User"`).
-        # 3. Inflected from the factory name — `:user` →
-        #    `"User"`, `:admin_user` → `"AdminUser"`. The
-        #    factory name is already singular by FactoryBot
-        #    convention, so we only need camelization.
+        # 1. Explicit `class: <Const>` keyword arg — ConstantReadNode / ConstantPathNode value.
+        # 2. Explicit `class: "<name>"` keyword arg — String value (supports `"Admin::User"`).
+        # 3. Inflected from the factory name — `:user` → `"User"`, `:admin_user` → `"AdminUser"`. The
+        #    factory name is already singular by FactoryBot convention, so we only need camelization.
         #
         # Returns a String (the canonical class name).
         def factory_model_class(call_node, factory_name)
           explicit = explicit_class_option(call_node)
           return explicit if explicit
 
-          # ADR-39: the real ActiveSupport::Inflector camelizes the factory
-          # name to its class (`admin_user` → `AdminUser`,
-          # `admin/user` → `Admin::User`), so the model-class fallback
+          # ADR-39: the real ActiveSupport::Inflector camelizes the factory name to its class
+          # (`admin_user` → `AdminUser`, `admin/user` → `Admin::User`), so the model-class fallback
           # matches Rails' real convention rather than an approximation.
           Rigor::Plugin::Inflector.camelize(factory_name)
         end
@@ -188,10 +172,9 @@ module Rigor
           attributes
         end
 
-        # Walks the block body collecting attribute names. Only
-        # top-level statements are examined — attributes inside
-        # `trait :admin do ... end` or other nested blocks are
-        # not collected (traits deferred to a follow-up).
+        # Walks the block body collecting attribute names. Only top-level statements are examined —
+        # attributes inside `trait :admin do ... end` or other nested blocks are not collected (traits
+        # deferred to a follow-up).
         def collect_attributes_from(node, accumulator)
           return unless node.is_a?(Prism::Node)
 
@@ -204,15 +187,14 @@ module Rigor
 
         def record_attribute(node, accumulator)
           return unless node.is_a?(Prism::CallNode) && node.receiver.nil?
-          # Skip association / sequence / trait / framework
-          # methods — only plain attribute declarations are recorded.
+          # Skip association / sequence / trait / framework methods — only plain attribute declarations
+          # are recorded.
           return if SKIPPED_METHODS.include?(node.name)
 
           name = if node.name == :add_attribute
                    literal_name_arg(node)
                  else
-                   # method_missing form: the call's method
-                   # name IS the attribute name.
+                   # method_missing form: the call's method name IS the attribute name.
                    node.name.to_s
                  end
           accumulator << name if name

--- a/plugins/rigor-factorybot/lib/rigor/plugin/factorybot/factory_index.rb
+++ b/plugins/rigor-factorybot/lib/rigor/plugin/factorybot/factory_index.rb
@@ -3,26 +3,22 @@
 module Rigor
   module Plugin
     class Factorybot < Rigor::Plugin::Base
-      # Per-run frozen index of discovered FactoryBot factories
-      # and the attribute keys each declares. Indexes only
-      # **literal symbol/string** factory names + **literal
-      # symbol** attribute names; sequences, parent/child
-      # relationships, traits, and dynamically-named factories
-      # are deferred to follow-up slices.
+      # Per-run frozen index of discovered FactoryBot factories and the attribute keys each declares.
+      # Indexes only **literal symbol/string** factory names + **literal symbol** attribute names;
+      # sequences, parent/child relationships, traits, and dynamically-named factories are deferred to
+      # follow-up slices.
       #
-      # Each entry carries a `model_class` — the inferred or
-      # explicit class the factory builds. Resolved from:
+      # Each entry carries a `model_class` — the inferred or explicit class the factory builds. Resolved
+      # from:
       #
-      #   1. An explicit `factory :user, class: User do`
-      #      keyword option (ConstantReadNode / ConstantPathNode
-      #      value).
-      #   2. An explicit `factory :user, class: "User"` keyword
-      #      option (String value, supports `"Admin::User"`).
-      #   3. Fallback: inflected from the factory name —
-      #      `:user` → `"User"`, `:admin_user` → `"AdminUser"`.
+      #   1. An explicit `factory :user, class: User do` keyword option (ConstantReadNode /
+      #      ConstantPathNode value).
+      #   2. An explicit `factory :user, class: "User"` keyword option (String value, supports
+      #      `"Admin::User"`).
+      #   3. Fallback: inflected from the factory name — `:user` → `"User"`, `:admin_user` →
+      #      `"AdminUser"`.
       #
-      # The structure is intentionally flat: one entry per
-      # factory name. Attribute lists deduplicate.
+      # The structure is intentionally flat: one entry per factory name. Attribute lists deduplicate.
       class FactoryIndex
         Entry = Data.define(:name, :attribute_names, :model_class)
 

--- a/plugins/rigor-graphql/demo/demo.rb
+++ b/plugins/rigor-graphql/demo/demo.rb
@@ -5,15 +5,12 @@
 #   cp .rigor.dist.yml .rigor.yml
 #   RUBYLIB=$PWD/../lib bundle exec rigor check
 #
-# Two canonical Schema::Object subclasses with mixed scalar /
-# user-defined field types. With the plugin enabled, rigor's
-# `prepare(services)` hook scans this file, sees the
-# subclasses, and publishes the `:graphql_type_table` fact
-# mapping each type to its field-type map.
+# Two canonical Schema::Object subclasses with mixed scalar / user-defined field types. With the plugin
+# enabled, rigor's `prepare(services)` hook scans this file, sees the subclasses, and publishes the
+# `:graphql_type_table` fact mapping each type to its field-type map.
 #
-# At slice 1 the observable change is fact-publication only;
-# the downstream uplift (resolver-method type-check, etc.)
-# lands in a later slice.
+# At slice 1 the observable change is fact-publication only; the downstream uplift (resolver-method
+# type-check, etc.) lands in a later slice.
 
 module Types
   class User < GraphQL::Schema::Object

--- a/plugins/rigor-graphql/lib/rigor-graphql.rb
+++ b/plugins/rigor-graphql/lib/rigor-graphql.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-graphql` under `plugins:`. The
-# loader expects this `require` to side-effect a call to
-# `Rigor::Plugin.register`, which the body of
-# `lib/rigor/plugin/graphql.rb` performs at load time.
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists `rigor-graphql` under
+# `plugins:`. The loader expects this `require` to side-effect a call to `Rigor::Plugin.register`,
+# which the body of `lib/rigor/plugin/graphql.rb` performs at load time.
 require_relative "rigor/plugin/graphql"

--- a/plugins/rigor-graphql/lib/rigor/plugin/graphql.rb
+++ b/plugins/rigor-graphql/lib/rigor/plugin/graphql.rb
@@ -12,51 +12,41 @@ module Rigor
     # [Rails plugins roadmap](../../../../../docs/design/20260508-rails-plugins-roadmap.md)
     # § "3D".
     #
-    # Recognises `class T < GraphQL::Schema::Object` subclasses
-    # and walks every `field :name, Type, null: false` declaration
-    # inside, publishing the resulting field-type map as the
-    # `:graphql_type_table` cross-plugin fact (ADR-9). The macro
-    # expansion library survey at
-    # [docs/notes/20260515-macro-expansion-library-survey.md](../../../../../docs/notes/20260515-macro-expansion-library-survey.md)
-    # § "GraphQL-Ruby" documents WHY this is a pure metadata-recorder
-    # plugin rather than an ADR-16 substrate consumer: graphql-ruby's
-    # `field` DSL emits NO Ruby methods (it just records a
-    # `Schema::Field` on the class's `own_fields`). The user writes
-    # resolver methods themselves; rigor's value here is producing a
-    # static type table downstream consumers can cross-reference.
+    # Recognises `class T < GraphQL::Schema::Object` subclasses and walks every `field :name, Type,
+    # null: false` declaration inside, publishing the resulting field-type map as the
+    # `:graphql_type_table` cross-plugin fact (ADR-9). The macro expansion library survey at
+    # docs/notes/20260515-macro-expansion-library-survey.md § "GraphQL-Ruby" documents WHY this is a
+    # pure metadata-recorder plugin rather than an ADR-16
+    # substrate consumer: graphql-ruby's `field` DSL emits NO Ruby methods (it just records a
+    # `Schema::Field` on the class's `own_fields`). The user writes resolver methods themselves; rigor's
+    # value here is producing a static type table downstream consumers can cross-reference.
     #
     # ## What downstream consumers DO with the published facts
     #
-    # The tables are the substrate for two future capabilities
-    # (demand-driven, not yet implemented):
+    # The tables are the substrate for two future capabilities (demand-driven, not yet implemented):
     #
-    # - Resolver-method check: for each `field :name, Type` whose
-    #   `name` is also defined as a Ruby method on the class, verify
-    #   the method's return type matches `Type`'s underlying class.
-    # - Schema-query result typing: a future `rigor-graphql-execute`
-    #   plugin could type `Schema.execute(query).to_h` against the
-    #   queried fields.
+    # - Resolver-method check: for each `field :name, Type` whose `name` is also defined as a Ruby method
+    #   on the class, verify the method's return type matches `Type`'s underlying class.
+    # - Schema-query result typing: a future `rigor-graphql-execute` plugin could type
+    #   `Schema.execute(query).to_h` against the queried fields.
     #
     # ## What's recognised
     #
-    # - `class T < GraphQL::Schema::Object` subclasses (including
-    #   nested namespaces); `field :name, Type, null: ...`
-    #   declarations with constant-reference or list-array types
-    #   and GraphQL→Ruby scalar mapping.
+    # - `class T < GraphQL::Schema::Object` subclasses (including nested namespaces); `field :name, Type,
+    #   null: ...` declarations with constant-reference or list-array types and GraphQL→Ruby scalar
+    #   mapping.
     # - `class T < GraphQL::Schema::Enum`; `value "ACTIVE"` calls.
-    # - `class T < GraphQL::Schema::InputObject` /
-    #   `GraphQL::Schema::Mutation`; `argument :name, Type,
+    # - `class T < GraphQL::Schema::InputObject` / `GraphQL::Schema::Mutation`; `argument :name, Type,
     #   required: ...` declarations.
     # - No user-facing diagnostics yet.
     #
     # ## Deferred (demand-driven)
     #
     # - **`resolver:` / `mutation:` reroute** recognition.
-    # - **String type expressions** (`field :foo, "User"`) — defeats
-    #   static resolution by design (graphql-ruby's `BuildType.parse_type`
-    #   constantizes at runtime); a future slice could surface these
-    #   as `graphql.string-type` `:info` diagnostics pointing the
-    #   user at the constant-reference form for static typing.
+    # - **String type expressions** (`field :foo, "User"`) — defeats static resolution by design
+    #   (graphql-ruby's `BuildType.parse_type` constantizes at runtime); a future slice could surface
+    #   these as `graphql.string-type` `:info` diagnostics pointing the user at the constant-reference
+    #   form for static typing.
     class Graphql < Rigor::Plugin::Base
       manifest(
         id: "graphql",

--- a/plugins/rigor-graphql/lib/rigor/plugin/graphql/type_scanner.rb
+++ b/plugins/rigor-graphql/lib/rigor/plugin/graphql/type_scanner.rb
@@ -6,17 +6,13 @@ require "rigor/source/literals"
 module Rigor
   module Plugin
     class Graphql < Rigor::Plugin::Base
-      # Walks project source for `class T < GraphQL::Schema::Object`
-      # subclasses and emits a `{type_class_fqn => {field_name => {type:, nullable:}}}`
-      # table covering every `field :name, Type, null: ...` declaration
-      # inside the class body.
+      # Walks project source for `class T < GraphQL::Schema::Object` subclasses and emits a
+      # `{type_class_fqn => {field_name => {type:, nullable:}}}` table covering every `field :name, Type,
+      # null: ...` declaration inside the class body.
       module TypeScanner
-        # The canonical GraphQL scalar type names accepted as
-        # `field`'s second positional argument. The plugin maps
-        # each to the underlying Ruby class name so downstream
-        # consumers can cross-reference against Ruby types
-        # without re-implementing the GraphQL→Ruby coercion
-        # table.
+        # The canonical GraphQL scalar type names accepted as `field`'s second positional argument. The
+        # plugin maps each to the underlying Ruby class name so downstream consumers can cross-reference
+        # against Ruby types without re-implementing the GraphQL→Ruby coercion table.
         CANONICAL_TYPES = {
           "String" => "String",
           "Integer" => "Integer",
@@ -26,21 +22,17 @@ module Rigor
           "ID" => "String"
         }.freeze
 
-        # The base class name a Schema::Object subclass MUST
-        # inherit from to be recognised. Match is on the
-        # rightmost segment of the superclass constant chain so
-        # both `GraphQL::Schema::Object` and the locally-aliased
-        # `BaseObject = GraphQL::Schema::Object` shape work when
-        # the alias's RHS is the canonical path.
+        # The base class name a Schema::Object subclass MUST inherit from to be recognised. Match is on
+        # the rightmost segment of the superclass constant chain so both `GraphQL::Schema::Object` and
+        # the locally-aliased `BaseObject = GraphQL::Schema::Object` shape work when the alias's RHS is
+        # the canonical path.
         SCHEMA_OBJECT_TAIL = "Object"
         SCHEMA_ENUM_TAIL = "Enum"
         SCHEMA_INPUT_OBJECT_TAIL = "InputObject"
         SCHEMA_MUTATION_TAIL = "Mutation"
-        # Common path-segment for `Schema::Object` / `Schema::Enum`
-        # / `Schema::InputObject` / `Schema::Mutation`; the
-        # second-to-last segment must be `Schema` (either
-        # fully-qualified `GraphQL::Schema::X` or lexically nested
-        # `Schema::X` inside `module GraphQL`).
+        # Common path-segment for `Schema::Object` / `Schema::Enum` / `Schema::InputObject` /
+        # `Schema::Mutation`; the second-to-last segment must be `Schema` (either fully-qualified
+        # `GraphQL::Schema::X` or lexically nested `Schema::X` inside `module GraphQL`).
         SCHEMA_PARENT_SEGMENTS = %w[Schema GraphQL].freeze
         private_constant :SCHEMA_OBJECT_TAIL, :SCHEMA_ENUM_TAIL,
                          :SCHEMA_INPUT_OBJECT_TAIL, :SCHEMA_MUTATION_TAIL,
@@ -48,15 +40,12 @@ module Rigor
 
         module_function
 
-        # @param paths [Array<String>] absolute paths to `.rb` files
-        #   the project's `paths:` resolves to.
-        # @return [Hash{Symbol => Hash}] frozen 4-key result:
-        #   `:types` (per-`Schema::Object` field table),
-        #   `:enums` (per-`Schema::Enum` value list),
-        #   `:input_objects` (per-`Schema::InputObject` argument table),
-        #   `:mutations` (per-`Schema::Mutation` arguments+fields table).
-        #   Any subset may be empty when no recognisable declaration
-        #   of that kind is found.
+        # @param paths [Array<String>] absolute paths to `.rb` files the project's `paths:` resolves to.
+        # @return [Hash{Symbol => Hash}] frozen 4-key result: `:types` (per-`Schema::Object` field
+        #   table), `:enums` (per-`Schema::Enum` value list), `:input_objects`
+        #   (per-`Schema::InputObject` argument table), `:mutations` (per-`Schema::Mutation`
+        #   arguments+fields table). Any subset may be empty when no recognisable declaration of that
+        #   kind is found.
         def scan(paths:)
           acc = empty_accumulator
           paths.each do |path|
@@ -97,10 +86,9 @@ module Rigor
         end
         private_class_method :scan_file
 
-        # Walks the AST collecting `class X < GraphQL::Schema::Object`,
-        # `Schema::Enum`, `Schema::InputObject`, and `Schema::Mutation`
-        # decls at any nesting level. Returns a 4-key hash so the
-        # caller can publish multiple cross-plugin facts from one walk.
+        # Walks the AST collecting `class X < GraphQL::Schema::Object`, `Schema::Enum`,
+        # `Schema::InputObject`, and `Schema::Mutation` decls at any nesting level. Returns a 4-key hash
+        # so the caller can publish multiple cross-plugin facts from one walk.
         def collect_definitions(node, qualified_prefix)
           return empty_accumulator if node.nil?
 
@@ -154,10 +142,9 @@ module Rigor
         end
         private_class_method :collect_module_node
 
-        # `class X < GraphQL::Schema::<Tail>` matches when the
-        # superclass's last two path segments are `Schema::<Tail>`.
-        # Matches both `< GraphQL::Schema::<Tail>` (fully qualified)
-        # and `< Schema::<Tail>` (lexically inside `module GraphQL`).
+        # `class X < GraphQL::Schema::<Tail>` matches when the superclass's last two path segments are
+        # `Schema::<Tail>`. Matches both `< GraphQL::Schema::<Tail>` (fully qualified) and `<
+        # Schema::<Tail>` (lexically inside `module GraphQL`).
         def schema_subclass?(class_node, tail)
           superclass = class_node.superclass
           return false if superclass.nil?
@@ -193,19 +180,16 @@ module Rigor
         end
         private_class_method :statement_nodes
 
-        # Walks every top-level `value "..."` call inside an
-        # enum subclass body and returns the value names as an
-        # Array<String>. Both shapes graphql-ruby accepts work:
+        # Walks every top-level `value "..."` call inside an enum subclass body and returns the value
+        # names as an Array<String>. Both shapes graphql-ruby accepts work:
         #
         #     value "ACTIVE"
         #     value "DISABLED", value: :off, description: "..."
         #
-        # The first positional must be a String literal — the
-        # graphql-ruby `value` API also accepts a Symbol form
-        # (`value :ACTIVE`) but the documented idiom is String.
-        # Only the GraphQL-side value name is stored; the optional
-        # `value:` kwarg (Ruby-side override) and `description:`
-        # are omitted from the published table.
+        # The first positional must be a String literal — the graphql-ruby `value` API also accepts a
+        # Symbol form (`value :ACTIVE`) but the documented idiom is String. Only the GraphQL-side value
+        # name is stored; the optional `value:` kwarg (Ruby-side override) and `description:` are
+        # omitted from the published table.
         def collect_values(body)
           return [] if body.nil?
 
@@ -220,13 +204,10 @@ module Rigor
         end
         private_class_method :collect_values
 
-        # Walks every top-level `argument :name, Type, required: ...`
-        # call inside an InputObject (or Mutation) subclass body and
-        # returns the per-argument shape table. Argument syntax
-        # mirrors `field` except the nullability axis is named
-        # `required:` (default `false` — per graphql-ruby's
-        # `argument` default; the OPPOSITE polarity of `field`'s
-        # `null:`).
+        # Walks every top-level `argument :name, Type, required: ...` call inside an InputObject (or
+        # Mutation) subclass body and returns the per-argument shape table. Argument syntax mirrors
+        # `field` except the nullability axis is named `required:` (default `false` — per graphql-ruby's
+        # `argument` default; the OPPOSITE polarity of `field`'s `null:`).
         #
         #     argument :name, String, required: true
         #     argument :tags, [String], required: false
@@ -270,10 +251,9 @@ module Rigor
         end
         private_class_method :parse_argument_call
 
-        # Mirror of `extract_nullability` but reads the `required:`
-        # kwarg, defaulting to `false` (graphql-ruby's argument
-        # default — the OPPOSITE polarity of `field`'s `null:` /
-        # nullability default).
+        # Mirror of `extract_nullability` but reads the `required:` kwarg, defaulting to `false`
+        # (graphql-ruby's argument default — the OPPOSITE polarity of `field`'s `null:` / nullability
+        # default).
         # rubocop:disable Naming/PredicateMethod  -- extractor returns the literal required value
         def extract_required_flag(args)
           kwargs = args.last
@@ -293,12 +273,10 @@ module Rigor
         # rubocop:enable Naming/PredicateMethod
         private_class_method :extract_required_flag
 
-        # `field :name, Type, null: false` shape. The first
-        # positional is a Symbol (field name); the second is a
-        # constant reference (GraphQL type) OR a single-element
-        # ArrayNode (`[Type]`) for GraphQL list types; `null:` is
-        # the nullability keyword (defaults to TRUE per
-        # graphql-ruby's field defaults so we mirror that).
+        # `field :name, Type, null: false` shape. The first positional is a Symbol (field name); the
+        # second is a constant reference (GraphQL type) OR a single-element ArrayNode (`[Type]`) for
+        # GraphQL list types; `null:` is the nullability keyword (defaults to TRUE per graphql-ruby's
+        # field defaults so we mirror that).
         def parse_field_call(node)
           args = node.arguments&.arguments
           return nil if args.nil? || args.size < 2
@@ -320,13 +298,10 @@ module Rigor
         end
         private_class_method :parse_field_call
 
-        # Resolves the `Type` positional argument to a
-        # `{type: "ClassName", list: bool}` tuple. ArrayNode
-        # forms (`[String]` / `[Types::User]`) unwrap the single
-        # element and mark `list: true`. Bare constant refs are
-        # not lists. Returns nil for unrecognised shapes (string
-        # types `"User"`, Proc lazy types, etc.) so callers drop
-        # the field.
+        # Resolves the `Type` positional argument to a `{type: "ClassName", list: bool}` tuple.
+        # ArrayNode forms (`[String]` / `[Types::User]`) unwrap the single element and mark `list: true`.
+        # Bare constant refs are not lists. Returns nil for unrecognised shapes (string types `"User"`,
+        # Proc lazy types, etc.) so callers drop the field.
         def resolve_field_type(node)
           if node.is_a?(Prism::ArrayNode)
             element = node.elements.first
@@ -354,9 +329,8 @@ module Rigor
         end
         private_class_method :resolve_constant_type
 
-        # Defaults to `true` (matches graphql-ruby's `field`
-        # default nullability). Looks for an explicit `null:`
-        # keyword and reads its boolean literal.
+        # Defaults to `true` (matches graphql-ruby's `field` default nullability). Looks for an explicit
+        # `null:` keyword and reads its boolean literal.
         # rubocop:disable Naming/PredicateMethod  -- extractor returns the literal nullability value
         def extract_nullability(args)
           kwargs = args.last
@@ -376,9 +350,8 @@ module Rigor
         # rubocop:enable Naming/PredicateMethod
         private_class_method :extract_nullability
 
-        # Returns the constant chain as an Array of String
-        # segments (`["GraphQL", "Schema", "Object"]`). Empty
-        # array for unrecognised node kinds.
+        # Returns the constant chain as an Array of String segments (`["GraphQL", "Schema", "Object"]`).
+        # Empty array for unrecognised node kinds.
         def constant_path_segments(node)
           case node
           when Prism::ConstantReadNode then [node.name.to_s]
@@ -397,9 +370,8 @@ module Rigor
         end
         private_class_method :constant_path_segments
 
-        # Joined `::`-form of {.constant_path_segments}. Returns
-        # nil for unrecognised node kinds (so callers can short-
-        # circuit).
+        # Joined `::`-form of {.constant_path_segments}. Returns nil for unrecognised node kinds (so
+        # callers can short-circuit).
         def constant_name_for(node)
           segments = constant_path_segments(node)
           segments.empty? ? nil : segments.join("::")

--- a/plugins/rigor-hanami/lib/rigor/plugin/hanami.rb
+++ b/plugins/rigor-hanami/lib/rigor/plugin/hanami.rb
@@ -9,37 +9,28 @@ module Rigor
   module Plugin
     # rigor-hanami — enforces the Hanami::Action protocol.
     #
-    # Hanami 3.x actions inherit from `Hanami::Action` and
-    # define a single entry-point:
+    # Hanami 3.x actions inherit from `Hanami::Action` and define a single entry-point:
     #
     #   def handle(request, response)
     #     response.status = 200
     #     response.body = "Hello"
     #   end
     #
-    # The method is void — the response is mutated in-place;
-    # the return value is discarded by the framework.
+    # The method is void — the response is mutated in-place; the return value is discarded by the
+    # framework.
     #
-    # This plugin uses the **ADR-28 path-scoped
-    # method-protocol contract** to:
+    # This plugin uses the **ADR-28 path-scoped method-protocol contract** to:
     #
-    # 1. **Provide** `Hanami::Action::Request` and
-    #    `Hanami::Action::Response` as the types of the
-    #    first and second parameters of every `#handle`
-    #    method defined inside `app/actions/**/*.rb`.
-    #    The engine substitutes these types for the usual
-    #    `Dynamic[Top]` fallback, so misuse of `request` or
-    #    `response` inside an action body surfaces as a
-    #    core diagnostic.
+    # 1. **Provide** `Hanami::Action::Request` and `Hanami::Action::Response` as the types of the first
+    #    and second parameters of every `#handle` method defined inside `app/actions/**/*.rb`. The
+    #    engine substitutes these types for the usual `Dynamic[Top]` fallback, so misuse of `request` or
+    #    `response` inside an action body surfaces as a core diagnostic.
     #
-    # 2. **Check** that every class under `app/actions/`
-    #    defines `#handle`. Missing definitions emit
+    # 2. **Check** that every class under `app/actions/` defines `#handle`. Missing definitions emit
     #    `missing-handle-method`.
     #
-    # Return-type conformance is NOT checked — Hanami
-    # actions are void by contract, and checking a void
-    # return would produce false positives on every `if`
-    # branch that doesn't end with an explicit `nil`.
+    # Return-type conformance is NOT checked — Hanami actions are void by contract, and checking a void
+    # return would produce false positives on every `if` branch that doesn't end with an explicit `nil`.
     #
     # ## Configuration
     #
@@ -55,10 +46,8 @@ module Rigor
     # | action class defines no `#handle`        | `:error` | `missing-handle-method` |
     # | `request` / `response` misuse in body    | core engine diagnostic  |
     #
-    # A misused `request` or `response` (e.g.
-    # `request.no_such_method`) surfaces as a standard
-    # engine `call.undefined-method` diagnostic once the
-    # plugin provides the parameter types.
+    # A misused `request` or `response` (e.g. `request.no_such_method`) surfaces as a standard engine
+    # `call.undefined-method` diagnostic once the plugin provides the parameter types.
     class Hanami < Rigor::Plugin::Base
       manifest(
         id: "hanami",
@@ -91,20 +80,17 @@ module Rigor
           end
       end
 
-      # ADR-28: override so the per-project `action_path` config
-      # reaches both the engine's parameter-provision tier and
-      # this plugin's check half.
+      # ADR-28: override so the per-project `action_path` config reaches both the engine's
+      # parameter-provision tier and this plugin's check half.
       def protocol_contracts
         @protocol_contracts || manifest.protocol_contracts
       end
 
-      # ADR-37 — per-class-node validation over the engine-owned walk.
-      # Each `Prism::ClassNode` is checked against every contract
-      # independently, so the plugin no longer ships its own `class_nodes`
-      # traversal; `ActionChecker#check_class` keeps the per-class
-      # contract logic. (A per-class contract check is exactly what
-      # `node_rule` is for — the return type is void, so no `scope`
-      # query is needed.)
+      # ADR-37 — per-class-node validation over the engine-owned walk. Each `Prism::ClassNode` is checked
+      # against every contract independently, so the plugin no longer ships its own `class_nodes`
+      # traversal; `ActionChecker#check_class` keeps the per-class contract logic. (A per-class contract
+      # check is exactly what `node_rule` is for — the return type is void, so no `scope` query is
+      # needed.)
       node_rule Prism::ClassNode do |node, _scope, path|
         contracts = protocol_contracts
         next [] if contracts.empty?

--- a/plugins/rigor-hanami/lib/rigor/plugin/hanami/action_checker.rb
+++ b/plugins/rigor-hanami/lib/rigor/plugin/hanami/action_checker.rb
@@ -5,16 +5,12 @@ require "prism"
 module Rigor
   module Plugin
     class Hanami < Rigor::Plugin::Base
-      # Checks the "presence" half of the Hanami::Action
-      # ADR-28 protocol contract.
+      # Checks the "presence" half of the Hanami::Action ADR-28 protocol contract.
       #
-      # Every class defined in a file matching a contract's
-      # `path_glob` must declare `#handle(request, response)`.
-      # The "provide" half — binding `Hanami::Action::Request`
-      # and `Hanami::Action::Response` into the method body —
-      # is handled engine-side by
-      # `Inference::MethodParameterBinder`. Return type is
-      # void so no conformance check is performed here.
+      # Every class defined in a file matching a contract's `path_glob` must declare `#handle(request,
+      # response)`. The "provide" half — binding `Hanami::Action::Request` and `Hanami::Action::Response`
+      # into the method body — is handled engine-side by `Inference::MethodParameterBinder`. Return type
+      # is void so no conformance check is performed here.
       class ActionChecker
         FNMATCH_FLAGS = File::FNM_PATHNAME | File::FNM_EXTGLOB
 
@@ -22,11 +18,10 @@ module Rigor
           @contracts = contracts
         end
 
-        # Per-`ClassNode` check over the engine-owned walk (ADR-37):
-        # called once per class node the `node_rule` in `hanami.rb`
-        # dispatches, against every contract whose `path_glob` matches
-        # the file. No cross-class-node state is needed, so the checker
-        # ships no `class_nodes` traversal of its own.
+        # Per-`ClassNode` check over the engine-owned walk (ADR-37): called once per class node the
+        # `node_rule` in `hanami.rb` dispatches, against every contract whose `path_glob` matches the
+        # file. No cross-class-node state is needed, so the checker ships no `class_nodes` traversal of
+        # its own.
         def check_class(class_node, path:)
           @contracts.filter_map do |contract|
             next unless path_matches?(contract.path_glob, path)
@@ -42,9 +37,8 @@ module Rigor
 
         private
 
-        # Contract globs are project-root-relative; the analyzer
-        # may supply a relative or absolute path, so the glob is
-        # matched both directly and with a `**/`-prefixed suffix.
+        # Contract globs are project-root-relative; the analyzer may supply a relative or absolute path,
+        # so the glob is matched both directly and with a `**/`-prefixed suffix.
         def path_matches?(glob, path)
           return false if path.nil?
 

--- a/plugins/rigor-mangrove/demo/demo.rb
+++ b/plugins/rigor-mangrove/demo/demo.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
-# Valid Mangrove usage. With rigor-mangrove loaded, each unwrap
-# resolves to the carrier's first type argument (here `String`),
-# so the chained calls below dispatch against the real type and
-# stay clean.
+# Valid Mangrove usage. With rigor-mangrove loaded, each unwrap resolves to the carrier's first type argument
+# (here `String`), so the chained calls below dispatch against the real type and stay clean.
 #
 # Run:  bundle exec rigor check
 #
-# Drop `rigor-mangrove` from .rigor.yml and the unwraps fall back
-# to `untyped`; the chains stay quiet here, but the typos in
-# errors_demo.rb then go unnoticed.
+# Drop `rigor-mangrove` from .rigor.yml and the unwraps fall back to `untyped`; the chains stay quiet here,
+# but the typos in errors_demo.rb then go unnoticed.
 
 def demo(ctx)
   session = Session.new

--- a/plugins/rigor-mangrove/demo/enum_demo.rb
+++ b/plugins/rigor-mangrove/demo/enum_demo.rb
@@ -2,14 +2,12 @@
 
 # ADR-36 nested-class emission — Mangrove's `Enum` DSL.
 #
-# `variants do variant <Const>, <Type> end` mints a nested subclass
-# per variant; rigor-mangrove synthesises each one statically so the
-# variant constant resolves, `.new` dispatches, and the `#inner`
-# reader resolves to the declared payload type — no need to run
-# Mangrove's runtime `const_missing` / `class_eval`.
+# `variants do variant <Const>, <Type> end` mints a nested subclass per variant; rigor-mangrove synthesises
+# each one statically so the variant constant resolves, `.new` dispatches, and the `#inner` reader resolves
+# to the declared payload type — no need to run Mangrove's runtime `const_missing` / `class_eval`.
 #
-# `Mangrove::Enum` is the extend-marker the substrate keys on; the
-# real gem supplies it. The demo stubs it so the file stands alone.
+# `Mangrove::Enum` is the extend-marker the substrate keys on; the real gem supplies it. The demo stubs it
+# so the file stands alone.
 module Mangrove
   module Enum; end
 end

--- a/plugins/rigor-mangrove/demo/errors_demo.rb
+++ b/plugins/rigor-mangrove/demo/errors_demo.rb
@@ -1,32 +1,24 @@
 # frozen_string_literal: true
 
-# DO NOT run via `ruby errors_demo.rb` — analyse with
-# `bundle exec rigor check` to see rigor-mangrove's effect.
+# DO NOT run via `ruby errors_demo.rb` — analyse with `bundle exec rigor check` to see rigor-mangrove's effect.
 #
-# Each unwrap below resolves to `String` ONLY because
-# rigor-mangrove instantiates the carrier generic at the call
-# site. That makes the typo'd chained method a real
-# `call.undefined-method` error. Without the plugin the unwraps
-# are `untyped`, `untyped` swallows the typos, and these bugs
-# ship silently.
+# Each unwrap below resolves to `String` ONLY because rigor-mangrove instantiates the carrier generic at the
+# call site. That makes the typo'd chained method a real `call.undefined-method` error. Without the plugin the
+# unwraps are `untyped`, `untyped` swallows the typos, and these bugs ship silently.
 
 def demo(ctx)
   session = Session.new
 
-  # `String#uppercaze` does not exist — caught only because
-  # `unwrap!` resolved to String.
+  # `String#uppercaze` does not exist — caught only because `unwrap!` resolved to String.
   session.token.unwrap!.uppercaze
 
-  # `String#lenght` typo — caught because `unwrap_in` resolved
-  # to String.
+  # `String#lenght` typo — caught because `unwrap_in` resolved to String.
   session.token.unwrap_in(ctx).lenght
 
-  # `String#revrse` typo — caught because `unwrap_or` resolved
-  # to String.
+  # `String#revrse` typo — caught because `unwrap_or` resolved to String.
   session.cached_user.unwrap_or("guest").revrse
 
-  # ADR-36 Enum: `Shape::Circle` (synthesised from enum_demo.rb's
-  # `variants do … end`) resolves, and `#inner` resolves to Float,
-  # so this non-Float method is caught as a real error.
+  # ADR-36 Enum: `Shape::Circle` (synthesised from enum_demo.rb's `variants do … end`) resolves, and `#inner`
+  # resolves to Float, so this non-Float method is caught as a real error.
   Shape::Circle.new(1.5).inner.no_such_float_method
 end

--- a/plugins/rigor-mangrove/lib/rigor/plugin/mangrove.rb
+++ b/plugins/rigor-mangrove/lib/rigor/plugin/mangrove.rb
@@ -5,75 +5,54 @@ require "rigor/plugin"
 
 module Rigor
   module Plugin
-    # rigor-mangrove — precision plugin for the
-    # [Mangrove](https://github.com/kazzix14/mangrove) functional
+    # rigor-mangrove — precision plugin for the [Mangrove](https://github.com/kazzix14/mangrove) functional
     # toolkit (Result / Option carriers).
     #
     # ## Why this plugin exists (and what it deliberately is NOT)
     #
-    # Mangrove is a Sorbet-first library: every carrier method is
-    # annotated with an inline `sig { ... }`, and the Enum DSL's
-    # dynamic variants are materialised by a bundled Tapioca DSL
-    # compiler. So the *type source* for Mangrove is already
-    # covered by `rigor-sorbet` (sig ingestion + RBI walking) —
-    # this plugin is NOT a parallel type source. See
-    # `docs/notes/20260530-mangrove-library-survey.md`.
+    # Mangrove is a Sorbet-first library: every carrier method is annotated with an inline `sig { ... }`, and
+    # the Enum DSL's dynamic variants are materialised by a bundled Tapioca DSL compiler. So the *type source*
+    # for Mangrove is already covered by `rigor-sorbet` (sig ingestion + RBI walking) — this plugin is NOT a
+    # parallel type source. See `docs/notes/20260530-mangrove-library-survey.md`.
     #
-    # What sig-ingestion (Sorbet-level precision) structurally
-    # cannot do is **instantiate the carrier's generic
-    # type-member at the unwrap call site**. Mangrove's `Result`
-    # interface declares:
+    # What sig-ingestion (Sorbet-level precision) structurally cannot do is **instantiate the carrier's generic
+    # type-member at the unwrap call site**. Mangrove's `Result` interface declares:
     #
     #     sig { abstract.returns(OkType) }
     #     def unwrap!; end
     #
-    # `OkType` is a `type_member(:out)`. When the receiver's
-    # static type is `Mangrove::Result[String, StandardError]`,
-    # `unwrap!` *should* yield `String` — but resolving the
-    # abstract `OkType` to the receiver's first type argument is
-    # generic instantiation, which neither `rigor-sorbet` (it
-    # contributes the cataloged sig's return type verbatim) nor a
-    # bare-`def unwrap!: () -> untyped` RBS stub performs. The
-    # call degrades to `Dynamic[top]`.
+    # `OkType` is a `type_member(:out)`. When the receiver's static type is
+    # `Mangrove::Result[String, StandardError]`, `unwrap!` *should* yield `String` — but resolving the abstract
+    # `OkType` to the receiver's first type argument is generic instantiation, which neither `rigor-sorbet` (it
+    # contributes the cataloged sig's return type verbatim) nor a bare-`def unwrap!: () -> untyped` RBS stub
+    # performs. The call degrades to `Dynamic[top]`.
     #
-    # This plugin closes exactly that gap. At every recognised
-    # unwrap-family call on a known Mangrove carrier, it reads the
-    # receiver's `Rigor::Type::Nominal#type_args` and contributes
-    # the first argument (the `OkType` / `InnerType`) as the
-    # call's return type. The receiver type is already known, so
-    # this only ever *sharpens* an existing `Dynamic[top]` into a
-    # concrete type — it never invents a receiver type and never
-    # emits a diagnostic of its own, so it cannot frighten working
-    # code (Rigor's false-positive discipline).
+    # This plugin closes exactly that gap. At every recognised unwrap-family call on a known Mangrove carrier,
+    # it reads the receiver's `Rigor::Type::Nominal#type_args` and contributes the first argument (the
+    # `OkType` / `InnerType`) as the call's return type. The receiver type is already known, so this only ever
+    # *sharpens* an existing `Dynamic[top]` into a concrete type — it never invents a receiver type and never
+    # emits a diagnostic of its own, so it cannot frighten working code (Rigor's false-positive discipline).
     #
     # ## Scope (slice 1)
     #
-    # - Result unwrap family → `OkType` (`type_args[0]`):
-    #   `unwrap!`, `unwrap_in`, `expect!`, `expect_with!`,
-    #   `unwrap_or_raise!`, `unwrap_or_raise_with!`,
-    #   `unwrap_or_raise_inner!`.
-    # - Option unwrap family → `InnerType` (`type_args[0]`):
-    #   `unwrap`, `unwrap!`, `unwrap_or`, `expect!`,
+    # - Result unwrap family → `OkType` (`type_args[0]`): `unwrap!`, `unwrap_in`, `expect!`, `expect_with!`,
+    #   `unwrap_or_raise!`, `unwrap_or_raise_with!`, `unwrap_or_raise_inner!`.
+    # - Option unwrap family → `InnerType` (`type_args[0]`): `unwrap`, `unwrap!`, `unwrap_or`, `expect!`,
     #   `expect_with!`.
     #
-    # The contribution fires only when the receiver resolves to a
-    # carrier Nominal carrying a non-empty `type_args` — i.e. when
-    # the Result/Option came from a method whose declared return
-    # type is an applied generic (`-> Result[String, E]`), the
-    # realistic Mangrove shape. The bare-constructor shape
-    # (`Result::Ok.new("x")`) currently yields a raw Nominal with
-    # no `type_args` (the engine does not infer generics from
-    # constructor arguments), so the plugin no-ops there rather
-    # than guessing — a conservative floor, not a regression.
+    # The contribution fires only when the receiver resolves to a carrier Nominal carrying a non-empty
+    # `type_args` — i.e. when the Result/Option came from a method whose declared return type is an applied
+    # generic (`-> Result[String, E]`), the realistic Mangrove shape. The bare-constructor shape
+    # (`Result::Ok.new("x")`) currently yields a raw Nominal with no `type_args` (the engine does not infer
+    # generics from constructor arguments), so the plugin no-ops there rather than guessing — a conservative
+    # floor, not a regression.
     #
     # ## Out of scope (tracked elsewhere)
     #
-    # - `is_a?(Result::Ok)` / `Some` / `None` exhaustive
-    #   narrowing — core control-flow analysis over a sealed
+    # - `is_a?(Result::Ok)` / `Some` / `None` exhaustive narrowing — core control-flow analysis over a sealed
     #   hierarchy, not a plugin surface.
-    # - The `variants do variant Const, Type end` Enum DSL is handled
-    #   via ADR-36 `nested_class_templates:` in this plugin's manifest
-    #   (Slice A — see `nested_class_templates:` block below).
+    # - The `variants do variant Const, Type end` Enum DSL is handled via ADR-36 `nested_class_templates:` in
+    #   this plugin's manifest (Slice A — see `nested_class_templates:` block below).
     class Mangrove < Rigor::Plugin::Base
       manifest(
         id: "mangrove",
@@ -90,10 +69,9 @@ module Rigor
         #     end
         #   end
         #
-        # mints `Shape::Circle < Shape` with `#inner : Float`. The
-        # substrate resolves the variant constant + its `#inner`
-        # reader statically so `Shape::Circle.new(1.0).inner`
-        # types as `Float` without running Mangrove's `const_missing`.
+        # mints `Shape::Circle < Shape` with `#inner : Float`. The substrate resolves the variant constant +
+        # its `#inner` reader statically so `Shape::Circle.new(1.0).inner` types as `Float` without running
+        # Mangrove's `const_missing`.
         nested_class_templates: [
           Rigor::Plugin::Macro::NestedClassTemplate.new(
             receiver_constraint: "Mangrove::Enum",
@@ -106,11 +84,9 @@ module Rigor
         ]
       )
 
-      # Carrier class names whose FIRST type argument is the
-      # value the unwrap family yields (`OkType` for Result,
-      # `InnerType` for Option). Matched with and without a
-      # leading `::` because `scope.type_of` reports the lexical
-      # form while user code may root the constant.
+      # Carrier class names whose FIRST type argument is the value the unwrap family yields (`OkType` for
+      # Result, `InnerType` for Option). Matched with and without a leading `::` because `scope.type_of`
+      # reports the lexical form while user code may root the constant.
       RESULT_CARRIERS = [
         "Mangrove::Result",
         "Mangrove::Result::Ok",
@@ -123,23 +99,19 @@ module Rigor
         "Mangrove::Option::None"
       ].freeze
 
-      # Methods on the Result carriers that return `OkType`
-      # (`type_args[0]`). All of these are documented as yielding
-      # the success value, raising / short-circuiting on `Err`.
+      # Methods on the Result carriers that return `OkType` (`type_args[0]`). All of these are documented as
+      # yielding the success value, raising / short-circuiting on `Err`.
       RESULT_UNWRAP_METHODS = %i[
         unwrap! unwrap_in expect! expect_with!
         unwrap_or_raise! unwrap_or_raise_with! unwrap_or_raise_inner!
       ].freeze
 
-      # Methods on the Option carriers that return `InnerType`
-      # (`type_args[0]`).
+      # Methods on the Option carriers that return `InnerType` (`type_args[0]`).
       OPTION_UNWRAP_METHODS = %i[unwrap unwrap! unwrap_or expect! expect_with!].freeze
 
-      # ADR-37 slice 2 — a pure return-type contributor. The engine
-      # gates on the receiver being a known carrier class (so the block
-      # only runs on Result/Option receivers); the block then confirms
-      # the call is an unwrap method on an instantiated carrier and
-      # yields the carried `type_args[0]`.
+      # ADR-37 slice 2 — a pure return-type contributor. The engine gates on the receiver being a known
+      # carrier class (so the block only runs on Result/Option receivers); the block then confirms the call
+      # is an unwrap method on an instantiated carrier and yields the carried `type_args[0]`.
       dynamic_return receivers: (RESULT_CARRIERS + OPTION_CARRIERS) do |call_node, scope|
         receiver = call_node.receiver
         next nil if receiver.nil?
@@ -152,18 +124,16 @@ module Rigor
 
       private
 
-      # @return [Rigor::Type, nil] the receiver's inferred type, or
-      #   nil when the engine raises on a synthetic / unrecognised
-      #   node (mirrors rigor-sorbet's defensive degrade).
+      # @return [Rigor::Type, nil] the receiver's inferred type, or nil when the engine raises on a synthetic
+      #   / unrecognised node (mirrors rigor-sorbet's defensive degrade).
       def receiver_type_of(receiver, scope)
         scope.type_of(receiver)
       rescue StandardError
         nil
       end
 
-      # The value the unwrap family yields for this receiver, or
-      # nil when the call is not an unwrap on a known carrier, or
-      # the carrier is raw (no `type_args` to instantiate).
+      # The value the unwrap family yields for this receiver, or nil when the call is not an unwrap on a
+      # known carrier, or the carrier is raw (no `type_args` to instantiate).
       def carried_type(receiver_type, method_name)
         class_name = normalize(receiver_type.class_name)
         type_args = receiver_type.type_args

--- a/plugins/rigor-minitest/demo/test/narrowing_test.rb
+++ b/plugins/rigor-minitest/demo/test/narrowing_test.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-# Worked example — Minitest narrowing through assert_* /
-# refute_* / _(x).must_* / .wont_*. Without rigor-minitest the
-# downstream `.upcase` / `.length` / `+` calls fall through
-# `Dynamic[top]` (no diagnostic, but also no precision); the
-# plugin emits a `post_return_fact` so the local resolves at
-# the narrowed type for the rest of the test body.
+# Worked example — Minitest narrowing through assert_* / refute_* / _(x).must_* / .wont_*. Without
+# rigor-minitest the downstream `.upcase` / `.length` / `+` calls fall through `Dynamic[top]` (no diagnostic,
+# but also no precision); the plugin emits a `post_return_fact` so the local resolves at the narrowed type
+# for the rest of the test body.
 
 require "minitest/autorun"
 

--- a/plugins/rigor-minitest/lib/rigor/plugin/minitest.rb
+++ b/plugins/rigor-minitest/lib/rigor/plugin/minitest.rb
@@ -6,61 +6,44 @@ require_relative "minitest/assertion_analyzer"
 
 module Rigor
   module Plugin
-    # rigor-minitest — narrows locals through Minitest /
-    # Test::Unit assertions.
+    # rigor-minitest — narrows locals through Minitest / Test::Unit assertions.
     #
-    # Recognises every supported `assert_*` / `refute_*` /
-    # `assert_not_*` shape (Minitest core + Test::Unit aliases),
-    # plus the Minitest/spec `_(x).must_*` / `.wont_*` matchers
-    # (`expect(x)` / `value(x)` wrappers covered too). For each
-    # recognised assertion the plugin emits a Rigor
-    # `post_return_fact` whose `:local`-kind target narrows the
-    # named local on the post-call edge so downstream calls in
-    # the same `it` / `test_` / `def test_*` body resolve
-    # against the narrowed type.
+    # Recognises every supported `assert_*` / `refute_*` / `assert_not_*` shape (Minitest core + Test::Unit
+    # aliases), plus the Minitest/spec `_(x).must_*` / `.wont_*` matchers (`expect(x)` / `value(x)` wrappers
+    # covered too). For each recognised assertion the plugin emits a Rigor `post_return_fact` whose
+    # `:local`-kind target narrows the named local on the post-call edge so downstream calls in the same
+    # `it` / `test_` / `def test_*` body resolve against the narrowed type.
     #
     # ## Why a single plugin covers two frameworks
     #
-    # Minitest and Test::Unit share the `assert_*` / `refute_*`
-    # surface (Test::Unit's `assert_not_*` aliases are
-    # recognised by the same rule table). The matchers_vaccine
-    # gem layers RSpec-style matcher composition on top of
-    # Minitest's `must` API and is covered by the spec-style
-    # recogniser without additional wiring.
+    # Minitest and Test::Unit share the `assert_*` / `refute_*` surface (Test::Unit's `assert_not_*` aliases
+    # are recognised by the same rule table). The matchers_vaccine gem layers RSpec-style matcher composition
+    # on top of Minitest's `must` API and is covered by the spec-style recogniser without additional wiring.
     #
     # ## Configuration
     #
-    # No configuration knobs. Activate via
-    # `plugins: ["rigor-minitest"]` in `.rigor.yml`.
+    # No configuration knobs. Activate via `plugins: ["rigor-minitest"]` in `.rigor.yml`.
     #
     # ## Limitations
     #
-    # - **No `assert_raises(T) { ... }`** — that's a block-shape
-    #   matcher and Rigor's narrowing model is for
+    # - **No `assert_raises(T) { ... }`** — that's a block-shape matcher and Rigor's narrowing model is for
     #   straight-line locals.
-    # - **No `assert_predicate(x, :foo?)`** — needs a
-    #   predicate-state carrier Rigor doesn't model today.
-    # - **No `assert_respond_to(x, :m)`** — same shape gap
-    #   (respond-to-set carrier).
-    # - **No legacy bare `x.must_be_kind_of(T)`** — the
-    #   receiver IS the value, so the analyzer has nothing to
+    # - **No `assert_predicate(x, :foo?)`** — needs a predicate-state carrier Rigor doesn't model today.
+    # - **No `assert_respond_to(x, :m)`** — same shape gap (respond-to-set carrier).
+    # - **No legacy bare `x.must_be_kind_of(T)`** — the receiver IS the value, so the analyzer has nothing to
     #   narrow against. Users should migrate to `_(x).must_*`.
-    # - **No `assert_in_delta` / `assert_operator`** — float-
-    #   range / generic operator narrowing is future work.
-    # - **No `assert_throws(:tag) { ... }` / `assert_raises`** —
-    #   block-form expectations need a separate slice.
+    # - **No `assert_in_delta` / `assert_operator`** — float-range / generic operator narrowing is future work.
+    # - **No `assert_throws(:tag) { ... }` / `assert_raises`** — block-form expectations need a separate slice.
     class Minitest < Rigor::Plugin::Base
       manifest(
         id: "minitest",
         version: "0.1.0",
         description: "Narrows locals through Minitest / Test::Unit `assert_*` / `refute_*` " \
                      "and Minitest/spec `_(x).must_*` / `.wont_*` matchers.",
-        # ADR-38 — `def setup` runs before every `def test_*`, so
-        # ivars it assigns are initialised by the time a test body
-        # reads them. Declaring it an additional initializer stops
-        # the read-before-write nil widening that would otherwise
-        # type `@conn` (set in `setup`, read in a test) as
-        # `T | nil` and surface a false nil-receiver diagnostic.
+        # ADR-38 — `def setup` runs before every `def test_*`, so ivars it assigns are initialised by the
+        # time a test body reads them. Declaring it an additional initializer stops the read-before-write
+        # nil widening that would otherwise type `@conn` (set in `setup`, read in a test) as `T | nil` and
+        # surface a false nil-receiver diagnostic.
         additional_initializers: [
           Rigor::Plugin::AdditionalInitializer.new(
             receiver_constraint: "Minitest::Test", methods: [:setup]
@@ -74,10 +57,8 @@ module Rigor
         ]
       )
 
-      # ADR-37 slice 2 — emits `post_return_facts` for every recognised
-      # assertion, method-gated by the engine. The engine routes
-      # `:local`-kind facts through
-      # `StatementEvaluator#apply_local_post_return_fact`.
+      # ADR-37 slice 2 — emits `post_return_facts` for every recognised assertion, method-gated by the
+      # engine. The engine routes `:local`-kind facts through `StatementEvaluator#apply_local_post_return_fact`.
       narrowing_facts methods: AssertionAnalyzer::SUPPORTED_METHODS do |call_node, scope|
         AssertionAnalyzer.contribution_for(call_node, environment: scope&.environment)&.post_return_facts
       end

--- a/plugins/rigor-minitest/lib/rigor/plugin/minitest/assertion_analyzer.rb
+++ b/plugins/rigor-minitest/lib/rigor/plugin/minitest/assertion_analyzer.rb
@@ -8,9 +8,8 @@ require "rigor/flow_contribution/fact"
 module Rigor
   module Plugin
     class Minitest < Rigor::Plugin::Base
-      # Recognises the four shapes of Minitest / Test::Unit
-      # assertions and emits a `post_return_fact` that narrows
-      # the named local on the post-call edge.
+      # Recognises the four shapes of Minitest / Test::Unit assertions and emits a `post_return_fact` that
+      # narrows the named local on the post-call edge.
       #
       # ## Recognised call shapes
       #
@@ -29,9 +28,8 @@ module Rigor
       #   refute_nil(x)               →  narrow x AWAY from nil
       #   refute_equal(literal, x)    →  narrow x AWAY from Constant<literal>
       #
-      # Test::Unit's `assert_not_nil(x)` / `assert_not_equal(...)` /
-      # `assert_not_kind_of(...)` / `assert_not_instance_of(...)`
-      # share the recognizer with `refute_*` (they're aliases).
+      # Test::Unit's `assert_not_nil(x)` / `assert_not_equal(...)` / `assert_not_kind_of(...)` /
+      # `assert_not_instance_of(...)` share the recognizer with `refute_*` (they're aliases).
       #
       # ### (3) Minitest/spec `_(x).must_*` (positive) ###
       #
@@ -41,12 +39,10 @@ module Rigor
       #   _(x).must_equal(literal)    →  narrow x to Constant<literal>
       #   _(x).must_match(regex)      →  narrow x to String
       #
-      # The legacy bare `x.must_be_kind_of(T)` form (Minitest <
-      # 6.0 monkey-patched onto Object) is intentionally NOT
-      # recognised — the receiver is the value itself rather
-      # than a wrapping `_(value)`, so the analyzer has nothing
-      # to narrow against. Users who still rely on the legacy
-      # form should migrate to `_(x).must_*`.
+      # The legacy bare `x.must_be_kind_of(T)` form (Minitest < 6.0 monkey-patched onto Object) is
+      # intentionally NOT recognised — the receiver is the value itself rather than a wrapping `_(value)`,
+      # so the analyzer has nothing to narrow against. Users who still rely on the legacy form should
+      # migrate to `_(x).must_*`.
       #
       # ### (4) Minitest/spec `_(x).wont_*` (negative) ###
       #
@@ -56,14 +52,10 @@ module Rigor
       #
       # ## Not yet recognised
       #
-      # `assert_predicate(x, :foo?)` (custom predicate) /
-      # `assert_respond_to(x, :method)` / `assert_includes` /
-      # `assert_operator` / `assert_throws` /
-      # `assert_raises(T) { ... }` etc. — each either needs a
-      # carrier Rigor doesn't model today (predicate-state,
-      # respond-to-set) or a multi-edge fact that the
-      # `post_return_facts` slot can't express. Queued for
-      # follow-up slices.
+      # `assert_predicate(x, :foo?)` (custom predicate) / `assert_respond_to(x, :method)` / `assert_includes`
+      # / `assert_operator` / `assert_throws` / `assert_raises(T) { ... }` etc. — each either needs a
+      # carrier Rigor doesn't model today (predicate-state, respond-to-set) or a multi-edge fact that the
+      # `post_return_facts` slot can't express. Queued for follow-up slices.
       module AssertionAnalyzer
         module_function
 
@@ -83,16 +75,12 @@ module Rigor
 
         # --- assert_* / refute_* / assert_not_* form ---
 
-        # Maps each recognised assertion name to a tuple
-        # `[shape, negative]`. `shape` is one of:
+        # Maps each recognised assertion name to a tuple `[shape, negative]`. `shape` is one of:
         #
-        # - :class_then_local   — `assert_kind_of(T, x)`, T at
-        #   args[0], local at args[1].
+        # - :class_then_local   — `assert_kind_of(T, x)`, T at args[0], local at args[1].
         # - :nil_local          — `assert_nil(x)`, local at args[0].
-        # - :literal_then_local — `assert_equal(literal, x)`,
-        #   literal at args[0], local at args[1].
-        # - :regex_then_local   — `assert_match(regex, x)`,
-        #   regex at args[0], local at args[1].
+        # - :literal_then_local — `assert_equal(literal, x)`, literal at args[0], local at args[1].
+        # - :regex_then_local   — `assert_match(regex, x)`, regex at args[0], local at args[1].
         ASSERT_FORM = {
           assert_kind_of: [:class_then_local, false],
           assert_instance_of: [:class_then_local, false],
@@ -123,8 +111,7 @@ module Rigor
 
         # --- _(x).must_* / .wont_* form ---
 
-        # Maps the spec-style matcher names to `[shape,
-        # negative]`. `shape`:
+        # Maps the spec-style matcher names to `[shape, negative]`. `shape`:
         # - :class_arg   — `_(x).must_be_kind_of(T)`, T at args[0].
         # - :no_arg_nil  — `_(x).must_be_nil`, no args.
         # - :literal_arg — `_(x).must_equal(literal)`, literal at args[0].
@@ -144,8 +131,8 @@ module Rigor
         }.freeze
         private_constant :SPEC_MATCHER_FORM
 
-        # ADR-37 slice 2 — the method names this analyzer narrows on,
-        # for the plugin's `narrowing_facts methods:` gate.
+        # ADR-37 slice 2 — the method names this analyzer narrows on, for the plugin's
+        # `narrowing_facts methods:` gate.
         SUPPORTED_METHODS = (ASSERT_FORM.keys + SPEC_MATCHER_FORM.keys).freeze
 
         def spec_form_fact(call_node, environment:)
@@ -160,10 +147,9 @@ module Rigor
           fact_for_spec_shape(shape, target_local, args, negative: negative, environment: environment)
         end
 
-        # `_(x)` returns a `Minitest::Expectation` wrapping x.
-        # Some specs use `value(x)` or `expect(x)` interchangeably
-        # (Minitest provides all three as aliases). Recognises the
-        # local-variable arg in any of those receiver-call shapes.
+        # `_(x)` returns a `Minitest::Expectation` wrapping x. Some specs use `value(x)` or `expect(x)`
+        # interchangeably (Minitest provides all three as aliases). Recognises the local-variable arg in
+        # any of those receiver-call shapes.
         SPEC_WRAPPER_NAMES = %i[_ value expect].freeze
         private_constant :SPEC_WRAPPER_NAMES
 

--- a/plugins/rigor-playground/lib/rigor/playground/app.rb
+++ b/plugins/rigor-playground/lib/rigor/playground/app.rb
@@ -61,8 +61,8 @@ module Rigor
         result = with_tempfile(source) do |tmppath|
           stdout = run_cli(["check", "--format=json", tmppath])
           data   = JSON.parse(stdout)
-          # Keep only diagnostics from the user's temp file; replace the raw
-          # temp path with the virtual "<playground>" label.
+          # Keep only diagnostics from the user's temp file; replace the raw temp path with the virtual
+          # "<playground>" label.
           diags = (data["diagnostics"] || []).filter_map do |d|
             next unless d["path"] == tmppath
 
@@ -88,9 +88,8 @@ module Rigor
         source = read_source(env)
         return too_large if source.bytesize > MAX_SOURCE_BYTES
 
-        # `annotate --format json` returns { "annotations": { line => type } }
-        # straight from the engine's line-type map — no `#=> <type>` text to
-        # reparse. Keys are 1-based line numbers as strings.
+        # `annotate --format json` returns { "annotations": { line => type } } straight from the engine's
+        # line-type map — no `#=> <type>` text to reparse. Keys are 1-based line numbers as strings.
         out = with_tempfile(source) { |path| run_cli(["annotate", "--format=json", path]) }
         json_response(200, JSON.parse(out))
       rescue JSON::ParserError

--- a/plugins/rigor-playground/puma.rb
+++ b/plugins/rigor-playground/puma.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-# ADR-29 WD5 — bind 127.0.0.1 for local development, 0.0.0.0
-# in containers (Fly.io and the included Dockerfile). The
-# Dockerfile / fly.toml export `PORT=8080`; absent that the
-# dev default keeps the old 9292 binding so `bundle exec puma
-# -C puma.rb` is unchanged for contributors.
+# ADR-29 WD5 — bind 127.0.0.1 for local development, 0.0.0.0 in containers (Fly.io and the included
+# Dockerfile). The Dockerfile / fly.toml export `PORT=8080`; absent that the dev default keeps the old 9292
+# binding so `bundle exec puma -C puma.rb` is unchanged for contributors.
 host = ENV.fetch("RACK_ENV", "development") == "production" ? "0.0.0.0" : "127.0.0.1"
 port = ENV.fetch("PORT", "9292").to_i
 bind "tcp://#{host}:#{port}"

--- a/plugins/rigor-playground/spec/rigor/playground/app_spec.rb
+++ b/plugins/rigor-playground/spec/rigor/playground/app_spec.rb
@@ -6,28 +6,24 @@ require "rspec"
 
 require_relative "../../../lib/rigor/playground/app"
 
-# ADR-29 backend smoke tests. Runs against an in-process
-# `Rigor::Playground::App` via `Rack::Test::Methods`; no Puma boot.
+# ADR-29 backend smoke tests. Runs against an in-process `Rigor::Playground::App` via `Rack::Test::Methods`;
+# no Puma boot.
 #
 # Run from `plugins/rigor-playground/`:
 #
 #   bundle exec rspec spec/rigor/playground/app_spec.rb
 #
-# These specs are intentionally separate from the main Rigor
-# spec suite (`spec/` at the project root) because the
-# playground backend has its own Gemfile (`puma`, `rack`,
-# `rack-test`) and a different `BUNDLE_GEMFILE` boundary. They
-# are NOT part of `make verify`.
+# These specs are intentionally separate from the main Rigor spec suite (`spec/` at the project root)
+# because the playground backend has its own Gemfile (`puma`, `rack`, `rack-test`) and a different
+# `BUNDLE_GEMFILE` boundary. They are NOT part of `make verify`.
 RSpec.describe Rigor::Playground::App do
   include Rack::Test::Methods
 
   let(:app) { described_class.new }
 
-  # ADR-32 example: a method with `# @rbs name: :asc | :desc`
-  # called with `:bad` must produce a `call.argument-type-mismatch`
-  # diagnostic, even WITHOUT the `# rbs_inline: enabled` magic
-  # comment — the playground sets `require_magic_comment: false`
-  # per ADR-29 WD4 amendment + ADR-32 WD10.
+  # ADR-32 example: a method with `# @rbs name: :asc | :desc` called with `:bad` must produce a
+  # `call.argument-type-mismatch` diagnostic, even WITHOUT the `# rbs_inline: enabled` magic comment — the
+  # playground sets `require_magic_comment: false` per ADR-29 WD4 amendment + ADR-32 WD10.
   let(:ascdesc_source) do
     <<~RUBY
       class AscDesc
@@ -85,8 +81,7 @@ RSpec.describe Rigor::Playground::App do
     end
   end
 
-  # ADR-29 slice 4 — the backend endpoint that the frontend's
-  # hoverTooltip extension consumes.
+  # ADR-29 slice 4 — the backend endpoint that the frontend's hoverTooltip extension consumes.
   describe "POST /type-of" do
     let(:source) { "x = \"hello\"\nputs x\n" }
 

--- a/plugins/rigor-playground/wasm/build_patches/libyaml_link.rb
+++ b/plugins/rigor-playground/wasm/build_patches/libyaml_link.rb
@@ -4,22 +4,19 @@
 #
 # Symptom: `rbwasm build` aborts at the final `wasm-ld` step with
 #   undefined symbol: yaml_get_version   (and the rest of the yaml_* API)
-# even though ruby_wasm builds `libyaml.a` and passes `--with-libyaml-dir` to
-# Ruby's configure. In a cross-compiled `--with-static-linked-ext` build,
-# psych's extconf does not propagate `-lyaml` into the final static link (the
-# host can't run a wasm link-probe, so the lib never lands on the link line),
-# so the libyaml archive is absent and every yaml_* symbol is undefined.
+# even though ruby_wasm builds `libyaml.a` and passes `--with-libyaml-dir` to Ruby's configure. In a
+# cross-compiled `--with-static-linked-ext` build, psych's extconf does not propagate `-lyaml` into the final
+# static link (the host can't run a wasm link-probe, so the lib never lands on the link line), so the libyaml
+# archive is absent and every yaml_* symbol is undefined.
 #
-# Fix: append the libyaml static archive to the crossruby XLDFLAGS the same way
-# ruby_wasm already does for wasi-vfs (`xldflags << @wasi_vfs.lib_wasi_vfs_a`),
-# guaranteeing the symbols are on the final link regardless of what psych's
-# Makefile requested. Loaded into the `rbwasm` process via RUBYOPT (see the
-# Rakefile build task), so it is active before the build runs and stays
-# confined to this build — ruby_wasm itself is untouched.
+# Fix: append the libyaml static archive to the crossruby XLDFLAGS the same way ruby_wasm already does for
+# wasi-vfs (`xldflags << @wasi_vfs.lib_wasi_vfs_a`), guaranteeing the symbols are on the final link regardless
+# of what psych's Makefile requested. Loaded into the `rbwasm` process via RUBYOPT (see the Rakefile build
+# task), so it is active before the build runs and stays confined to this build — ruby_wasm itself is
+# untouched.
 #
-# RUBYOPT `-r` runs at interpreter startup, which can be *before* bundler has
-# put the bundle's gems on the load path, so activate the bundle ourselves
-# first (idempotent — a no-op if bundler/setup already ran).
+# RUBYOPT `-r` runs at interpreter startup, which can be *before* bundler has put the bundle's gems on the
+# load path, so activate the bundle ourselves first (idempotent — a no-op if bundler/setup already ran).
 require "bundler/setup"
 require "ruby_wasm"
 

--- a/plugins/rigor-playground/wasm/vfs/boot.rb
+++ b/plugins/rigor-playground/wasm/vfs/boot.rb
@@ -2,59 +2,51 @@
 
 # ADR-29 WD8/WD9 — the in-VM adapter packed into the ruby.wasm build.
 #
-# This is the wasm analogue of plugins/rigor-playground/lib/rigor/playground/app.rb:
-# it exposes the same four operations (check / annotate / annotate-lines /
-# type-of) but as in-process Ruby callable from JavaScript via `vm.eval`,
-# with no Rack, no HTTP, and no network. The frontend (index.html) sets the
-# request as a JSON string on a JS global, calls `vm.eval`, and reads the
-# returned JSON string back.
+# This is the wasm analogue of plugins/rigor-playground/lib/rigor/playground/app.rb: it exposes the same
+# four operations (check / annotate / annotate-lines / type-of) but as in-process Ruby callable from
+# JavaScript via `vm.eval`, with no Rack, no HTTP, and no network. The frontend (index.html) sets the
+# request as a JSON string on a JS global, calls `vm.eval`, and reads the returned JSON string back.
 #
-# Contract fidelity (ADR-29 WD2): every operation routes through
-# `Rigor::CLI.start(argv, out:, err:)` against StringIO buffers — byte-for-byte
-# the same invocation the backend's `run_cli` uses — so the JSON shapes are
-# identical between the server and the browser. Only the bytes' origin differs.
+# Contract fidelity (ADR-29 WD2): every operation routes through `Rigor::CLI.start(argv, out:, err:)`
+# against StringIO buffers — byte-for-byte the same invocation the backend's `run_cli` uses — so the JSON
+# shapes are identical between the server and the browser. Only the bytes' origin differs.
 
-# The nix/wasi runtime can default to US-ASCII; force UTF-8 so File.read and
-# JSON handle non-ASCII source. Mirrors app.rb's preamble.
+# The nix/wasi runtime can default to US-ASCII; force UTF-8 so File.read and JSON handle non-ASCII source.
+# Mirrors app.rb's preamble.
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
 # ── WASI POSIX shim (ADR-29 WD6 condition ③) ────────────────────────────────
 #
 # WASI provides no flock(2) and a no-op fsync; the cache write path
-# (lib/rigor/cache/store.rb#atomically_replace) calls both. A single-VM
-# playground needs no cross-process atomicity, so neutralising these two
-# calls lets the existing content-keyed cache operate purely in the in-memory
-# WASI filesystem — which is a *feature*: it persists across keystrokes within
-# the page session, giving the RBS-environment reuse the WD8 perf note asks
-# for, without a bespoke persistent-Runner path. The shim is confined to this
-# wasm boot file; the engine is untouched. (Fallback if a ruby_wasm version's
-# memfs misbehaves on cache writes: see wasm/README.md — neutralise
-# Cache::Store#atomically_replace instead, which forces a pure no-op cache.)
+# (lib/rigor/cache/store.rb#atomically_replace) calls both. A single-VM playground needs no cross-process
+# atomicity, so neutralising these two calls lets the existing content-keyed cache operate purely in the
+# in-memory WASI filesystem — which is a *feature*: it persists across keystrokes within the page session,
+# giving the RBS-environment reuse the WD8 perf note asks for, without a bespoke persistent-Runner path.
+# The shim is confined to this wasm boot file; the engine is untouched. (Fallback if a ruby_wasm version's
+# memfs misbehaves on cache writes: see wasm/README.md — neutralise Cache::Store#atomically_replace
+# instead, which forces a pure no-op cache.)
 File.class_eval { def flock(*) = 0 }
 IO.class_eval   { def fsync(*) = 0 }
 
-# ruby.wasm runs with rubygems disabled (`Gem` is a stub that is never fully
-# loaded; `/bundle/setup` only unshifts $LOAD_PATH). Rigor's RBS environment
-# loader needs the real rubygems (`Gem::MissingSpecError`, `Gem::Requirement`,
-# …), and without it the RBS env builds EMPTY — the analysis then runs with
-# zero type information and flags nothing. A single require initialises it.
+# ruby.wasm runs with rubygems disabled (`Gem` is a stub that is never fully loaded; `/bundle/setup` only
+# unshifts $LOAD_PATH). Rigor's RBS environment loader needs the real rubygems (`Gem::MissingSpecError`,
+# `Gem::Requirement`, …), and without it the RBS env builds EMPTY — the analysis then runs with zero type
+# information and flags nothing. A single require initialises it.
 require "rubygems"
 require "json"
 require "fileutils"
 require "stringio"
 require "rigor/cli"
 
-# WASI exposes the packed gem + config tree (/bundle, /playground) READ-ONLY,
-# and the host (index.html / smoke.mjs) provides exactly one writable mount at
-# /work. Rigor's cache is cwd-relative (`<cwd>/.rigor/`) and the adapter writes
-# a per-request buffer file, so both need a writable cwd — stage one under
-# /work by copying the read-only config in and chdir-ing there.
+# WASI exposes the packed gem + config tree (/bundle, /playground) READ-ONLY, and the host (index.html /
+# smoke.mjs) provides exactly one writable mount at /work. Rigor's cache is cwd-relative (`<cwd>/.rigor/`)
+# and the adapter writes a per-request buffer file, so both need a writable cwd — stage one under /work by
+# copying the read-only config in and chdir-ing there.
 WASM_WORK_DIR = "/work"
 
-# `js` only exists in the browser ruby.wasm build. Guard the require so this
-# file can also be loaded under a plain wasmtime/WASI smoke run (WD6 ③ CI),
-# where the request is read from $stdin instead of a JS global.
+# `js` only exists in the browser ruby.wasm build. Guard the require so this file can also be loaded under
+# a plain wasmtime/WASI smoke run (WD6 ③ CI), where the request is read from $stdin instead of a JS global.
 begin
   require "js"
   HAS_JS = true
@@ -64,8 +56,8 @@ end
 
 module Rigor
   module Playground
-    # In-VM request handler. Stateless except for the buffer file it writes
-    # under the (packed, writable) working directory.
+    # In-VM request handler. Stateless except for the buffer file it writes under the (packed, writable)
+    # working directory.
     module Wasm
       MAX_SOURCE_BYTES = 64 * 1024            # mirrors app.rb
       BUFFER_PATH      = "buffer.rb"          # relative to Dir.pwd (/playground)
@@ -73,9 +65,8 @@ module Rigor
 
       module_function
 
-      # Browser entry point: read the request JSON from the JS global set by
-      # the frontend, dispatch, and return a JSON string. `kind` is one of
-      # "check" / "annotate" / "annotate-lines" / "type-of".
+      # Browser entry point: read the request JSON from the JS global set by the frontend, dispatch, and
+      # return a JSON string. `kind` is one of "check" / "annotate" / "annotate-lines" / "type-of".
       def dispatch(kind)
         req = JSON.parse(JS.global[:rigorRequestJson].to_s)
         run(kind, req)
@@ -83,8 +74,8 @@ module Rigor
         JSON.generate({ "error" => e.message })
       end
 
-      # Transport-agnostic core. `request` is a Hash with "source" and, for
-      # type-of, "line"/"column". Returns a JSON string.
+      # Transport-agnostic core. `request` is a Hash with "source" and, for type-of, "line"/"column".
+      # Returns a JSON string.
       def run(kind, request)
         source = request.fetch("source", "").to_s
         return too_large if source.bytesize > MAX_SOURCE_BYTES
@@ -122,9 +113,8 @@ module Rigor
 
       def annotate_lines(source)
         path = write_buffer(source)
-        # `annotate --format json` returns { "annotations": { line => type } }
-        # straight from the engine's line-type map — no `#=> <type>` text to
-        # reparse. Round-trip through parse/generate to validate.
+        # `annotate --format json` returns { "annotations": { line => type } } straight from the engine's
+        # line-type map — no `#=> <type>` text to reparse. Round-trip through parse/generate to validate.
         JSON.generate(JSON.parse(run_cli(["annotate", "--format=json", path])))
       rescue JSON::ParserError
         JSON.generate({ "annotations" => {} })
@@ -159,17 +149,15 @@ module Rigor
   end
 end
 
-# Stage the writable working dir: copy the packed (read-only) .rigor.yml into
-# /work and chdir there, so `Rigor::CLI.start`'s cwd-based config discovery
-# finds it (loads rigor-rbs-inline, strict severity) and the cwd-relative cache
-# + buffer writes land on the writable mount.
+# Stage the writable working dir: copy the packed (read-only) .rigor.yml into /work and chdir there, so
+# `Rigor::CLI.start`'s cwd-based config discovery finds it (loads rigor-rbs-inline, strict severity) and the
+# cwd-relative cache + buffer writes land on the writable mount.
 FileUtils.mkdir_p(WASM_WORK_DIR)
 FileUtils.cp(File.join(File.dirname(__FILE__), ".rigor.yml"), File.join(WASM_WORK_DIR, ".rigor.yml"))
 Dir.chdir(WASM_WORK_DIR)
 
-# Plain-WASI smoke path (WD6 ③): `wasmtime … -- /playground/boot.rb <kind>`
-# reads the source from stdin and prints the JSON result. No-ops in the
-# browser, where dispatch() is driven by JS instead.
+# Plain-WASI smoke path (WD6 ③): `wasmtime … -- /playground/boot.rb <kind>` reads the source from stdin and
+# prints the JSON result. No-ops in the browser, where dispatch() is driven by JS instead.
 if !HAS_JS && $PROGRAM_NAME == __FILE__ && !ARGV.empty?
   kind = ARGV[0]
   puts Rigor::Playground::Wasm.run(kind, { "source" => $stdin.read })

--- a/plugins/rigor-pundit/demo/app/policies/post_policy.rb
+++ b/plugins/rigor-pundit/demo/app/policies/post_policy.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
-# Sample Pundit policy — rigor-pundit discovers this class
-# because its direct superclass is `ApplicationPolicy` (the
-# default `policy_base_classes`). The discoverer collects
-# every instance-side `def name?` predicate method.
+# Sample Pundit policy — rigor-pundit discovers this class because its direct superclass is
+# `ApplicationPolicy` (the default `policy_base_classes`). The discoverer collects every instance-side
+# `def name?` predicate method.
 
 class ApplicationPolicy # rubocop:disable Lint/EmptyClass
-  # Stand-in base class so this file parses standalone.
-  # rigor-pundit doesn't care whether the base class is
-  # declared here or anywhere else — it only matches by
-  # name against `policy_base_classes`.
+  # Stand-in base class so this file parses standalone. rigor-pundit doesn't care whether the base class is
+  # declared here or anywhere else — it only matches by name against `policy_base_classes`.
 end
 
 class PostPolicy < ApplicationPolicy

--- a/plugins/rigor-pundit/demo/demo.rb
+++ b/plugins/rigor-pundit/demo/demo.rb
@@ -1,28 +1,23 @@
 # frozen_string_literal: true
 
-# Demo: rigor-pundit recognises every `authorize(...)` /
-# `policy(...)` / `policy_scope(...)` call and validates
-# the resolved policy class + (when present) the predicate
-# method. Run with `bundle exec rigor check` from this
-# directory.
+# Demo: rigor-pundit recognises every `authorize(...)` / `policy(...)` / `policy_scope(...)` call and
+# validates the resolved policy class + (when present) the predicate method. Run with `bundle exec rigor
+# check` from this directory.
 
 # Stand-in implementations so this file parses standalone.
 def authorize(_record, _action = nil); end
 def policy(_record); end
 def policy_scope(_scope); end
 
-# `Post` is a constant; the plugin maps it to `PostPolicy`
-# directly without needing inferred-type information.
+# `Post` is a constant; the plugin maps it to `PostPolicy` directly without needing inferred-type information.
 authorize(Post, :show)
 authorize(Post, :update?) # `:update?` and `:update` both work
 authorize(Post, :destroy)
 
-# `policy(...)` and `policy_scope(...)` get the same
-# class-existence check.
+# `policy(...)` and `policy_scope(...)` get the same class-existence check.
 policy(Comment)
 policy_scope(Comment)
 
-# Implicit-form `authorize(record)` (the action is taken
-# from the controller at runtime). The plugin still
+# Implicit-form `authorize(record)` (the action is taken from the controller at runtime). The plugin still
 # validates the policy class.
 authorize(Post)

--- a/plugins/rigor-pundit/demo/errors_demo.rb
+++ b/plugins/rigor-pundit/demo/errors_demo.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# DO NOT run via `ruby errors_demo.rb` — analyse with
-# `bundle exec rigor check` to see rigor-pundit's
+# DO NOT run via `ruby errors_demo.rb` — analyse with `bundle exec rigor check` to see rigor-pundit's
 # diagnostics.
 
 def authorize(_record, _action = nil); end
@@ -15,8 +14,7 @@ authorize(Post, :destory)
 #   plugin.pundit.unknown-policy-method
 authorize(Post, :archive)
 
-# Misspelled record (so the policy class doesn't exist) —
-# flagged with did-you-mean against the known policies:
+# Misspelled record (so the policy class doesn't exist) — flagged with did-you-mean against the known policies:
 #   plugin.pundit.unknown-policy-class
 authorize(Commnet, :edit)
 

--- a/plugins/rigor-pundit/lib/rigor/plugin/pundit.rb
+++ b/plugins/rigor-pundit/lib/rigor/plugin/pundit.rb
@@ -8,13 +8,11 @@ require_relative "pundit/analyzer"
 
 module Rigor
   module Plugin
-    # rigor-pundit — validates Pundit `authorize` /
-    # `policy` / `policy_scope` calls against the project's
+    # rigor-pundit — validates Pundit `authorize` / `policy` / `policy_scope` calls against the project's
     # `app/policies/` tree.
     #
     # Tier 3B of the [Rails plugins roadmap](../../../../docs/design/20260508-rails-plugins-roadmap.md).
-    # Statically discovers policy classes by walking
-    # `policy_search_paths` and parsing each file with
+    # Statically discovers policy classes by walking `policy_search_paths` and parsing each file with
     # Prism — no `pundit` runtime dependency.
     #
     # ## Configuration
@@ -27,34 +25,22 @@ module Rigor
     #
     # ## What it checks
     #
-    # 1. **Policy class existence** — `authorize(record, ...)`
-    #    looks up `<inferred-type>Policy` in the index.
-    #    Missing policies emit `unknown-policy-class` with
-    #    a did-you-mean suggestion.
-    # 2. **Predicate method existence** — for the
-    #    `authorize(record, :action)` form, validates that
-    #    `<Policy>#<action>?` is defined. Missing methods
-    #    emit `unknown-policy-method` listing the known
+    # 1. **Policy class existence** — `authorize(record, ...)` looks up `<inferred-type>Policy` in the index.
+    #    Missing policies emit `unknown-policy-class` with a did-you-mean suggestion.
+    # 2. **Predicate method existence** — for the `authorize(record, :action)` form, validates that
+    #    `<Policy>#<action>?` is defined. Missing methods emit `unknown-policy-method` listing the known
     #    predicates.
     #
     # ## Limitations (v0.1.0)
     #
-    # - Records whose inferred type is NOT a `Nominal[T]`
-    #   (untyped local variables, untyped instance
-    #   variables) are silently passed through. The plugin
-    #   only validates what it can prove from the static
-    #   carrier.
-    # - The two-argument form
-    #   `authorize(record, :action_symbol)` is the only
-    #   one validated. The implicit form
-    #   `authorize(record)` (which Pundit resolves at
-    #   runtime against the controller's current action) is
-    #   passed through with the policy-class check only.
-    # - Direct-superclass match for `policy_base_classes`.
-    #   Indirect inheritance (`AdminPolicy <
-    #   ApplicationPolicy`) needs `AdminPolicy` listed in
-    #   `policy_base_classes` if subclasses inherit from
-    #   it.
+    # - Records whose inferred type is NOT a `Nominal[T]` (untyped local variables, untyped instance
+    #   variables) are silently passed through. The plugin only validates what it can prove from the
+    #   static carrier.
+    # - The two-argument form `authorize(record, :action_symbol)` is the only one validated. The implicit
+    #   form `authorize(record)` (which Pundit resolves at runtime against the controller's current action)
+    #   is passed through with the policy-class check only.
+    # - Direct-superclass match for `policy_base_classes`. Indirect inheritance (`AdminPolicy <
+    #   ApplicationPolicy`) needs `AdminPolicy` listed in `policy_base_classes` if subclasses inherit from it.
     class Pundit < Rigor::Plugin::Base
       manifest(
         id: "pundit",
@@ -79,10 +65,9 @@ module Rigor
         @policy_base_classes = Array(config.fetch("policy_base_classes")).map(&:to_s)
       end
 
-      # File-level only: the load-error emission. The per-call policy
-      # validation runs over the engine-owned walk via the node_rule
-      # below (ADR-37). The index is lazily loaded + memoised by
-      # `producer_value`, so both surfaces share one load.
+      # File-level only: the load-error emission. The per-call policy validation runs over the engine-owned
+      # walk via the node_rule below (ADR-37). The index is lazily loaded + memoised by `producer_value`,
+      # so both surfaces share one load.
       def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
         index = producer_value(:policy_index)
         return [load_error_diagnostic(path)] if index.nil? && producer_error(:policy_index)

--- a/plugins/rigor-pundit/lib/rigor/plugin/pundit/analyzer.rb
+++ b/plugins/rigor-pundit/lib/rigor/plugin/pundit/analyzer.rb
@@ -6,41 +6,32 @@ require "prism"
 module Rigor
   module Plugin
     class Pundit < Rigor::Plugin::Base
-      # Walks a parsed file's AST looking for Pundit
-      # entry-point calls and validates each against the
+      # Walks a parsed file's AST looking for Pundit entry-point calls and validates each against the
       # {PolicyIndex}.
       #
       # Recognised shapes:
       #
-      # - `authorize(record, :action)` — record's inferred
-      #   type → `<Type>Policy#<action>?` lookup. Both the
+      # - `authorize(record, :action)` — record's inferred type → `<Type>Policy#<action>?` lookup. Both the
       #   policy class and the predicate must exist.
-      # - `authorize(record)` — without an action argument,
-      #   we only validate that `<Type>Policy` exists. The
-      #   action name is determined at runtime from the
-      #   controller's current action; static validation
+      # - `authorize(record)` — without an action argument, we only validate that `<Type>Policy` exists. The
+      #   action name is determined at runtime from the controller's current action; static validation
       #   isn't possible without controller context.
-      # - `policy(record)` / `policy_scope(scope)` — same
-      #   `<Type>Policy` existence check.
+      # - `policy(record)` / `policy_scope(scope)` — same `<Type>Policy` existence check.
       #
-      # When the first argument's inferred type is NOT a
-      # `Nominal[T]` (e.g. an untyped local variable), the
-      # call is silently passed through. The plugin only
-      # validates what it can prove from the static type
+      # When the first argument's inferred type is NOT a `Nominal[T]` (e.g. an untyped local variable), the
+      # call is silently passed through. The plugin only validates what it can prove from the static type
       # carrier.
       module Analyzer
         ENTRY_METHODS = %i[authorize policy policy_scope].freeze
 
-        # One policy violation: the kebab-case `rule`, `severity`, and
-        # human-readable `message`. Carries no path/location — the caller
-        # (the `node_rule` block) positions it via `Plugin::Base#diagnostic`.
+        # One policy violation: the kebab-case `rule`, `severity`, and human-readable `message`. Carries no
+        # path/location — the caller (the `node_rule` block) positions it via `Plugin::Base#diagnostic`.
         Violation = Struct.new(:rule, :severity, :message, keyword_init: true)
 
         module_function
 
-        # The policy violations for a single call node (0..2 of them), or
-        # `[]` when the node is not a Pundit entry call or its record type
-        # is not statically determinable. ADR-37: the engine owns the
+        # The policy violations for a single call node (0..2 of them), or `[]` when the node is not a
+        # Pundit entry call or its record type is not statically determinable. ADR-37: the engine owns the
         # walk, so this is per-node logic.
         #
         # @param call_node [Prism::Node]
@@ -71,15 +62,11 @@ module Rigor
           ENTRY_METHODS.include?(node.name) && node.receiver.nil?
         end
 
-        # Resolves the first-argument expression to a policy
-        # class name. The candidates are:
+        # Resolves the first-argument expression to a policy class name. The candidates are:
         # - `Foo` (a constant) → `FooPolicy`
-        # - `Foo.method(...)` whose inferred type is
-        #   `Nominal[Bar]` → `BarPolicy`
-        # - any other expression whose inferred type is
-        #   `Nominal[Bar]` → `BarPolicy`
-        # Returns `nil` when the type isn't statically
-        # determinable.
+        # - `Foo.method(...)` whose inferred type is `Nominal[Bar]` → `BarPolicy`
+        # - any other expression whose inferred type is `Nominal[Bar]` → `BarPolicy`
+        # Returns `nil` when the type isn't statically determinable.
         def derive_policy_class_name(record_node, scope)
           if record_node.is_a?(Prism::ConstantReadNode) || record_node.is_a?(Prism::ConstantPathNode)
             constant_name = constant_receiver_name(record_node)
@@ -118,10 +105,8 @@ module Rigor
           )
         end
 
-        # Validates the `authorize(record, :action)` form.
-        # Returns nil when the call has no second argument
-        # (the runtime infers it from the controller — out
-        # of scope here) or when the second argument isn't
+        # Validates the `authorize(record, :action)` form. Returns nil when the call has no second argument
+        # (the runtime infers it from the controller — out of scope here) or when the second argument isn't
         # a literal symbol / string.
         def action_violation(call_node, policy_entry)
           args = call_node.arguments&.arguments || []

--- a/plugins/rigor-pundit/lib/rigor/plugin/pundit/policy_discoverer.rb
+++ b/plugins/rigor-pundit/lib/rigor/plugin/pundit/policy_discoverer.rb
@@ -7,22 +7,17 @@ require_relative "policy_index"
 module Rigor
   module Plugin
     class Pundit < Rigor::Plugin::Base
-      # Walks the configured policy-search paths via the
-      # plugin's `IoBoundary`, parses each `.rb` file with
-      # Prism, and collects classes whose immediate
-      # superclass is one of the configured base classes.
+      # Walks the configured policy-search paths via the plugin's `IoBoundary`, parses each `.rb` file with
+      # Prism, and collects classes whose immediate superclass is one of the configured base classes.
       #
-      # For each discovered policy class, the discoverer
-      # collects every instance-side `def name?` predicate
-      # method. Non-predicate methods (`initialize`,
-      # `resolve`, helper methods) are ignored — Pundit's
+      # For each discovered policy class, the discoverer collects every instance-side `def name?` predicate
+      # method. Non-predicate methods (`initialize`, `resolve`, helper methods) are ignored — Pundit's
       # `authorize` only ever calls predicate methods.
       #
       # Limitations (intentional for v0.1.0):
       #
       # - Direct-superclass match only.
-      # - Predicate methods are read from the syntactic
-      #   `def` list. Methods built via `define_method` /
+      # - Predicate methods are read from the syntactic `def` list. Methods built via `define_method` /
       #   inherited from a sibling concern are out of scope.
       class PolicyDiscoverer
         def initialize(io_boundary:, search_paths:, base_classes:)
@@ -120,8 +115,7 @@ module Rigor
           end
         end
 
-        # Returns symbolic predicate names (`:update?`,
-        # `:show?`, …) defined on the policy. Only
+        # Returns symbolic predicate names (`:update?`, `:show?`, …) defined on the policy. Only
         # instance-side names that end in `?` are recorded.
         def collect_predicate_methods(body)
           return [] if body.nil?

--- a/plugins/rigor-pundit/lib/rigor/plugin/pundit/policy_index.rb
+++ b/plugins/rigor-pundit/lib/rigor/plugin/pundit/policy_index.rb
@@ -3,14 +3,11 @@
 module Rigor
   module Plugin
     class Pundit < Rigor::Plugin::Base
-      # Frozen catalogue of discovered Pundit policy classes
-      # keyed by policy class name (e.g. `"PostPolicy"`).
-      # Each entry tracks the set of predicate methods
-      # defined on the policy (instance-side `def name?`)
+      # Frozen catalogue of discovered Pundit policy classes keyed by policy class name (e.g. `"PostPolicy"`).
+      # Each entry tracks the set of predicate methods defined on the policy (instance-side `def name?`)
       # plus the source file path.
       #
-      # The analyzer maps a record's inferred type
-      # (`Nominal[Post]`) to the policy class name
+      # The analyzer maps a record's inferred type (`Nominal[Post]`) to the policy class name
       # (`"PostPolicy"`) and looks up the predicate.
       class PolicyIndex
         Entry = Data.define(:policy_class_name, :file_path, :predicate_methods) do
@@ -22,8 +19,7 @@ module Rigor
             predicate_methods.to_a.sort
           end
 
-          # Normalises an action symbol / string by ensuring
-          # a trailing `?`. `:update` and `:update?` both
+          # Normalises an action symbol / string by ensuring a trailing `?`. `:update` and `:update?` both
           # resolve to `update?`.
           def normalize(name)
             string = name.to_s

--- a/plugins/rigor-rails-i18n/demo/demo.rb
+++ b/plugins/rigor-rails-i18n/demo/demo.rb
@@ -1,24 +1,19 @@
 # frozen_string_literal: true
 
-# Demo: rigor-rails-i18n recognises every literal-string
-# `t(...)` / `I18n.t(...)` / `I18n.translate(...)` call and
-# validates the key against `config/locales/*.yml`. Run
-# with `bundle exec rigor check` from this directory.
+# Demo: rigor-rails-i18n recognises every literal-string `t(...)` / `I18n.t(...)` / `I18n.translate(...)`
+# call and validates the key against `config/locales/*.yml`. Run with `bundle exec rigor check` from this
+# directory.
 
-# Define `t` so this file parses standalone (without
-# Rails). The plugin only inspects call shape; it doesn't
-# care that the runtime method here is a no-op.
+# Define `t` so this file parses standalone (without Rails). The plugin only inspects call shape; it
+# doesn't care that the runtime method here is a no-op.
 def t(_key, **_options); end
 
-# `users.welcome` exists in both `en` and `ja` and takes a
-# `%{name}` placeholder.
+# `users.welcome` exists in both `en` and `ja` and takes a `%{name}` placeholder.
 t("users.welcome", name: "Alice")
 
-# `users.bye` exists in both locales without any
-# placeholders.
+# `users.bye` exists in both locales without any placeholders.
 I18n.t("users.bye")
 
-# `errors.messages.too_short` only exists in `en`. The
-# call site passes `default:` so the missing-locale
+# `errors.messages.too_short` only exists in `en`. The call site passes `default:` so the missing-locale
 # warning is suppressed.
 t("errors.messages.too_short", count: 8, default: "too short")

--- a/plugins/rigor-rails-i18n/demo/errors_demo.rb
+++ b/plugins/rigor-rails-i18n/demo/errors_demo.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# DO NOT run via `ruby errors_demo.rb` — analyse with
-# `bundle exec rigor check` to see rigor-rails-i18n's
+# DO NOT run via `ruby errors_demo.rb` — analyse with `bundle exec rigor check` to see rigor-rails-i18n's
 # diagnostics.
 
 def t(_key, **_options); end
@@ -18,8 +17,7 @@ t("users.welcome")
 #   plugin.rails-i18n.extra-interpolation
 t("users.welcome", name: "Alice", extra: "unused")
 
-# `errors.messages.blank` is only in `en`; this project's
-# `configured_locales` is `[en, ja]` and there is no
+# `errors.messages.blank` is only in `en`; this project's `configured_locales` is `[en, ja]` and there is no
 # `default:`, so we get a missing-locale warning:
 #   plugin.rails-i18n.missing-locale
 t("errors.messages.blank")

--- a/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n.rb
+++ b/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n.rb
@@ -8,16 +8,12 @@ require_relative "rails_i18n/analyzer"
 
 module Rigor
   module Plugin
-    # rigor-rails-i18n — validates `t('key.path')` /
-    # `I18n.t(...)` calls against `config/locales/*.yml`.
+    # rigor-rails-i18n — validates `t('key.path')` / `I18n.t(...)` calls against `config/locales/*.yml`.
     #
     # Tier 1B of the [Rails plugins roadmap](../../../../docs/design/20260508-rails-plugins-roadmap.md).
-    # Statically reads every YAML file under
-    # `locale_search_paths` (default `config/locales/`),
-    # builds a flat `dotted_key => Entry` index keyed by the
-    # leaf key path, and validates every `t(literal_key, ...)`
-    # call site against the catalogue. No Rails runtime
-    # dependency.
+    # Statically reads every YAML file under `locale_search_paths` (default `config/locales/`), builds a
+    # flat `dotted_key => Entry` index keyed by the leaf key path, and validates every `t(literal_key, ...)`
+    # call site against the catalogue. No Rails runtime dependency.
     #
     # ## Configuration
     #
@@ -30,55 +26,37 @@ module Rigor
     #
     # ## What it checks
     #
-    # 1. **Key existence** — `t('users.welcome')` is flagged
-    #    when `users.welcome` does not appear in any locale.
-    # 2. **Per-locale coverage** — when the key resolves in
-    #    some locales but not all configured locales, the
-    #    plugin emits a `missing-locale` warning. Suppressed
-    #    when the call site passes `default:`.
-    # 3. **Interpolation variables** — the leaf string's
-    #    `%{var}` placeholders must match the call's keyword
-    #    arguments. Missing placeholders are errors; extra
-    #    arguments are warnings.
-    # 4. **View template lazy keys** — `t('.title')` inside
-    #    `app/views/setting/index.html.erb` expands to
-    #    `setting.index.title` and is validated against the
-    #    locale index. ERB, Haml, and Slim templates are
+    # 1. **Key existence** — `t('users.welcome')` is flagged when `users.welcome` does not appear in any
+    #    locale.
+    # 2. **Per-locale coverage** — when the key resolves in some locales but not all configured locales,
+    #    the plugin emits a `missing-locale` warning. Suppressed when the call site passes `default:`.
+    # 3. **Interpolation variables** — the leaf string's `%{var}` placeholders must match the call's
+    #    keyword arguments. Missing placeholders are errors; extra arguments are warnings.
+    # 4. **View template lazy keys** — `t('.title')` inside `app/views/setting/index.html.erb` expands to
+    #    `setting.index.title` and is validated against the locale index. ERB, Haml, and Slim templates are
     #    scanned under `view_search_paths`.
     #
     # ## Limitations
     #
-    # - Only literal-string keys are validated. `t(key)` with
-    #   a variable receiver is silently passed through.
-    # - Lazy lookup (`t('.key')`) is supported for controller
-    #   files (`app/controllers/**/*_controller.rb`): the key
-    #   is expanded to `<controller_scope>.<action>.<key>`
-    #   using the file path and the innermost enclosing `def`.
-    #   Lazy keys in non-controller `.rb` files (models, helpers,
-    #   mailers, …) are silently skipped — the controller/action
-    #   scope cannot be statically determined there.
-    # - View template lazy keys (`t('.key')` inside ERB / Haml /
-    #   Slim) are validated for key existence and per-locale
-    #   coverage. Interpolation variable validation is skipped
-    #   for view templates (the hash may come from controller
-    #   instance variables not visible in the template).
-    #   The view scan is a project-wide pass surfaced through the
-    #   per-file diagnostic hook, so under `--workers` each
-    #   fork-pool worker re-emits the full set (the same
-    #   once-per-run limitation the `load-error` path carries);
+    # - Only literal-string keys are validated. `t(key)` with a variable receiver is silently passed through.
+    # - Lazy lookup (`t('.key')`) is supported for controller files (`app/controllers/**/*_controller.rb`):
+    #   the key is expanded to `<controller_scope>.<action>.<key>` using the file path and the innermost
+    #   enclosing `def`. Lazy keys in non-controller `.rb` files (models, helpers, mailers, …) are silently
+    #   skipped — the controller/action scope cannot be statically determined there.
+    # - View template lazy keys (`t('.key')` inside ERB / Haml / Slim) are validated for key existence and
+    #   per-locale coverage. Interpolation variable validation is skipped for view templates (the hash may
+    #   come from controller instance variables not visible in the template). The view scan is a
+    #   project-wide pass surfaced through the per-file diagnostic hook, so under `--workers` each fork-pool
+    #   worker re-emits the full set (the same once-per-run limitation the `load-error` path carries);
     #   sequential `rigor check` is unaffected.
-    # - Pluralization (`t('errors.messages.too_short',
-    #   count: n)`) is recognised at the call site but the
-    #   `count` key is not used to validate the locale's
-    #   pluralization branches.
-    # - YAML aliases / merges are accepted (Psych's standard
-    #   `aliases: true`) but custom Ruby classes inside the
-    #   YAML are NOT permitted (`safe_load`).
+    # - Pluralization (`t('errors.messages.too_short', count: n)`) is recognised at the call site but the
+    #   `count` key is not used to validate the locale's pluralization branches.
+    # - YAML aliases / merges are accepted (Psych's standard `aliases: true`) but custom Ruby classes
+    #   inside the YAML are NOT permitted (`safe_load`).
     class RailsI18n < Rigor::Plugin::Base
       manifest(
         id: "rails-i18n",
-        # Bumped 2026-06-23 — view template lazy-key scanning
-        # (`t('.key')` inside ERB / Haml / Slim under
+        # Bumped 2026-06-23 — view template lazy-key scanning (`t('.key')` inside ERB / Haml / Slim under
         # `view_search_paths`).
         version: "0.3.0",
         description: "Validates I18n `t(key)` calls against `config/locales/*.yml`.",
@@ -89,12 +67,10 @@ module Rigor
         }
       )
 
-      # `watch:` covers every `.yml` / `.yaml` file under the locale
-      # search paths so the cache invalidates when locale files are
-      # added, removed, or edited (ADR-60 WD3). `@load_errors` is a
-      # producer-side capture: it is populated only when the block
-      # runs (a cache miss / a watched file changed), which is exactly
-      # when a malformed YAML must re-surface.
+      # `watch:` covers every `.yml` / `.yaml` file under the locale search paths so the cache invalidates
+      # when locale files are added, removed, or edited (ADR-60 WD3). `@load_errors` is a producer-side
+      # capture: it is populated only when the block runs (a cache miss / a watched file changed), which is
+      # exactly when a malformed YAML must re-surface.
       producer :locale_index, watch: -> { [[@locale_search_paths, "**/*.yml", "**/*.yaml"]] } do |_params|
         loader = LocaleLoader.new(
           io_boundary: io_boundary,
@@ -105,14 +81,12 @@ module Rigor
         index
       end
 
-      # Scans view templates under `view_search_paths` for lazy
-      # `t('.key')` / `I18n.translate('.key')` calls and validates
-      # each expanded key against the locale index. Interpolation
-      # validation is skipped — the hash may come from controller
-      # instance variables not visible in the template source.
+      # Scans view templates under `view_search_paths` for lazy `t('.key')` / `I18n.translate('.key')`
+      # calls and validates each expanded key against the locale index. Interpolation validation is
+      # skipped — the hash may come from controller instance variables not visible in the template source.
       #
-      # Watches `**/*.{erb,haml,slim}` under each search root so
-      # the cache invalidates when templates are edited.
+      # Watches `**/*.{erb,haml,slim}` under each search root so the cache invalidates when templates are
+      # edited.
       producer :view_diagnostics, watch: -> { [[@view_search_paths, "**/*.erb", "**/*.haml", "**/*.slim"]] } do |_params|
         index = producer_value(:locale_index)
         next [] if index.nil? || index.empty?
@@ -129,11 +103,10 @@ module Rigor
         @view_diagnostics_emitted = false
       end
 
-      # File-level only: the once-per-run YAML load errors + the
-      # runtime (cache-load) error + the view-template scan. Per-call
-      # `t('key')` validation runs over the engine-owned walk via the
-      # node_rule below (ADR-37). The locale index and view diagnostics
-      # are lazily loaded + memoised by `producer_value`.
+      # File-level only: the once-per-run YAML load errors + the runtime (cache-load) error + the
+      # view-template scan. Per-call `t('key')` validation runs over the engine-owned walk via the
+      # node_rule below (ADR-37). The locale index and view diagnostics are lazily loaded + memoised by
+      # `producer_value`.
       def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
         index = producer_value(:locale_index)
         diagnostics = []
@@ -151,9 +124,8 @@ module Rigor
         diagnostics
       end
 
-      # The lazy-key (`t('.key')`) expansion needs the enclosing method
-      # (the controller action), supplied by the node-rule NodeContext;
-      # the controller scope comes from the file path.
+      # The lazy-key (`t('.key')`) expansion needs the enclosing method (the controller action), supplied
+      # by the node-rule NodeContext; the controller scope comes from the file path.
       node_rule Prism::CallNode do |node, _scope, path, _fc, context|
         index = producer_value(:locale_index)
         next [] if index.nil? || index.empty?
@@ -205,12 +177,10 @@ module Rigor
         end.sort
       end
 
-      # Diagnostics anchor on a path relative to the working
-      # directory — the same base `File.expand_path` globbed the
-      # view files against — so view diagnostics render and match
-      # baselines like every other diagnostic (which carry
-      # project-relative paths). Falls back to the absolute path
-      # for a view outside the working tree.
+      # Diagnostics anchor on a path relative to the working directory — the same base `File.expand_path`
+      # globbed the view files against — so view diagnostics render and match baselines like every other
+      # diagnostic (which carry project-relative paths). Falls back to the absolute path for a view outside
+      # the working tree.
       def relative_view_path(absolute_path)
         Pathname.new(absolute_path).relative_path_from(Pathname.pwd).to_s
       rescue ArgumentError
@@ -232,12 +202,9 @@ module Rigor
         )
       end
 
-      # The runner only invokes `diagnostics_for_file` for
-      # Ruby files (`paths:` is filtered to `.rb`). YAML
-      # parse errors therefore can't be anchored on the
-      # offending locale file directly; instead, we emit
-      # them once per run on the first analyzed Ruby file,
-      # naming the offending YAML path in the message.
+      # The runner only invokes `diagnostics_for_file` for Ruby files (`paths:` is filtered to `.rb`). YAML
+      # parse errors therefore can't be anchored on the offending locale file directly; instead, we emit
+      # them once per run on the first analyzed Ruby file, naming the offending YAML path in the message.
       def consume_load_error_diagnostics(path)
         return [] if @load_errors_emitted
 

--- a/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/analyzer.rb
+++ b/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/analyzer.rb
@@ -6,85 +6,64 @@ require "prism"
 module Rigor
   module Plugin
     class RailsI18n < Rigor::Plugin::Base
-      # Walks a parsed file's AST looking for `t(...)` /
-      # `I18n.t(...)` / `I18n.translate(...)` calls with a
-      # literal-string first argument. Calls with a non-literal
-      # key (variable, expression) are silently passed through —
-      # the plugin only validates what it can prove statically.
+      # Walks a parsed file's AST looking for `t(...)` / `I18n.t(...)` / `I18n.translate(...)` calls with a
+      # literal-string first argument. Calls with a non-literal key (variable, expression) are silently
+      # passed through — the plugin only validates what it can prove statically.
       #
       # ## What gets emitted per recognised call
       #
-      # - `plugin.rails-i18n.translation-call` (info) names the
-      #   key and the locales it resolves in.
-      # - `plugin.rails-i18n.unknown-key` (error) when the key
-      #   is missing from every loaded locale; the message
-      #   includes a did-you-mean suggestion drawn from the
-      #   index.
-      # - `plugin.rails-i18n.missing-locale` (warning) when the
-      #   key resolves in some configured locales but is absent
-      #   from at least one. Suppressed when the call passes
-      #   `default:` (the user has signalled they're aware of
-      #   the partial coverage).
-      # - `plugin.rails-i18n.wrong-interpolation` (error) when
-      #   the call's interpolation hash uses keys that don't
-      #   match the value's `%{var}` placeholders, or omits a
-      #   required placeholder.
+      # - `plugin.rails-i18n.translation-call` (info) names the key and the locales it resolves in.
+      # - `plugin.rails-i18n.unknown-key` (error) when the key is missing from every loaded locale; the
+      #   message includes a did-you-mean suggestion drawn from the index.
+      # - `plugin.rails-i18n.missing-locale` (warning) when the key resolves in some configured locales but
+      #   is absent from at least one. Suppressed when the call passes `default:` (the user has signalled
+      #   they're aware of the partial coverage).
+      # - `plugin.rails-i18n.wrong-interpolation` (error) when the call's interpolation hash uses keys that
+      #   don't match the value's `%{var}` placeholders, or omits a required placeholder.
       module Analyzer
         TRANSLATE_METHODS = %i[t translate].freeze
 
-        # Methods that are always I18n receivers (`I18n.t`,
-        # `::I18n.t`).
+        # Methods that are always I18n receivers (`I18n.t`, `::I18n.t`).
         I18N_RECEIVER_NAMES = %w[I18n ::I18n].freeze
 
-        # Matches controller file paths so lazy keys (`.key`)
-        # can be expanded to `<controller_scope>.<action>.<key>`.
-        # Captures the path segment between `controllers/` and
+        # Matches controller file paths so lazy keys (`.key`) can be expanded to
+        # `<controller_scope>.<action>.<key>`. Captures the path segment between `controllers/` and
         # `_controller.rb` (e.g. `users`, `admin/users`).
         CONTROLLER_PATH_RE = %r{(?:^|/)controllers/(.+)_controller\.rb$}
 
-        # Matches Rails view-template file paths to derive the
-        # I18n "virtual path" — the scope that Rails uses for
-        # lazy `t('.key')` lookups inside a template.
+        # Matches Rails view-template file paths to derive the I18n "virtual path" — the scope that Rails
+        # uses for lazy `t('.key')` lookups inside a template.
         #
-        # Captures the path segment between `views/` and the
-        # format+variant+handler suffix, then strips a leading
-        # underscore from each segment — Rails templates resolve
-        # `_form.html.erb` as "form", not "_form".
+        # Captures the path segment between `views/` and the format+variant+handler suffix, then strips a
+        # leading underscore from each segment — Rails templates resolve `_form.html.erb` as "form", not
+        # "_form".
         #
         #   app/views/setting/index.html.erb      → setting.index
         #   app/views/admin/users/new.html.erb    → admin.users.new
         #   app/views/home/index.html+mobile.erb  → home.index
         #   app/views/users/_form.html.erb        → users.form
         #
-        # The view-scope lazy expansion replaces the action
-        # part with the view's virtual path:
+        # The view-scope lazy expansion replaces the action part with the view's virtual path:
         #   `<%= t('.title') %>` → `setting.index.title`
         VIEW_SCOPE_RE = %r{views/(.+?)\.(?:\w+)(?:\+\w+)?\.\w+\z}
 
-        # Regex to extract lazy-key arguments from ERB / HTML
-        # template content. Matches `t('.key')`, `t(".key")`,
-        # `I18n.t('.key')`, and `I18n.translate('.key')` with a
-        # leading dot on the key string. Captures only the key
-        # part after the dot.
+        # Regex to extract lazy-key arguments from ERB / HTML template content. Matches `t('.key')`,
+        # `t(".key")`, `I18n.t('.key')`, and `I18n.translate('.key')` with a leading dot on the key string.
+        # Captures only the key part after the dot.
         LAZY_T_KEY_RE = /\b(?:I18n\.)?(?:t|translate)\s*\(\s*(?:"\.([^"\\]*)"|'\.([^'\\]*)')/
 
-        # Reserved option keys — these are recognised by I18n
-        # itself and not treated as interpolation variables.
+        # Reserved option keys — these are recognised by I18n itself and not treated as interpolation
+        # variables.
         RESERVED_OPTION_KEYS = %i[
           default scope locale count raise throw fallback
           fallback_in_progress separator deep_interpolation
         ].to_set.freeze
 
-        # Key prefixes Rails / `rails-i18n` ship in every
-        # locale by default. Projects whose own locale files
-        # don't redeclare them still get them at runtime (via
-        # the `rails-i18n` gem's bundled locale catalogues).
-        # `t('date.order')` is the canonical Mastodon case —
-        # used by `Settings::Date::Order` and date-of-birth
-        # selects, never authored project-side. Skip
-        # `unknown-key` for these; downstream interpolation
-        # checks have nothing to validate without a leaf entry
-        # so they decline silently too.
+        # Key prefixes Rails / `rails-i18n` ship in every locale by default. Projects whose own locale
+        # files don't redeclare them still get them at runtime (via the `rails-i18n` gem's bundled locale
+        # catalogues). `t('date.order')` is the canonical Mastodon case — used by `Settings::Date::Order`
+        # and date-of-birth selects, never authored project-side. Skip `unknown-key` for these; downstream
+        # interpolation checks have nothing to validate without a leaf entry so they decline silently too.
         RAILS_SHIPPED_KEY_PREFIXES = %w[
           date.
           time.
@@ -101,9 +80,8 @@ module Rigor
           activerecord.errors.models.
         ].freeze
 
-        # One translation-call observation. Carries no path/location —
-        # the caller (the `node_rule` block) positions it via
-        # `Plugin::Base#diagnostic`.
+        # One translation-call observation. Carries no path/location — the caller (the `node_rule` block)
+        # positions it via `Plugin::Base#diagnostic`.
         Violation = Struct.new(:rule, :severity, :message, keyword_init: true)
 
         module_function
@@ -118,12 +96,10 @@ module Rigor
         # @param locale_index [LocaleIndex]
         # @param configured_locales [Array<String>]
         # @return [Array<Diagnostic>]
-        # The translation violations for a single call node, or `[]`
-        # when it is not a recognised `t` / `translate` call with a
-        # literal key. ADR-37: the engine owns the walk; `action` (the
-        # enclosing method, for lazy `t('.key')` expansion) comes from
-        # the node-rule `NodeContext`, and `controller_scope` from the
-        # file path.
+        # The translation violations for a single call node, or `[]` when it is not a recognised `t` /
+        # `translate` call with a literal key. ADR-37: the engine owns the walk; `action` (the enclosing
+        # method, for lazy `t('.key')` expansion) comes from the node-rule `NodeContext`, and
+        # `controller_scope` from the file path.
         #
         # @param call_node [Prism::Node]
         # @param locale_index [LocaleIndex]
@@ -143,11 +119,11 @@ module Rigor
           options = options_hash(call_node)
           entry = locale_index.find(literal_key)
           if entry.nil?
-            # CLDR pluralization namespace: `t('accounts.posts', count: n)`
-            # resolves through a `.one` / `.other` child — not missing.
+            # CLDR pluralization namespace: `t('accounts.posts', count: n)` resolves through a `.one` /
+            # `.other` child — not missing.
             return [] if locale_index.pluralization_namespace?(literal_key)
-            # Rails / rails-i18n ship `date.order`, `time.am`, etc. in
-            # every locale at runtime even when project files omit them.
+            # Rails / rails-i18n ship `date.order`, `time.am`, etc. in every locale at runtime even when
+            # project files omit them.
             return [] if rails_shipped_key?(literal_key)
 
             return [unknown_key_violation(literal_key, locale_index)]
@@ -162,9 +138,8 @@ module Rigor
           violations
         end
 
-        # Derives the Rails controller scope from the file path,
-        # e.g. `app/controllers/admin/users_controller.rb` → `admin.users`.
-        # Returns nil for non-controller paths.
+        # Derives the Rails controller scope from the file path, e.g.
+        # `app/controllers/admin/users_controller.rb` → `admin.users`. Returns nil for non-controller paths.
         def controller_scope_from_path(path)
           m = CONTROLLER_PATH_RE.match(path.to_s)
           return nil unless m
@@ -198,12 +173,10 @@ module Rigor
           violations
         end
 
-        # Expands a lazy key (starting with `.`) to its full
-        # dotted path using the controller scope and action name.
-        # Returns the raw key unchanged for absolute keys.
-        # Returns nil for lazy keys outside a controller context
-        # or without an enclosing action — these are silently
-        # skipped to avoid false positives.
+        # Expands a lazy key (starting with `.`) to its full dotted path using the controller scope and
+        # action name. Returns the raw key unchanged for absolute keys. Returns nil for lazy keys outside a
+        # controller context or without an enclosing action — these are silently skipped to avoid false
+        # positives.
         def expand_key(raw_key, controller_scope:, action:)
           return raw_key unless raw_key.start_with?(".")
           return nil unless controller_scope && action
@@ -219,9 +192,8 @@ module Rigor
           I18N_RECEIVER_NAMES.include?(receiver_name)
         end
 
-        # Extracts the literal-string first argument when
-        # present. Returns nil for variable / expression keys —
-        # only literal keys are statically validated.
+        # Extracts the literal-string first argument when present. Returns nil for variable / expression
+        # keys — only literal keys are statically validated.
         def literal_key_for(call_node)
           args = call_node.arguments&.arguments || []
           return nil if args.empty?
@@ -232,11 +204,9 @@ module Rigor
           first.unescaped
         end
 
-        # Pulls the interpolation hash from the call's
-        # arguments. The trailing `Hash` argument (or
-        # `Prism::KeywordHashNode`) carries both reserved I18n
-        # options (`default:`, `scope:`, …) and interpolation
-        # variables. Returns:
+        # Pulls the interpolation hash from the call's arguments. The trailing `Hash` argument (or
+        # `Prism::KeywordHashNode`) carries both reserved I18n options (`default:`, `scope:`, …) and
+        # interpolation variables. Returns:
         #   {
         #     :has_default     => bool,
         #     :all_keys        => Set<Symbol>     (every assoc key in the hash),
@@ -244,15 +214,11 @@ module Rigor
         #     :hash_node       => Prism::Node (or nil)
         #   }
         #
-        # Note: a reserved option key (e.g. `count:`) can
-        # also serve as an interpolation value when the
-        # locale's leaf string has `%{count}`. The analyzer
-        # therefore checks the missing-placeholder set
-        # against `all_keys` (so `count:` satisfies a
-        # `%{count}` placeholder) and the
-        # extra-placeholder set against `non_reserved` (so
-        # `default:` / `scope:` are never reported as
-        # extra interpolation arguments).
+        # Note: a reserved option key (e.g. `count:`) can also serve as an interpolation value when the
+        # locale's leaf string has `%{count}`. The analyzer therefore checks the missing-placeholder set
+        # against `all_keys` (so `count:` satisfies a `%{count}` placeholder) and the extra-placeholder set
+        # against `non_reserved` (so `default:` / `scope:` are never reported as extra interpolation
+        # arguments).
         def options_hash(call_node)
           args = call_node.arguments&.arguments || []
           last = args.last
@@ -275,8 +241,8 @@ module Rigor
         end
 
         def collect_assoc_keys(hash_node)
-          # Both `Prism::HashNode` and `Prism::KeywordHashNode`
-          # expose `#elements`, so a single path handles both.
+          # Both `Prism::HashNode` and `Prism::KeywordHashNode` expose `#elements`, so a single path
+          # handles both.
           hash_node.elements.filter_map do |element|
             next nil unless element.is_a?(Prism::AssocNode)
 

--- a/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/locale_index.rb
+++ b/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/locale_index.rb
@@ -3,23 +3,17 @@
 module Rigor
   module Plugin
     class RailsI18n < Rigor::Plugin::Base
-      # Frozen catalogue of every dotted key discovered across
-      # all loaded locale files. Each entry tracks the locales
-      # the key appears in and, for each locale, the set of
-      # `%{var}` interpolation placeholders observed in the
-      # leaf string.
+      # Frozen catalogue of every dotted key discovered across all loaded locale files. Each entry tracks
+      # the locales the key appears in and, for each locale, the set of `%{var}` interpolation placeholders
+      # observed in the leaf string.
       #
-      # The catalogue is intentionally lossy: it only records
-      # the *presence* of each key per locale and the
-      # placeholder names. The actual translated values are
-      # not retained — the analyzer doesn't need them and
-      # keeping them would bloat the cache slice.
+      # The catalogue is intentionally lossy: it only records the *presence* of each key per locale and the
+      # placeholder names. The actual translated values are not retained — the analyzer doesn't need them
+      # and keeping them would bloat the cache slice.
       class LocaleIndex
-        # `placeholders` is a Hash: `locale_name => Set<String>`.
-        # `array_value` is true when at least one locale's leaf
-        # is an Array (used by `l(time, format:)` and similar).
-        # `value_kinds` is a Hash: `locale_name => Symbol`
-        # (`:string` / `:array` / `:hash`).
+        # `placeholders` is a Hash: `locale_name => Set<String>`. `array_value` is true when at least one
+        # locale's leaf is an Array (used by `l(time, format:)` and similar). `value_kinds` is a Hash:
+        # `locale_name => Symbol` (`:string` / `:array` / `:hash`).
         Entry = Data.define(:dotted_key, :placeholders, :value_kinds) do
           def locales
             placeholders.keys
@@ -33,8 +27,7 @@ module Rigor
             placeholders.fetch(locale.to_s) { Set.new }
           end
 
-          # Union of placeholder names across all known
-          # locales — used by the analyzer when no specific
+          # Union of placeholder names across all known locales — used by the analyzer when no specific
           # locale is in scope.
           def all_placeholders
             placeholders.values.reduce(Set.new) { |acc, set| acc | set }
@@ -44,8 +37,7 @@ module Rigor
         attr_reader :entries, :locales
 
         # @param entries [Array<Entry>]
-        # @param locales [Array<String>] all locale names
-        #   that contributed at least one key.
+        # @param locales [Array<String>] all locale names that contributed at least one key.
         def initialize(entries, locales:)
           @entries = entries.freeze
           @locales = locales.dup.freeze
@@ -62,19 +54,15 @@ module Rigor
           @by_key.key?(dotted_key.to_s)
         end
 
-        # CLDR plural form keys recognised by Ruby I18n. When a
-        # locale defines `accounts.posts.one`, `accounts.posts.other`,
-        # the call `t('accounts.posts', count: n)` resolves into
-        # the matching plural sub-key — the parent `accounts.posts`
-        # is a **pluralization namespace**, not a missing key.
-        # Mastodon hits this on `accounts.posts` /
-        # `accounts.following` / `accounts.followers` for the post,
-        # follow, and follower counts shown on the profile page.
+        # CLDR plural form keys recognised by Ruby I18n. When a locale defines `accounts.posts.one`,
+        # `accounts.posts.other`, the call `t('accounts.posts', count: n)` resolves into the matching
+        # plural sub-key — the parent `accounts.posts` is a **pluralization namespace**, not a missing key.
+        # Mastodon hits this on `accounts.posts` / `accounts.following` / `accounts.followers` for the
+        # post, follow, and follower counts shown on the profile page.
         PLURAL_SUBKEYS = %w[zero one two few many other].freeze
 
-        # Returns true when the dotted key itself isn't a leaf in
-        # any locale, but at least one of its CLDR plural form
-        # children exists.
+        # Returns true when the dotted key itself isn't a leaf in any locale, but at least one of its CLDR
+        # plural form children exists.
         def pluralization_namespace?(dotted_key)
           base = dotted_key.to_s
           PLURAL_SUBKEYS.any? { |sub| @by_key.key?("#{base}.#{sub}") }
@@ -88,14 +76,12 @@ module Rigor
           @entries.size
         end
 
-        # All known dotted keys, sorted for stable did-you-mean
-        # output.
+        # All known dotted keys, sorted for stable did-you-mean output.
         def keys
           @by_key.keys.sort
         end
 
-        # Returns the locales (set of strings) in which a key
-        # is *missing*, given the configured locale list.
+        # Returns the locales (set of strings) in which a key is *missing*, given the configured locale list.
         def missing_locales_for(dotted_key, configured_locales:)
           entry = find(dotted_key)
           return configured_locales.to_set if entry.nil?

--- a/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/locale_loader.rb
+++ b/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/locale_loader.rb
@@ -7,27 +7,21 @@ require_relative "locale_index"
 module Rigor
   module Plugin
     class RailsI18n < Rigor::Plugin::Base
-      # Walks `locale_search_paths` for `.yml` / `.yaml`
-      # files, reads each through the trusted IoBoundary,
-      # parses with `YAML.safe_load`, and folds the resulting
-      # nested hash into a flat `dotted_key => Entry` table.
+      # Walks `locale_search_paths` for `.yml` / `.yaml` files, reads each through the trusted IoBoundary,
+      # parses with `YAML.safe_load`, and folds the resulting nested hash into a flat `dotted_key => Entry`
+      # table.
       #
-      # The top-level YAML key is the locale (`en:`, `ja:`,
-      # …). Anything underneath is recursively flattened into
-      # dotted keys (`users.welcome`, `errors.messages.blank`,
-      # …). For each leaf string, `%{var}` placeholders are
-      # extracted via a simple regex.
+      # The top-level YAML key is the locale (`en:`, `ja:`, …). Anything underneath is recursively
+      # flattened into dotted keys (`users.welcome`, `errors.messages.blank`, …). For each leaf string,
+      # `%{var}` placeholders are extracted via a simple regex.
       #
-      # Files that fail to parse are skipped with a load-error
-      # diagnostic surfaced through the plugin's error
-      # channel. Non-Hash YAML roots (e.g. a top-level
-      # sequence) are also skipped — the format is locale-keyed
-      # by convention.
+      # Files that fail to parse are skipped with a load-error diagnostic surfaced through the plugin's
+      # error channel. Non-Hash YAML roots (e.g. a top-level sequence) are also skipped — the format is
+      # locale-keyed by convention.
       class LocaleLoader
         PLACEHOLDER_RE = /%\{(?<name>[^}]+)\}/
 
-        # Errno classes that indicate "this file is not
-        # readable as a YAML locale" — swallowed so a single
+        # Errno classes that indicate "this file is not readable as a YAML locale" — swallowed so a single
         # bad path doesn't take down the rest of the index.
         IO_ERRORS = [Errno::ENOENT, Errno::EACCES, Errno::EISDIR].freeze
 
@@ -100,19 +94,15 @@ module Rigor
           end.sort
         end
 
-        # Recursively walks the per-locale subtree, yielding
-        # `[dotted_key, leaf_value]` for each leaf. Hash leaves are
-        # *not* recorded as entries themselves — only their
-        # descendants — but every leaf scalar / array IS recorded.
+        # Recursively walks the per-locale subtree, yielding `[dotted_key, leaf_value]` for each leaf. Hash
+        # leaves are *not* recorded as entries themselves — only their descendants — but every leaf scalar
+        # / array IS recorded.
         #
-        # `breadcrumbs` is a single mutable stack reused across the
-        # whole walk (push before recursing, pop after): for the
-        # 530-file / 14 MB Mastodon locale corpus the old
-        # `flat_map { flatten_tree(v, breadcrumbs + [k]) }` shape
-        # allocated a fresh breadcrumb Array at every node plus an
-        # intermediate result Array at every level — millions of
-        # short-lived objects and the run's top allocation site. The
-        # dotted key is still materialised once per leaf (it has to
+        # `breadcrumbs` is a single mutable stack reused across the whole walk (push before recursing, pop
+        # after): for the 530-file / 14 MB Mastodon locale corpus the old
+        # `flat_map { flatten_tree(v, breadcrumbs + [k]) }` shape allocated a fresh breadcrumb Array at
+        # every node plus an intermediate result Array at every level — millions of short-lived objects and
+        # the run's top allocation site. The dotted key is still materialised once per leaf (it has to
         # be); everything else is now allocation-free traversal.
         def each_flattened(node, breadcrumbs, &)
           if node.is_a?(Hash)
@@ -129,9 +119,8 @@ module Rigor
         def extract_placeholders(value)
           case value
           when String
-            # Most locale leaves carry no `%{var}`; skip the scan +
-            # flatten + to_set allocation trio for them. A string with
-            # no `%{` yields an empty placeholder set either way.
+            # Most locale leaves carry no `%{var}`; skip the scan + flatten + to_set allocation trio for
+            # them. A string with no `%{` yields an empty placeholder set either way.
             return Set.new unless value.include?("%{")
 
             value.scan(PLACEHOLDER_RE).flatten.to_set

--- a/plugins/rigor-rails-routes/demo/config/routes.rb
+++ b/plugins/rigor-rails-routes/demo/config/routes.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# Sample Rails routes file for the rigor-rails-routes demo.
-# rigor-rails-routes statically interprets this DSL via Prism;
-# nothing here is executed.
+# Sample Rails routes file for the rigor-rails-routes demo. rigor-rails-routes statically interprets this
+# DSL via Prism; nothing here is executed.
 
 Rails.application.routes.draw do
   root to: "home#index"

--- a/plugins/rigor-rails-routes/demo/demo.rb
+++ b/plugins/rigor-rails-routes/demo/demo.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
-# Demo: rigor-rails-routes recognises every helper Rails would
-# generate from `config/routes.rb` (statically — no Rails
-# runtime). Run with `bundle exec rigor check` from this
-# directory.
+# Demo: rigor-rails-routes recognises every helper Rails would generate from `config/routes.rb`
+# (statically — no Rails runtime). Run with `bundle exec rigor check` from this directory.
 
-# Stubs so `ruby demo.rb` doesn't fail at runtime — the
-# plugin reads the call shapes statically and doesn't care
-# about the runtime values.
+# Stubs so `ruby demo.rb` doesn't fail at runtime — the plugin reads the call shapes statically and
+# doesn't care about the runtime values.
 def root_path = "/"
 def users_path = "/users"
 def user_path(_id) = "/users/x"
@@ -21,8 +18,8 @@ def admin_widget_path(_id) = "/admin/widgets/x"
 def about_path = "/about"
 def about_url = "https://example.invalid/about"
 
-# All recognised helpers. Each line surfaces an info diagnostic
-# from rigor-rails-routes naming the HTTP method + path.
+# All recognised helpers. Each line surfaces an info diagnostic from rigor-rails-routes naming the HTTP
+# method + path.
 puts root_path
 puts users_path
 puts user_path(1)

--- a/plugins/rigor-rails-routes/demo/errors_demo.rb
+++ b/plugins/rigor-rails-routes/demo/errors_demo.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# DO NOT run via `ruby errors_demo.rb` — analyse with
-# `bundle exec rigor check` to see rigor-rails-routes'
+# DO NOT run via `ruby errors_demo.rb` — analyse with `bundle exec rigor check` to see rigor-rails-routes'
 # diagnostics.
 
 def widgts_path = "/widgets"

--- a/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes.rb
+++ b/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes.rb
@@ -9,13 +9,12 @@ require_relative "rails_routes/analyzer"
 
 module Rigor
   module Plugin
-    # rigor-rails-routes — validates Rails route-helper calls
-    # (`users_path`, `edit_user_path(@user)`, …) against the
-    # project's `config/routes.rb`.
+    # rigor-rails-routes — validates Rails route-helper calls (`users_path`, `edit_user_path(@user)`, …)
+    # against the project's `config/routes.rb`.
     #
     # Tier 1A of the [Rails plugins roadmap](../../../../docs/design/20260508-rails-plugins-roadmap.md).
-    # Statically interprets the routes DSL via Prism — no
-    # `rails` runtime dependency. Recognised v0.1.0 surface:
+    # Statically interprets the routes DSL via Prism — no `rails` runtime dependency. Recognised v0.1.0
+    # surface:
     #
     # - `Rails.application.routes.draw do ... end`
     # - `resources :name [, only: [...] | except: [...]]`
@@ -25,10 +24,8 @@ module Rigor
     # - One level of `namespace :foo do ... end`
     # - One level of nested `resources`
     #
-    # The plugin publishes its parsed `:helper_table` through
-    # the ADR-9 cross-plugin fact store; `rigor-actionpack`
-    # Phase 4 consumes it for route-helper validation in
-    # controller code.
+    # The plugin publishes its parsed `:helper_table` through the ADR-9 cross-plugin fact store;
+    # `rigor-actionpack` Phase 4 consumes it for route-helper validation in controller code.
     #
     # ## Configuration
     #
@@ -39,66 +36,47 @@ module Rigor
     #
     # ## Limitations (v0.1.0)
     #
-    # - `scope :path:` / `scope :module:` / `scope :as:` are
-    #   not interpreted — helpers nested inside these
+    # - `scope :path:` / `scope :module:` / `scope :as:` are not interpreted — helpers nested inside these
     #   constructs are silently skipped.
-    # - Constraints / format restrictions / mountable
-    #   engines are out of scope.
-    # - The English inflector is intentionally tiny: it
-    #   handles `posts` ↔ `post`, `users` ↔ `user`,
-    #   `categories` ↔ `category`, `boxes` ↔ `box`. Custom
-    #   inflections (`fish` ↔ `fish`, `child` ↔ `children`)
-    #   are out of scope; users who need them ship a hand-
-    #   written RBS for the affected helper.
+    # - Constraints / format restrictions / mountable engines are out of scope.
+    # - The English inflector is intentionally tiny: it handles `posts` ↔ `post`, `users` ↔ `user`,
+    #   `categories` ↔ `category`, `boxes` ↔ `box`. Custom inflections (`fish` ↔ `fish`, `child` ↔
+    #   `children`) are out of scope; users who need them ship a hand-written RBS for the affected helper.
     class RailsRoutes < Rigor::Plugin::Base
       manifest(
         id: "rails-routes",
-        # Bumped 2026-05-28 — GitLab FOSS sweep adds: (a)
-        # `draw_all :name` support (action_dispatch-draw_all
-        # gem; single-file load semantics matching `draw :name`);
-        # (b) keyword-style `scope(path: ':project_id',
-        # as: :project)` — path read from the `:path` keyword,
-        # not only from the positional first arg; (c) detection
-        # of iterative `direct(name.sub(FROM, TO)) do ... end`
-        # alias-generation idiom — generates `<TO>_*` aliases
-        # for every registered `<FROM>_*` helper. GitLab uses
-        # this to shorten `namespace_project_*` → `project_*`.
+        # Bumped 2026-05-28 — GitLab FOSS sweep adds: (a) `draw_all :name` support (action_dispatch-draw_all
+        # gem; single-file load semantics matching `draw :name`); (b) keyword-style `scope(path:
+        # ':project_id', as: :project)` — path read from the `:path` keyword, not only from the positional
+        # first arg; (c) detection of iterative `direct(name.sub(FROM, TO)) do ... end` alias-generation
+        # idiom — generates `<TO>_*` aliases for every registered `<FROM>_*` helper. GitLab uses this to
+        # shorten `namespace_project_*` → `project_*`.
         version: "0.27.0",
         description: "Validates Rails route-helper calls against `config/routes.rb`.",
         config_schema: {
           "routes_file" => { kind: :string, default: "config/routes.rb" },
-          # `helper_paths` — the directories `HelperDiscoverer` walks
-          # for project-defined `*_path` / `*_url` methods. Default to
-          # the whole `app/` tree — the suffix filter inside the
-          # discoverer keeps the registered set tight, and real-world
-          # Rails apps routinely keep URL builders under
-          # `app/controllers` (private `def page_url`, `def callback_url`
-          # shapes), `app/lib` (Mastodon's
-          # `TranslationService::DeepL#base_url`), `app/services`
-          # (`SoftwareUpdateCheckService#api_url`), `app/serializers`,
-          # `app/presenters`, `app/decorators`, not only `app/helpers/`.
-          # Walking the whole tree is the honest answer to "does this
-          # `_path` / `_url` name exist anywhere in the project?"; the
-          # cost is a one-time Prism parse per file at startup, which is
-          # bounded.
+          # `helper_paths` — the directories `HelperDiscoverer` walks for project-defined `*_path` / `*_url`
+          # methods. Default to the whole `app/` tree — the suffix filter inside the discoverer keeps the
+          # registered set tight, and real-world Rails apps routinely keep URL builders under
+          # `app/controllers` (private `def page_url`, `def callback_url` shapes), `app/lib` (Mastodon's
+          # `TranslationService::DeepL#base_url`), `app/services` (`SoftwareUpdateCheckService#api_url`),
+          # `app/serializers`, `app/presenters`, `app/decorators`, not only `app/helpers/`. Walking the
+          # whole tree is the honest answer to "does this `_path` / `_url` name exist anywhere in the
+          # project?"; the cost is a one-time Prism parse per file at startup, which is bounded.
           "helper_paths" => { kind: :array, default: ["app"] }
         },
         produces: [:helper_table]
       )
 
-      # Cached producer — reads `config/routes.rb` through
-      # the trusted `IoBoundary` and parses through
-      # {RoutesParser}. The descriptor's auto-collected
-      # `FileEntry` digest invalidates the cache on routes-
-      # file edits.
+      # Cached producer — reads `config/routes.rb` through the trusted `IoBoundary` and parses through
+      # {RoutesParser}. The descriptor's auto-collected `FileEntry` digest invalidates the cache on
+      # routes-file edits.
       #
-      # Passes a `file_reader` lambda so the parser can follow
-      # `draw(:admin)` → `config/routes/admin.rb` partials.
-      # `watch:` (ADR-60 WD3) covers every `.rb` under `helper_paths:`
-      # so ADDING a helper file invalidates the table — the producer's
-      # own in-block reads (the routes file + the partials it follows
-      # via `draw`) are captured post-compute, but a brand-new helper
-      # file the prior run never read would otherwise read as fresh.
+      # Passes a `file_reader` lambda so the parser can follow `draw(:admin)` → `config/routes/admin.rb`
+      # partials. `watch:` (ADR-60 WD3) covers every `.rb` under `helper_paths:` so ADDING a helper file
+      # invalidates the table — the producer's own in-block reads (the routes file + the partials it
+      # follows via `draw`) are captured post-compute, but a brand-new helper file the prior run never read
+      # would otherwise read as fresh.
       producer :helper_table, watch: -> { @helper_paths.map { |dir| [dir, "**/*.rb"] } } do |_params|
         routes_dir = "#{File.dirname(@routes_file)}/routes"
         file_reader = lambda do |name|
@@ -119,14 +97,11 @@ module Rigor
         @load_error = nil
       end
 
-      # Walks every configured `helper_paths:` directory
-      # through the trusted `IoBoundary` and returns the set
-      # of project-defined `*_path` / `*_url` method names
-      # for {HelperDiscoverer}. Each file digest is captured
-      # by the boundary so editing a helper file invalidates
-      # the `:helper_table` cache automatically. Returns the
-      # empty set when nothing under `helper_paths:` exists —
-      # the routes table still works.
+      # Walks every configured `helper_paths:` directory through the trusted `IoBoundary` and returns the
+      # set of project-defined `*_path` / `*_url` method names for {HelperDiscoverer}. Each file digest is
+      # captured by the boundary so editing a helper file invalidates the `:helper_table` cache
+      # automatically. Returns the empty set when nothing under `helper_paths:` exists — the routes table
+      # still works.
       def discover_custom_helpers
         contents_per_path = {}
         each_helper_file do |path|
@@ -146,8 +121,7 @@ module Rigor
         end
       end
 
-      # Publishes the parsed table to the cross-plugin fact
-      # store; `rigor-actionpack` Phase 4 reads it via
+      # Publishes the parsed table to the cross-plugin fact store; `rigor-actionpack` Phase 4 reads it via
       # `services.fact_store.read`.
       def prepare(services)
         table = helper_table_or_nil
@@ -160,10 +134,9 @@ module Rigor
         )
       end
 
-      # File-level only: the once-per-run load-error emission. Per-call
-      # helper validation runs over the engine-owned walk via the
-      # node_rule below (ADR-37), with the same-file `shadowing` set
-      # built once as the node-rule file context.
+      # File-level only: the once-per-run load-error emission. Per-call helper validation runs over the
+      # engine-owned walk via the node_rule below (ADR-37), with the same-file `shadowing` set built once
+      # as the node-rule file context.
       def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
         table = helper_table_or_nil
         if table.nil? && @load_error
@@ -191,31 +164,23 @@ module Rigor
 
       private
 
-      # The load-error path used to emit the same warning on
-      # every analyzed file in the project. On large monorepos
-      # (Mastodon: 1,302 files; Solidus: ~1,000 files) and on
-      # legacy projects without a top-level `config/routes.rb`,
-      # this multiplied a single root cause into 1,000+
-      # identical diagnostics. The error is project-global —
-      # report it once per run.
+      # The load-error path used to emit the same warning on every analyzed file in the project. On large
+      # monorepos (Mastodon: 1,302 files; Solidus: ~1,000 files) and on legacy projects without a top-level
+      # `config/routes.rb`, this multiplied a single root cause into 1,000+ identical diagnostics. The
+      # error is project-global — report it once per run.
 
       def helper_table_or_nil
-        # Memoise the build *attempt*, not just a truthy result: when the
-        # routes file is missing or unparseable the table is nil, and the
-        # old `return @helper_table if @helper_table` re-ran the whole
-        # read-and-parse on every call. The engine consults this per
-        # route-helper dispatch, so a nil table meant re-reading (and, on
-        # a real project, re-parsing) `config/routes.rb` tens of thousands
-        # of times per run. The result — nil included — is stable for the
-        # run, so one attempt is correct.
+        # Memoise the build *attempt*, not just a truthy result: when the routes file is missing or
+        # unparseable the table is nil, and the old `return @helper_table if @helper_table` re-ran the
+        # whole read-and-parse on every call. The engine consults this per route-helper dispatch, so a nil
+        # table meant re-reading (and, on a real project, re-parsing) `config/routes.rb` tens of thousands
+        # of times per run. The result — nil included — is stable for the run, so one attempt is correct.
         return @helper_table if @helper_table_built
 
         @helper_table_built = true
-        # ADR-60 WD3 record-and-validate: the producer's in-block reads
-        # (the routes file + the partials it follows) are captured into
-        # the dependency descriptor AFTER the block runs, and the
-        # producer's `watch:` covers helper-file additions — so no
-        # priming read is needed here.
+        # ADR-60 WD3 record-and-validate: the producer's in-block reads (the routes file + the partials it
+        # follows) are captured into the dependency descriptor AFTER the block runs, and the producer's
+        # `watch:` covers helper-file additions — so no priming read is needed here.
         @helper_table = cache_for(:helper_table, params: {}).call
       rescue Plugin::AccessDeniedError => e
         @load_error = "rigor-rails-routes: #{e.message}"

--- a/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/analyzer.rb
+++ b/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/analyzer.rb
@@ -6,18 +6,13 @@ require "rigor/source/literals"
 module Rigor
   module Plugin
     class RailsRoutes < Rigor::Plugin::Base
-      # Walks a parsed file's AST looking for `*_path` /
-      # `*_url` calls and validates each against the
-      # plugin's {HelperTable}. Emits info diagnostics for
-      # recognised helpers and error diagnostics for typos /
-      # arity mismatches.
+      # Walks a parsed file's AST looking for `*_path` / `*_url` calls and validates each against the
+      # plugin's {HelperTable}. Emits info diagnostics for recognised helpers and error diagnostics for
+      # typos / arity mismatches.
       module Analyzer
-        # Built-in Rails helpers we don't want to flag as
-        # unknown. The plugin's HelperTable describes
-        # user-declared routes; Rails (and a small set of
-        # widely-used asset gems) ship built-in helpers
-        # (`url_for`, `polymorphic_path`, vite_ruby's
-        # `vite_asset_path`, …) the plugin deliberately ignores.
+        # Built-in Rails helpers we don't want to flag as unknown. The plugin's HelperTable describes
+        # user-declared routes; Rails (and a small set of widely-used asset gems) ship built-in helpers
+        # (`url_for`, `polymorphic_path`, vite_ruby's `vite_asset_path`, …) the plugin deliberately ignores.
         BUILTIN_PASSTHROUGH = %w[
           url_for_path url_for_url
           polymorphic_path polymorphic_url
@@ -32,35 +27,27 @@ module Rigor
           audio_path audio_url
         ].freeze
 
-        # One route-helper observation. Carries no path/location — the
-        # caller (the `node_rule` block) positions it via
-        # `Plugin::Base#diagnostic`.
+        # One route-helper observation. Carries no path/location — the caller (the `node_rule` block)
+        # positions it via `Plugin::Base#diagnostic`.
         Violation = Struct.new(:rule, :severity, :message, keyword_init: true)
 
         module_function
 
-        # RSpec / Minitest DSL methods that DECLARE a memoized
-        # local — `let(:foo) { ... }`, `subject(:foo) { ... }`,
-        # plus the bang and let_it_be variants. The first
-        # positional Symbol argument is the local name. A bare
-        # `subject { ... }` (no arg) defines `:subject` itself.
+        # RSpec / Minitest DSL methods that DECLARE a memoized local — `let(:foo) { ... }`, `subject(:foo)
+        # { ... }`, plus the bang and let_it_be variants. The first positional Symbol argument is the local
+        # name. A bare `subject { ... }` (no arg) defines `:subject` itself.
         SHADOWING_DSL = %i[
           let let! let_it_be let_it_be!
           subject subject!
         ].freeze
 
-        # Paths under which `unknown-helper` is suppressed. Route
-        # helpers are not customarily resolved through these
-        # directories, so a bare `shared_inbox_url` call inside
-        # `app/models/account.rb` (the call-site is the
-        # `accounts.shared_inbox_url` AR column accessor — same
-        # name as a hypothetical route helper) or a `default_url`
-        # inside `lib/paperclip/url_generator_extensions.rb` (the
-        # call-site is `Paperclip::UrlGenerator#default_url`, a
-        # gem-side instance method) would be a false positive.
-        # The core engine's `call.undefined-method` still catches
-        # a genuinely unreachable receiver. Cheap path-prefix
-        # check; no AR-column / gem-include analysis required.
+        # Paths under which `unknown-helper` is suppressed. Route helpers are not customarily resolved
+        # through these directories, so a bare `shared_inbox_url` call inside `app/models/account.rb` (the
+        # call-site is the `accounts.shared_inbox_url` AR column accessor — same name as a hypothetical
+        # route helper) or a `default_url` inside `lib/paperclip/url_generator_extensions.rb` (the
+        # call-site is `Paperclip::UrlGenerator#default_url`, a gem-side instance method) would be a false
+        # positive. The core engine's `call.undefined-method` still catches a genuinely unreachable
+        # receiver. Cheap path-prefix check; no AR-column / gem-include analysis required.
         SKIP_UNKNOWN_HELPER_PATHS = [
           %r{(?:\A|/)app/models/},
           %r{(?:\A|/)app/services/},
@@ -78,12 +65,10 @@ module Rigor
         # @param root [Prism::Node]
         # @param helper_table [HelperTable]
         # @return [Array<Diagnostic>]
-        # The route-helper violations for a single call node (0..2),
-        # or `[]` when the node is not an implicit `*_path` / `*_url`
-        # helper call, is shadowed by a same-file binding, or is in a
-        # suppressed directory. ADR-37: the engine owns the walk; the
-        # same-file `shadowing` set is built once as the node-rule file
-        # context.
+        # The route-helper violations for a single call node (0..2), or `[]` when the node is not an
+        # implicit `*_path` / `*_url` helper call, is shadowed by a same-file binding, or is in a
+        # suppressed directory. ADR-37: the engine owns the walk; the same-file `shadowing` set is built
+        # once as the node-rule file context.
         #
         # @param call_node [Prism::Node]
         # @param helper_table [HelperTable]
@@ -97,9 +82,8 @@ module Rigor
           return [] if BUILTIN_PASSTHROUGH.include?(name)
           return [] if shadowing.include?(name)
 
-          # The SKIP set silences both `unknown-helper` and `wrong-arity`:
-          # a `group_path` inside `app/services/...` is more likely the
-          # file's own method (an `attr_accessor`) than a route helper.
+          # The SKIP set silences both `unknown-helper` and `wrong-arity`: a `group_path` inside
+          # `app/services/...` is more likely the file's own method (an `attr_accessor`) than a route helper.
           suppress_unknown = SKIP_UNKNOWN_HELPER_PATHS.any? { |re| path.match?(re) }
 
           entry = helper_table.find(name)
@@ -111,26 +95,21 @@ module Rigor
             violations << arity if arity
             violations
           elsif helper_table.recognised?(name) || suppress_unknown
-            # Recognised custom / dynamic helper (no arity to check), or
-            # a directory where helpers aren't customarily resolved.
+            # Recognised custom / dynamic helper (no arity to check), or a directory where helpers aren't
+            # customarily resolved.
             []
           else
             [unknown_helper_violation(name, helper_table)]
           end
         end
 
-        # Walks the AST once and returns the Set of names that
-        # shadow a route helper for this file. Includes:
+        # Walks the AST once and returns the Set of names that shadow a route helper for this file. Includes:
         #
-        # - `def name` declarations (any level — the
-        #   per-method-scope visibility model Ruby uses means a
-        #   local `def` shadows the helper at every call site
-        #   reachable from where it is defined; we approximate
-        #   "reachable" with "anywhere in the same file").
-        # - RSpec `let` / `let!` / `let_it_be` / `let_it_be!` /
-        #   `subject` / `subject!` declarations.
-        # - Local assignments at any scope
-        #   (`foo_url = "..."`).
+        # - `def name` declarations (any level — the per-method-scope visibility model Ruby uses means a
+        #   local `def` shadows the helper at every call site reachable from where it is defined; we
+        #   approximate "reachable" with "anywhere in the same file").
+        # - RSpec `let` / `let!` / `let_it_be` / `let_it_be!` / `subject` / `subject!` declarations.
+        # - Local assignments at any scope (`foo_url = "..."`).
         def collect_shadowing_names(root)
           names = Set.new
           Source::NodeWalker.each(root) do |node|
@@ -160,22 +139,17 @@ module Rigor
           end
         end
 
-        # `*_path` / `*_url` calls without an explicit
-        # receiver. Calls like `obj.users_path` or
-        # `Foo::users_path` are NOT route-helper invocations
-        # in Rails — controllers / views call helpers
+        # `*_path` / `*_url` calls without an explicit receiver. Calls like `obj.users_path` or
+        # `Foo::users_path` are NOT route-helper invocations in Rails — controllers / views call helpers
         # implicitly.
         def implicit_helper_call?(node)
           node.receiver.nil? && (node.name.to_s.end_with?("_path") || node.name.to_s.end_with?("_url"))
         end
 
-        # Paths where the implicit-params-fill pattern is
-        # idiomatic — controllers / mailers / views routinely
-        # call `*_path` / `*_url` helpers with fewer args than
-        # the route's static placeholder count because Rails
-        # fills `:foo_id` segments from `request.params` at
-        # runtime (controllers / views) or from the call's
-        # polymorphic-friendly receiver (mailers).
+        # Paths where the implicit-params-fill pattern is idiomatic — controllers / mailers / views
+        # routinely call `*_path` / `*_url` helpers with fewer args than the route's static placeholder
+        # count because Rails fills `:foo_id` segments from `request.params` at runtime (controllers /
+        # views) or from the call's polymorphic-friendly receiver (mailers).
         IMPLICIT_FILL_PATHS = [
           %r{(?:\A|/)app/controllers/},
           %r{(?:\A|/)app/mailers/},
@@ -200,40 +174,29 @@ module Rigor
         def arity_violation(call_node, entry, helper_table, path)
           args = call_node.arguments&.arguments || []
           actual = args.size
-          # Uncountable nouns (`news` / `series` / `media`) cause
-          # Rails to register two entries under the same helper
-          # name — `news_path` accepts both arity 0 (index) and
-          # arity 1 (show). The HelperTable multimap stores both;
-          # accepts_arity? checks the full set.
+          # Uncountable nouns (`news` / `series` / `media`) cause Rails to register two entries under the
+          # same helper name — `news_path` accepts both arity 0 (index) and arity 1 (show). The HelperTable
+          # multimap stores both; accepts_arity? checks the full set.
           return nil if helper_table.accepts_arity?(entry.name, actual)
 
-          # Rails accepts a kwargs-only call shape that supplies
-          # route segments by name:
+          # Rails accepts a kwargs-only call shape that supplies route segments by name:
           #   short_account_status_url(account_username: u, id: i)
-          # for the route `/@:account_username/:id` (arity 2).
-          # Our positional-arg count is 1 (the KeywordHashNode),
-          # so the strict check rejects — but Rails would
-          # resolve every segment from the hash. When the call
-          # has a trailing KeywordHashNode AND the positional
-          # count (excluding it) is `<= expected_arity`, accept
-          # — the kwargs may carry the missing segments.
+          # for the route `/@:account_username/:id` (arity 2). Our positional-arg count is 1 (the
+          # KeywordHashNode), so the strict check rejects — but Rails would resolve every segment from the
+          # hash. When the call has a trailing KeywordHashNode AND the positional count (excluding it) is
+          # `<= expected_arity`, accept — the kwargs may carry the missing segments.
           if args.last.is_a?(Prism::KeywordHashNode)
             positional = actual - 1
             return nil if helper_table.acceptable_arities(entry.name).any? { |exp| positional <= exp }
           end
 
-          # Underflow tolerance for controllers / mailers /
-          # views. A `redirect_to namespace_project_milestones_path`
-          # inside `Projects::MilestonesController` legitimately
-          # passes 0 args — Rails fills the missing `:namespace_id`
-          # / `:project_id` segments from `request.params` at
-          # runtime. Mailers reach helpers polymorphically too
-          # (`project_commit_url(commit)` resolves project from
-          # commit.project). Silence when `actual < min_arity`
-          # AND the call site is in a controller / mailer / view
-          # directory (where the implicit-params-fill pattern is
-          # idiomatic). Overflow (`actual > max_arity`) still
-          # fires — that's almost always a typo.
+          # Underflow tolerance for controllers / mailers / views. A `redirect_to
+          # namespace_project_milestones_path` inside `Projects::MilestonesController` legitimately passes
+          # 0 args — Rails fills the missing `:namespace_id` / `:project_id` segments from `request.params`
+          # at runtime. Mailers reach helpers polymorphically too (`project_commit_url(commit)` resolves
+          # project from commit.project). Silence when `actual < min_arity` AND the call site is in a
+          # controller / mailer / view directory (where the implicit-params-fill pattern is idiomatic).
+          # Overflow (`actual > max_arity`) still fires — that's almost always a typo.
           arities_set = helper_table.acceptable_arities(entry.name)
           min_arity = arities_set.min
           return nil if actual < min_arity && implicit_fill_path?(path)
@@ -248,8 +211,8 @@ module Rigor
         end
 
         def unknown_helper_violation(name, helper_table)
-          # ADR-39 / boilerplate 0c — the shared DidYouMean-backed suggester
-          # replaces the hand-rolled Levenshtein this module used to carry.
+          # ADR-39 / boilerplate 0c — the shared DidYouMean-backed suggester replaces the hand-rolled
+          # Levenshtein this module used to carry.
           suggestion = Rigor::Plugin::Base.suggest(name, helper_table.names)
           message = "no route helper `#{name}`"
           message += " (did you mean `#{suggestion}`?)" if suggestion

--- a/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/devise_routes.rb
+++ b/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/devise_routes.rb
@@ -3,53 +3,35 @@
 module Rigor
   module Plugin
     class RailsRoutes < Rigor::Plugin::Base
-      # Generates the catalogue of route helpers a `devise_for
-      # :resources` call adds to a Rails app's routing table.
-      # The set is fixed and well-documented (the
-      # [Devise wiki](https://github.com/heartcombo/devise/wiki/How-To:-Add-routes-helpers)
-      # enumerates every generated helper); the generator
-      # mirrors it.
+      # Generates the catalogue of route helpers a `devise_for :resources` call adds to a Rails app's
+      # routing table. The set is fixed and well-documented (the
+      # [Devise wiki](https://github.com/heartcombo/devise/wiki/How-To:-Add-routes-helpers) enumerates
+      # every generated helper); the generator mirrors it.
       #
-      # Used by `RoutesParser` when it sees a top-level
-      # `devise_for :name` (or `devise_for :name, skip:
-      # [...]`) call. Each generated helper is materialised as
-      # a `HelperTable::Entry` so the analyzer's
-      # `unknown-helper` rule recognises them and the arity
-      # check accepts the canonical signatures (Devise helpers
-      # take zero positional args plus an optional trailing
-      # options hash, which `HelperTable#accepts_arity?`
-      # already handles via the `arity + 1` rule).
+      # Used by `RoutesParser` when it sees a top-level `devise_for :name` (or `devise_for :name, skip:
+      # [...]`) call. Each generated helper is materialised as a `HelperTable::Entry` so the analyzer's
+      # `unknown-helper` rule recognises them and the arity check accepts the canonical signatures (Devise
+      # helpers take zero positional args plus an optional trailing options hash, which
+      # `HelperTable#accepts_arity?` already handles via the `arity + 1` rule).
       #
       # Scope:
       #
-      # - Recognises the standard six controllers
-      #   (`:sessions`, `:passwords`, `:confirmations`,
-      #   `:unlocks`, `:registrations`, `:omniauth_callbacks`).
-      # - Honours `skip: [...]` to suppress controllers the
-      #   project disables.
-      # - Honours `path: "..."` to remap the URL path (does
-      #   NOT remap the helper-name prefix — Devise uses the
-      #   resource name for the helper, not the path).
-      # - Does NOT yet honour `as: "..."` overrides, `class_name:`,
-      #   `controllers: { ... }` (these are rare; expand on
-      #   demand).
-      # - `omniauth_callbacks` helpers are dynamic — the
-      #   provider name is supplied at call time
-      #   (`user_facebook_omniauth_authorize_path`) and Devise
-      #   declares them from the configured providers, which
-      #   live in an initializer this static parser does not
-      #   read. The suffix patterns are registered in
-      #   `OMNIAUTH_SUFFIXES` and consulted by
-      #   `HelperTable#omniauth_match?`.
+      # - Recognises the standard six controllers (`:sessions`, `:passwords`, `:confirmations`, `:unlocks`,
+      #   `:registrations`, `:omniauth_callbacks`).
+      # - Honours `skip: [...]` to suppress controllers the project disables.
+      # - Honours `path: "..."` to remap the URL path (does NOT remap the helper-name prefix — Devise uses
+      #   the resource name for the helper, not the path).
+      # - Does NOT yet honour `as: "..."` overrides, `class_name:`, `controllers: { ... }` (these are rare;
+      #   expand on demand).
+      # - `omniauth_callbacks` helpers are dynamic — the provider name is supplied at call time
+      #   (`user_facebook_omniauth_authorize_path`) and Devise declares them from the configured providers,
+      #   which live in an initializer this static parser does not read. The suffix patterns are registered
+      #   in `OMNIAUTH_SUFFIXES` and consulted by `HelperTable#omniauth_match?`.
       module DeviseRoutes
-        # The standard Devise controllers and the helper
-        # actions each generates. Keys are the controller
-        # name; values are arrays of `[helper_prefix,
-        # http_method, action]` triples — `helper_prefix` is
-        # the part BEFORE the resource-name segment (Rails
-        # produces `<prefix>_<resource>_<suffix>_path`; for
-        # the bare `<resource>_session_path` shape the prefix
-        # is empty).
+        # The standard Devise controllers and the helper actions each generates. Keys are the controller
+        # name; values are arrays of `[helper_prefix, http_method, action]` triples — `helper_prefix` is
+        # the part BEFORE the resource-name segment (Rails produces `<prefix>_<resource>_<suffix>_path`;
+        # for the bare `<resource>_session_path` shape the prefix is empty).
         CONTROLLER_HELPERS = {
           sessions: [
             ["new", "session", :get, :new],
@@ -77,13 +59,10 @@ module Rigor
           ]
         }.freeze
 
-        # Dynamic-provider helper patterns. `_omniauth_authorize_path`
-        # and `_omniauth_callback_path` are generated per
-        # configured provider (Facebook, GitHub, …) by an
-        # initializer this parser does not read. We treat any
-        # `<resource>_<provider>_omniauth_(authorize|callback)_(path|url)`
-        # call as recognised when the resource is one the
-        # project declared via `devise_for`.
+        # Dynamic-provider helper patterns. `_omniauth_authorize_path` and `_omniauth_callback_path` are
+        # generated per configured provider (Facebook, GitHub, …) by an initializer this parser does not
+        # read. We treat any `<resource>_<provider>_omniauth_(authorize|callback)_(path|url)` call as
+        # recognised when the resource is one the project declared via `devise_for`.
         OMNIAUTH_SUFFIXES = %w[
           _omniauth_authorize_path _omniauth_authorize_url
           _omniauth_callback_path _omniauth_callback_url
@@ -91,16 +70,12 @@ module Rigor
 
         module_function
 
-        # @param resource [String, Symbol] the `devise_for`
-        #   argument — typically `:users`. Used as both the
-        #   helper-name segment (`new_user_session_path`) and
-        #   to derive the resource path.
-        # @param skip [Array<Symbol>] controllers the project
-        #   disables via `devise_for :users, skip: [:registrations]`.
-        # @return [Array<HelperTable::Entry>] one entry per
-        #   generated `_path` helper. The caller is expected to
-        #   pair `_url` variants the same way `RoutesParser` does
-        #   for other entries.
+        # @param resource [String, Symbol] the `devise_for` argument — typically `:users`. Used as both the
+        #   helper-name segment (`new_user_session_path`) and to derive the resource path.
+        # @param skip [Array<Symbol>] controllers the project disables via `devise_for :users, skip:
+        #   [:registrations]`.
+        # @return [Array<HelperTable::Entry>] one entry per generated `_path` helper. The caller is
+        #   expected to pair `_url` variants the same way `RoutesParser` does for other entries.
         def generate(resource:, skip: [])
           resource_segment = singularize(resource.to_s)
           skip_set = skip.to_set(&:to_sym)
@@ -126,21 +101,15 @@ module Rigor
             end
           end
 
-          # Devise also ships *scoped* helpers
-          # (`Devise::Controllers::UrlHelpers`) that DROP the
-          # resource segment and take the scope as a positional
-          # argument: `new_password_path(resource_name)` is the
+          # Devise also ships *scoped* helpers (`Devise::Controllers::UrlHelpers`) that DROP the resource
+          # segment and take the scope as a positional argument: `new_password_path(resource_name)` is the
           # bare form of `new_user_password_path`. Used inside
-          # `Auth::PasswordsController < Devise::PasswordsController`
-          # (Mastodon's idiom). Arity 1 (the scope), and a
-          # trailing options-hash bumps it via the existing
-          # `arity + 1` rule.
+          # `Auth::PasswordsController < Devise::PasswordsController` (Mastodon's idiom). Arity 1 (the
+          # scope), and a trailing options-hash bumps it via the existing `arity + 1` rule.
           entries.concat(scoped_helpers(skip_set))
 
-          # `omniauth_authorize_path(scope, provider)` and
-          # `omniauth_callback_path(scope, provider)` are
-          # `Devise::Controllers::UrlHelpers` scoped helpers
-          # that delegate to the OmniAuth gem. Arity 2.
+          # `omniauth_authorize_path(scope, provider)` and `omniauth_callback_path(scope, provider)` are
+          # `Devise::Controllers::UrlHelpers` scoped helpers that delegate to the OmniAuth gem. Arity 2.
           unless skip_set.include?(:omniauth_callbacks)
             %w[omniauth_authorize_path omniauth_callback_path].each do |name|
               entries << HelperTable::Entry.new(
@@ -156,11 +125,9 @@ module Rigor
           entries
         end
 
-        # Scoped helpers Devise exposes inside its controllers.
-        # The arity-1 family — caller supplies the resource
-        # scope (`:user` etc.) as the first positional arg.
-        # Names mirror the qualified `<scope>_<name>_path`
-        # entries above, minus the scope segment.
+        # Scoped helpers Devise exposes inside its controllers. The arity-1 family — caller supplies the
+        # resource scope (`:user` etc.) as the first positional arg. Names mirror the qualified
+        # `<scope>_<name>_path` entries above, minus the scope segment.
         SCOPED_HELPERS = {
           sessions: %w[new_session_path session_path destroy_session_path],
           passwords: %w[new_password_path edit_password_path password_path],
@@ -186,28 +153,22 @@ module Rigor
           end
         end
 
-        # Returns the set of OmniAuth pattern suffixes the
-        # analyzer accepts for a given resource. The analyzer
-        # consults this set (via `HelperTable#omniauth_match?`)
-        # when a `*_path` / `*_url` call's name does not match
-        # any registered entry and its prefix matches a Devise
-        # resource.
+        # Returns the set of OmniAuth pattern suffixes the analyzer accepts for a given resource. The
+        # analyzer consults this set (via `HelperTable#omniauth_match?`) when a `*_path` / `*_url` call's
+        # name does not match any registered entry and its prefix matches a Devise resource.
         def omniauth_suffixes
           OMNIAUTH_SUFFIXES
         end
 
-        # ADR-39 — delegates to the shared inflector (real
-        # `ActiveSupport::Inflector` when available), replacing the tiny
-        # AS-replica this module used to duplicate from `RoutesParser`.
+        # ADR-39 — delegates to the shared inflector (real `ActiveSupport::Inflector` when available),
+        # replacing the tiny AS-replica this module used to duplicate from `RoutesParser`.
         def singularize(word)
           Rigor::Plugin::Inflector.singularize(word)
         end
 
-        # Approximate path generation. We don't honour the
-        # `path:` Devise option here because the helper NAME
-        # is what the analyzer cares about; the `path` field is
-        # informational and surfaces only in the `:helper` info
-        # diagnostic.
+        # Approximate path generation. We don't honour the `path:` Devise option here because the helper
+        # NAME is what the analyzer cares about; the `path` field is informational and surfaces only in
+        # the `:helper` info diagnostic.
         def devise_path_for(resource_segment, controller, action)
           plural = "#{resource_segment}s"
           base = "/#{plural}"

--- a/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/doorkeeper_routes.rb
+++ b/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/doorkeeper_routes.rb
@@ -3,39 +3,27 @@
 module Rigor
   module Plugin
     class RailsRoutes < Rigor::Plugin::Base
-      # Generates the catalogue of OAuth route helpers a
-      # `use_doorkeeper do ... end` block adds to a Rails app's
-      # routing table. The set is the Doorkeeper gem's
-      # documented default — see Doorkeeper's
-      # [Routing](https://github.com/doorkeeper-gem/doorkeeper/wiki/Customizing-routes)
-      # documentation; this module mirrors the canonical
-      # helper names.
+      # Generates the catalogue of OAuth route helpers a `use_doorkeeper do ... end` block adds to a Rails
+      # app's routing table. The set is the Doorkeeper gem's documented default — see Doorkeeper's
+      # [Routing](https://github.com/doorkeeper-gem/doorkeeper/wiki/Customizing-routes) documentation; this
+      # module mirrors the canonical helper names.
       #
-      # Used by `RoutesParser` when it sees a `use_doorkeeper`
-      # call. Each generated helper is materialised as a
-      # `HelperTable::Entry` so the analyzer's
-      # `unknown-helper` rule recognises them. Arity for the
-      # `oauth_application_path(:id)` / `oauth_authorized_application_path(:id)`
-      # forms is 1 (the `:id`); all other Doorkeeper helpers
-      # are arity 0.
+      # Used by `RoutesParser` when it sees a `use_doorkeeper` call. Each generated helper is materialised
+      # as a `HelperTable::Entry` so the analyzer's `unknown-helper` rule recognises them. Arity for the
+      # `oauth_application_path(:id)` / `oauth_authorized_application_path(:id)` forms is 1 (the `:id`);
+      # all other Doorkeeper helpers are arity 0.
       #
       # Scope:
       #
-      # - Recognises the standard helper set: authorization,
-      #   token, revoke, introspect, token_info, userinfo,
-      #   applications (resources), authorized_applications.
-      # - Honours `skip_controllers <names>` inside the block
-      #   to omit the named controller's helpers.
-      # - Does NOT yet honour `controllers ...:` remappings —
-      #   those change WHICH class serves the route but not
-      #   the helper NAMES, so omitting them is sound.
-      # - Does NOT yet honour custom `as:` / `at:` on
-      #   `use_doorkeeper` itself.
+      # - Recognises the standard helper set: authorization, token, revoke, introspect, token_info,
+      #   userinfo, applications (resources), authorized_applications.
+      # - Honours `skip_controllers <names>` inside the block to omit the named controller's helpers.
+      # - Does NOT yet honour `controllers ...:` remappings — those change WHICH class serves the route but
+      #   not the helper NAMES, so omitting them is sound.
+      # - Does NOT yet honour custom `as:` / `at:` on `use_doorkeeper` itself.
       module DoorkeeperRoutes
-        # Per-controller helper catalogue. Keys are the
-        # `skip_controllers :<key>` names; values are the
-        # entries (name + arity + path + http_method).
-        # Both `_path` and `_url` variants are paired by
+        # Per-controller helper catalogue. Keys are the `skip_controllers :<key>` names; values are the
+        # entries (name + arity + path + http_method). Both `_path` and `_url` variants are paired by
         # `RoutesParser` after registration.
         CONTROLLER_HELPERS = {
           authorizations: [
@@ -78,8 +66,7 @@ module Rigor
 
         module_function
 
-        # @param skip [Array<Symbol>] controller names the
-        #   project omits via `skip_controllers :name, ...`.
+        # @param skip [Array<Symbol>] controller names the project omits via `skip_controllers :name, ...`.
         # @return [Array<HelperTable::Entry>] flattened entries.
         def generate(skip: [])
           skip_set = skip.to_set(&:to_sym)

--- a/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/helper_discoverer.rb
+++ b/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/helper_discoverer.rb
@@ -5,76 +5,54 @@ require "prism"
 module Rigor
   module Plugin
     class RailsRoutes < Rigor::Plugin::Base
-      # Walks `app/helpers/**/*.rb` (or any configured set of
-      # helper directories) and extracts every public
-      # module-level method name so the analyzer's
-      # `unknown-helper` rule does not false-fire on calls to
-      # project-defined `*_path` / `*_url` helpers (the
-      # canonical Rails pattern: a `UrlHelper` module exposing
-      # `full_asset_url`, `host_to_url`, `frontend_asset_url`,
-      # and so on).
+      # Walks `app/helpers/**/*.rb` (or any configured set of helper directories) and extracts every public
+      # module-level method name so the analyzer's `unknown-helper` rule does not false-fire on calls to
+      # project-defined `*_path` / `*_url` helpers (the canonical Rails pattern: a `UrlHelper` module
+      # exposing `full_asset_url`, `host_to_url`, `frontend_asset_url`, and so on).
       #
       # The discoverer is deliberately conservative:
       #
-      # - Walks `def name(...)` declarations at the module /
-      #   class top level. Nested `def` inside a method body or
-      #   a `define_method` macro is NOT extracted (the same
-      #   reason `rigor-actionpack` is not the canonical
-      #   custom-helper source — metaprogrammed helpers are out
-      #   of scope for a static scan).
-      # - **Visibility-agnostic.** A `private` / `protected`
-      #   `def some_url` IS registered. The `unknown-helper`
-      #   rule is a project-wide name-presence check, not a
-      #   visibility check — if the user wrote a `_path` /
-      #   `_url` method anywhere in `app/`, they very likely
-      #   intend to call it (often Mastodon's pattern: a
-      #   controller's `private def page_url(page)` invoked
-      #   by a `link_to` in its own view). The core engine's
-      #   `call.undefined-method` rule still catches the case
-      #   where the receiver genuinely cannot see the method.
-      # - Ignores `def self.x` (singleton-method definitions) —
-      #   Rails helpers are instance methods on the helper
-      #   module; class-side `self.x` shapes are usually
-      #   internal utilities, not view helpers.
-      # - Filters the resulting set to names ending in `_path`
-      #   or `_url` (the dispatch surface the analyzer's rule
-      #   actually cares about). A helper whose name does not
-      #   end with either suffix is irrelevant to the rule's
-      #   false-positive surface, so excluding it costs nothing
-      #   and keeps the registered set focused.
+      # - Walks `def name(...)` declarations at the module / class top level. Nested `def` inside a method
+      #   body or a `define_method` macro is NOT extracted (the same reason `rigor-actionpack` is not the
+      #   canonical custom-helper source — metaprogrammed helpers are out of scope for a static scan).
+      # - **Visibility-agnostic.** A `private` / `protected` `def some_url` IS registered. The
+      #   `unknown-helper` rule is a project-wide name-presence check, not a visibility check — if the user
+      #   wrote a `_path` / `_url` method anywhere in `app/`, they very likely intend to call it (often
+      #   Mastodon's pattern: a controller's `private def page_url(page)` invoked by a `link_to` in its own
+      #   view). The core engine's `call.undefined-method` rule still catches the case where the receiver
+      #   genuinely cannot see the method.
+      # - Ignores `def self.x` (singleton-method definitions) — Rails helpers are instance methods on the
+      #   helper module; class-side `self.x` shapes are usually internal utilities, not view helpers.
+      # - Filters the resulting set to names ending in `_path` or `_url` (the dispatch surface the
+      #   analyzer's rule actually cares about). A helper whose name does not end with either suffix is
+      #   irrelevant to the rule's false-positive surface, so excluding it costs nothing and keeps the
+      #   registered set focused.
       #
       # Out of scope (intentional):
       #
-      # - Helpers defined via `define_method` or via macros like
-      #   `inheritance_traversed_helpers`. These would need
-      #   ADR-16 macro substrate or per-plugin custom recognizers.
-      # - Helpers inherited from gems (`Devise::Controllers::Helpers`,
-      #   `ViteRails::TagHelpers`, etc.). Those need their own
-      #   handling — Devise auto-routes are covered by the
-      #   companion `DeviseRoutes` generator; other gem-injected
-      #   helpers fall to ADR-25 plugin-contributed RBS or the
-      #   ADR-10 `dependencies.source_inference:` path.
+      # - Helpers defined via `define_method` or via macros like `inheritance_traversed_helpers`. These
+      #   would need ADR-16 macro substrate or per-plugin custom recognizers.
+      # - Helpers inherited from gems (`Devise::Controllers::Helpers`, `ViteRails::TagHelpers`, etc.).
+      #   Those need their own handling — Devise auto-routes are covered by the companion `DeviseRoutes`
+      #   generator; other gem-injected helpers fall to ADR-25 plugin-contributed RBS or the ADR-10
+      #   `dependencies.source_inference:` path.
       module HelperDiscoverer
         HELPER_SUFFIXES = [/_path\z/, /_url\z/].freeze
 
         module_function
 
-        # @param contents_per_path [Hash{String => String}]
-        #   file path → source text. The caller is responsible
-        #   for reading files (typically through the trusted
-        #   `IoBoundary` so cache invalidation works).
-        # @return [Set<String>] method names suitable for
-        #   inclusion in the `HelperTable`'s custom-helper set.
+        # @param contents_per_path [Hash{String => String}] file path → source text. The caller is
+        #   responsible for reading files (typically through the trusted `IoBoundary` so cache invalidation
+        #   works).
+        # @return [Set<String>] method names suitable for inclusion in the `HelperTable`'s custom-helper set.
         def discover(contents_per_path)
           names = []
           contents_per_path.each_value do |contents|
             names.concat(extract_from_contents(contents))
           rescue StandardError
-            # Skip any file whose AST walk explodes — discovery
-            # is best-effort and a parse failure in one helper
-            # file MUST NOT abort discovery for the rest. Other
-            # rules will still surface the parse failure on the
-            # affected file through the core pipeline.
+            # Skip any file whose AST walk explodes — discovery is best-effort and a parse failure in one
+            # helper file MUST NOT abort discovery for the rest. Other rules will still surface the parse
+            # failure on the affected file through the core pipeline.
             next
           end
           names.to_set
@@ -89,17 +67,9 @@ module Rigor
           walker.helper_names
         end
 
-        # Per-file AST walker. Tracks the current visibility
-        # mode (`:public` by default; `private` / `protected`
-        # calls flip the bit) so a `def` declared after a bare
-        # `private` is excluded.
-        #
-        # The walker is recursive into module / class bodies so
-        # `module UrlHelpers; module Routing; def foo_url; end;
-        # end; end` registers `foo_url`. It does NOT recurse
-        # into method bodies (a `def inside def` would be
-        # `define_method`-shaped, which we skip per the
-        # docstring).
+        # Per-file AST walker. The walker is recursive into module / class bodies so `module UrlHelpers;
+        # module Routing; def foo_url; end; end; end` registers `foo_url`. It does NOT recurse into method
+        # bodies (a `def inside def` would be `define_method`-shaped, which we skip per the docstring).
         class ModuleBodyWalker
           attr_reader :helper_names
 
@@ -134,11 +104,9 @@ module Rigor
           def visit_statements(body)
             return if body.nil?
 
-            # Visibility tracking is intentionally absent — see
-            # the "visibility-agnostic" point in the module
-            # docstring. A `private def page_url(page)` inside
-            # a controller IS registered so a caller in the
-            # paired view does not false-fire `unknown-helper`.
+            # Visibility tracking is intentionally absent — see the "visibility-agnostic" point in the
+            # module docstring. A `private def page_url(page)` inside a controller IS registered so a
+            # caller in the paired view does not false-fire `unknown-helper`.
             statements_of(body).each do |stmt|
               case stmt
               when Prism::DefNode

--- a/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/helper_table.rb
+++ b/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/helper_table.rb
@@ -6,71 +6,50 @@ require_relative "doorkeeper_routes"
 module Rigor
   module Plugin
     class RailsRoutes < Rigor::Plugin::Base
-      # Frozen catalogue of route helpers parsed from
-      # `config/routes.rb`. Each entry maps a helper name
-      # (`users_path`, `edit_user_path`, …) to the metadata
-      # downstream consumers and the analyzer's per-call
+      # Frozen catalogue of route helpers parsed from `config/routes.rb`. Each entry maps a helper name
+      # (`users_path`, `edit_user_path`, …) to the metadata downstream consumers and the analyzer's per-call
       # validation need:
       #
-      # - `arity`: number of positional arguments the helper
-      #   takes. `users_path` → 0; `user_path(:id)` → 1;
+      # - `arity`: number of positional arguments the helper takes. `users_path` → 0; `user_path(:id)` → 1;
       #   `user_post_path(:user_id, :id)` → 2.
-      # - `path`: the path template Rails generates
-      #   (`/users/:user_id/posts/:id`).
-      # - `http_method`: `:get` / `:post` / `:patch` / `:put` /
-      #   `:delete` for the canonical action; `nil` for
-      #   helpers that span multiple methods (a `resources`
-      #   show helper isn't HTTP-method-specific in the
-      #   helper sense — it's path-sensitive only).
-      # - `action`: `:index` / `:show` / `:new` / `:edit` /
-      #   `:create` / `:update` / `:destroy` for resourceful
-      #   routes; `:custom` for explicit `get`/`post`/etc.;
-      #   `:root` for the root route.
+      # - `path`: the path template Rails generates (`/users/:user_id/posts/:id`).
+      # - `http_method`: `:get` / `:post` / `:patch` / `:put` / `:delete` for the canonical action; `nil`
+      #   for helpers that span multiple methods (a `resources` show helper isn't HTTP-method-specific in
+      #   the helper sense — it's path-sensitive only).
+      # - `action`: `:index` / `:show` / `:new` / `:edit` / `:create` / `:update` / `:destroy` for
+      #   resourceful routes; `:custom` for explicit `get`/`post`/etc.; `:root` for the root route.
       #
-      # Both `_path` and `_url` forms share the same metadata —
-      # the table records each helper twice (once with `_path`,
-      # once with `_url`) for `O(1)` lookup at the call site.
+      # Both `_path` and `_url` forms share the same metadata — the table records each helper twice (once
+      # with `_path`, once with `_url`) for `O(1)` lookup at the call site.
       class HelperTable
         Entry = Data.define(:name, :arity, :path, :http_method, :action)
 
         attr_reader :entries, :custom_helpers, :devise_resources
 
-        # @param entries [Array<Entry>] freshly built; the
-        #   factory below is the canonical construction path.
-        # @param custom_helpers [Enumerable<String>] names of
-        #   project-defined helper methods (typically pulled
-        #   from `app/helpers/**/*.rb` by
-        #   {HelperDiscoverer}) that the analyzer should treat
-        #   as known — they do NOT correspond to a route but
-        #   their presence MUST NOT fire `unknown-helper`. No
-        #   arity / path metadata is recorded; the analyzer
-        #   skips the route-side checks for these names.
-        # @param devise_resources [Enumerable<String>] resource
-        #   names declared via `devise_for :resource` (already
-        #   singularised, e.g. `"user"`). Used to recognise the
-        #   dynamic OmniAuth helper family
-        #   (`<resource>_<provider>_omniauth_(authorize|callback)_(path|url)`)
-        #   whose provider segment is supplied at runtime — no
-        #   per-name entry is registered for them but they MUST
-        #   NOT fire `unknown-helper` either.
+        # @param entries [Array<Entry>] freshly built; the factory below is the canonical construction path.
+        # @param custom_helpers [Enumerable<String>] names of project-defined helper methods (typically
+        #   pulled from `app/helpers/**/*.rb` by {HelperDiscoverer}) that the analyzer should treat as
+        #   known — they do NOT correspond to a route but their presence MUST NOT fire `unknown-helper`. No
+        #   arity / path metadata is recorded; the analyzer skips the route-side checks for these names.
+        # @param devise_resources [Enumerable<String>] resource names declared via `devise_for :resource`
+        #   (already singularised, e.g. `"user"`). Used to recognise the dynamic OmniAuth helper family
+        #   (`<resource>_<provider>_omniauth_(authorize|callback)_(path|url)`) whose provider segment is
+        #   supplied at runtime — no per-name entry is registered for them but they MUST NOT fire
+        #   `unknown-helper` either.
         def initialize(entries, custom_helpers: [], devise_resources: [])
           @entries = entries.freeze
-          # Multimap: a single helper name can map to multiple
-          # entries when an uncountable-noun resource registers
-          # both an arity-0 index helper and an arity-1 show
-          # helper under the same `news_path` name. `find`
-          # returns the first entry (preserving the previous
-          # API); `accepts_arity?` checks against every entry.
+          # Multimap: a single helper name can map to multiple entries when an uncountable-noun resource
+          # registers both an arity-0 index helper and an arity-1 show helper under the same `news_path`
+          # name. `find` returns the first entry (preserving the previous API); `accepts_arity?` checks
+          # against every entry.
           @by_name = entries.group_by(&:name).transform_values(&:freeze).freeze
           @custom_helpers = custom_helpers.to_set.freeze
           @devise_resources = devise_resources.to_set(&:to_s).freeze
           freeze
         end
 
-        # @return [Entry, nil] First matching entry; for the
-        #   uncountable-noun case this is the index helper
-        #   (the show helper is also registered but starts
-        #   second).
+        # @return [Entry, nil] First matching entry; for the uncountable-noun case this is the index helper
+        #   (the show helper is also registered but starts second).
         def find(helper_name)
           @by_name[helper_name.to_s]&.first
         end
@@ -80,14 +59,10 @@ module Rigor
           @by_name.key?(helper_name.to_s)
         end
 
-        # True when `helper_name` is either a registered route
-        # helper, a discovered project-defined custom helper,
-        # OR a dynamic OmniAuth-shaped helper for one of the
-        # declared `devise_for` resources. The
-        # `unknown-helper` rule consults this predicate to
-        # decide whether to fire — `known?` alone misses
-        # custom helpers and OmniAuth providers, which would
-        # then false-fire on canonical Rails-app patterns.
+        # True when `helper_name` is either a registered route helper, a discovered project-defined custom
+        # helper, OR a dynamic OmniAuth-shaped helper for one of the declared `devise_for` resources. The
+        # `unknown-helper` rule consults this predicate to decide whether to fire — `known?` alone misses
+        # custom helpers and OmniAuth providers, which would then false-fire on canonical Rails-app patterns.
         def recognised?(helper_name)
           name = helper_name.to_s
           return true if @by_name.key?(name)
@@ -96,11 +71,9 @@ module Rigor
           omniauth_match?(name)
         end
 
-        # `<resource>_<provider>_omniauth_(authorize|callback)_(path|url)` — when
-        # `<resource>` matches a declared `devise_for` resource
-        # the helper is dynamic-provider Devise OmniAuth. The
-        # provider segment is opaque to a static parser, so we
-        # accept any non-empty token between the resource and
+        # `<resource>_<provider>_omniauth_(authorize|callback)_(path|url)` — when `<resource>` matches a
+        # declared `devise_for` resource the helper is dynamic-provider Devise OmniAuth. The provider
+        # segment is opaque to a static parser, so we accept any non-empty token between the resource and
         # the omniauth suffix.
         def omniauth_match?(name)
           return false if @devise_resources.empty?
@@ -115,19 +88,16 @@ module Rigor
           end
         end
 
-        # @return [Boolean] true when any entry under this
-        #   helper name accepts the given positional arity.
+        # @return [Boolean] true when any entry under this helper name accepts the given positional arity.
         #
-        # Rails helpers have the signature `helper(*segments, options = {})`,
-        # so `expected + 1` is always valid — the extra argument is treated
-        # as a query-params/options hash (e.g. `users_path(page: 2)` or
-        # `user_path(@u, pagination_params(...))`).
+        # Rails helpers have the signature `helper(*segments, options = {})`, so `expected + 1` is always
+        # valid — the extra argument is treated as a query-params/options hash (e.g. `users_path(page: 2)`
+        # or `user_path(@u, pagination_params(...))`).
         def accepts_arity?(helper_name, arity)
           (@by_name[helper_name.to_s] || []).any? { |entry| entry.arity == arity || entry.arity + 1 == arity }
         end
 
-        # @return [Array<Integer>] all accepted positional
-        #   arities for a helper name. Empty when unknown.
+        # @return [Array<Integer>] all accepted positional arities for a helper name. Empty when unknown.
         def acceptable_arities(helper_name)
           (@by_name[helper_name.to_s] || []).map(&:arity).uniq
         end
@@ -146,11 +116,9 @@ module Rigor
         end
 
         def to_h
-          # Plain dump for fact-store publishing (ADR-9). Each
-          # name serialises as a small Hash for the FIRST entry
-          # under that name, with `acceptable_arities` carrying
-          # the full arity set so cross-plugin consumers can
-          # honour the uncountable-noun multi-arity case.
+          # Plain dump for fact-store publishing (ADR-9). Each name serialises as a small Hash for the
+          # FIRST entry under that name, with `acceptable_arities` carrying the full arity set so
+          # cross-plugin consumers can honour the uncountable-noun multi-arity case.
           @by_name.transform_values do |group|
             entry = group.first
             { name: entry.name, arity: entry.arity, path: entry.path,

--- a/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/routes_parser.rb
+++ b/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/routes_parser.rb
@@ -8,27 +8,21 @@ require_relative "helper_table"
 module Rigor
   module Plugin
     class RailsRoutes < Rigor::Plugin::Base
-      # Statically interprets `config/routes.rb`'s DSL via
-      # Prism — never executes the file. The interpreter is
-      # deliberately narrow; it covers the subset documented
-      # in the plugin's README and degrades silently on
-      # constructs it doesn't recognise.
+      # Statically interprets `config/routes.rb`'s DSL via Prism — never executes the file. The interpreter
+      # is deliberately narrow; it covers the subset documented in the plugin's README and degrades
+      # silently on constructs it doesn't recognise.
       #
-      # Recognised DSL surface (per the Rails-plugins
-      # roadmap):
+      # Recognised DSL surface (per the Rails-plugins roadmap):
       #
-      # - `Rails.application.routes.draw do ... end` (entry
-      #   block; the body is interpreted)
+      # - `Rails.application.routes.draw do ... end` (entry block; the body is interpreted)
       # - `resources :name [, only: [...] | except: [...]]`
       # - `resource :name`
       # - `get/post/patch/put/delete "path", to:, as:`
       # - `root to: "..."` / `root "..."`
       # - `scope "path", as: :name do ... end` (with `as:` key)
       # - One level of `namespace :foo do ... end`
-      # - One level of nested `resources` (`resources :users
-      #   do; resources :posts; end`)
-      # - `member do ... end` / `collection do ... end`
-      #   inside `resources`
+      # - One level of nested `resources` (`resources :users do; resources :posts; end`)
+      # - `member do ... end` / `collection do ... end` inside `resources`
       #
       # Out of scope for v0.1.0 (silent skips):
       #
@@ -40,12 +34,10 @@ module Rigor
       module RoutesParser
         # Standard resource actions Rails generates by default.
         DEFAULT_RESOURCE_ACTIONS = %i[index show new create edit update destroy].freeze
-        # Default actions for `resource` (singular) — no index,
-        # no `:id` segment.
+        # Default actions for `resource` (singular) — no index, no `:id` segment.
         DEFAULT_SINGULAR_ACTIONS = %i[show new create edit update destroy].freeze
 
-        # Helper-name conventions per action. `:show` and
-        # `:update` / `:destroy` share the singular-form
+        # Helper-name conventions per action. `:show` and `:update` / `:destroy` share the singular-form
         # helper (Rails dedupes).
         ACTION_HTTP_METHODS = {
           index: :get,
@@ -71,10 +63,8 @@ module Rigor
           context = Context.new(file_reader: file_reader)
           interpret(parse_result.value, context)
 
-          # Apply name-transform alias rules discovered during
-          # the walk (the `direct(name.sub(X, Y)) do |...| send(
-          # "#{name}_url", ...) end` GitLab pattern — see
-          # `collect_alias_rules` below).
+          # Apply name-transform alias rules discovered during the walk (the `direct(name.sub(X, Y)) do
+          # |...| send("#{name}_url", ...) end` GitLab pattern — see `collect_alias_rules` below).
           apply_alias_rules(context)
 
           # Each helper has both `_path` and `_url` forms.
@@ -93,21 +83,15 @@ module Rigor
           HelperTable.new(paired, custom_helpers: custom_helpers, devise_resources: context.devise_resources)
         end
 
-        # For every registered alias rule `(from_str, to_str,
-        # arity_delta)`, find every existing entry whose name
-        # contains `from_str` and register an aliased entry with
-        # `from_str → to_str` substitution. The pattern matches
-        # GitLab's shorthand-helper idiom: a loop over registered
-        # route names that invokes `direct(new_name) do |project,
-        # *args| send("#{name}_url", project&.namespace,
-        # project, *args) end` where `new_name = name.sub(FROM,
-        # TO)`. The direct block extracts the namespace from
-        # `project` and forwards the rest, so the alias's arity
-        # is one LESS than the original helper's
-        # (`namespace_project_blob_path(namespace_id, project_id,
-        # blob_id)` → `project_blob_path(project, blob_id)`).
-        # We register each alias under the original entry's
-        # arity AND `original - 1` to span both interpretations.
+        # For every registered alias rule `(from_str, to_str, arity_delta)`, find every existing entry whose
+        # name contains `from_str` and register an aliased entry with `from_str → to_str` substitution. The
+        # pattern matches GitLab's shorthand-helper idiom: a loop over registered route names that invokes
+        # `direct(new_name) do |project, *args| send("#{name}_url", project&.namespace, project, *args) end`
+        # where `new_name = name.sub(FROM, TO)`. The direct block extracts the namespace from `project` and
+        # forwards the rest, so the alias's arity is one LESS than the original helper's
+        # (`namespace_project_blob_path(namespace_id, project_id, blob_id)` →
+        # `project_blob_path(project, blob_id)`). We register each alias under the original entry's arity
+        # AND `original - 1` to span both interpretations.
         def apply_alias_rules(context)
           return if context.alias_rules.empty?
 
@@ -119,10 +103,8 @@ module Rigor
               new_name = entry.name.sub(from, to)
               next if new_name == entry.name
 
-              # Register at original arity AND at arity-1 so the
-              # common GitLab `|project, *args|` pattern (which
-              # collapses namespace_id + project_id into project)
-              # passes the arity check.
+              # Register at original arity AND at arity-1 so the common GitLab `|project, *args|` pattern
+              # (which collapses namespace_id + project_id into project) passes the arity check.
               [entry.arity, [entry.arity - 1, 0].max].uniq.each do |arity|
                 aliases << HelperTable::Entry.new(
                   name: new_name, arity: arity,
@@ -135,9 +117,8 @@ module Rigor
           context.entries.concat(aliases)
         end
 
-        # Per-parse mutable accumulator. Tracks the current
-        # nesting prefix (namespaces + parent resource) and the
-        # entries collected so far.
+        # Per-parse mutable accumulator. Tracks the current nesting prefix (namespaces + parent resource)
+        # and the entries collected so far.
         class Context
           attr_reader :entries, :file_reader, :devise_resources, :alias_rules
 
@@ -149,22 +130,15 @@ module Rigor
             # - `{ kind: :scope, parent: "user", arity_segments: [":user_id"] }`
             # - `{ kind: :as_scope, name: "event", path: "/:event_slug", arity: 1 }`
             @stack = []
-            # Devise resource segments (singularised) declared
-            # via `devise_for :resource`. Drives the
+            # Devise resource segments (singularised) declared via `devise_for :resource`. Drives the
             # OmniAuth-helper recognition in `HelperTable#omniauth_match?`.
             @devise_resources = []
-            # Registered `concern :name do ... end` blocks.
-            # Keyed by Symbol name; value is the block's body
-            # node. `resources :foo, concerns: :name do ... end`
-            # replays the body at the resource's site.
+            # Registered `concern :name do ... end` blocks. Keyed by Symbol name; value is the block's body
+            # node. `resources :foo, concerns: :name do ... end` replays the body at the resource's site.
             @concerns = {}
-            # `(from_str, to_str)` pairs collected from
-            # iterative `direct(name.sub(FROM, TO)) do ... end`
-            # patterns. Applied after parsing via
-            # `apply_alias_rules` to generate substituted-name
-            # aliases for every matching entry — closes
-            # GitLab's `namespace_project_*` → `project_*`
-            # shorthand idiom.
+            # `(from_str, to_str)` pairs collected from iterative `direct(name.sub(FROM, TO)) do ... end`
+            # patterns. Applied after parsing via `apply_alias_rules` to generate substituted-name aliases
+            # for every matching entry — closes GitLab's `namespace_project_*` → `project_*` shorthand idiom.
             @alias_rules = []
           end
 
@@ -200,17 +174,12 @@ module Rigor
             @stack.pop
           end
 
-          # `resource :foo do ... end` (SINGULAR resource) —
-          # adds the resource name to the helper prefix and
-          # path for nested declarations, but DOESN'T
-          # contribute a dynamic `:id` segment (singular
-          # resources have no `:id`). So `resource :instance
-          # do; resources :domain_blocks; end` generates
-          # `instance_domain_blocks_path` (arity 0), not
-          # `instance_domain_blocks_path(:id)`.
+          # `resource :foo do ... end` (SINGULAR resource) — adds the resource name to the helper prefix
+          # and path for nested declarations, but DOESN'T contribute a dynamic `:id` segment (singular
+          # resources have no `:id`). So `resource :instance do; resources :domain_blocks; end` generates
+          # `instance_domain_blocks_path` (arity 0), not `instance_domain_blocks_path(:id)`.
           #
-          # Helper-prefix segment uses the AS-GIVEN name (no
-          # singularising — `resource :foo` keeps `foo`).
+          # Helper-prefix segment uses the AS-GIVEN name (no singularising — `resource :foo` keeps `foo`).
           def push_singular_resource(parent_name)
             name = parent_name.to_s
             @stack.push(kind: :singular_scope, parent: name, path_segment: "/#{name}")
@@ -219,14 +188,10 @@ module Rigor
             @stack.pop
           end
 
-          # `member do ... end` / `collection do ... end` —
-          # records the mode so subsequent shorthand HTTP-verb
-          # calls (`post :memorialize`) inside the block can
-          # derive their helper name from the enclosing
-          # resource. The frame also carries the immediate
-          # parent's singular / plural names so member /
-          # collection actions can pick the correct form
-          # (`memorialize_account_path(id)` vs
+          # `member do ... end` / `collection do ... end` — records the mode so subsequent shorthand
+          # HTTP-verb calls (`post :memorialize`) inside the block can derive their helper name from the
+          # enclosing resource. The frame also carries the immediate parent's singular / plural names so
+          # member / collection actions can pick the correct form (`memorialize_account_path(id)` vs
           # `memorialize_accounts_path`).
           def push_action_block(mode, parent_singular, parent_plural)
             @stack.push(kind: :"#{mode}_block", parent_singular: parent_singular, parent_plural: parent_plural)
@@ -235,11 +200,9 @@ module Rigor
             @stack.pop
           end
 
-          # `with_options only: [:index], concerns: :batch do
-          # ... end` — every call inside the block inherits
-          # these default options (each call's own options
-          # override the defaults). `effective_options_for`
-          # below merges them in caller-precedence order.
+          # `with_options only: [:index], concerns: :batch do ... end` — every call inside the block
+          # inherits these default options (each call's own options override the defaults).
+          # `effective_options_for` below merges them in caller-precedence order.
           def push_with_options(defaults)
             @stack.push(kind: :with_options, defaults: defaults)
             yield
@@ -247,15 +210,10 @@ module Rigor
             @stack.pop
           end
 
-          # The merged default-options chain from every
-          # enclosing `with_options` frame on the stack
-          # (outer-most first; inner frames take precedence).
-          # `handle_resources` / `handle_resource` merge this
-          # with the node's own option hash so a bare
-          # `resources :links` inside `with_options only:
-          # [:index], concerns: :batch do ... end` is
-          # treated as if it had those options written
-          # inline.
+          # The merged default-options chain from every enclosing `with_options` frame on the stack
+          # (outer-most first; inner frames take precedence). `handle_resources` / `handle_resource` merge
+          # this with the node's own option hash so a bare `resources :links` inside `with_options only:
+          # [:index], concerns: :batch do ... end` is treated as if it had those options written inline.
           def with_options_defaults
             defaults = {}
             @stack.each do |frame|
@@ -266,10 +224,8 @@ module Rigor
             defaults
           end
 
-          # Returns the top-most `:scope` frame's singular /
-          # plural names, or `nil` when not inside a resources
-          # / resource block. Used by `handle_member_or_collection`
-          # to push the action-block frame.
+          # Returns the top-most `:scope` frame's singular / plural names, or `nil` when not inside a
+          # resources / resource block. Used by `handle_member_or_collection` to push the action-block frame.
           def innermost_resource
             scope_frame = @stack.rfind { |f| f[:kind] == :scope }
             return nil if scope_frame.nil?
@@ -277,17 +233,14 @@ module Rigor
             { singular: scope_frame[:parent], plural: scope_frame[:parent_plural] || scope_frame[:parent] }
           end
 
-          # Top-most `:member_block` / `:collection_block`
-          # frame, or nil when not in a shorthand action
-          # context. `handle_explicit_route` uses this to
-          # detect a `post :memorialize` symbol-only call shape.
+          # Top-most `:member_block` / `:collection_block` frame, or nil when not in a shorthand action
+          # context. `handle_explicit_route` uses this to detect a `post :memorialize` symbol-only call shape.
           def innermost_action_block
             @stack.rfind { |f| %i[member_block collection_block].include?(f[:kind]) }
           end
 
-          # `scope "/:slug", as: "foo" do ... end` — adds a
-          # helper-name prefix without the "parent resource" arity
-          # arithmetic that push_resource uses.
+          # `scope "/:slug", as: "foo" do ... end` — adds a helper-name prefix without the "parent
+          # resource" arity arithmetic that push_resource uses.
           def push_as_scope(name, path, arity_count)
             @stack.push(kind: :as_scope, name: name.to_s, path: path, arity: arity_count)
             yield
@@ -295,20 +248,16 @@ module Rigor
             @stack.pop
           end
 
-          # Helper-name prefix from namespaces (`admin_`,
-          # `admin_users_`, …).
+          # Helper-name prefix from namespaces (`admin_`, `admin_users_`, …).
           def helper_prefix
             segments = @stack.filter_map { |frame| frame_helper_segment(frame) }
             segments.map { |segment| "#{segment}_" }.join
           end
 
-          # The chain of resource-singular segments above the
-          # current scope, in order — used to form member-route
-          # helper names of the form `<as>_<singular_chain>_path`.
-          # Includes nested resources (`resources :projects do;
-          # resources :issues do; get 'foo', as: 'bar'; end; end`
-          # → `bar_project_issue_path`). Returns `""` outside any
-          # `:scope` / `:singular_scope` frame.
+          # The chain of resource-singular segments above the current scope, in order — used to form
+          # member-route helper names of the form `<as>_<singular_chain>_path`. Includes nested resources
+          # (`resources :projects do; resources :issues do; get 'foo', as: 'bar'; end; end` →
+          # `bar_project_issue_path`). Returns `""` outside any `:scope` / `:singular_scope` frame.
           def resource_singular_chain
             segments = @stack.filter_map do |frame|
               case frame[:kind]
@@ -319,12 +268,10 @@ module Rigor
             segments.empty? ? "" : "#{segments.join('_')}_"
           end
 
-          # Namespace-only prefix (drops the resource-singular
-          # segments that `helper_prefix` includes). Used so that
-          # an `:as => 'foo'` inside `namespace :admin do
-          # resources :projects do; ...; end; end` generates
-          # `admin_foo_project_path` — namespace first, then
-          # `:as` action prefix, then singular chain.
+          # Namespace-only prefix (drops the resource-singular segments that `helper_prefix` includes).
+          # Used so that an `:as => 'foo'` inside `namespace :admin do resources :projects do; ...; end;
+          # end` generates `admin_foo_project_path` — namespace first, then `:as` action prefix, then
+          # singular chain.
           def namespace_only_prefix
             segments = @stack.filter_map do |frame|
               case frame[:kind]
@@ -335,34 +282,28 @@ module Rigor
             segments.empty? ? "" : "#{segments.join('_')}_"
           end
 
-          # True when we're inside a `resources` or `resource`
-          # scope (the AST has pushed a `:scope` or
-          # `:singular_scope` frame). Drives member-route
-          # helper-name generation in `handle_explicit_route`.
+          # True when we're inside a `resources` or `resource` scope (the AST has pushed a `:scope` or
+          # `:singular_scope` frame). Drives member-route helper-name generation in `handle_explicit_route`.
           def inside_resource_scope?
             @stack.any? { |frame| %i[scope singular_scope].include?(frame[:kind]) }
           end
 
-          # The innermost `:scope` frame (plural resource),
-          # carrying `parent` (singular) and `parent_plural`.
-          # Used by the inline `:on => :collection` / `:on =>
-          # :member` form to derive the helper name.
+          # The innermost `:scope` frame (plural resource), carrying `parent` (singular) and
+          # `parent_plural`. Used by the inline `:on => :collection` / `:on => :member` form to derive the
+          # helper name.
           def innermost_scope_frame
             @stack.rfind { |f| f[:kind] == :scope }
           end
 
-          # Path prefix — including the parent's `:user_id`
-          # segments for nested resources and the namespace
-          # path prefix.
+          # Path prefix — including the parent's `:user_id` segments for nested resources and the
+          # namespace path prefix.
           def path_prefix
             parts = @stack.flat_map { |frame| frame_path_segments(frame) }
             parts.join
           end
 
-          # Number of dynamic segments (`:user_id`-style)
-          # captured by the parent scope chain. Used to
-          # compute helper arity for nested resources.
-          # Each nested-resource `:scope` frame contributes 1;
+          # Number of dynamic segments (`:user_id`-style) captured by the parent scope chain. Used to
+          # compute helper arity for nested resources. Each nested-resource `:scope` frame contributes 1;
           # each `:as_scope` frame contributes its own arity.
           def parent_segment_count
             @stack.sum do |frame|
@@ -381,10 +322,8 @@ module Rigor
             when :namespace then frame[:name]
             when :scope then frame[:parent]
             when :as_scope
-              # An `:as_scope` frame with an empty `:name` is a
-              # path-only frame pushed by `scope(path: 'X')`
-              # without `:as` — contributes path/arity but no
-              # helper-prefix segment.
+              # An `:as_scope` frame with an empty `:name` is a path-only frame pushed by `scope(path: 'X')`
+              # without `:as` — contributes path/arity but no helper-prefix segment.
               frame[:name].to_s.empty? ? nil : frame[:name]
             when :singular_scope then frame[:parent]
             end
@@ -394,12 +333,9 @@ module Rigor
             case frame[:kind]
             when :namespace then ["/#{frame[:name]}"]
             when :scope
-              # Use the as-given plural when available
-              # (`parent_plural` was captured at
-              # push_resource time) — the singularize /
-              # pluralize round-trip is lossy for irregular
-              # forms (`media → medium → medias`) but the
-              # original name is always correct.
+              # Use the as-given plural when available (`parent_plural` was captured at push_resource
+              # time) — the singularize / pluralize round-trip is lossy for irregular forms (`media →
+              # medium → medias`) but the original name is always correct.
               plural = frame[:parent_plural] || pluralize(frame[:parent])
               ["/#{plural}/:#{frame[:parent]}_id"]
             when :as_scope then frame[:path] ? [frame[:path]] : []
@@ -408,18 +344,14 @@ module Rigor
             end
           end
 
-          # ADR-39: inflection delegates to the shared
-          # `Rigor::Plugin::Inflector`, which calls the real
-          # `ActiveSupport::Inflector` (the authority Rails itself uses to
-          # generate helper names) when available, falling back to a
-          # built-in approximation otherwise. This replaces the hand-tuned
-          # AS-replica these methods used to carry — every special case
-          # they accreted (`news` uncountable, `media`→`medium`,
-          # `databases`→`database`, `custom_css` ss-preservation,
-          # `async_refresh`→`async_refreshes`) was reverse-engineered
-          # `ActiveSupport::Inflector` behaviour, so the real inflector
-          # produces the same result for those and the correct one for the
-          # words the replica never covered.
+          # ADR-39: inflection delegates to the shared `Rigor::Plugin::Inflector`, which calls the real
+          # `ActiveSupport::Inflector` (the authority Rails itself uses to generate helper names) when
+          # available, falling back to a built-in approximation otherwise. This replaces the hand-tuned
+          # AS-replica these methods used to carry — every special case they accreted (`news` uncountable,
+          # `media`→`medium`, `databases`→`database`, `custom_css` ss-preservation,
+          # `async_refresh`→`async_refreshes`) was reverse-engineered `ActiveSupport::Inflector` behaviour,
+          # so the real inflector produces the same result for those and the correct one for the words the
+          # replica never covered.
           def singularize(word)
             Rigor::Plugin::Inflector.singularize(word)
           end
@@ -447,21 +379,15 @@ module Rigor
               # `Rails.application.routes.draw do ... end`
               interpret_block_body(node, context)
             else
-              # `draw(:admin)` — routing partial at
-              # config/routes/{name}.rb.
+              # `draw(:admin)` — routing partial at config/routes/{name}.rb.
               load_drawn_routes(node, context)
             end
           when :draw_all
-            # `draw_all :user` — from the
-            # `action_dispatch-draw_all` gem (used by GitLab
-            # FOSS). Same single-file load semantics as `draw`
-            # — the gem just allows multiple route-dir search
-            # paths (we look in the one we know about).
-            # GitLab's `draw_all :user` loads
-            # `config/routes/user.rb` containing `devise_for
-            # :users, controllers: ...` plus the broader user
-            # route catalogue; without this every Devise
-            # session helper reads as `unknown-helper`.
+            # `draw_all :user` — from the `action_dispatch-draw_all` gem (used by GitLab FOSS). Same
+            # single-file load semantics as `draw` — the gem just allows multiple route-dir search paths
+            # (we look in the one we know about). GitLab's `draw_all :user` loads
+            # `config/routes/user.rb` containing `devise_for :users, controllers: ...` plus the broader
+            # user route catalogue; without this every Devise session helper reads as `unknown-helper`.
             load_drawn_routes(node, context)
           when :namespace
             handle_namespace(node, context)
@@ -474,21 +400,15 @@ module Rigor
           when :scope
             handle_scope(node, context)
           when :get, :post, :patch, :put, :delete, :match
-            # `match 'login', :to => 'a#b', :as => :signin, :via => [:get, :post]`
-            # generates the same helper-name shape as `get` /
-            # `post` (first arg = path string, `:as` overrides the
-            # derived helper name). The only difference is the
-            # HTTP-method set (driven by `:via`); the helper-name
-            # generation logic is identical, so reuse the same
-            # handler. Redmine relies heavily on `match` for
-            # multi-method endpoints (`account/lost_password`,
-            # `news/preview`, etc.).
+            # `match 'login', :to => 'a#b', :as => :signin, :via => [:get, :post]` generates the same
+            # helper-name shape as `get` / `post` (first arg = path string, `:as` overrides the derived
+            # helper name). The only difference is the HTTP-method set (driven by `:via`); the helper-name
+            # generation logic is identical, so reuse the same handler. Redmine relies heavily on `match`
+            # for multi-method endpoints (`account/lost_password`, `news/preview`, etc.).
             handle_explicit_route(node, context)
           when :member, :collection
-            # Inside a `resources` block, `member do ... end`
-            # / `collection do ... end` introduces extra
-            # routes. Interpreted only when we have a parent
-            # scope (otherwise the call is meaningless).
+            # Inside a `resources` block, `member do ... end` / `collection do ... end` introduces extra
+            # routes. Interpreted only when we have a parent scope (otherwise the call is meaningless).
             handle_member_or_collection(node, context)
           when :devise_for
             handle_devise_for(node, context)
@@ -501,19 +421,14 @@ module Rigor
           when :concern
             handle_concern_definition(node, context)
           when :direct
-            # `direct(:name) do |args...| ... end` — Rails DSL
-            # for a custom URL helper. We register `name_path`
-            # and (auto-paired) `name_url`. The arity comes
-            # from the block's required-parameter count. Only
-            # literal Symbol/String names are handled here;
-            # non-literal forms are caught by the
+            # `direct(:name) do |args...| ... end` — Rails DSL for a custom URL helper. We register
+            # `name_path` and (auto-paired) `name_url`. The arity comes from the block's required-parameter
+            # count. Only literal Symbol/String names are handled here; non-literal forms are caught by the
             # `detect_alias_rule_in_each` walker upstream.
             handle_direct(node, context)
           when :each
-            # `.each do |name| ... end` — scan the block for
-            # the GitLab `direct(name.sub(X, Y)) do ... end`
-            # alias-generation idiom. If found, record the
-            # (X, Y) pair so `apply_alias_rules` can expand
+            # `.each do |name| ... end` — scan the block for the GitLab `direct(name.sub(X, Y)) do ... end`
+            # alias-generation idiom. If found, record the (X, Y) pair so `apply_alias_rules` can expand
             # every matching registered entry.
             detect_alias_rule_in_each(node, context)
             interpret_block_body(node, context)
@@ -522,11 +437,9 @@ module Rigor
           end
         end
 
-        # `direct(:name) do |arg1, arg2, ...| ... end` — Rails
-        # adds a custom URL helper. We register `name_path`
-        # with the block's required-arg count as the arity (the
-        # auto-pairing in `parse` adds `name_url`). Only handled
-        # for literal Symbol or String first-arg.
+        # `direct(:name) do |arg1, arg2, ...| ... end` — Rails adds a custom URL helper. We register
+        # `name_path` with the block's required-arg count as the arity (the auto-pairing in `parse` adds
+        # `name_url`). Only handled for literal Symbol or String first-arg.
         def handle_direct(node, context)
           name = Rigor::Source::Literals.symbol_or_string_name(node.arguments&.arguments&.first)
           return if name.nil? || name.empty?
@@ -556,13 +469,10 @@ module Rigor
         # Walks a `.each do |loop_var| ... end` body looking for:
         #   - `<new_name_var> = <loop_var>.sub(FROM_STR, TO_STR)`
         #   - `direct(<new_name_var>) do |...| ... end`
-        # When both shapes appear with the same `<new_name_var>`,
-        # registers `(FROM_STR, TO_STR)` as an alias rule. The
-        # iterated collection (`Rails.application.routes.set`)
-        # is assumed to yield the names of already-registered
-        # helpers — GitLab's idiom. Other iterations that happen
-        # to match the shape are rare; the FP risk is bounded
-        # because alias generation only adds entries.
+        # When both shapes appear with the same `<new_name_var>`, registers `(FROM_STR, TO_STR)` as an
+        # alias rule. The iterated collection (`Rails.application.routes.set`) is assumed to yield the
+        # names of already-registered helpers — GitLab's idiom. Other iterations that happen to match the
+        # shape are rare; the FP risk is bounded because alias generation only adds entries.
         def detect_alias_rule_in_each(each_node, context)
           block = each_node.block
           return unless block.is_a?(Prism::BlockNode)
@@ -573,8 +483,7 @@ module Rigor
           body = block.body
           return if body.nil?
 
-          # First pass: gather every `<var> = <loop_var>.sub(FROM, TO)`
-          # assignment.
+          # First pass: gather every `<var> = <loop_var>.sub(FROM, TO)` assignment.
           sub_assignments = {}
           walk_for_alias_pattern(body) do |node|
             next unless node.is_a?(Prism::LocalVariableWriteNode)
@@ -596,9 +505,8 @@ module Rigor
 
           return if sub_assignments.empty?
 
-          # Second pass: find `direct(<var>) do ... end` calls
-          # whose first arg is one of the captured assignment
-          # variables.
+          # Second pass: find `direct(<var>) do ... end` calls whose first arg is one of the captured
+          # assignment variables.
           walk_for_alias_pattern(body) do |node|
             next unless node.is_a?(Prism::CallNode) && node.name == :direct
             next if node.arguments.nil?
@@ -644,14 +552,11 @@ module Rigor
           context.push_namespace(name) { interpret_block_body(node, context) }
         end
 
-        # `devise_for :users [, skip: [...], path: "..."]` —
-        # generates the standard Devise route-helper catalogue
-        # for the named resource. Symbol-literal first arg
-        # only; non-literal forms (e.g. dynamic resource names
-        # built from constants) are silently skipped because the
-        # helper SET depends on the literal name and we cannot
-        # statically resolve a variable here. `skip:` is read
-        # so the project's omitted controllers do not register.
+        # `devise_for :users [, skip: [...], path: "..."]` — generates the standard Devise route-helper
+        # catalogue for the named resource. Symbol-literal first arg only; non-literal forms (e.g. dynamic
+        # resource names built from constants) are silently skipped because the helper SET depends on the
+        # literal name and we cannot statically resolve a variable here. `skip:` is read so the project's
+        # omitted controllers do not register.
         def handle_devise_for(node, context)
           resource = symbol_argument(node, 0)
           return if resource.nil?
@@ -664,18 +569,13 @@ module Rigor
           end
         end
 
-        # `with_options X do ... end` — applies the `X`
-        # options hash as defaults for every call inside the
-        # block. Mastodon's `with_options only: [:index],
-        # concerns: :batch do resources :links; resources
-        # :tags; end` lets us register the inner resources
-        # with the implicit defaults — closing `batch_*_path`
-        # cluster generated via the `:batch` concern.
+        # `with_options X do ... end` — applies the `X` options hash as defaults for every call inside the
+        # block. Mastodon's `with_options only: [:index], concerns: :batch do resources :links; resources
+        # :tags; end` lets us register the inner resources with the implicit defaults — closing
+        # `batch_*_path` cluster generated via the `:batch` concern.
         #
-        # We push a `:with_options` frame carrying the
-        # defaults; `effective_options_for(node)` (in
-        # `handle_resources` / `handle_resource`) merges them
-        # in before reading specific option keys.
+        # We push a `:with_options` frame carrying the defaults; `effective_options_for(node)` (in
+        # `handle_resources` / `handle_resource`) merges them in before reading specific option keys.
         def handle_with_options(node, context)
           defaults = options_hash(node)
           context.push_with_options(defaults) do
@@ -683,18 +583,13 @@ module Rigor
           end
         end
 
-        # `mount Foo::Engine, at: '/path', as: :name` —
-        # mounted Rails engines. The mount adds a single
-        # helper for the mount point itself: `<as>_path` /
-        # `<as>_url` (arity 0). The engine's own internal
-        # helpers are out of scope (they'd need the engine's
-        # routes.rb available; almost no static parser
-        # follows that). Mastodon uses `mount Sidekiq::Web,
-        # at: 'sidekiq', as: :sidekiq` and similar.
+        # `mount Foo::Engine, at: '/path', as: :name` — mounted Rails engines. The mount adds a single
+        # helper for the mount point itself: `<as>_path` / `<as>_url` (arity 0). The engine's own internal
+        # helpers are out of scope (they'd need the engine's routes.rb available; almost no static parser
+        # follows that). Mastodon uses `mount Sidekiq::Web, at: 'sidekiq', as: :sidekiq` and similar.
         #
-        # When `as:` is omitted Rails derives a helper name
-        # from the engine class — that's harder to compute
-        # statically, so we silently skip.
+        # When `as:` is omitted Rails derives a helper name from the engine class — that's harder to
+        # compute statically, so we silently skip.
         def handle_mount(node, context)
           options = options_hash(node)
           as_name = options[:as]
@@ -710,15 +605,11 @@ module Rigor
           )
         end
 
-        # `use_doorkeeper do ... end` — Doorkeeper gem's
-        # standard OAuth route helpers (`oauth_token_path`,
-        # `oauth_authorization_path`, `oauth_application_path`,
-        # etc.). We generate the full catalogue plus walk the
-        # block body for `skip_controllers <names>` calls so
-        # the project's omitted controllers don't register.
-        # `controllers <hash>` mappings inside the block change
-        # the serving controller class but not the helper
-        # names — they can stay unmodelled.
+        # `use_doorkeeper do ... end` — Doorkeeper gem's standard OAuth route helpers (`oauth_token_path`,
+        # `oauth_authorization_path`, `oauth_application_path`, etc.). We generate the full catalogue plus
+        # walk the block body for `skip_controllers <names>` calls so the project's omitted controllers
+        # don't register. `controllers <hash>` mappings inside the block change the serving controller
+        # class but not the helper names — they can stay unmodelled.
         def handle_use_doorkeeper(node, context)
           skip = collect_doorkeeper_skips(node)
           DoorkeeperRoutes.generate(skip: skip).each do |entry|
@@ -750,37 +641,27 @@ module Rigor
 
         # `scope "/:slug", as: "event" do ... end`
         #
-        # When `as:` is present the block body is interpreted under a
-        # new `:as_scope` stack frame that adds the given prefix to
-        # every helper registered inside.  Dynamic path segments
-        # (`:slug`) are counted so nested-resource arities stay
-        # correct.
+        # When `as:` is present the block body is interpreted under a new `:as_scope` stack frame that
+        # adds the given prefix to every helper registered inside. Dynamic path segments (`:slug`) are
+        # counted so nested-resource arities stay correct.
         #
-        # When `as:` is absent the block is interpreted without any
-        # prefix change — helper names are unaffected by the scope's
-        # path, which matches Rails' behaviour for path-only scopes.
+        # When `as:` is absent the block is interpreted without any prefix change — helper names are
+        # unaffected by the scope's path, which matches Rails' behaviour for path-only scopes.
         def handle_scope(node, context)
           as_name = keyword_symbol(node, :as)
-          # `scope :path_arg, as: :name` (path as a positional
-          # arg) vs `scope(path: ':project_id', as: :project)`
-          # (path as a `:path` keyword). GitLab's project routes
-          # rely on the latter for the `*namespace_id` /
-          # `:project_id` outer scopes. The leading `/` is added
-          # if missing so the path-prefix join produces clean
-          # segments.
+          # `scope :path_arg, as: :name` (path as a positional arg) vs `scope(path: ':project_id', as:
+          # :project)` (path as a `:path` keyword). GitLab's project routes rely on the latter for the
+          # `*namespace_id` / `:project_id` outer scopes. The leading `/` is added if missing so the
+          # path-prefix join produces clean segments.
           path = string_argument(node, 0) || keyword_value_string(node, :path)
           path = "/#{path}" if path && !path.start_with?("/")
           arity = path ? count_path_placeholders(path) : 0
 
           if as_name.nil?
-            # Even without `:as`, a `scope(path: 'groups/*id')`
-            # still contributes its path / arity segments to
-            # helpers declared inside (GitLab's
-            # `scope(path: 'groups/*id', controller: :groups)
-            # do; get :edit, as: :edit_group end` → arity 1).
-            # Skip the frame when there's also no path
-            # contribution (a pure `scope(module: :foo)` with
-            # no helper-name / path effect).
+            # Even without `:as`, a `scope(path: 'groups/*id')` still contributes its path / arity segments
+            # to helpers declared inside (GitLab's `scope(path: 'groups/*id', controller: :groups) do; get
+            # :edit, as: :edit_group end` → arity 1). Skip the frame when there's also no path contribution
+            # (a pure `scope(module: :foo)` with no helper-name / path effect).
             return interpret_block_body(node, context) if path.nil? || arity.zero?
 
             context.push_as_scope("", path, arity) do
@@ -801,13 +682,10 @@ module Rigor
           options = effective_options_for(node, context)
           actions = restrict_actions_from(options, DEFAULT_RESOURCE_ACTIONS)
           base_arity = context.parent_segment_count
-          # `resources :collections, as: :actor_collections`
-          # remaps the helper name family —
-          # `actor_collections_path` for index,
-          # `actor_collection_path(id)` for show. Path / arity
-          # are unaffected. Mastodon uses this inside a
-          # concern (`resources :collections, only: [:show],
-          # as: :actor_collections`).
+          # `resources :collections, as: :actor_collections` remaps the helper name family —
+          # `actor_collections_path` for index, `actor_collection_path(id)` for show. Path / arity are
+          # unaffected. Mastodon uses this inside a concern (`resources :collections, only: [:show], as:
+          # :actor_collections`).
           helper_name = options[:as] || name
 
           register_resourceful_helpers(helper_name, actions, base_arity, context, plural: true)
@@ -827,30 +705,23 @@ module Rigor
           base_arity = context.parent_segment_count
           helper_name = options[:as] || name
 
-          # Singular resource — no `:id` segment, no `:index`
-          # / pluralised helper. The "show" helper is
+          # Singular resource — no `:id` segment, no `:index` / pluralised helper. The "show" helper is
           # `<name>_path` (singular).
           register_resourceful_helpers(helper_name, actions, base_arity, context, plural: false)
 
-          # Push a `:singular_scope` frame so nested
-          # declarations pick up the singular resource's
-          # name in their helper prefix (Mastodon's
-          # `resource :instance do; scope module: :instances
-          # do; resources :domain_blocks; end; end` →
-          # `instance_domain_blocks_path`). The singular
-          # frame adds NO `:id` segment to arity — singular
-          # resources don't carry one.
+          # Push a `:singular_scope` frame so nested declarations pick up the singular resource's name in
+          # their helper prefix (Mastodon's `resource :instance do; scope module: :instances do; resources
+          # :domain_blocks; end; end` → `instance_domain_blocks_path`). The singular frame adds NO `:id`
+          # segment to arity — singular resources don't carry one.
           context.push_singular_resource(name) do
             replay_concerns(node, context)
             interpret_block_body(node, context)
           end
         end
 
-        # `concern :account_resources do ... end` registers the
-        # body for later replay; we DO NOT interpret it at the
-        # definition site (the body has no parent-resource
-        # context yet). Concerns at the top level land in the
-        # Context's `concerns` map by Symbol name.
+        # `concern :account_resources do ... end` registers the body for later replay; we DO NOT interpret
+        # it at the definition site (the body has no parent-resource context yet). Concerns at the top
+        # level land in the Context's `concerns` map by Symbol name.
         def handle_concern_definition(node, context)
           name = symbol_argument(node, 0)
           body = node.block&.body
@@ -859,12 +730,9 @@ module Rigor
           context.register_concern(name, body)
         end
 
-        # `resources :accounts, concerns: :account_resources do ... end`
-        # — replays the registered concern body inside the
-        # current Context (which already has the accounts
-        # resource frame pushed). Supports both single-symbol
-        # (`concerns: :name`) and array-of-symbols
-        # (`concerns: [:a, :b]`) forms.
+        # `resources :accounts, concerns: :account_resources do ... end` — replays the registered concern
+        # body inside the current Context (which already has the accounts resource frame pushed). Supports
+        # both single-symbol (`concerns: :name`) and array-of-symbols (`concerns: [:a, :b]`) forms.
         def replay_concerns(resource_node, context)
           replay_concerns_from_options(effective_options_for(resource_node, context), context)
         end
@@ -881,33 +749,25 @@ module Rigor
           end
         end
 
-        # Returns the merged option hash for a node — the
-        # caller's own options override `with_options`
-        # defaults from the surrounding Context stack. Used by
-        # `handle_resources` / `handle_resource` so a bare
-        # `resources :foo` inside `with_options only: [:index],
-        # concerns: :batch do ... end` is treated as if it
-        # had those options written inline.
+        # Returns the merged option hash for a node — the caller's own options override `with_options`
+        # defaults from the surrounding Context stack. Used by `handle_resources` / `handle_resource` so a
+        # bare `resources :foo` inside `with_options only: [:index], concerns: :batch do ... end` is
+        # treated as if it had those options written inline.
         def effective_options_for(node, context)
           context.with_options_defaults.merge(options_hash(node))
         end
 
-        # Reads the value of an options-hash key. Distinct from
-        # `keyword_symbol` / `keyword_array` because `concerns:`
-        # accepts EITHER a single Symbol or an Array of Symbols
-        # — same Rails idiom Rails accepts.
+        # Reads the value of an options-hash key. Distinct from `keyword_symbol` / `keyword_array` because
+        # `concerns:` accepts EITHER a single Symbol or an Array of Symbols — same Rails idiom Rails accepts.
         def keyword_value(node, key)
           options_hash(node)[key]
         end
 
         def handle_root(node, context)
-          # `root to: "..."` / `root "..."` — single helper
-          # `root_path`, arity 0, GET. Real-world Rails apps also
-          # use `root :to => 'welcome#index', :as => 'home'` (the
-          # canonical Redmine idiom across 230+ call sites), which
-          # registers an additional `home_path` / `home_url` alias
-          # for the same path. Mastodon and Solidus also use the
-          # `as:` form occasionally for analytics-friendly URL
+          # `root to: "..."` / `root "..."` — single helper `root_path`, arity 0, GET. Real-world Rails
+          # apps also use `root :to => 'welcome#index', :as => 'home'` (the canonical Redmine idiom across
+          # 230+ call sites), which registers an additional `home_path` / `home_url` alias for the same
+          # path. Mastodon and Solidus also use the `as:` form occasionally for analytics-friendly URL
           # naming.
           path = context.path_prefix.empty? ? "/" : context.path_prefix
           context.entries << HelperTable::Entry.new(
@@ -925,23 +785,17 @@ module Rigor
         end
 
         def handle_explicit_route(node, context)
-          # Member / collection block shorthand: `post :memorialize`
-          # inside `member do ... end` (no path arg, just a
-          # SymbolNode). Rails generates a helper based on the
-          # action name + the enclosing resource: a member
-          # action becomes `<action>_<singular_chain>_path(id)`,
-          # a collection action becomes
-          # `<action>_<plural_chain>_path`.
+          # Member / collection block shorthand: `post :memorialize` inside `member do ... end` (no path
+          # arg, just a SymbolNode). Rails generates a helper based on the action name + the enclosing
+          # resource: a member action becomes `<action>_<singular_chain>_path(id)`, a collection action
+          # becomes `<action>_<plural_chain>_path`.
           return register_member_collection_action(node, context) if member_collection_shorthand?(node, context)
 
-          # `:on => :collection` / `:on => :member` inline form
-          # — Rails accepts this as a shorthand for `collection
-          # do ... end` / `member do ... end` wrappers around a
-          # single action. `get 'report', :on => :collection`
-          # inside `resources :time_entries` generates
-          # `report_time_entries_path` (collection-style: action
-          # prefix on the plural resource name). Treat the action
-          # name as the path's basename string (Redmine's idiom).
+          # `:on => :collection` / `:on => :member` inline form — Rails accepts this as a shorthand for
+          # `collection do ... end` / `member do ... end` wrappers around a single action. `get 'report',
+          # :on => :collection` inside `resources :time_entries` generates `report_time_entries_path`
+          # (collection-style: action prefix on the plural resource name). Treat the action name as the
+          # path's basename string (Redmine's idiom).
           on_target = keyword_symbol(node, :on)
           if on_target && context.inside_resource_scope?
             path_arg = string_argument(node, 0) || symbol_argument(node, 0)&.to_s
@@ -949,36 +803,27 @@ module Rigor
             return register_on_target_action(node, context, as_name, on_target) if as_name
           end
 
-          # `get "/about", to: "static#about", as: :about` —
-          # path as the first positional arg. Also handle the
-          # hashrocket-key form `get 'help/*path' => 'help#show',
-          # as: :help_page` where the path is the String key in
-          # the trailing keyword/options hash (its value is the
-          # `controller#action`). Without this, the arity check
-          # underestimates because the placeholder count comes
-          # from a nil path.
+          # `get "/about", to: "static#about", as: :about` — path as the first positional arg. Also handle
+          # the hashrocket-key form `get 'help/*path' => 'help#show', as: :help_page` where the path is the
+          # String key in the trailing keyword/options hash (its value is the `controller#action`). Without
+          # this, the arity check underestimates because the placeholder count comes from a nil path.
           path = string_argument(node, 0) || hashrocket_path_key(node)
           as_name = keyword_symbol(node, :as)
           return if as_name.nil? && path.nil?
 
-          # When `as:` is omitted, Rails derives a helper name
-          # from the path for static paths (no :segment). We
-          # do the same when the path has no placeholders. The
-          # special case `get '/'` inside a `:as_scope` (e.g.
-          # `scope path: '/blob/*id', as: :blob do; get '/' end`)
-          # has empty path content after stripping the leading
-          # slash — Rails reuses the enclosing as_scope's name.
-          # We surface that by registering the helper with an
-          # empty `as_name`, which `explicit_route_helper_name`
-          # then composes from `helper_prefix.chomp("_")`.
+          # When `as:` is omitted, Rails derives a helper name from the path for static paths (no
+          # :segment). We do the same when the path has no placeholders. The special case `get '/'` inside
+          # a `:as_scope` (e.g. `scope path: '/blob/*id', as: :blob do; get '/' end`) has empty path
+          # content after stripping the leading slash — Rails reuses the enclosing as_scope's name. We
+          # surface that by registering the helper with an empty `as_name`, which
+          # `explicit_route_helper_name` then composes from `helper_prefix.chomp("_")`.
           if as_name.nil?
             return if path.nil? || path.include?(":")
 
             as_name = path.delete_prefix("/").tr("/", "_")
             if as_name.empty? && context.helper_prefix.empty?
-              # `get '/'` style — only meaningful when the
-              # helper_prefix is non-empty (otherwise Rails would
-              # generate a root helper, handled elsewhere).
+              # `get '/'` style — only meaningful when the helper_prefix is non-empty (otherwise Rails
+              # would generate a root helper, handled elsewhere).
               return
             end
           end
@@ -987,11 +832,9 @@ module Rigor
           total_placeholders = count_path_placeholders(path)
           optional = count_optional_path_placeholders(path)
           base_arity = context.parent_segment_count + total_placeholders
-          # Register the maximum-arity entry; if the path
-          # carries `(...)` optional segments (e.g.
-          # `'settings(/:tab)'`), register additional entries
-          # for each smaller arity so the call-site arity check
-          # accepts `settings_project_path(:id)` (no `:tab`).
+          # Register the maximum-arity entry; if the path carries `(...)` optional segments (e.g.
+          # `'settings(/:tab)'`), register additional entries for each smaller arity so the call-site
+          # arity check accepts `settings_project_path(:id)` (no `:tab`).
           (0..optional).each do |drop|
             context.entries << HelperTable::Entry.new(
               name: name, arity: base_arity - drop,
@@ -1001,28 +844,21 @@ module Rigor
           end
         end
 
-        # Builds the helper name for an explicit `get` / `post`
-        # / `match` route. Rails uses two distinct shapes:
+        # Builds the helper name for an explicit `get` / `post` / `match` route. Rails uses two distinct
+        # shapes:
         #
-        # - **Outside a `resources` scope** (top-level or inside
-        #   `namespace` / `scope`): `<namespace_prefix><as>_path`
-        #   — e.g. `match 'login', as: :signin` →
-        #   `signin_path`; inside `namespace :admin` →
-        #   `admin_signin_path`.
-        # - **Inside a `resources` scope**: the `:as` acts as
-        #   the ACTION prefix on the resource's singular chain.
-        #   `resources :projects do; get 'settings', as:
-        #   :settings; end` → `settings_project_path(:id)` (NOT
-        #   `project_settings_path`). The namespace prefix still
-        #   leads: `namespace :admin do; resources :projects do;
-        #   get 'foo', as: :bar; end; end` →
+        # - **Outside a `resources` scope** (top-level or inside `namespace` / `scope`):
+        #   `<namespace_prefix><as>_path` — e.g. `match 'login', as: :signin` → `signin_path`; inside
+        #   `namespace :admin` → `admin_signin_path`.
+        # - **Inside a `resources` scope**: the `:as` acts as the ACTION prefix on the resource's singular
+        #   chain. `resources :projects do; get 'settings', as: :settings; end` →
+        #   `settings_project_path(:id)` (NOT `project_settings_path`). The namespace prefix still leads:
+        #   `namespace :admin do; resources :projects do; get 'foo', as: :bar; end; end` →
         #   `admin_bar_project_path(:id)`.
         def explicit_route_helper_name(context, as_name)
-          # Empty `as_name` is the `get '/'`-inside-an-as_scope
-          # case (e.g. `scope path: '/blob/*id', as: :blob do;
-          # get '/' end` → `blob_path(:id)`). Use the
-          # helper_prefix as-is (drop the trailing underscore)
-          # — Rails reuses the enclosing scope's name verbatim.
+          # Empty `as_name` is the `get '/'`-inside-an-as_scope case (e.g. `scope path: '/blob/*id', as:
+          # :blob do; get '/' end` → `blob_path(:id)`). Use the helper_prefix as-is (drop the trailing
+          # underscore) — Rails reuses the enclosing scope's name verbatim.
           return "#{context.helper_prefix.chomp('_')}_path" if as_name.to_s.empty?
 
           if context.inside_resource_scope?
@@ -1032,25 +868,20 @@ module Rigor
           end
         end
 
-        # True when the call is `<verb> :symbol [, options...]`
-        # or `<verb> 'string'` inside one of:
-        # - a `member do ... end` / `collection do ... end`
-        #   block (canonical shorthand context), or
-        # - a `resources :name do ... end` / `resource :name
-        #   do ... end` block at the *direct* nesting level.
-        #   Rails defaults a bare symbol- or string-named verb
-        #   inside resources to a member action (GitLab's
-        #   `resource :application_settings do; match :general,
-        #   via: [...] end` → `general_application_settings_path`).
+        # True when the call is `<verb> :symbol [, options...]` or `<verb> 'string'` inside one of:
+        # - a `member do ... end` / `collection do ... end` block (canonical shorthand context), or
+        # - a `resources :name do ... end` / `resource :name do ... end` block at the *direct* nesting
+        #   level. Rails defaults a bare symbol- or string-named verb inside resources to a member action
+        #   (GitLab's `resource :application_settings do; match :general, via: [...] end` →
+        #   `general_application_settings_path`).
         def member_collection_shorthand?(node, context)
           return false unless context.innermost_action_block || context.inside_resource_scope?
 
           first_arg = node.arguments&.arguments&.first
           return true if first_arg.is_a?(Prism::SymbolNode)
 
-          # A plain action-name string with no `/` or `:` —
-          # treat it as if it were a symbol (`get 'report'` ==
-          # `get :report` inside member/collection block).
+          # A plain action-name string with no `/` or `:` — treat it as if it were a symbol (`get 'report'`
+          # == `get :report` inside member/collection block).
           first_arg.is_a?(Prism::StringNode) &&
             !first_arg.unescaped.include?("/") &&
             !first_arg.unescaped.include?(":")
@@ -1058,20 +889,16 @@ module Rigor
 
         # Generates the member / collection action helper.
         # Member: `<action>_<helper_prefix>path(id)`, arity =
-        #   parent_segment_count (which already includes the
-        #   enclosing resource's `:id`).
+        #   parent_segment_count (which already includes the enclosing resource's `:id`).
         # Collection: `<action>_<plural_helper_prefix>path`,
-        #   arity = parent_segment_count - 1 (no `:id` segment;
-        #   the collection URL is /<resource>/<action>).
+        #   arity = parent_segment_count - 1 (no `:id` segment; the collection URL is /<resource>/<action>).
         def register_member_collection_action(node, context)
           action_name = symbol_argument(node, 0)&.to_s ||
                         string_argument(node, 0).to_s
           frame = context.innermost_action_block
-          # No `member do` / `collection do` wrapper but we're
-          # inside a resources block — Rails defaults a bare
-          # `<verb> :symbol` inside resources to a MEMBER
-          # action (e.g. `get :preview` → `preview_<singular>_path
-          # (:id)`).
+          # No `member do` / `collection do` wrapper but we're inside a resources block — Rails defaults a
+          # bare `<verb> :symbol` inside resources to a MEMBER action (e.g. `get :preview` →
+          # `preview_<singular>_path(:id)`).
           if frame.nil?
             register_member_action(node, context, action_name)
           elsif frame[:kind] == :member_block
@@ -1081,12 +908,9 @@ module Rigor
           end
         end
 
-        # `get 'report', :on => :collection` (or `:member`)
-        # inline form inside `resources`. The helper name shape
-        # matches member_action / collection_action: the action
-        # name prefixes the resource's singular (member) or
-        # plural (collection). Closes Redmine's
-        # `report_time_entries_path` cluster.
+        # `get 'report', :on => :collection` (or `:member`) inline form inside `resources`. The helper name
+        # shape matches member_action / collection_action: the action name prefixes the resource's
+        # singular (member) or plural (collection). Closes Redmine's `report_time_entries_path` cluster.
         def register_on_target_action(node, context, action_name, on_target)
           scope_frame = context.innermost_scope_frame
           return if scope_frame.nil?
@@ -1114,12 +938,9 @@ module Rigor
         end
 
         def register_member_action(node, context, action_name)
-          # `helper_prefix` already ends with "_" (each segment
-          # appends one); the formula below yields e.g.
-          # `memorialize_admin_account_path`. Arity equals the
-          # parent segment count — Rails member URLs carry the
-          # enclosing resource's `:id`, which the :scope frame
-          # already counts.
+          # `helper_prefix` already ends with "_" (each segment appends one); the formula below yields e.g.
+          # `memorialize_admin_account_path`. Arity equals the parent segment count — Rails member URLs
+          # carry the enclosing resource's `:id`, which the :scope frame already counts.
           name = "#{action_name}_#{context.helper_prefix}path"
           context.entries << HelperTable::Entry.new(
             name: name, arity: context.parent_segment_count,
@@ -1129,10 +950,8 @@ module Rigor
         end
 
         def register_collection_action(node, context, action_name, frame)
-          # Collection URL drops the immediate parent's `:id`
-          # segment. The plural helper prefix swaps the
-          # singular form (in `helper_prefix`) for the plural
-          # — the immediate-resource frame stored both.
+          # Collection URL drops the immediate parent's `:id` segment. The plural helper prefix swaps the
+          # singular form (in `helper_prefix`) for the plural — the immediate-resource frame stored both.
           plural_prefix = context.helper_prefix.sub(/#{frame[:parent_singular]}_\z/, "#{frame[:parent_plural]}_")
           name = "#{action_name}_#{plural_prefix}path"
           arity = [context.parent_segment_count - 1, 0].max
@@ -1159,8 +978,7 @@ module Rigor
         end
 
         def handle_member_or_collection(node, context)
-          # Only meaningful when we're inside a `resources` /
-          # `resource` block. The Context's stack tells us.
+          # Only meaningful when we're inside a `resources` / `resource` block. The Context's stack tells us.
           resource = context.innermost_resource
           return interpret_block_body(node, context) if resource.nil?
 
@@ -1171,25 +989,20 @@ module Rigor
         end
 
         def in_singular_resource?(*)
-          # Stub: always returns true so member / collection
-          # blocks descend. The singular-resource frame
-          # (`push_singular_resource`) is modelled in Context;
-          # a future caller could use it to tighten this check.
+          # Stub: always returns true so member / collection blocks descend. The singular-resource frame
+          # (`push_singular_resource`) is modelled in Context; a future caller could use it to tighten this
+          # check.
           true
         end
 
-        # Generate the standard helpers for a resource(s).
-        # `plural: true` for `resources :users`, `false` for
-        # `resource :profile`.
+        # Generate the standard helpers for a resource(s). `plural: true` for `resources :users`, `false`
+        # for `resource :profile`.
         def register_resourceful_helpers(name, actions, base_arity, context, plural:)
-          # Plural resources (`resources :users`) singularise
-          # for show / new / edit helpers → `user_path(id)`.
-          # Singular resources (`resource :foo`) use the name
-          # AS-IS — singularising would mangle deliberately-
-          # plural names like Mastodon's `resource
-          # :relationships` → `relationships_path`, not
-          # `relationship_path`. The URL path uses `name`
-          # in both shapes (Rails never singularises the URL).
+          # Plural resources (`resources :users`) singularise for show / new / edit helpers →
+          # `user_path(id)`. Singular resources (`resource :foo`) use the name AS-IS — singularising would
+          # mangle deliberately-plural names like Mastodon's `resource :relationships` →
+          # `relationships_path`, not `relationship_path`. The URL path uses `name` in both shapes (Rails
+          # never singularises the URL).
           singular = plural ? singularize_word(name.to_s) : name.to_s
           path_base = "#{context.path_prefix}/#{name}"
 
@@ -1203,20 +1016,13 @@ module Rigor
           end
         end
 
-        # Maps an action keyword to the route-helper entry it
-        # produces. The five "named-helper" actions
-        # (`:index` / `:show` / `:new` / `:edit` plus
-        # singular-resource `:show`) generate a distinct
-        # helper; the three "verb-only" actions (`:create` /
-        # `:update` / `:destroy`) Rails serves under the same
-        # path-helper Rails reuses for show / index forms — so
-        # we emit them too, otherwise an `only: [:create]`
-        # resource (e.g. Mastodon's `resource :inbox, only:
-        # [:create]`) registers NO helpers and downstream
-        # callers see a false `unknown-helper inbox_path`.
-        # The HelperTable already dedupes by name, so a
-        # resource that lists both `:show` and `:update` does
-        # not double-register.
+        # Maps an action keyword to the route-helper entry it produces. The five "named-helper" actions
+        # (`:index` / `:show` / `:new` / `:edit` plus singular-resource `:show`) generate a distinct
+        # helper; the three "verb-only" actions (`:create` / `:update` / `:destroy`) Rails serves under the
+        # same path-helper Rails reuses for show / index forms — so we emit them too, otherwise an `only:
+        # [:create]` resource (e.g. Mastodon's `resource :inbox, only: [:create]`) registers NO helpers and
+        # downstream callers see a false `unknown-helper inbox_path`. The HelperTable already dedupes by
+        # name, so a resource that lists both `:show` and `:update` does not double-register.
         def entry_for_action(action, name:, singular:, base_arity:, path_base:, helper_prefix:, plural:)
           case action
           when :index then index_entry(plural, helper_prefix, name, base_arity, path_base, singular)
@@ -1229,18 +1035,14 @@ module Rigor
             )
           when :edit then edit_entry(plural, helper_prefix, singular, base_arity, path_base)
           when :create
-            # Plural `resources` collection POST shares the
-            # index helper (`<name>_path` → collection URL).
-            # Singular `resource` POST shares the show helper
-            # (`<name>_path` → resource URL). Both shapes
-            # produce a `<prefix><name>_path` entry; only the
-            # arity / path differ.
+            # Plural `resources` collection POST shares the index helper (`<name>_path` → collection URL).
+            # Singular `resource` POST shares the show helper (`<name>_path` → resource URL). Both shapes
+            # produce a `<prefix><name>_path` entry; only the arity / path differ.
             create_entry(plural, helper_prefix, name, singular, base_arity, path_base)
           when :update, :destroy
-            # Member PATCH / PUT / DELETE on plural resources
-            # share the show helper (`<prefix><singular>_path(id)`).
-            # Singular-resource PATCH / DELETE shares
-            # `<prefix><name>_path` (no `:id`).
+            # Member PATCH / PUT / DELETE on plural resources share the show helper
+            # (`<prefix><singular>_path(id)`). Singular-resource PATCH / DELETE shares `<prefix><name>_path`
+            # (no `:id`).
             show_entry(plural, helper_prefix, singular, base_arity, path_base)
           end
         end
@@ -1264,27 +1066,18 @@ module Rigor
         def index_entry(plural, helper_prefix, name, base_arity, path_base, singular)
           return nil unless plural
 
-          # Rails appends `_index_path` to the index helper
-          # name when the singular form of the resource matches
-          # the plural form AND the noun isn't in the canonical
-          # UNCOUNTABLE list. The collision would otherwise put
-          # both the index (`:id`-less) and show (`:id`-bearing)
-          # helpers under the same name, and Rails disambiguates
-          # by suffixing the index form. Mastodon's
-          # `resources :reblogged_by, controller:
-          # :reblogged_by_accounts, only: :index` and similar
-          # rely on this — calls like
-          # `api_v1_status_reblogged_by_index_url(status.id)`
-          # would otherwise read as `unknown-helper`.
+          # Rails appends `_index_path` to the index helper name when the singular form of the resource
+          # matches the plural form AND the noun isn't in the canonical UNCOUNTABLE list. The collision
+          # would otherwise put both the index (`:id`-less) and show (`:id`-bearing) helpers under the same
+          # name, and Rails disambiguates by suffixing the index form. Mastodon's `resources
+          # :reblogged_by, controller: :reblogged_by_accounts, only: :index` and similar rely on this —
+          # calls like `api_v1_status_reblogged_by_index_url(status.id)` would otherwise read as
+          # `unknown-helper`.
           #
-          # Rails adds `_index_` whenever `singular == plural`
-          # — including for UNCOUNTABLE nouns (Redmine's
-          # `resources :news` registers `news_index_path` for
-          # the index). The earlier "skip UNCOUNTABLE" carve-out
-          # was empirically wrong; only the
-          # IRREGULAR-singular path (e.g. `media → medium`)
-          # actually has `singular != plural` and skips
-          # `_index_`.
+          # Rails adds `_index_` whenever `singular == plural` — including for UNCOUNTABLE nouns (Redmine's
+          # `resources :news` registers `news_index_path` for the index). The earlier "skip UNCOUNTABLE"
+          # carve-out was empirically wrong; only the IRREGULAR-singular path (e.g. `media → medium`)
+          # actually has `singular != plural` and skips `_index_`.
           index_name = if name.to_s == singular
                          "#{helper_prefix}#{name}_index_path"
                        else
@@ -1322,9 +1115,8 @@ module Rigor
         end
 
         def restrict_actions_from(options, default)
-          # `resources :foo, only: :show` is the same as
-          # `only: [:show]` in Rails; `options_hash` preserves the
-          # Symbol shape from the source, so coerce here.
+          # `resources :foo, only: :show` is the same as `only: [:show]` in Rails; `options_hash` preserves
+          # the Symbol shape from the source, so coerce here.
           if (only = options[:only])
             Array(only) & default
           elsif (except = options[:except])
@@ -1362,21 +1154,17 @@ module Rigor
           options_hash(node)[key]
         end
 
-        # Reads a keyword option whose value is a literal String
-        # (returned as-is). Returns nil when the key is missing
-        # or the value is non-literal. Used for `scope(path:
-        # ':project_id', ...)` shape parsing where `:path` is
-        # passed as a keyword rather than a positional arg.
+        # Reads a keyword option whose value is a literal String (returned as-is). Returns nil when the key
+        # is missing or the value is non-literal. Used for `scope(path: ':project_id', ...)` shape parsing
+        # where `:path` is passed as a keyword rather than a positional arg.
         def keyword_value_string(node, key)
           value = options_hash(node)[key]
           value.is_a?(String) ? value : nil
         end
 
-        # `get 'help/*path' => 'help#show', as: :help_page` —
-        # the path lives in a String-keyed AssocNode of the
-        # trailing keyword/options hash (its value is the
-        # `controller#action` String). Returns the path String,
-        # or nil when no such hashrocket-key entry exists.
+        # `get 'help/*path' => 'help#show', as: :help_page` — the path lives in a String-keyed AssocNode of
+        # the trailing keyword/options hash (its value is the `controller#action` String). Returns the
+        # path String, or nil when no such hashrocket-key entry exists.
         def hashrocket_path_key(node)
           args = node.arguments&.arguments || []
           last = args.last
@@ -1409,29 +1197,24 @@ module Rigor
         def count_path_placeholders(path)
           return 0 if path.nil?
 
-          # Both `:name` (regular segment) and `*name` (wildcard
-          # / "globbing" segment) are Rails path parameters and
-          # contribute to helper arity. GitLab's
-          # `path: '*namespace_id'` outer scope adds 1 to the
-          # arity of every helper underneath.
+          # Both `:name` (regular segment) and `*name` (wildcard / "globbing" segment) are Rails path
+          # parameters and contribute to helper arity. GitLab's `path: '*namespace_id'` outer scope adds 1
+          # to the arity of every helper underneath.
           path.scan(/[:*][a-z_][a-z0-9_]*/).size
         end
 
-        # Number of placeholders inside `(...)` groups — Rails'
-        # optional-segment syntax (`'settings(/:tab)'`). Required
-        # arity is `count_path_placeholders - count_optional`;
-        # callers accepting a `(required..required+optional)`
-        # arity range register an entry per achievable arity.
+        # Number of placeholders inside `(...)` groups — Rails' optional-segment syntax
+        # (`'settings(/:tab)'`). Required arity is `count_path_placeholders - count_optional`; callers
+        # accepting a `(required..required+optional)` arity range register an entry per achievable arity.
         def count_optional_path_placeholders(path)
           return 0 if path.nil?
 
           path.scan(/\([^)]*\)/).sum { |group| group.scan(/[:*][a-z_][a-z0-9_]*/).size }
         end
 
-        # ADR-39 — delegates to the shared inflector (real
-        # `ActiveSupport::Inflector` when available). Previously a
-        # hand-tuned AS-replica kept in sync with `Context#singularize`;
-        # both now share the one authoritative implementation.
+        # ADR-39 — delegates to the shared inflector (real `ActiveSupport::Inflector` when available).
+        # Previously a hand-tuned AS-replica kept in sync with `Context#singularize`; both now share the
+        # one authoritative implementation.
         def singularize_word(word)
           Rigor::Plugin::Inflector.singularize(word)
         end

--- a/plugins/rigor-rails/lib/rigor-rails.rb
+++ b/plugins/rigor-rails/lib/rigor-rails.rb
@@ -1,26 +1,19 @@
 # frozen_string_literal: true
 
-# Convenience entry point. `require "rigor-rails"` requires
-# every Tier 1+2 Rails ecosystem plugin in one go, so projects
-# that prefer a single require statement (some `spec_helper`
-# patterns, ad-hoc scripts) do not have to list seven require
-# lines.
+# Convenience entry point. `require "rigor-rails"` requires every Tier 1+2 Rails ecosystem plugin in one go,
+# so projects that prefer a single require statement (some `spec_helper` patterns, ad-hoc scripts) do not
+# have to list seven require lines.
 #
-# Note: requiring this entry point does NOT mark every plugin as
-# active. The Rigor plugin loader walks `.rigor.yml`'s `plugins:`
-# list and instantiates only the plugins enumerated there. This
-# is per ADR-12 WD1's "Gemfile-convenience meta-gem" pattern —
-# users still control which plugins participate in analysis via
-# `.rigor.yml`.
+# Note: requiring this entry point does NOT mark every plugin as active. The Rigor plugin loader walks
+# `.rigor.yml`'s `plugins:` list and instantiates only the plugins enumerated there. This is per ADR-12
+# WD1's "Gemfile-convenience meta-gem" pattern — users still control which plugins participate in analysis
+# via `.rigor.yml`.
 #
-# Sub-plugins ARE registered with `Rigor::Plugin` when this file
-# loads (each gem's entry point side-effects a `Plugin.register`
-# call); the loader's lookup phase finds them by id when listed.
+# Sub-plugins ARE registered with `Rigor::Plugin` when this file loads (each gem's entry point side-effects
+# a `Plugin.register` call); the loader's lookup phase finds them by id when listed.
 #
-# Adding the gem to a project's Gemfile without listing any
-# plugin in `.rigor.yml` is harmless: the requires happen on
-# `Bundler.require`, but no plugin's `init` / `prepare` / hooks
-# run.
+# Adding the gem to a project's Gemfile without listing any plugin in `.rigor.yml` is harmless: the requires
+# happen on `Bundler.require`, but no plugin's `init` / `prepare` / hooks run.
 
 require "rigor-rails-routes"
 require "rigor-rails-i18n"

--- a/plugins/rigor-rbs-inline/lib/rigor-rbs-inline.rb
+++ b/plugins/rigor-rbs-inline/lib/rigor-rbs-inline.rb
@@ -1,17 +1,12 @@
 # frozen_string_literal: true
 
-# rigor-rbs-inline — ingests rbs-inline-shaped comments
-# (`# @rbs name: T`, `#: () -> T`, `# @rbs return: T`, attribute
-# `#:`, ivars, generics, override, …) as RBS contributions to
-# the analysis environment.
+# rigor-rbs-inline — ingests rbs-inline-shaped comments (`# @rbs name: T`, `#: () -> T`, `# @rbs return: T`,
+# attribute `#:`, ivars, generics, override, …) as RBS contributions to the analysis environment.
 #
-# Per ADR-32 the plugin gates per file on the upstream
-# `# rbs_inline: enabled` magic comment by default. A host
-# context that owns the entire analysis scope (e.g. the
-# ADR-29 browser playground) can set `require_magic_comment:
-# false` in the plugin config to skip the gate — every file
-# the synthesizer sees is treated as if it carried the magic
-# comment.
+# Per ADR-32 the plugin gates per file on the upstream `# rbs_inline: enabled` magic comment by default. A
+# host context that owns the entire analysis scope (e.g. the ADR-29 browser playground) can set
+# `require_magic_comment: false` in the plugin config to skip the gate — every file the synthesizer sees is
+# treated as if it carried the magic comment.
 #
 #     # .rigor.yml
 #     plugins:
@@ -19,6 +14,6 @@
 #         config:
 #           require_magic_comment: false   # default true
 #
-# The plugin depends on the upstream `rbs-inline` gem; Rigor's
-# core `rigortype` gemspec stays zero-dep per ADR-0 / ADR-32 WD1.
+# The plugin depends on the upstream `rbs-inline` gem; Rigor's core `rigortype` gemspec stays zero-dep per
+# ADR-0 / ADR-32 WD1.
 require_relative "rigor/plugin/rbs_inline"

--- a/plugins/rigor-rbs-inline/lib/rigor/plugin/rbs_inline.rb
+++ b/plugins/rigor-rbs-inline/lib/rigor/plugin/rbs_inline.rb
@@ -4,24 +4,18 @@ require "rigor/plugin"
 
 # ADR-32 — bundled `rigor-rbs-inline` plugin.
 #
-# Synthesises RBS from project Ruby files that carry
-# rbs-inline-shaped comments (`#: () -> T`, `# @rbs name: T`,
-# `# @rbs return: T`, attribute `#:`, …) and contributes the
-# result to the analysis environment through the
-# `source_rbs_synthesizer:` manifest hook.
+# Synthesises RBS from project Ruby files that carry rbs-inline-shaped comments (`#: () -> T`, `# @rbs
+# name: T`, `# @rbs return: T`, attribute `#:`, …) and contributes the result to the analysis environment
+# through the `source_rbs_synthesizer:` manifest hook.
 #
-# By default (WD2) only files starting with the upstream
-# `# rbs_inline: enabled` magic comment are processed; a host
-# context can flip this off by setting `require_magic_comment:
-# false` in the plugin config (WD10).
+# By default (WD2) only files starting with the upstream `# rbs_inline: enabled` magic comment are
+# processed; a host context can flip this off by setting `require_magic_comment: false` in the plugin
+# config (WD10).
 module Rigor
   module Plugin
-    # The plugin gem requires `rbs/inline` at load time; without
-    # the upstream library the synthesizer can't do its job.
-    # Wrapped in a begin/rescue so the analyzer still loads if
-    # the user activated this plugin without installing the
-    # `rbs-inline` gem (loud-on-activation, fail-soft to no
-    # contribution).
+    # The plugin gem requires `rbs/inline` at load time; without the upstream library the synthesizer can't
+    # do its job. Wrapped in a begin/rescue so the analyzer still loads if the user activated this plugin
+    # without installing the `rbs-inline` gem (loud-on-activation, fail-soft to no contribution).
     begin
       require "prism"
       require "rbs/inline"
@@ -37,18 +31,13 @@ module Rigor
     end
 
     class RbsInline < Rigor::Plugin::Base
-      # Synthesizer callable invoked once per project Ruby
-      # source file by `Environment.for_project` at env-build
-      # time. Returns the synthesised RBS source as a String,
-      # or `nil` when the file contributes nothing (no magic
-      # comment in the default mode, empty annotation set,
-      # parse error per WD6).
+      # Synthesizer callable invoked once per project Ruby source file by `Environment.for_project` at
+      # env-build time. Returns the synthesised RBS source as a String, or `nil` when the file contributes
+      # nothing (no magic comment in the default mode, empty annotation set, parse error per WD6).
       class Synthesizer
-        # @param require_magic_comment [Boolean] when `true`
-        #   (the default, WD2), only files with
-        #   `# rbs_inline: enabled` at the top are processed.
-        #   When `false` (WD10 host-context override), every
-        #   file is treated as if it carried the magic comment.
+        # @param require_magic_comment [Boolean] when `true` (the default, WD2), only files with
+        #   `# rbs_inline: enabled` at the top are processed. When `false` (WD10 host-context override),
+        #   every file is treated as if it carried the magic comment.
         def initialize(require_magic_comment:)
           @require_magic_comment = require_magic_comment
           freeze
@@ -57,8 +46,7 @@ module Rigor
         # Return value contract:
         # - `String` (non-empty)         → successful synthesis
         # - `nil`                        → no contribution
-        # - `[:error, message_string]`   → parse failed, surface
-        #   info diagnostic per ADR-32 WD6
+        # - `[:error, message_string]`   → parse failed, surface info diagnostic per ADR-32 WD6
         def call(source_file_path)
           return nil unless RBS_INLINE_AVAILABLE
           return nil unless File.file?(source_file_path)
@@ -67,10 +55,8 @@ module Rigor
           return nil if source.empty?
 
           result = ::Prism.parse(source)
-          # `opt_in: true` is rbs-inline's "require the magic
-          # comment" mode (per upstream parser.rb:62). The
-          # plugin's `require_magic_comment:` config knob maps
-          # directly onto it.
+          # `opt_in: true` is rbs-inline's "require the magic comment" mode (per upstream parser.rb:62).
+          # The plugin's `require_magic_comment:` config knob maps directly onto it.
           parsed = ::RBS::Inline::Parser.parse(result, opt_in: @require_magic_comment)
           return nil if parsed.nil?
 
@@ -80,11 +66,9 @@ module Rigor
 
           rendered
         rescue ::StandardError => e
-          # WD6 fail-soft — surface a structured error tuple so
-          # the engine's `Environment.for_project` can emit a
-          # `source-rbs-synthesis-failed` info diagnostic
-          # naming the file + the upstream error message,
-          # without crashing analysis.
+          # WD6 fail-soft — surface a structured error tuple so the engine's `Environment.for_project` can
+          # emit a `source-rbs-synthesis-failed` info diagnostic naming the file + the upstream error
+          # message, without crashing analysis.
           [:error, "#{e.class}: #{e.message.to_s.lines.first.to_s.strip}"]
         end
       end
@@ -98,24 +82,19 @@ module Rigor
         source_rbs_synthesizer: nil # set per-instance below
       )
 
-      # Per-instance synthesizer — built from the manifest's
-      # default + the project's plugin config. The manifest
-      # `source_rbs_synthesizer:` is nil at the class level so
-      # the registry sees the instance's override (returned by
-      # `#manifest`, which `Plugin::Registry#source_rbs_synthesizers`
-      # consults via `plugin.manifest.source_rbs_synthesizer`).
+      # Per-instance synthesizer — built from the manifest's default + the project's plugin config. The
+      # manifest `source_rbs_synthesizer:` is nil at the class level so the registry sees the instance's
+      # override (returned by `#manifest`, which `Plugin::Registry#source_rbs_synthesizers` consults via
+      # `plugin.manifest.source_rbs_synthesizer`).
       #
-      # ADR-32 WD10 — `require_magic_comment` defaults to
-      # `true`. Setting it to `false` in `.rigor.yml` flips the
-      # synthesizer into "process every file" mode.
+      # ADR-32 WD10 — `require_magic_comment` defaults to `true`. Setting it to `false` in `.rigor.yml`
+      # flips the synthesizer into "process every file" mode.
       def initialize(services:, config: {})
         super
         @require_magic_comment = config.fetch("require_magic_comment", true) ? true : false
         @synthesizer = Synthesizer.new(require_magic_comment: @require_magic_comment)
-        # Build the per-instance manifest eagerly (before
-        # `freeze`) so the registry's repeated reads return
-        # the same object and we don't need to mutate a
-        # frozen instance later.
+        # Build the per-instance manifest eagerly (before `freeze`) so the registry's repeated reads
+        # return the same object and we don't need to mutate a frozen instance later.
         base = self.class.manifest
         @manifest_with_synth = build_manifest_with_synthesizer(base)
         freeze
@@ -123,10 +102,9 @@ module Rigor
 
       attr_reader :synthesizer
 
-      # Override the manifest-level `source_rbs_synthesizer:`
-      # (which is nil at the class level) with the per-instance
-      # synthesizer built from the merged config. The registry
-      # reads this through `plugin.manifest.source_rbs_synthesizer`.
+      # Override the manifest-level `source_rbs_synthesizer:` (which is nil at the class level) with the
+      # per-instance synthesizer built from the merged config. The registry reads this through
+      # `plugin.manifest.source_rbs_synthesizer`.
       def manifest
         @manifest_with_synth
       end

--- a/plugins/rigor-rspec-rails/demo/spec/http_status_spec.rb
+++ b/plugins/rigor-rspec-rails/demo/spec/http_status_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-# Worked example — rigor-rspec-rails fires
-# `have_http_status.out-of-range` for numeric args outside
-# 100..599 and `have_http_status.unknown-symbol` for typos
-# in the symbol set. Recognised symbols / valid numerics
-# stay silent.
+# Worked example — rigor-rspec-rails fires `have_http_status.out-of-range` for numeric args outside
+# 100..599 and `have_http_status.unknown-symbol` for typos in the symbol set. Recognised symbols / valid
+# numerics stay silent.
 
 RSpec.describe "HomeController" do
   it "every recognised shape stays silent" do

--- a/plugins/rigor-rspec-rails/lib/rigor/plugin/rspec_rails.rb
+++ b/plugins/rigor-rspec-rails/lib/rigor/plugin/rspec_rails.rb
@@ -6,49 +6,36 @@ require_relative "rspec_rails/have_http_status_analyzer"
 
 module Rigor
   module Plugin
-    # rigor-rspec-rails — validates rspec-rails matchers whose
-    # arguments are statically checkable.
+    # rigor-rspec-rails — validates rspec-rails matchers whose arguments are statically checkable.
     #
     # v0.1.0 covers `have_http_status(int_or_symbol)`:
     #
     # - Integer: must be in `100..599`.
-    # - Symbol: must be one of the
-    #   `Rack::Utils::SYMBOL_TO_STATUS_CODE` keys or one of
-    #   Rails' status-group aliases (`:success`, `:successful`,
-    #   `:missing`, `:redirect`, `:error`, `:client_error`,
+    # - Symbol: must be one of the `Rack::Utils::SYMBOL_TO_STATUS_CODE` keys or one of Rails' status-group
+    #   aliases (`:success`, `:successful`, `:missing`, `:redirect`, `:error`, `:client_error`,
     #   `:server_error`, `:informational`).
     #
     # ## Why this is a separate plugin from rigor-rspec
     #
-    # `rigor-rspec` handles the **type-narrowing** matchers
-    # (`be_a`, `be_kind_of`, `be_nil`, `eq(literal)`, etc.) —
-    # ones that refine a local's static type so downstream
-    # calls in the same `it` body resolve at the narrowed
-    # type. `rigor-rspec-rails` handles the **behavioral**
-    # matchers — ones that assert runtime state (HTTP status,
-    # rendered template, route shape) without narrowing a
-    # type. The two are activated independently in `.rigor.yml`.
+    # `rigor-rspec` handles the **type-narrowing** matchers (`be_a`, `be_kind_of`, `be_nil`, `eq(literal)`,
+    # etc.) — ones that refine a local's static type so downstream calls in the same `it` body resolve at
+    # the narrowed type. `rigor-rspec-rails` handles the **behavioral** matchers — ones that assert runtime
+    # state (HTTP status, rendered template, route shape) without narrowing a type. The two are activated
+    # independently in `.rigor.yml`.
     #
     # ## Deferred matchers
     #
-    # - `render_template(...)` — overlaps with
-    #   `rigor-actionpack`'s render-target validation
-    #   (`render :show` against the view tree). A separate
-    #   slice would coordinate the two to avoid
-    #   double-firing.
-    # - `route_to(...)` / `redirect_to(...)` — needs the
-    #   routes table from `rigor-rails-routes`
+    # - `render_template(...)` — overlaps with `rigor-actionpack`'s render-target validation (`render
+    #   :show` against the view tree). A separate slice would coordinate the two to avoid double-firing.
+    # - `route_to(...)` / `redirect_to(...)` — needs the routes table from `rigor-rails-routes`
     #   (`:helper_table` cross-plugin fact). Future slice.
-    # - `have_enqueued_job(JobClass)` /
-    #   `have_enqueued_mail(MailerClass)` — class-existence
-    #   check overlaps with engine's
-    #   `inference.unresolved-constant`; queued behind a
-    #   decision on which surface owns the diagnostic.
-    # - `have_received(:method)` — overlaps with engine's
-    #   `call.undefined-method`; same coordination question.
+    # - `have_enqueued_job(JobClass)` / `have_enqueued_mail(MailerClass)` — class-existence check overlaps
+    #   with engine's `inference.unresolved-constant`; queued behind a decision on which surface owns the
+    #   diagnostic.
+    # - `have_received(:method)` — overlaps with engine's `call.undefined-method`; same coordination
+    #   question.
     # - `be_routable` — needs routes table.
-    # - `match_response_schema(...)` (rswag / OpenAPI) — out
-    #   of scope, separate plugin.
+    # - `match_response_schema(...)` (rswag / OpenAPI) — out of scope, separate plugin.
     class RspecRails < Rigor::Plugin::Base
       manifest(
         id: "rspec-rails",
@@ -56,10 +43,9 @@ module Rigor
         description: "Validates rspec-rails behavioral matchers (have_http_status floor)."
       )
 
-      # ADR-37 — the engine walks each file and hands us every
-      # CallNode; the analyzer is now pure per-node logic. The
-      # diagnostic points at the matcher name (`message_loc`),
-      # reproducing the previous `message_loc || location` positioning.
+      # ADR-37 — the engine walks each file and hands us every CallNode; the analyzer is now pure per-node
+      # logic. The diagnostic points at the matcher name (`message_loc`), reproducing the previous
+      # `message_loc || location` positioning.
       node_rule Prism::CallNode do |node, _scope, path|
         violation = HaveHttpStatusAnalyzer.violation_for(node)
         next [] unless violation

--- a/plugins/rigor-rspec-rails/lib/rigor/plugin/rspec_rails/have_http_status_analyzer.rb
+++ b/plugins/rigor-rspec-rails/lib/rigor/plugin/rspec_rails/have_http_status_analyzer.rb
@@ -7,48 +7,39 @@ require_relative "http_status_codes"
 module Rigor
   module Plugin
     class RspecRails < Rigor::Plugin::Base
-      # Validates `expect(response).to have_http_status(arg)` /
-      # the negated `.not_to have_http_status(arg)` and the
-      # bare matcher form `should have_http_status(arg)`.
+      # Validates `expect(response).to have_http_status(arg)` / the negated `.not_to have_http_status(arg)`
+      # and the bare matcher form `should have_http_status(arg)`.
       #
       # Recognised argument shapes:
       #
-      # - **IntegerNode**: must be in `100..599`. Numbers outside
-      #   that range fire `have_http_status.out-of-range`.
-      # - **SymbolNode**: must be one of the known
-      #   `Rack::Utils::SYMBOL_TO_STATUS_CODE` keys OR a Rails
-      #   status-group alias (`:success` / `:successful` /
-      #   `:missing` / `:redirect` / `:error` / `:client_error` /
-      #   `:server_error` / `:informational`). Unknown symbols
-      #   fire `have_http_status.unknown-symbol` (typo-flavoured).
-      # - **StringNode**: passed through silently (a literal
-      #   `"200"` is accepted by Rails at runtime; we don't
-      #   second-guess the user's intent for the String form).
-      # - **Anything else** (variable, method call, computed
-      #   expression): skipped — the plugin can't statically
-      #   prove the runtime value.
+      # - **IntegerNode**: must be in `100..599`. Numbers outside that range fire
+      #   `have_http_status.out-of-range`.
+      # - **SymbolNode**: must be one of the known `Rack::Utils::SYMBOL_TO_STATUS_CODE` keys OR a Rails
+      #   status-group alias (`:success` / `:successful` / `:missing` / `:redirect` / `:error` /
+      #   `:client_error` / `:server_error` / `:informational`). Unknown symbols fire
+      #   `have_http_status.unknown-symbol` (typo-flavoured).
+      # - **StringNode**: passed through silently (a literal `"200"` is accepted by Rails at runtime; we
+      #   don't second-guess the user's intent for the String form).
+      # - **Anything else** (variable, method call, computed expression): skipped — the plugin can't
+      #   statically prove the runtime value.
       #
-      # Walks every `Prism::CallNode` looking for matcher
-      # invocations rather than only the `expect(...).to ...`
-      # chain because `have_http_status` is also used as a
-      # plain matcher inside Rails' `assert_response` shim and
-      # in shared-context bodies; the diagnostic is the same
-      # regardless of the surrounding chain.
+      # Walks every `Prism::CallNode` looking for matcher invocations rather than only the
+      # `expect(...).to ...` chain because `have_http_status` is also used as a plain matcher inside Rails'
+      # `assert_response` shim and in shared-context bodies; the diagnostic is the same regardless of the
+      # surrounding chain.
       module HaveHttpStatusAnalyzer
-        # One matcher violation: the kebab-case `rule` and the
-        # human-readable `message`. Carries no location/path — the
-        # caller (the `node_rule` block) positions the diagnostic at the
-        # matcher's `message_loc` via `Plugin::Base#diagnostic`.
+        # One matcher violation: the kebab-case `rule` and the human-readable `message`. Carries no
+        # location/path — the caller (the `node_rule` block) positions the diagnostic at the matcher's
+        # `message_loc` via `Plugin::Base#diagnostic`.
         Violation = Struct.new(:rule, :message, keyword_init: true)
 
         MATCHER_NAME = :have_http_status
 
         module_function
 
-        # The matcher violation for a single CallNode, or nil when the
-        # node is not a `have_http_status(<int|symbol>)` matcher or its
-        # argument is statically valid. ADR-37: the engine owns the
-        # walk, so this is per-node logic — no traversal here.
+        # The matcher violation for a single CallNode, or nil when the node is not a
+        # `have_http_status(<int|symbol>)` matcher or its argument is statically valid. ADR-37: the engine
+        # owns the walk, so this is per-node logic — no traversal here.
         #
         # @param call_node [Prism::Node]
         # @return [Violation, nil]
@@ -58,12 +49,9 @@ module Rigor
           diagnostic_for(call_node)
         end
 
-        # `have_http_status` is a matcher — called either with
-        # no receiver (`have_http_status(200)` inside `.to(...)`)
-        # or with a receiver chain we don't care about here.
-        # Either way we want the call node whose name is
-        # `have_http_status` and that carries exactly one
-        # positional argument.
+        # `have_http_status` is a matcher — called either with no receiver (`have_http_status(200)` inside
+        # `.to(...)`) or with a receiver chain we don't care about here. Either way we want the call node
+        # whose name is `have_http_status` and that carries exactly one positional argument.
         def call_to_matcher?(node)
           node.is_a?(Prism::CallNode) &&
             node.name == MATCHER_NAME &&
@@ -97,8 +85,8 @@ module Rigor
         def symbol_violation(symbol_node)
           sym = symbol_node.unescaped.to_sym
           known = HttpStatusCodes.known_symbols
-          # ADR-39: Rack unavailable → the accepted symbol set is
-          # unknowable, so decline rather than flag from a guess.
+          # ADR-39: Rack unavailable → the accepted symbol set is unknowable, so decline rather than flag
+          # from a guess.
           return nil if known.nil?
           return nil if known.include?(sym)
 

--- a/plugins/rigor-rspec-rails/lib/rigor/plugin/rspec_rails/http_status_codes.rb
+++ b/plugins/rigor-rspec-rails/lib/rigor/plugin/rspec_rails/http_status_codes.rb
@@ -6,18 +6,15 @@ module Rigor
       # The set of HTTP-status symbols `have_http_status` accepts.
       #
       # ADR-39 — the HTTP status symbols come from the **real**
-      # `Rack::Utils::SYMBOL_TO_STATUS_CODE` (the authority `have_http_status`
-      # itself resolves through `Rack::Utils.status_code`), not a vendored
-      # snapshot: a snapshot that lagged the installed Rack would flag a
-      # newly-added status symbol as a false `unknown-symbol` (a false
-      # positive on working code). When Rack cannot be loaded the symbol
-      # set is unknowable, so {known_symbols} returns `nil` and the caller
-      # **declines** to flag anything — reduced coverage, never a guess.
+      # `Rack::Utils::SYMBOL_TO_STATUS_CODE` (the authority `have_http_status` itself resolves through
+      # `Rack::Utils.status_code`), not a vendored snapshot: a snapshot that lagged the installed Rack
+      # would flag a newly-added status symbol as a false `unknown-symbol` (a false positive on working
+      # code). When Rack cannot be loaded the symbol set is unknowable, so {known_symbols} returns `nil`
+      # and the caller **declines** to flag anything — reduced coverage, never a guess.
       #
-      # The Rails status-group aliases (`:success`, `:missing`, …) are a
-      # small, stable convention set defined by Rails
-      # (`ActionDispatch::TestResponse`) — not a growing catalogue — so
-      # they are kept as a constant rather than pulling in actionpack.
+      # The Rails status-group aliases (`:success`, `:missing`, …) are a small, stable convention set
+      # defined by Rails (`ActionDispatch::TestResponse`) — not a growing catalogue — so they are kept as a
+      # constant rather than pulling in actionpack.
       module HttpStatusCodes
         RAILS_STATUS_GROUP_ALIASES = %i[
           informational success successful redirect
@@ -28,11 +25,10 @@ module Rigor
 
         module_function
 
-        # The authoritative set of accepted `have_http_status` symbols
-        # (real Rack status symbols ∪ the Rails group aliases), or `nil`
-        # when it cannot be determined because Rack is unavailable. A
-        # `nil` return means "decline" — the caller MUST NOT flag any
-        # symbol as unknown (ADR-39: never guess from a stale copy).
+        # The authoritative set of accepted `have_http_status` symbols (real Rack status symbols ∪ the
+        # Rails group aliases), or `nil` when it cannot be determined because Rack is unavailable. A `nil`
+        # return means "decline" — the caller MUST NOT flag any symbol as unknown (ADR-39: never guess from
+        # a stale copy).
         def known_symbols
           rack = rack_status_symbols
           return nil if rack.nil?
@@ -40,9 +36,8 @@ module Rigor
           rack | RAILS_STATUS_GROUP_ALIASES
         end
 
-        # The real `Rack::Utils::SYMBOL_TO_STATUS_CODE` keys, or `nil` when
-        # Rack is not loadable. Lazy require (core Rigor carries no Rack
-        # dependency; the plugin brings it); memoised for the process.
+        # The real `Rack::Utils::SYMBOL_TO_STATUS_CODE` keys, or `nil` when Rack is not loadable. Lazy
+        # require (core Rigor carries no Rack dependency; the plugin brings it); memoised for the process.
         def rack_status_symbols
           return @rack_status_symbols if defined?(@rack_status_symbols)
 

--- a/plugins/rigor-rspec/demo/spec/errors_spec.rb
+++ b/plugins/rigor-rspec/demo/spec/errors_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# DO NOT run via `rspec spec/errors_spec.rb` — analyse
-# with `bundle exec rigor check` to see rigor-rspec's
+# DO NOT run via `rspec spec/errors_spec.rb` — analyse with `bundle exec rigor check` to see rigor-rspec's
 # diagnostics.
 
 # rubocop:disable RSpec/OverwritingSetup, RSpec/LeadingSubject, RSpec/MultipleSubjects, RSpec/EmptyExampleGroup, RSpec/EmptyLineAfterSubject
@@ -17,15 +16,13 @@ def subject(_name = :subject, &); end
 def context(*, &); end
 
 RSpec.describe "Mistakes" do
-  # Duplicate `let(:user)` in the same scope —
-  # the second one wins at runtime, the first is
-  # silently shadowed:
+  # Duplicate `let(:user)` in the same scope — the second one wins at runtime, the first is silently
+  # shadowed:
   #   plugin.rspec.duplicate-let
   let(:user) { :alice }
   let(:user) { :bob }
 
-  # Self-referencing `let` — calls `tags` from inside its
-  # own block body, which infinite-loops at runtime:
+  # Self-referencing `let` — calls `tags` from inside its own block body, which infinite-loops at runtime:
   #   plugin.rspec.self-reference
   let(:tags) { tags.map(&:upcase) }
 

--- a/plugins/rigor-rspec/demo/spec/matcher_narrowing_spec.rb
+++ b/plugins/rigor-rspec/demo/spec/matcher_narrowing_spec.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-# Pillar 2 Slice 1 demo — `expect(x).to MATCHER` narrows `x`
-# downstream so subsequent calls in the same `it` body resolve
-# against the narrowed type. Without this slice, `x` would
-# stay at its entry type (typically `untyped` for spec-local
-# bindings) and the downstream `.length` / `.upcase` calls
-# would either fall through `Dynamic[top]` or fire
-# `possible-nil-receiver`.
+# Pillar 2 Slice 1 demo — `expect(x).to MATCHER` narrows `x` downstream so subsequent calls in the same
+# `it` body resolve against the narrowed type. Without this slice, `x` would stay at its entry type
+# (typically `untyped` for spec-local bindings) and the downstream `.length` / `.upcase` calls would
+# either fall through `Dynamic[top]` or fire `possible-nil-receiver`.
 
 RSpec.describe "matcher narrowing" do
   it "narrows to String through be_a(String)" do

--- a/plugins/rigor-rspec/demo/spec/user_spec.rb
+++ b/plugins/rigor-rspec/demo/spec/user_spec.rb
@@ -1,22 +1,18 @@
 # frozen_string_literal: true
 
-# Demo: rigor-rspec walks RSpec.describe blocks and
-# validates the `let` / `subject` declarations inside
-# each scope. This file shows clean usage — no
-# diagnostics expected.
+# Demo: rigor-rspec walks RSpec.describe blocks and validates the `let` / `subject` declarations inside
+# each scope. This file shows clean usage — no diagnostics expected.
 
 # rubocop:disable RSpec/LeadingSubject, RSpec/EmptyLineAfterFinalLet, RSpec/EmptyExampleGroup
 
-# Stand-in `RSpec.describe` so this file parses
-# standalone (without RSpec loaded).
+# Stand-in `RSpec.describe` so this file parses standalone (without RSpec loaded).
 module RSpec
   def self.describe(*, &)
     yield
   end
 end
 
-# Stand-ins for the DSL methods that get called inside a
-# describe block.
+# Stand-ins for the DSL methods that get called inside a describe block.
 def let(_name, &); end
 def subject(_name = :subject, &); end
 def context(*, &); end

--- a/plugins/rigor-rspec/lib/rigor/plugin/rspec.rb
+++ b/plugins/rigor-rspec/lib/rigor/plugin/rspec.rb
@@ -10,62 +10,41 @@ require_relative "rspec/let_type_resolver"
 
 module Rigor
   module Plugin
-    # rigor-rspec — validates RSpec `let` / `subject`
-    # declarations within each describe / context scope,
-    # narrows `expect(x).to MATCHER` assertions downstream,
-    # and binds `let`/`subject` locals to their inferred
-    # return types inside `it` bodies.
+    # rigor-rspec — validates RSpec `let` / `subject` declarations within each describe / context scope,
+    # narrows `expect(x).to MATCHER` assertions downstream, and binds `let`/`subject` locals to their
+    # inferred return types inside `it` bodies.
     #
     # Tier 3A of the [Rails plugins roadmap](../../../../docs/design/20260508-rails-plugins-roadmap.md).
     # Ships four checks:
     #
-    # 1. **Duplicate `let` / `subject` declarations** in
-    #    the same scope (`warning`). RSpec's runtime lets
-    #    the last declaration win, so the first one is
-    #    silently shadowed — almost always a copy-paste
-    #    bug.
-    # 2. **Self-referencing `let` / `subject`** — calling
-    #    the declared name *inside* its own block body
-    #    (`error`). At runtime this infinite-loops; users
-    #    typically meant to call a different method or
+    # 1. **Duplicate `let` / `subject` declarations** in the same scope (`warning`). RSpec's runtime lets
+    #    the last declaration win, so the first one is silently shadowed — almost always a copy-paste bug.
+    # 2. **Self-referencing `let` / `subject`** — calling the declared name *inside* its own block body
+    #    (`error`). At runtime this infinite-loops; users typically meant to call a different method or
     #    forgot to introduce a `super`.
-    # 3. **`expect(x).to MATCHER` narrowing** — narrows
-    #    the named local `x` on the post-call edge for
-    #    eight matchers (see `MatcherAnalyzer`).
-    # 4. **`let`/`subject` local binding** — binds `let`
-    #    / `subject` names in `it` bodies to the block's
+    # 3. **`expect(x).to MATCHER` narrowing** — narrows the named local `x` on the post-call edge for eight
+    #    matchers (see `MatcherAnalyzer`).
+    # 4. **`let`/`subject` local binding** — binds `let` / `subject` names in `it` bodies to the block's
     #    inferred return type (see `LetTypeResolver`).
     #
     # ## Configuration
     #
-    # No configuration knobs. The plugin walks every
-    # analysed file for `RSpec.describe ... do` blocks;
-    # spec files outside the project's `paths:` are not
-    # scanned.
+    # No configuration knobs. The plugin walks every analysed file for `RSpec.describe ... do` blocks; spec
+    # files outside the project's `paths:` are not scanned.
     #
     # ## Limitations
     #
-    # - **No let-typo detection.** Detecting an `it`
-    #   block's reference to a misspelled `let` name
-    #   requires resolving every method call inside the
-    #   block against the let scope chain, the included
-    #   modules, the matchers DSL, and helper methods.
-    #   Reliable diagnostics here need a much heavier
-    #   walker — see the README's `Future direction`.
-    # - **No mock-target validation.**
-    #   `expect(x).to receive(:nme)` validating against
-    #   `x`'s methods is a separate slice; it overlaps with
-    #   the engine's general method-existence
-    #   diagnostics and needs careful coordination to avoid
-    #   double-firing.
-    # - **No shared-context resolution.** `include_context`,
-    #   `shared_context`, and `it_behaves_like` are
-    #   recognised as scope-opening calls but their
-    #   declarations are not pulled into the host scope.
-    # - **Constant validation is not done here.**
-    #   `RSpec.describe SomeClass do` does not validate
-    #   `SomeClass`; the engine's `inference.unresolved-constant`
-    #   already catches that.
+    # - **No let-typo detection.** Detecting an `it` block's reference to a misspelled `let` name requires
+    #   resolving every method call inside the block against the let scope chain, the included modules,
+    #   the matchers DSL, and helper methods. Reliable diagnostics here need a much heavier walker — see
+    #   the README's `Future direction`.
+    # - **No mock-target validation.** `expect(x).to receive(:nme)` validating against `x`'s methods is a
+    #   separate slice; it overlaps with the engine's general method-existence diagnostics and needs
+    #   careful coordination to avoid double-firing.
+    # - **No shared-context resolution.** `include_context`, `shared_context`, and `it_behaves_like` are
+    #   recognised as scope-opening calls but their declarations are not pulled into the host scope.
+    # - **Constant validation is not done here.** `RSpec.describe SomeClass do` does not validate
+    #   `SomeClass`; the engine's `inference.unresolved-constant` already catches that.
     class Rspec < Rigor::Plugin::Base
       manifest(
         id: "rspec",
@@ -79,10 +58,9 @@ module Rigor
           { plugin_id: "factorybot", name: :factory_index, optional: true }
         ],
         additional_initializers: [
-          # ADR-38 block-form: `before { @ivar = … }`, `let(:x) { @ivar = … }`,
-          # and `subject { @ivar = … }` establish ivar state before `it` bodies
-          # run. Declaring them here suppresses the read-before-write nil
-          # widening that would otherwise appear on those ivars in `it` / `specify`
+          # ADR-38 block-form: `before { @ivar = … }`, `let(:x) { @ivar = … }`, and `subject { @ivar = … }`
+          # establish ivar state before `it` bodies run. Declaring them here suppresses the
+          # read-before-write nil widening that would otherwise appear on those ivars in `it` / `specify`
           # sibling blocks.
           Rigor::Plugin::AdditionalInitializer.new(
             receiver_constraint: "RSpec::ExampleGroup",
@@ -92,53 +70,44 @@ module Rigor
       )
 
       def init(_services)
-        # Per-path `LetScopeIndex` cache. The let-binding
-        # `dynamic_return` rule (and its `file_methods:` gate)
-        # consult the index per call node; building it once
-        # per file is essential for performance.
+        # Per-path `LetScopeIndex` cache. The let-binding `dynamic_return` rule (and its `file_methods:`
+        # gate) consult the index per call node; building it once per file is essential for performance.
         @let_index_cache = {}
       end
 
       def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
-        # Build the let-scope index for this file while we
-        # have the parsed root in hand — the let-binding rule
-        # picks it up from `@let_index_cache` keyed on path.
+        # Build the let-scope index for this file while we have the parsed root in hand — the let-binding
+        # rule picks it up from `@let_index_cache` keyed on path.
         @let_index_cache[path] ||= LetScopeIndex.build(root)
         Analyzer.diagnose(path: path, root: root).map { |diag| build_diagnostic(diag) }
       end
 
-      # ADR-37 slice 2 — matcher narrowing
-      # (`expect(x).to be_a(T)` → `post_return_facts` on `x`),
+      # ADR-37 slice 2 — matcher narrowing (`expect(x).to be_a(T)` → `post_return_facts` on `x`),
       # method-gated by the engine on the expectation verbs.
       narrowing_facts methods: %i[to not_to to_not] do |call_node, scope|
         MatcherAnalyzer.contribution_for(call_node, environment: scope&.environment)&.post_return_facts
       end
 
-      # ADR-52 slice 5a — binds local reads in `it` /
-      # spec bodies to their `let(:name) { ... }` block's inferred return
-      # type. The name set varies per file (each spec file's
-      # `describe`/`let` structure), so the rule gates on the per-file
-      # `file_methods:` form: the engine resolves the file's let names
-      # once per analysed file and consults the block only for a listed
-      # name; the line-scoped shadowing resolution stays in the block.
+      # ADR-52 slice 5a — binds local reads in `it` / spec bodies to their `let(:name) { ... }` block's
+      # inferred return type. The name set varies per file (each spec file's `describe`/`let` structure),
+      # so the rule gates on the per-file `file_methods:` form: the engine resolves the file's let names
+      # once per analysed file and consults the block only for a listed name; the line-scoped shadowing
+      # resolution stays in the block.
       dynamic_return file_methods: ->(path) { let_names_for(path) } do |call_node, scope|
         let_binding_return_type(call_node, scope)
       end
 
       private
 
-      # The `file_methods:` gate set — every `let` / `subject` name the
-      # file declares anywhere. A safe over-approximation of the block's
-      # own `let_block_at` line-scoped lookup (a name read outside its
+      # The `file_methods:` gate set — every `let` / `subject` name the file declares anywhere. A safe
+      # over-approximation of the block's own `let_block_at` line-scoped lookup (a name read outside its
       # describe scope passes the gate and is declined by the block).
       def let_names_for(path)
         let_scope_index_for(path)&.let_names || []
       end
 
-      # When the call node is a no-receiver
-      # method call (`user`, `subject`, etc.) inside an RSpec
-      # `describe` block whose lets include a matching name,
-      # return the let block's inferred type.
+      # When the call node is a no-receiver method call (`user`, `subject`, etc.) inside an RSpec
+      # `describe` block whose lets include a matching name, return the let block's inferred type.
       def let_binding_return_type(call_node, scope)
         return nil if scope.nil?
         return nil unless candidate_call?(call_node)
@@ -163,10 +132,9 @@ module Rigor
         call_node.is_a?(Prism::CallNode) &&
           call_node.receiver.nil? &&
           call_node.block.nil? &&
-          # Calls with arguments are matcher / DSL invocations,
-          # not let-bound name reads. `subject` / `user` etc.
-          # without args are the implicit-method-call shape RSpec
-          # uses to expose let / subject in `it` bodies.
+          # Calls with arguments are matcher / DSL invocations, not let-bound name reads. `subject` /
+          # `user` etc. without args are the implicit-method-call shape RSpec uses to expose let / subject
+          # in `it` bodies.
           (call_node.arguments.nil? || call_node.arguments.arguments.empty?)
       end
 

--- a/plugins/rigor-rspec/lib/rigor/plugin/rspec/analyzer.rb
+++ b/plugins/rigor-rspec/lib/rigor/plugin/rspec/analyzer.rb
@@ -9,16 +9,12 @@ module Rigor
     class Rspec < Rigor::Plugin::Base
       # Per-file walker that:
       #
-      # 1. Collects every RSpec scope (each `RSpec.describe`
-      #    plus its nested `describe` / `context` blocks)
+      # 1. Collects every RSpec scope (each `RSpec.describe` plus its nested `describe` / `context` blocks)
       #    via {ScopeWalker}.
-      # 2. Reports duplicate `let(:name)` / `subject(:name)`
-      #    declarations within the same scope (the second
-      #    declaration wins at runtime — an easy
-      #    copy-paste bug).
-      # 3. Reports recursive self-references —
-      #    `let(:user) { user.something }` will infinite-loop
-      #    at runtime — an easy oversight.
+      # 2. Reports duplicate `let(:name)` / `subject(:name)` declarations within the same scope (the second
+      #    declaration wins at runtime — an easy copy-paste bug).
+      # 3. Reports recursive self-references — `let(:user) { user.something }` will infinite-loop at
+      #    runtime — an easy oversight.
       module Analyzer
         Diagnostic = Struct.new(:path, :line, :column, :severity, :rule, :message, keyword_init: true)
 
@@ -49,11 +45,9 @@ module Rigor
         end
 
         def duplicate_diagnostics_for(path, name, decls)
-          # Report each subsequent occurrence; the first
-          # one is the "winner" only by literal source
-          # order, but RSpec lets the LAST declaration win
-          # at runtime, so flag everything after the first
-          # so the user can see the full list.
+          # Report each subsequent occurrence; the first one is the "winner" only by literal source order,
+          # but RSpec lets the LAST declaration win at runtime, so flag everything after the first so the
+          # user can see the full list.
           decls.drop(1).map do |decl|
             Diagnostic.new(
               path: path,
@@ -76,8 +70,7 @@ module Rigor
           end
         end
 
-        # Walks the declaration's block body looking for a
-        # call to its own name with no explicit receiver.
+        # Walks the declaration's block body looking for a call to its own name with no explicit receiver.
         # Returns true if at least one such call exists.
         def self_references?(decl)
           body = decl.block_node&.body

--- a/plugins/rigor-rspec/lib/rigor/plugin/rspec/let_scope_index.rb
+++ b/plugins/rigor-rspec/lib/rigor/plugin/rspec/let_scope_index.rb
@@ -8,22 +8,17 @@ require_relative "scope_walker"
 module Rigor
   module Plugin
     class Rspec < Rigor::Plugin::Base
-      # Per-file index of RSpec scope hierarchy. Each
-      # describe scope carries:
+      # Per-file index of RSpec scope hierarchy. Each describe scope carries:
       #
-      # - `outer_range`: `Range[Integer]` of line numbers
-      #   covered by the describe's block body (start_line..end_line).
-      # - `describe_const`: the model constant string named in
-      #   `RSpec.describe SomeModel do` / `describe SomeModel do`,
-      #   or `nil` when the describe's first arg is a String
-      #   (`describe ".foo"`).
-      # - `lets`: `Hash{Symbol => Prism::BlockNode}` of `let(:name)
-      #   { ... }` and `subject(:name) { ... }` declarations.
-      #   `:subject` is the key for the implicit `subject { ... }`.
+      # - `outer_range`: `Range[Integer]` of line numbers covered by the describe's block body
+      #   (start_line..end_line).
+      # - `describe_const`: the model constant string named in `RSpec.describe SomeModel do` / `describe
+      #   SomeModel do`, or `nil` when the describe's first arg is a String (`describe ".foo"`).
+      # - `lets`: `Hash{Symbol => Prism::BlockNode}` of `let(:name) { ... }` and `subject(:name) { ... }`
+      #   declarations. `:subject` is the key for the implicit `subject { ... }`.
       #
-      # Used by the plugin's let-binding `dynamic_return`
-      # rule to bind `let`-named method-shape calls inside
-      # `it` bodies to the let block's inferred type.
+      # Used by the plugin's let-binding `dynamic_return` rule to bind `let`-named method-shape calls
+      # inside `it` bodies to the let block's inferred type.
       class LetScopeIndex
         Record = Struct.new(:outer_range, :describe_const, :lets, keyword_init: true) do
           def contains?(line) = outer_range.cover?(line)
@@ -38,27 +33,22 @@ module Rigor
           freeze
         end
 
-        # Returns every record whose outer_range contains the
-        # given line, ordered from outermost to innermost. The
-        # innermost wins on `let` name collisions per Ruby's
-        # method-resolution order (RSpec nested `let` shadows
-        # the outer `let`).
+        # Returns every record whose outer_range contains the given line, ordered from outermost to
+        # innermost. The innermost wins on `let` name collisions per Ruby's method-resolution order (RSpec
+        # nested `let` shadows the outer `let`).
         def records_at(line)
           @records.select { |rec| rec.contains?(line) }
         end
 
-        # ADR-52 slice 5a — every `let` / `subject` name declared
-        # anywhere in the file, across all describe scopes. Feeds the
-        # plugin's `dynamic_return file_methods:` gate: the engine only
-        # consults the rule for a call whose name appears here; the
-        # precise line-scoped resolution stays in `let_block_at`.
+        # ADR-52 slice 5a — every `let` / `subject` name declared anywhere in the file, across all describe
+        # scopes. Feeds the plugin's `dynamic_return file_methods:` gate: the engine only consults the rule
+        # for a call whose name appears here; the precise line-scoped resolution stays in `let_block_at`.
         # @return [Array<Symbol>]
         def let_names
           @records.flat_map { |rec| rec.lets.keys }.uniq
         end
 
-        # Resolves a `let` name at the given line by walking
-        # records innermost to outermost.
+        # Resolves a `let` name at the given line by walking records innermost to outermost.
         # @return [Prism::BlockNode, nil]
         def let_block_at(line, name)
           name_sym = name.to_sym
@@ -68,9 +58,8 @@ module Rigor
           nil
         end
 
-        # Resolves the `describe`-anchor constant name at the
-        # given line. The innermost describe with a constant
-        # anchor wins; describe-with-String anchors are skipped.
+        # Resolves the `describe`-anchor constant name at the given line. The innermost describe with a
+        # constant anchor wins; describe-with-String anchors are skipped.
         # @return [String, nil]
         def describe_const_at(line)
           records_at(line).reverse.each do |rec|
@@ -92,9 +81,8 @@ module Rigor
           if describe_call?(node)
             record = build_record(node, anchor)
             accumulator << record
-            # `describe_call?` already guarantees a `Prism::CallNode`; the
-            # explicit `is_a?` re-states it so the analyzer narrows `node`
-            # from `Prism::Node` and resolves `#block` (a CallNode method).
+            # `describe_call?` already guarantees a `Prism::CallNode`; the explicit `is_a?` re-states it so
+            # the analyzer narrows `node` from `Prism::Node` and resolves `#block` (a CallNode method).
             if node.is_a?(Prism::CallNode) && node.block&.body
               collect(node.block.body, anchor: record.describe_const || anchor, accumulator: accumulator)
             end
@@ -123,8 +111,7 @@ module Rigor
           return false unless ScopeWalker::SCOPE_METHODS.include?(node.name) || node.name == :describe
           return false unless node.block.is_a?(Prism::BlockNode)
 
-          # `RSpec.describe ...` has receiver = RSpec; bare
-          # `describe ... do` has nil receiver. Accept both.
+          # `RSpec.describe ...` has receiver = RSpec; bare `describe ... do` has nil receiver. Accept both.
           node.receiver.nil? || describe_receiver?(node.receiver)
         end
 
@@ -158,11 +145,9 @@ module Rigor
           end
         end
 
-        # Walks the describe's body shallowly: collects every
-        # top-level `let(:name) { ... }` / `subject(:name) { ... }`
-        # / `subject { ... }` declaration. Does NOT recurse into
-        # nested describe / context blocks — those have their
-        # own record built by `collect` above.
+        # Walks the describe's body shallowly: collects every top-level `let(:name) { ... }` /
+        # `subject(:name) { ... }` / `subject { ... }` declaration. Does NOT recurse into nested describe /
+        # context blocks — those have their own record built by `collect` above.
         def self.collect_lets(body)
           return {} unless body.is_a?(Prism::Node)
 

--- a/plugins/rigor-rspec/lib/rigor/plugin/rspec/let_type_resolver.rb
+++ b/plugins/rigor-rspec/lib/rigor/plugin/rspec/let_type_resolver.rb
@@ -6,28 +6,22 @@ require "rigor/type"
 module Rigor
   module Plugin
     class Rspec < Rigor::Plugin::Base
-      # Resolves the runtime type of a
-      # `let(:name) { body }` or `subject(:name) { body }`
-      # block by pattern-matching its body's tail expression.
+      # Resolves the runtime type of a `let(:name) { body }` or `subject(:name) { body }` block by
+      # pattern-matching its body's tail expression.
       #
       # Recognised body shapes (floor):
       #
       # - `ConstantClass.new(...)` → `Nominal[ConstantClass]`
       # - `Foo::Bar.new(...)` → `Nominal[Foo::Bar]`
-      # - `described_class.new(...)` → `Nominal[<describe const>]`
-      #   when the surrounding describe block has a constant
-      #   anchor.
-      # - `create(:factory)` / `build(:factory)` /
-      #   `build_stubbed(:factory)` / `attributes_for(:factory)`
-      #   → `Nominal[<factory.model_class>]` when the
-      #   `:factory_index` ADR-9 fact is available and the
+      # - `described_class.new(...)` → `Nominal[<describe const>]` when the surrounding describe block has
+      #   a constant anchor.
+      # - `create(:factory)` / `build(:factory)` / `build_stubbed(:factory)` / `attributes_for(:factory)` →
+      #   `Nominal[<factory.model_class>]` when the `:factory_index` ADR-9 fact is available and the
       #   factory name is known.
-      # - `FactoryBot.create(:factory)` etc. — same as the
-      #   implicit-receiver factorybot form.
+      # - `FactoryBot.create(:factory)` etc. — same as the implicit-receiver factorybot form.
       #
-      # Returns `nil` for any other body shape. Multi-statement
-      # bodies use the LAST statement (the block's return
-      # value).
+      # Returns `nil` for any other body shape. Multi-statement bodies use the LAST statement (the block's
+      # return value).
       module LetTypeResolver
         FACTORYBOT_ENTRY_METHODS = %i[
           create build build_stubbed attributes_for
@@ -38,9 +32,8 @@ module Rigor
 
         # @param block_node [Prism::BlockNode]
         # @param describe_const [String, nil]
-        # @param factory_index [Object, nil] something
-        #   responding to `find(factory_name)` and returning
-        #   an entry that responds to `model_class`.
+        # @param factory_index [Object, nil] something responding to `find(factory_name)` and returning an
+        #   entry that responds to `model_class`.
         # @param environment [Rigor::Environment, nil]
         # @return [Rigor::Type, nil]
         def resolve(block_node, describe_const:, factory_index:, environment:)
@@ -103,10 +96,8 @@ module Rigor
           nominal_for(model_class, environment: environment)
         end
 
-        # Recognises both `create(:name)` (implicit receiver,
-        # via `include FactoryBot::Syntax::Methods`) and the
-        # explicit `FactoryBot.create(:name)` /
-        # `FactoryGirl.create(:name)` (legacy) forms.
+        # Recognises both `create(:name)` (implicit receiver, via `include FactoryBot::Syntax::Methods`)
+        # and the explicit `FactoryBot.create(:name)` / `FactoryGirl.create(:name)` (legacy) forms.
         def factorybot_call?(call_node)
           return false unless FACTORYBOT_ENTRY_METHODS.include?(call_node.name)
 

--- a/plugins/rigor-rspec/lib/rigor/plugin/rspec/matcher_analyzer.rb
+++ b/plugins/rigor-rspec/lib/rigor/plugin/rspec/matcher_analyzer.rb
@@ -8,59 +8,42 @@ require "rigor/flow_contribution/fact"
 module Rigor
   module Plugin
     class Rspec < Rigor::Plugin::Base
-      # Recognises `expect(x).to MATCHER`
-      # patterns at per-call recognition time and emits
-      # `post_return_facts` that narrow the named local on the
-      # post-call edge.
+      # Recognises `expect(x).to MATCHER` patterns at per-call recognition time and emits
+      # `post_return_facts` that narrow the named local on the post-call edge.
       #
-      # The supported matchers are the lowest-false-positive
-      # floor of the RSpec matcher DSL:
+      # The supported matchers are the lowest-false-positive floor of the RSpec matcher DSL:
       #
-      # - `be_a(T)` / `be_kind_of(T)` — `x is_a?(T)` style class
-      #   membership; narrows `x` to `T`.
-      # - `be_instance_of(T)` — exact-class match; narrows
-      #   `x` to `T` (the engine currently treats Nominal[T]
-      #   uniformly, so the distinction with `be_a` is observed
-      #   at the carrier level but not the runtime).
+      # - `be_a(T)` / `be_kind_of(T)` — `x is_a?(T)` style class membership; narrows `x` to `T`.
+      # - `be_instance_of(T)` — exact-class match; narrows `x` to `T` (the engine currently treats
+      #   Nominal[T] uniformly, so the distinction with `be_a` is observed at the carrier level but not the
+      #   runtime).
       # - `be_nil` — narrows `x` to `Constant<nil>`.
-      # - `eq(LITERAL)` for a literal-value argument — narrows
-      #   `x` to `Constant<literal>`.
+      # - `eq(LITERAL)` for a literal-value argument — narrows `x` to `Constant<literal>`.
       #
-      # The matchers below this floor (`be_truthy` / `be_falsey`
-      # / `be_within` / `be > / < / >=` / `include` / `start_with`
-      # / `match(regex)` / `raise_error` / receive-style mocks)
-      # require either edge-aware fragments (`truthy_facts` /
-      # `falsey_facts` rather than `post_return_facts`) or
-      # diagnostic-only enforcement; both are queued for follow-up
-      # slices.
+      # The matchers below this floor (`be_truthy` / `be_falsey` / `be_within` / `be > / < / >=` /
+      # `include` / `start_with` / `match(regex)` / `raise_error` / receive-style mocks) require either
+      # edge-aware fragments (`truthy_facts` / `falsey_facts` rather than `post_return_facts`) or
+      # diagnostic-only enforcement; both are queued for follow-up slices.
       #
       # The analyzer fires ONLY when:
       #
-      # 1. The call node is one of `<recv>.to(matcher)` /
-      #    `<recv>.not_to(matcher)` / `<recv>.to_not(matcher)`.
-      #    `not_to` / `to_not` flip the fact's `negative` flag
-      #    so the engine narrows AWAY from the matcher's type
-      #    (e.g. `not_to be_nil` removes nil from the receiver).
-      # 2. The receiver is `expect(<local_var>)` — exactly one
-      #    positional argument that's a LocalVariableReadNode.
-      #    Composite receivers (`expect(foo.bar)`,
-      #    `expect { ... }.to raise_error`) fall through.
-      # 3. The matcher is one of the recognised forms above
-      #    (`be_a` / `be_kind_of` / `be_instance_of` /
-      #    `be_an_instance_of` / `be_nil` / `eq(literal)` /
-      #    `eql(literal)` / `match(/regex/)`).
+      # 1. The call node is one of `<recv>.to(matcher)` / `<recv>.not_to(matcher)` /
+      #    `<recv>.to_not(matcher)`. `not_to` / `to_not` flip the fact's `negative` flag so the engine
+      #    narrows AWAY from the matcher's type (e.g. `not_to be_nil` removes nil from the receiver).
+      # 2. The receiver is `expect(<local_var>)` — exactly one positional argument that's a
+      #    LocalVariableReadNode. Composite receivers (`expect(foo.bar)`, `expect { ... }.to raise_error`)
+      #    fall through.
+      # 3. The matcher is one of the recognised forms above (`be_a` / `be_kind_of` / `be_instance_of` /
+      #    `be_an_instance_of` / `be_nil` / `eq(literal)` / `eql(literal)` / `match(/regex/)`).
       module MatcherAnalyzer
         module_function
 
-        # @param call_node [Prism::CallNode] the call whose
-        #   contribution we're computing. Returns nil when the
-        #   call shape does not match `expect(local).to matcher`.
-        # @param environment [Rigor::Environment, nil] the
-        #   surrounding environment used to resolve a matcher's
-        #   class-name argument to a `Type::Nominal`. When nil,
-        #   class-name resolution falls back to a bare
-        #   `Nominal[<name>]` carrier (sound — the receiver
-        #   constant may be a user class not in RBS).
+        # @param call_node [Prism::CallNode] the call whose contribution we're computing. Returns nil when
+        #   the call shape does not match `expect(local).to matcher`.
+        # @param environment [Rigor::Environment, nil] the surrounding environment used to resolve a
+        #   matcher's class-name argument to a `Type::Nominal`. When nil, class-name resolution falls back
+        #   to a bare `Nominal[<name>]` carrier (sound — the receiver constant may be a user class not in
+        #   RBS).
         # @return [Rigor::FlowContribution, nil]
         def contribution_for(call_node, environment:)
           verb = assertion_verb(call_node)
@@ -136,11 +119,9 @@ module Rigor
           when :eq, :eql
             constant_type_for_literal_arg(matcher)
           when :match
-            # `match(/regex/)` narrows x to String. `match("...")`
-            # or `match(arbitrary_object)` falls through — the
-            # broader matcher dispatch needs the receiver to be a
-            # String, but we can only assert that for a literal
-            # regex.
+            # `match(/regex/)` narrows x to String. `match("...")` or `match(arbitrary_object)` falls
+            # through — the broader matcher dispatch needs the receiver to be a String, but we can only
+            # assert that for a literal regex.
             string_type_for_regex_arg(matcher)
           end
         end
@@ -184,10 +165,9 @@ module Rigor
         NO_LITERAL = Object.new.freeze
         private_constant :NO_LITERAL
 
-        # Returns the Ruby value of a literal-AST argument, or
-        # `NO_LITERAL` when the node isn't a recognised literal
-        # shape. Recognised forms cover the common `eq(literal)`
-        # case: integer, float, true/false/nil, string, symbol.
+        # Returns the Ruby value of a literal-AST argument, or `NO_LITERAL` when the node isn't a
+        # recognised literal shape. Recognised forms cover the common `eq(literal)` case: integer, float,
+        # true/false/nil, string, symbol.
         def literal_value_for(node)
           case node
           when Prism::IntegerNode then node.value
@@ -206,10 +186,8 @@ module Rigor
           args.nil? || args.empty?
         end
 
-        # Renders a `Prism::ConstantReadNode` /
-        # `Prism::ConstantPathNode` chain as a `"Foo::Bar"`
-        # String. Returns nil when the node isn't a constant
-        # reference.
+        # Renders a `Prism::ConstantReadNode` / `Prism::ConstantPathNode` chain as a `"Foo::Bar"` String.
+        # Returns nil when the node isn't a constant reference.
         def constant_path_name(node)
           case node
           when Prism::ConstantReadNode

--- a/plugins/rigor-rspec/lib/rigor/plugin/rspec/scope_walker.rb
+++ b/plugins/rigor-rspec/lib/rigor/plugin/rspec/scope_walker.rb
@@ -6,52 +6,40 @@ require "rigor/source/literals"
 module Rigor
   module Plugin
     class Rspec < Rigor::Plugin::Base
-      # Walks an RSpec spec file's AST and yields, for each
-      # describe / context block (including the outer
-      # `RSpec.describe`), a `Scope` value with the `let`
-      # and `subject` declarations recorded inside that
+      # Walks an RSpec spec file's AST and yields, for each describe / context block (including the outer
+      # `RSpec.describe`), a `Scope` value with the `let` and `subject` declarations recorded inside that
       # scope.
       #
-      # Scope hierarchy is preserved: each `Scope` carries
-      # a list of its `nested_scopes`. The analyzer uses the
-      # hierarchy to detect cross-scope shadowing.
+      # Scope hierarchy is preserved: each `Scope` carries a list of its `nested_scopes`. The analyzer uses
+      # the hierarchy to detect cross-scope shadowing.
       #
-      # Recognised scope methods (when called without a
-      # receiver, or with `RSpec` as the receiver):
+      # Recognised scope methods (when called without a receiver, or with `RSpec` as the receiver):
       #
-      # - `describe` / `context` — both open a new nested
-      #   scope.
+      # - `describe` / `context` — both open a new nested scope.
       # - `RSpec.describe` — the outermost scope.
       #
-      # Recognised declaration methods (inside any scope,
-      # called without a receiver):
+      # Recognised declaration methods (inside any scope, called without a receiver):
       #
-      # - `let(:name) { ... }` — caches the block result
-      #   per-example; recorded as a Declaration.
-      # - `let!(:name) { ... }` — same, but evaluated
-      #   eagerly via a `before` hook; same shape for our
+      # - `let(:name) { ... }` — caches the block result per-example; recorded as a Declaration.
+      # - `let!(:name) { ... }` — same, but evaluated eagerly via a `before` hook; same shape for our
       #   purposes.
-      # - `subject(:name) { ... }` — special-cases name
-      #   `:subject` when called without a name.
+      # - `subject(:name) { ... }` — special-cases name `:subject` when called without a name.
       module ScopeWalker
         SCOPE_METHODS = %i[describe context].freeze
         DECLARATION_METHODS = %i[let let! subject].freeze
 
         # @!attribute [r] kind
-        #   `:describe`, `:context`, or `:rspec_describe` for
-        #   the root.
+        #   `:describe`, `:context`, or `:rspec_describe` for the root.
         # @!attribute [r] declarations
         #   `Array<Declaration>` declared in this scope.
         # @!attribute [r] nested_scopes
         #   `Array<Scope>` nested under this scope.
         # @!attribute [r] location
-        #   `Prism::Location` of the call node that opened
-        #   this scope.
+        #   `Prism::Location` of the call node that opened this scope.
         Scope = Struct.new(:kind, :declarations, :nested_scopes, :location, keyword_init: true)
 
         # @!attribute [r] name
-        #   `Symbol` declared name (`:user`, `:subject`,
-        #   ...).
+        #   `Symbol` declared name (`:user`, `:subject`, ...).
         # @!attribute [r] kind
         #   `:let`, `:let!`, or `:subject`.
         # @!attribute [r] location
@@ -62,18 +50,15 @@ module Rigor
 
         module_function
 
-        # Walks the parsed file and returns an array of
-        # top-level scopes (each `RSpec.describe` is a
-        # separate root). Files with no recognised scopes
-        # return an empty array.
+        # Walks the parsed file and returns an array of top-level scopes (each `RSpec.describe` is a
+        # separate root). Files with no recognised scopes return an empty array.
         def collect_scopes(root)
           scopes = []
           walk_top_level(root, scopes)
           scopes
         end
 
-        # Walks every scope in a tree (root + descendants)
-        # and yields each in turn.
+        # Walks every scope in a tree (root + descendants) and yields each in turn.
         def each_scope(scope, &)
           yield scope
           scope.nested_scopes.each { |child| each_scope(child, &) }
@@ -89,8 +74,7 @@ module Rigor
           end
         end
 
-        # Returns true for `RSpec.describe ... do |...| ...
-        # end` calls.
+        # Returns true for `RSpec.describe ... do |...| ... end` calls.
         def rspec_describe_call?(node)
           return false unless node.is_a?(Prism::CallNode)
           return false unless node.name == :describe
@@ -100,10 +84,8 @@ module Rigor
           %w[RSpec ::RSpec].include?(receiver_name)
         end
 
-        # Returns true for `describe ... do ... end` /
-        # `context ... do ... end` (called without an
-        # explicit receiver — `RSpec.describe` is handled
-        # separately by `rspec_describe_call?`).
+        # Returns true for `describe ... do ... end` / `context ... do ... end` (called without an
+        # explicit receiver — `RSpec.describe` is handled separately by `rspec_describe_call?`).
         def nested_scope_call?(node)
           node.is_a?(Prism::CallNode) &&
             SCOPE_METHODS.include?(node.name) &&
@@ -117,9 +99,8 @@ module Rigor
             node.receiver.nil?
         end
 
-        # Constructs a Scope from a describe / context /
-        # RSpec.describe call node. Walks the block body
-        # for declarations + nested scopes.
+        # Constructs a Scope from a describe / context / RSpec.describe call node. Walks the block body for
+        # declarations + nested scopes.
         def build_scope(call_node, kind:)
           declarations = []
           nested = []
@@ -146,8 +127,7 @@ module Rigor
 
         def build_declaration(call_node)
           first_arg = call_node.arguments&.arguments&.first
-          # `subject(&block)` (no name) defaults to the
-          # implicit subject; record it as `:subject`.
+          # `subject(&block)` (no name) defaults to the implicit subject; record it as `:subject`.
           if first_arg.nil?
             return nil unless call_node.name == :subject
 

--- a/plugins/rigor-shoulda-matchers/demo/spec/user_spec.rb
+++ b/plugins/rigor-shoulda-matchers/demo/spec/user_spec.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-# Worked example — rigor-shoulda-matchers validates the
-# columns / associations referenced by shoulda matchers
-# against the `:model_index` published by
-# `rigor-activerecord`. Activate both plugins for the cross-
-# check to fire; with `rigor-activerecord` alone, the column
-# / association names are silently accepted.
+# Worked example — rigor-shoulda-matchers validates the columns / associations referenced by shoulda
+# matchers against the `:model_index` published by `rigor-activerecord`. Activate both plugins for the
+# cross-check to fire; with `rigor-activerecord` alone, the column / association names are silently
+# accepted.
 
 RSpec.describe User do
   it { is_expected.to validate_presence_of(:email) }      # OK if `email` is a column

--- a/plugins/rigor-shoulda-matchers/lib/rigor/plugin/shoulda_matchers.rb
+++ b/plugins/rigor-shoulda-matchers/lib/rigor/plugin/shoulda_matchers.rb
@@ -6,18 +6,15 @@ require_relative "shoulda_matchers/analyzer"
 
 module Rigor
   module Plugin
-    # rigor-shoulda-matchers — validates shoulda-matchers
-    # matchers against the `:model_index` cross-plugin fact
-    # (ADR-9) published by `rigor-activerecord`.
+    # rigor-shoulda-matchers — validates shoulda-matchers matchers against the `:model_index` cross-plugin
+    # fact (ADR-9) published by `rigor-activerecord`.
     #
-    # The plugin walks every `RSpec.describe <ModelConst> do
-    # ... end` block and validates the matchers inside
-    # against the model's known columns / associations.
+    # The plugin walks every `RSpec.describe <ModelConst> do ... end` block and validates the matchers
+    # inside against the model's known columns / associations.
     #
     # ## Recognised matchers (v0.1.0)
     #
-    # **Column matchers** (validate the named column exists on
-    # the model):
+    # **Column matchers** (validate the named column exists on the model):
     #
     #   validate_presence_of(:col), validate_uniqueness_of(:col),
     #   validate_length_of(:col), validate_numericality_of(:col),
@@ -26,38 +23,27 @@ module Rigor
     #   validate_format_of(:col), validate_confirmation_of(:col),
     #   have_db_column(:col), have_db_index(:col)
     #
-    # **Association matchers** (validate the association exists
-    # AND its kind matches):
+    # **Association matchers** (validate the association exists AND its kind matches):
     #
     #   belong_to(:assoc), have_one(:assoc)            ← :singular
     #   have_many(:assoc), have_and_belong_to_many(:assoc) ← :collection
     #
     # ## Cross-plugin dependency
     #
-    # The plugin consumes `:model_index` from `rigor-activerecord`.
-    # When `rigor-activerecord` is NOT loaded (or hasn't
-    # published an index for the analysed model), the plugin
-    # falls silent — the cross-check is opt-in. Adding
-    # `rigor-activerecord` to `.rigor.yml` unlocks the
-    # diagnostics.
+    # The plugin consumes `:model_index` from `rigor-activerecord`. When `rigor-activerecord` is NOT
+    # loaded (or hasn't published an index for the analysed model), the plugin falls silent — the
+    # cross-check is opt-in. Adding `rigor-activerecord` to `.rigor.yml` unlocks the diagnostics.
     #
     # ## Limitations (v0.1.0)
     #
-    # - **No chained-matcher arg validation.** The chain
-    #   options on `validate_length_of(:col).is_at_most(50)`,
-    #   `validate_inclusion_of(:col).in_array([...])`,
-    #   `allow_value("foo").for(:col)`, etc. are NOT validated
-    #   (the `.is_at_most` etc. terminals are runtime-only).
-    # - **No polymorphic / through validation.** `belong_to(:user).polymorphic`,
-    #   `have_many(:posts, through: :memberships)` only check
-    #   the named association; the chain modifiers are
-    #   ignored.
-    # - **No nested-attribute matchers.** `accept_nested_attributes_for(:posts)`
-    #   not yet covered.
-    # - **No callback matchers.** `callback(:before_save).before(:save)`
-    #   would need a separate slice (overlaps with the
-    #   model_index's `callbacks` column already exposed but
-    #   no rspec-side recogniser yet).
+    # - **No chained-matcher arg validation.** The chain options on `validate_length_of(:col).is_at_most(50)`,
+    #   `validate_inclusion_of(:col).in_array([...])`, `allow_value("foo").for(:col)`, etc. are NOT
+    #   validated (the `.is_at_most` etc. terminals are runtime-only).
+    # - **No polymorphic / through validation.** `belong_to(:user).polymorphic`, `have_many(:posts,
+    #   through: :memberships)` only check the named association; the chain modifiers are ignored.
+    # - **No nested-attribute matchers.** `accept_nested_attributes_for(:posts)` not yet covered.
+    # - **No callback matchers.** `callback(:before_save).before(:save)` would need a separate slice
+    #   (overlaps with the model_index's `callbacks` column already exposed but no rspec-side recogniser yet).
     class ShouldaMatchers < Rigor::Plugin::Base
       manifest(
         id: "shoulda-matchers",
@@ -70,12 +56,10 @@ module Rigor
         ]
       )
 
-      # ADR-37 — per-matcher validation over the engine-owned walk. The
-      # model anchor (the enclosing `describe <Model>` const) comes from
-      # the node-rule NodeContext ancestors; the diagnostic points at the
-      # matcher name (message_loc). The :model_index fact (from
-      # rigor-activerecord) is read lazily via `read_fact`; without it
-      # the rule is silent.
+      # ADR-37 — per-matcher validation over the engine-owned walk. The model anchor (the enclosing
+      # `describe <Model>` const) comes from the node-rule NodeContext ancestors; the diagnostic points at
+      # the matcher name (message_loc). The :model_index fact (from rigor-activerecord) is read lazily via
+      # `read_fact`; without it the rule is silent.
       node_rule Prism::CallNode do |node, _scope, path, _fc, context|
         index = read_fact(plugin_id: "activerecord", name: :model_index)
         next [] if index.nil?

--- a/plugins/rigor-shoulda-matchers/lib/rigor/plugin/shoulda_matchers/analyzer.rb
+++ b/plugins/rigor-shoulda-matchers/lib/rigor/plugin/shoulda_matchers/analyzer.rb
@@ -5,17 +5,13 @@ require "prism"
 module Rigor
   module Plugin
     class ShouldaMatchers < Rigor::Plugin::Base
-      # Walks every `RSpec.describe <ModelConst> do ... end` /
-      # `describe <ModelConst> do ... end` block and validates
-      # the shoulda-matchers calls inside its body (any depth
-      # of nested `describe` / `context`) against the
-      # `:model_index` published by `rigor-activerecord`.
+      # Walks every `RSpec.describe <ModelConst> do ... end` / `describe <ModelConst> do ... end` block and
+      # validates the shoulda-matchers calls inside its body (any depth of nested `describe` / `context`)
+      # against the `:model_index` published by `rigor-activerecord`.
       #
-      # The "anchor" for cross-checking is the OUTERMOST
-      # describe block whose argument is a constant — that
-      # constant names the model being specced. Nested
-      # `describe ".some_method"` (String / Symbol args) does
-      # NOT change the anchor.
+      # The "anchor" for cross-checking is the OUTERMOST describe block whose argument is a constant —
+      # that constant names the model being specced. Nested `describe ".some_method"` (String / Symbol
+      # args) does NOT change the anchor.
       #
       # ## Recognised matcher calls (v0.1.0)
       #
@@ -34,8 +30,7 @@ module Rigor
       #   have_db_column(:col)
       #   have_db_index(:col)
       #
-      # All look up `:col` against the model's columns
-      # (`Entry#column?`). Unknown columns fire
+      # All look up `:col` against the model's columns (`Entry#column?`). Unknown columns fire
       # `unknown-column`.
       #
       # ### Association matchers
@@ -45,19 +40,15 @@ module Rigor
       #   have_many(:assoc)           ← expects :collection
       #   have_and_belong_to_many(:assoc) ← expects :collection
       #
-      # Unknown associations fire
-      # `unknown-association`. Known
-      # associations with mismatched kind (`should belong_to(:posts)`
-      # where `:posts` is `has_many`) fire
-      # `association-kind-mismatch`.
+      # Unknown associations fire `unknown-association`. Known associations with mismatched kind (`should
+      # belong_to(:posts)` where `:posts` is `has_many`) fire `association-kind-mismatch`.
       module Analyzer
-        # One matcher violation (always `:warning`). Carries no
-        # path/location — the caller (the `node_rule` block) positions it
-        # at the matcher name (`message_loc`) via `Plugin::Base#diagnostic`.
+        # One matcher violation (always `:warning`). Carries no path/location — the caller (the
+        # `node_rule` block) positions it at the matcher name (`message_loc`) via `Plugin::Base#diagnostic`.
         Violation = Struct.new(:rule, :message, keyword_init: true)
 
-        # `(matcher_name) => (:column | :association_singular | :association_collection)`
-        # — the validation lane each matcher routes to.
+        # `(matcher_name) => (:column | :association_singular | :association_collection)` — the
+        # validation lane each matcher routes to.
         MATCHER_TABLE = {
           # Column matchers — validate the named column exists on the model.
           validate_presence_of: :column,
@@ -72,8 +63,7 @@ module Rigor
           validate_confirmation_of: :column,
           have_db_column: :column,
           have_db_index: :column,
-          # Association matchers — validate the association
-          # exists AND its kind matches the matcher.
+          # Association matchers — validate the association exists AND its kind matches the matcher.
           belong_to: :association_singular,
           have_one: :association_singular,
           have_many: :association_collection,
@@ -84,17 +74,13 @@ module Rigor
 
         # @param path [String]
         # @param root [Prism::Node]
-        # @param model_index [Object, nil] the `:model_index`
-        #   fact value. When nil the analyzer falls silent.
+        # @param model_index [Object, nil] the `:model_index` fact value. When nil the analyzer falls silent.
         # @return [Array<Diagnostic>]
-        # The matcher violations for a single call node (0..1), or `[]`
-        # when it is not a shoulda matcher, sits outside any
-        # `describe <ModelConst>` block, or the model is unknown.
-        # ADR-37: the engine owns the walk; the model anchor comes from
-        # the node-rule `NodeContext` ancestors (the innermost enclosing
-        # `describe`-with-constant — nested const describes override,
-        # `describe ".method"` string blocks inherit), exactly as the
-        # former recursive anchor propagation did.
+        # The matcher violations for a single call node (0..1), or `[]` when it is not a shoulda matcher,
+        # sits outside any `describe <ModelConst>` block, or the model is unknown. ADR-37: the engine owns
+        # the walk; the model anchor comes from the node-rule `NodeContext` ancestors (the innermost
+        # enclosing `describe`-with-constant — nested const describes override, `describe ".method"`
+        # string blocks inherit), exactly as the former recursive anchor propagation did.
         #
         # @param matcher_call [Prism::Node]
         # @param ancestors [Array<Prism::Node>]
@@ -114,20 +100,17 @@ module Rigor
           violation ? [violation] : []
         end
 
-        # The model anchor in effect at a node: the constant named by the
-        # innermost enclosing `describe <Const> do … end`, or nil.
+        # The model anchor in effect at a node: the constant named by the innermost enclosing `describe
+        # <Const> do … end`, or nil.
         def anchor_for(ancestors)
           describe = ancestors.rfind { |n| describe_with_constant?(n) }
           describe && describe_const_name(describe)
         end
 
-        # A direct matcher invocation is a `CallNode` whose
-        # `name` is in `MATCHER_TABLE` and whose first argument
-        # is a `SymbolNode`. The chain shape (`should`,
-        # `expect(...).to`, `is_expected.to`) is irrelevant —
-        # we always recurse to the inner matcher, so a
-        # diagnostic fires on the matcher regardless of the
-        # surrounding chain.
+        # A direct matcher invocation is a `CallNode` whose `name` is in `MATCHER_TABLE` and whose first
+        # argument is a `SymbolNode`. The chain shape (`should`, `expect(...).to`, `is_expected.to`) is
+        # irrelevant — we always recurse to the inner matcher, so a diagnostic fires on the matcher
+        # regardless of the surrounding chain.
         def matcher_invocation?(node)
           node.is_a?(Prism::CallNode) && MATCHER_TABLE.key?(node.name) && symbol_first_arg?(node)
         end
@@ -137,10 +120,8 @@ module Rigor
           !args.empty? && args.first.is_a?(Prism::SymbolNode)
         end
 
-        # Detects `RSpec.describe(Const) do ... end` and
-        # `describe(Const) do ... end`. Either form opens a
-        # scope whose anchor is `Const`. The receiver shape
-        # (RSpec vs nil) is allowed in both cases.
+        # Detects `RSpec.describe(Const) do ... end` and `describe(Const) do ... end`. Either form opens a
+        # scope whose anchor is `Const`. The receiver shape (RSpec vs nil) is allowed in both cases.
         def describe_with_constant?(node)
           return false unless node.is_a?(Prism::CallNode)
           return false unless node.name == :describe

--- a/plugins/rigor-sidekiq/demo/app/workers/welcome_email_worker.rb
+++ b/plugins/rigor-sidekiq/demo/app/workers/welcome_email_worker.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 
-# Sample workers — rigor-sidekiq discovers these classes
-# because each one `include`s `Sidekiq::Job` (one of the
-# default `worker_marker_modules`). The discoverer reads
-# the `#perform` method's parameter list to compute arity.
+# Sample workers — rigor-sidekiq discovers these classes because each one `include`s `Sidekiq::Job` (one
+# of the default `worker_marker_modules`). The discoverer reads the `#perform` method's parameter list to
+# compute arity.
 
 module Sidekiq
   module Job
-    # Stand-in marker module so this file parses standalone
-    # (without Sidekiq loaded). rigor-sidekiq doesn't care
-    # whether the module is declared here or anywhere else
-    # — it only matches by name against
+    # Stand-in marker module so this file parses standalone (without Sidekiq loaded). rigor-sidekiq
+    # doesn't care whether the module is declared here or anywhere else — it only matches by name against
     # `worker_marker_modules`.
     def self.perform_async(*); end
     def self.perform_in(*); end
@@ -23,8 +20,7 @@ class WelcomeEmailWorker
   include Sidekiq::Job
 
   def perform(user_id, locale = "en")
-    # Body is not analysed by rigor-sidekiq — only the
-    # signature.
+    # Body is not analysed by rigor-sidekiq — only the signature.
     [user_id, locale]
   end
 end
@@ -33,8 +29,7 @@ class ReportWorker
   include Sidekiq::Job
 
   def perform(*report_ids)
-    # `*report_ids` makes the upper bound unbounded
-    # (`0+` arity). Calling `ReportWorker.perform_async`
+    # `*report_ids` makes the upper bound unbounded (`0+` arity). Calling `ReportWorker.perform_async`
     # with no arguments is OK.
     report_ids
   end

--- a/plugins/rigor-sidekiq/demo/demo.rb
+++ b/plugins/rigor-sidekiq/demo/demo.rb
@@ -1,20 +1,16 @@
 # frozen_string_literal: true
 
-# Demo: rigor-sidekiq recognises every
-# `Worker.perform_async` / `.perform_in` / `.perform_at` /
-# `.perform_inline` call and validates argument count
-# against the discovered `#perform`. Run with `bundle
+# Demo: rigor-sidekiq recognises every `Worker.perform_async` / `.perform_in` / `.perform_at` /
+# `.perform_inline` call and validates argument count against the discovered `#perform`. Run with `bundle
 # exec rigor check` from this directory.
 
-# `WelcomeEmailWorker#perform(user_id, locale = "en")` →
-# arity 1..2. Direct entry points forward all args.
+# `WelcomeEmailWorker#perform(user_id, locale = "en")` → arity 1..2. Direct entry points forward all args.
 WelcomeEmailWorker.perform_async(123)
 WelcomeEmailWorker.perform_async(123, "ja")
 WelcomeEmailWorker.perform_inline(123)
 
-# Scheduled entry points consume the first arg as the
-# schedule (a Time / Integer / duration). The remaining
-# args are forwarded to `#perform`.
+# Scheduled entry points consume the first arg as the schedule (a Time / Integer / duration). The
+# remaining args are forwarded to `#perform`.
 WelcomeEmailWorker.perform_in(60, 123)
 WelcomeEmailWorker.perform_at(Time.now + 60, 123, "ja")
 

--- a/plugins/rigor-sidekiq/demo/errors_demo.rb
+++ b/plugins/rigor-sidekiq/demo/errors_demo.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-# DO NOT run via `ruby errors_demo.rb` — analyse with
-# `bundle exec rigor check` to see rigor-sidekiq's
+# DO NOT run via `ruby errors_demo.rb` — analyse with `bundle exec rigor check` to see rigor-sidekiq's
 # diagnostics.
 
-# `WelcomeEmailWorker#perform(user_id, locale = "en")` →
-# arity 1..2. These call sites are wrong:
+# `WelcomeEmailWorker#perform(user_id, locale = "en")` → arity 1..2. These call sites are wrong:
 
 # Missing required user_id:
 #   plugin.sidekiq.wrong-arity
@@ -15,12 +13,10 @@ WelcomeEmailWorker.perform_async
 #   plugin.sidekiq.wrong-arity
 WelcomeEmailWorker.perform_async(123, "ja", :extra)
 
-# `perform_in` consumes the first arg as the schedule;
-# zero-arg calls are missing-schedule:
+# `perform_in` consumes the first arg as the schedule; zero-arg calls are missing-schedule:
 #   plugin.sidekiq.missing-schedule
 WelcomeEmailWorker.perform_in
 
-# `perform_at(time)` schedules but forwards 0 args, so the
-# required user_id is missing:
+# `perform_at(time)` schedules but forwards 0 args, so the required user_id is missing:
 #   plugin.sidekiq.wrong-arity
 WelcomeEmailWorker.perform_at(Time.now + 60)

--- a/plugins/rigor-sidekiq/lib/rigor/plugin/sidekiq.rb
+++ b/plugins/rigor-sidekiq/lib/rigor/plugin/sidekiq.rb
@@ -8,14 +8,11 @@ require_relative "sidekiq/analyzer"
 
 module Rigor
   module Plugin
-    # rigor-sidekiq — validates `Worker.perform_async(...)`
-    # / `.perform_in(...)` / `.perform_at(...)` /
-    # `.perform_inline(...)` argument arity against the
-    # discovered `#perform` definitions.
+    # rigor-sidekiq — validates `Worker.perform_async(...)` / `.perform_in(...)` / `.perform_at(...)` /
+    # `.perform_inline(...)` argument arity against the discovered `#perform` definitions.
     #
     # Tier 3C of the [Rails plugins roadmap](../../../../docs/design/20260508-rails-plugins-roadmap.md).
-    # Statically discovers Sidekiq workers by walking
-    # `worker_search_paths` and parsing each file with
+    # Statically discovers Sidekiq workers by walking `worker_search_paths` and parsing each file with
     # Prism — no `sidekiq` runtime dependency.
     #
     # ## Configuration
@@ -28,30 +25,19 @@ module Rigor
     #
     # ## What it checks
     #
-    # 1. **Argument arity** — `perform_async(args)` /
-    #    `perform_inline(args)` forward every argument to
-    #    `#perform`; `perform_in(t, args)` /
-    #    `perform_at(t, args)` consume the first argument
-    #    as the schedule and forward the rest. Mismatches
-    #    emit `wrong-arity`.
-    # 2. **Missing schedule** — `perform_in()` /
-    #    `perform_at()` with zero arguments emit
-    #    `missing-schedule`.
+    # 1. **Argument arity** — `perform_async(args)` / `perform_inline(args)` forward every argument to
+    #    `#perform`; `perform_in(t, args)` / `perform_at(t, args)` consume the first argument as the
+    #    schedule and forward the rest. Mismatches emit `wrong-arity`.
+    # 2. **Missing schedule** — `perform_in()` / `perform_at()` with zero arguments emit `missing-schedule`.
     #
     # ## Limitations (v0.1.0)
     #
-    # - Direct `include` matches only against the
-    #   configured marker modules. Indirect includes via a
+    # - Direct `include` matches only against the configured marker modules. Indirect includes via a
     #   custom concern are out of scope.
-    # - `#perform` arity is read from the syntactic
-    #   parameter list. `define_method` actions are out of
-    #   scope.
-    # - Required keyword arguments are not validated at
-    #   the call site (positional-only for v0.1.0). Sidekiq
-    #   serialises arguments to JSON, so keyword args are
-    #   uncommon in practice.
-    # - The schedule argument's type isn't validated (no
-    #   "is this a Time?" check); we just consume it.
+    # - `#perform` arity is read from the syntactic parameter list. `define_method` actions are out of scope.
+    # - Required keyword arguments are not validated at the call site (positional-only for v0.1.0).
+    #   Sidekiq serialises arguments to JSON, so keyword args are uncommon in practice.
+    # - The schedule argument's type isn't validated (no "is this a Time?" check); we just consume it.
     class Sidekiq < Rigor::Plugin::Base
       manifest(
         id: "sidekiq",
@@ -76,9 +62,8 @@ module Rigor
         @worker_marker_modules = Array(config.fetch("worker_marker_modules")).map(&:to_s)
       end
 
-      # File-level only: the load-error emission. The per-call arity
-      # validation runs over the engine-owned walk via the node_rule
-      # below (ADR-37). The worker index is lazily loaded + memoised by
+      # File-level only: the load-error emission. The per-call arity validation runs over the engine-owned
+      # walk via the node_rule below (ADR-37). The worker index is lazily loaded + memoised by
       # `producer_value`, shared by both surfaces.
       def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
         index = producer_value(:worker_index)

--- a/plugins/rigor-sidekiq/lib/rigor/plugin/sidekiq/analyzer.rb
+++ b/plugins/rigor-sidekiq/lib/rigor/plugin/sidekiq/analyzer.rb
@@ -5,43 +5,35 @@ require "prism"
 module Rigor
   module Plugin
     class Sidekiq < Rigor::Plugin::Base
-      # Walks a parsed file's AST looking for
-      # `<WorkerClass>.perform_async(...)` /
-      # `.perform_inline(...)` / `.perform_in(time, ...)` /
-      # `.perform_at(time, ...)` calls and validates each
-      # against the {WorkerIndex}.
+      # Walks a parsed file's AST looking for `<WorkerClass>.perform_async(...)` / `.perform_inline(...)` /
+      # `.perform_in(time, ...)` / `.perform_at(time, ...)` calls and validates each against the
+      # {WorkerIndex}.
       #
       # Argument-shape rules:
       #
-      # - `perform_async` / `perform_inline` — every
-      #   argument is forwarded to `#perform`. Validate
-      #   `actual == #perform.arity`.
-      # - `perform_in(interval, ...args)` /
-      #   `perform_at(time, ...args)` — the FIRST argument
-      #   is the schedule (a Time / Integer / ActiveSupport
-      #   duration); the rest are forwarded to `#perform`.
+      # - `perform_async` / `perform_inline` — every argument is forwarded to `#perform`. Validate `actual
+      #   == #perform.arity`.
+      # - `perform_in(interval, ...args)` / `perform_at(time, ...args)` — the FIRST argument is the
+      #   schedule (a Time / Integer / ActiveSupport duration); the rest are forwarded to `#perform`.
       #   Validate `actual_args - 1 == #perform.arity`.
       module Analyzer
         # Methods that delegate to `#perform` 1:1.
         DIRECT_ENTRY_METHODS = %i[perform_async perform_inline].freeze
 
-        # Methods whose first argument is a schedule (the
-        # remaining args are forwarded to `#perform`).
+        # Methods whose first argument is a schedule (the remaining args are forwarded to `#perform`).
         SCHEDULED_ENTRY_METHODS = %i[perform_in perform_at].freeze
 
         ENTRY_METHODS = (DIRECT_ENTRY_METHODS + SCHEDULED_ENTRY_METHODS).freeze
 
-        # One worker-call observation: the kebab-case `rule`, `severity`,
-        # and human-readable `message`. Carries no path/location — the
-        # caller (the `node_rule` block) positions it via
+        # One worker-call observation: the kebab-case `rule`, `severity`, and human-readable `message`.
+        # Carries no path/location — the caller (the `node_rule` block) positions it via
         # `Plugin::Base#diagnostic`.
         Violation = Struct.new(:rule, :severity, :message, keyword_init: true)
 
         module_function
 
-        # The worker-call violations for a single call node (0..2), or
-        # `[]` when the node is not a `<Worker>.perform_*` entry call on a
-        # known worker. ADR-37: the engine owns the walk.
+        # The worker-call violations for a single call node (0..2), or `[]` when the node is not a
+        # `<Worker>.perform_*` entry call on a known worker. ADR-37: the engine owns the walk.
         #
         # @param call_node [Prism::Node]
         # @param worker_index [WorkerIndex]
@@ -77,8 +69,7 @@ module Rigor
 
         def arity_violation(call_node, entry)
           all_args = (call_node.arguments&.arguments || []).size
-          # Scheduled entries consume the first arg as the
-          # schedule; the rest are forwarded.
+          # Scheduled entries consume the first arg as the schedule; the rest are forwarded.
           forwarded_count = SCHEDULED_ENTRY_METHODS.include?(call_node.name) ? all_args - 1 : all_args
 
           if SCHEDULED_ENTRY_METHODS.include?(call_node.name) && all_args.zero?

--- a/plugins/rigor-sidekiq/lib/rigor/plugin/sidekiq/worker_discoverer.rb
+++ b/plugins/rigor-sidekiq/lib/rigor/plugin/sidekiq/worker_discoverer.rb
@@ -7,28 +7,20 @@ require_relative "worker_index"
 module Rigor
   module Plugin
     class Sidekiq < Rigor::Plugin::Base
-      # Walks the configured worker-search paths via the
-      # plugin's `IoBoundary`, parses each `.rb` file with
-      # Prism, and collects classes that `include
-      # Sidekiq::Job` (or one of the configured marker
-      # modules). For each discovered class, the discoverer
-      # also reads the `#perform` method's parameter list
-      # and computes the arity envelope.
+      # Walks the configured worker-search paths via the plugin's `IoBoundary`, parses each `.rb` file with
+      # Prism, and collects classes that `include Sidekiq::Job` (or one of the configured marker modules).
+      # For each discovered class, the discoverer also reads the `#perform` method's parameter list and
+      # computes the arity envelope.
       #
       # Limitations (intentional for v0.1.0):
       #
-      # - Only direct `include` matches against the
-      #   configured marker modules. `class MyWorker;
-      #   include Concerns::Sidekiqable; end` where
-      #   `Concerns::Sidekiqable` re-includes `Sidekiq::Job`
-      #   is NOT discovered. Add the intermediate module to
-      #   `worker_marker_modules` if needed.
-      # - The qualified class name is the lexical path
-      #   (`Admin::WelcomeWorker` for a class declared
-      #   inside `module Admin`).
-      # - `#perform` arity is read from the syntactic
-      #   parameter list. Methods built via
-      #   `define_method` are out of scope.
+      # - Only direct `include` matches against the configured marker modules. `class MyWorker; include
+      #   Concerns::Sidekiqable; end` where `Concerns::Sidekiqable` re-includes `Sidekiq::Job` is NOT
+      #   discovered. Add the intermediate module to `worker_marker_modules` if needed.
+      # - The qualified class name is the lexical path (`Admin::WelcomeWorker` for a class declared inside
+      #   `module Admin`).
+      # - `#perform` arity is read from the syntactic parameter list. Methods built via `define_method`
+      #   are out of scope.
       class WorkerDiscoverer
         def initialize(io_boundary:, search_paths:, marker_modules:)
           @io_boundary = io_boundary
@@ -101,9 +93,8 @@ module Rigor
           walk_for_workers(node.body, inner_path, &) if node.body
         end
 
-        # Returns true if the class body contains a top-level
-        # `include <Module>` call where `<Module>` matches
-        # one of the configured marker modules.
+        # Returns true if the class body contains a top-level `include <Module>` call where `<Module>`
+        # matches one of the configured marker modules.
         def includes_marker_module?(body)
           return false if body.nil?
 
@@ -137,9 +128,8 @@ module Rigor
           end
         end
 
-        # Returns the instance-side `def perform(...)` node
-        # from a class body, or `nil` when the class doesn't
-        # override `#perform`.
+        # Returns the instance-side `def perform(...)` node from a class body, or `nil` when the class
+        # doesn't override `#perform`.
         def lookup_perform_def(body)
           return nil if body.nil?
 
@@ -152,12 +142,9 @@ module Rigor
           nil
         end
 
-        # Builds a `WorkerIndex::Entry` from the discovered
-        # class's `#perform` def. When the class doesn't
-        # override `#perform`, we record an "any-arity"
-        # entry — Sidekiq itself doesn't supply a default
-        # `#perform`, so calling `perform_async` on a
-        # worker without one is the user's bug, not the
+        # Builds a `WorkerIndex::Entry` from the discovered class's `#perform` def. When the class doesn't
+        # override `#perform`, we record an "any-arity" entry — Sidekiq itself doesn't supply a default
+        # `#perform`, so calling `perform_async` on a worker without one is the user's bug, not the
         # plugin's call to flag without runtime context.
         def build_entry(class_name, perform_def)
           if perform_def.nil?

--- a/plugins/rigor-sidekiq/lib/rigor/plugin/sidekiq/worker_index.rb
+++ b/plugins/rigor-sidekiq/lib/rigor/plugin/sidekiq/worker_index.rb
@@ -3,17 +3,13 @@
 module Rigor
   module Plugin
     class Sidekiq < Rigor::Plugin::Base
-      # Frozen catalogue of discovered Sidekiq worker
-      # classes keyed by qualified class name. Each entry
-      # holds the `#perform` method's arity envelope so the
-      # analyzer can validate `Worker.perform_async(...)`
-      # call sites.
+      # Frozen catalogue of discovered Sidekiq worker classes keyed by qualified class name. Each entry
+      # holds the `#perform` method's arity envelope so the analyzer can validate
+      # `Worker.perform_async(...)` call sites.
       #
-      # Uses the same `min_arity` / `max_arity` closed-range
-      # envelope as `rigor-activejob`'s `JobIndex::Entry`
-      # (`Float::INFINITY` upper bound when `*args` is present);
-      # Sidekiq workers serialize args to JSON so keyword arity
-      # is not tracked here.
+      # Uses the same `min_arity` / `max_arity` closed-range envelope as `rigor-activejob`'s
+      # `JobIndex::Entry` (`Float::INFINITY` upper bound when `*args` is present); Sidekiq workers
+      # serialize args to JSON so keyword arity is not tracked here.
       class WorkerIndex
         Entry = Data.define(:class_name, :min_arity, :max_arity) do
           def arity_label

--- a/plugins/rigor-sinatra/demo/demo.rb
+++ b/plugins/rigor-sinatra/demo/demo.rb
@@ -4,17 +4,13 @@
 #
 #   RUBYLIB=$PWD/../lib bundle exec rigor check
 #
-# The .rigor.yml in this directory enables the plugin and
-# points signature_paths at the local sig/ stub that mocks the
-# subset of Sinatra::Base the demo touches. With Tier A active,
-# bare identifiers inside each `get/post/...` block (params,
-# redirect, halt) resolve through Sinatra::Base's RBS.
+# The .rigor.yml in this directory enables the plugin and points signature_paths at the local sig/ stub
+# that mocks the subset of Sinatra::Base the demo touches. With Tier A active, bare identifiers inside each
+# `get/post/...` block (params, redirect, halt) resolve through Sinatra::Base's RBS.
 #
-# Without Tier A the same blocks would type-check against the
-# enclosing class body's Singleton[MyApp] self_type, where
-# `redirect` and friends do not exist — every call would fall
-# through to Dynamic[T] and the analyzer would lose track of
-# the block's return type.
+# Without Tier A the same blocks would type-check against the enclosing class body's Singleton[MyApp]
+# self_type, where `redirect` and friends do not exist — every call would fall through to Dynamic[T] and
+# the analyzer would lose track of the block's return type.
 
 class MyApp < Sinatra::Base
   get "/" do

--- a/plugins/rigor-sinatra/lib/rigor-sinatra.rb
+++ b/plugins/rigor-sinatra/lib/rigor-sinatra.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-sinatra` under `plugins:`. The
-# loader expects this `require` to side-effect a call to
-# `Rigor::Plugin.register`, which the body of
-# `lib/rigor/plugin/sinatra.rb` performs at load time.
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists `rigor-sinatra` under
+# `plugins:`. The loader expects this `require` to side-effect a call to `Rigor::Plugin.register`, which
+# the body of `lib/rigor/plugin/sinatra.rb` performs at load time.
 require_relative "rigor/plugin/sinatra"

--- a/plugins/rigor-sinatra/lib/rigor/plugin/sinatra.rb
+++ b/plugins/rigor-sinatra/lib/rigor/plugin/sinatra.rb
@@ -4,8 +4,7 @@ require "rigor/plugin"
 
 module Rigor
   module Plugin
-    # ADR-16 Tier A worked plugin: recognises Sinatra's class-
-    # level route DSL.
+    # ADR-16 Tier A worked plugin: recognises Sinatra's class-level route DSL.
     #
     # Sinatra's modular style:
     #
@@ -20,52 +19,35 @@ module Rigor
     #       end
     #     end
     #
-    # At runtime `Sinatra::Base#generate_method`
-    # (`lib/sinatra/base.rb:1788-1793`) does `define_method(name,
-    # &block); remove_method`, turning each block into a real
-    # instance method of the user's app class. The substrate's
-    # Tier A hook (`Rigor::Inference::MacroBlockSelfType`)
-    # replays the same contract statically: the block runs with
-    # `self : Nominal[MyApp]`, so bare identifiers (`params`,
-    # `redirect`, `halt`, `session`, `headers`, `content_type`,
-    # `body`, `status`, `erb`, …) resolve through
-    # `Sinatra::Base`'s RBS via rigor's normal inference path.
+    # At runtime `Sinatra::Base#generate_method` (`lib/sinatra/base.rb:1788-1793`) does
+    # `define_method(name, &block); remove_method`, turning each block into a real instance method of the
+    # user's app class. The substrate's Tier A hook (`Rigor::Inference::MacroBlockSelfType`) replays the
+    # same contract statically: the block runs with `self : Nominal[MyApp]`, so bare identifiers
+    # (`params`, `redirect`, `halt`, `session`, `headers`, `content_type`, `body`, `status`, `erb`, …)
+    # resolve through `Sinatra::Base`'s RBS via rigor's normal inference path.
     #
     # ## Reach
     #
-    # All nine class-level HTTP verb methods Sinatra exposes:
-    # `get`, `post`, `put`, `delete`, `head`, `options`, `patch`,
-    # `link`, `unlink` (`lib/sinatra/base.rb:1531-1553`). Both
-    # modular-style subclasses of `Sinatra::Base` and `Sinatra::Application`
-    # (classic top-level style, when used via `class App <
-    # Sinatra::Application`) match because the receiver
-    # constraint accepts every subclass.
+    # All nine class-level HTTP verb methods Sinatra exposes: `get`, `post`, `put`, `delete`, `head`,
+    # `options`, `patch`, `link`, `unlink` (`lib/sinatra/base.rb:1531-1553`). Both modular-style subclasses
+    # of `Sinatra::Base` and `Sinatra::Application` (classic top-level style, when used via `class App <
+    # Sinatra::Application`) match because the receiver constraint accepts every subclass.
     #
     # ## What the plugin does NOT do (yet)
     #
-    # - **Routing diagnostics.** Path uniqueness, conflict
-    #   detection, named-route reverse lookup — none of these
-    #   are in slice 1c's scope.
-    # - **Custom helpers.** `helpers do ... end` blocks that
-    #   inject module methods into the app's instance namespace
-    #   are Tier C / Tier B work, not Tier A.
-    # - **Configure / settings.** `configure do ... end` and
-    #   `set :session_secret, "..."` are settings DSL, not
-    #   route DSL — handled by separate substrate entries when
-    #   demand surfaces.
-    # - **Classic-style top-level routes.** A bare
-    #   `get '/path' do ... end` at the top of a script (no
-    #   enclosing `class < Sinatra::Base`) is the classic-mode
-    #   pattern (`lib/sinatra/main.rb`). Tier A as currently
-    #   wired requires the receiver's class to be visible at
-    #   the call site; a top-level call's receiver is the
-    #   classic-mode `Sinatra::Application`, which the
-    #   `Sinatra::Delegator` mixin forwards from `main`. The
-    #   classic style is deferred until the demand justifies
-    #   the extra match shape.
+    # - **Routing diagnostics.** Path uniqueness, conflict detection, named-route reverse lookup — none of
+    #   these are in slice 1c's scope.
+    # - **Custom helpers.** `helpers do ... end` blocks that inject module methods into the app's instance
+    #   namespace are Tier C / Tier B work, not Tier A.
+    # - **Configure / settings.** `configure do ... end` and `set :session_secret, "..."` are settings
+    #   DSL, not route DSL — handled by separate substrate entries when demand surfaces.
+    # - **Classic-style top-level routes.** A bare `get '/path' do ... end` at the top of a script (no
+    #   enclosing `class < Sinatra::Base`) is the classic-mode pattern (`lib/sinatra/main.rb`). Tier A as
+    #   currently wired requires the receiver's class to be visible at the call site; a top-level call's
+    #   receiver is the classic-mode `Sinatra::Application`, which the `Sinatra::Delegator` mixin forwards
+    #   from `main`. The classic style is deferred until the demand justifies the extra match shape.
     #
-    # See `plugins/rigor-sinatra/README.md` for usage and the
-    # demo script under `plugins/rigor-sinatra/demo/`.
+    # See `plugins/rigor-sinatra/README.md` for usage and the demo script under `plugins/rigor-sinatra/demo/`.
     class Sinatra < Rigor::Plugin::Base
       manifest(
         id: "sinatra",

--- a/plugins/rigor-sorbet/demo/demo.rb
+++ b/plugins/rigor-sorbet/demo/demo.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
-# Demo: rigor-sorbet picks up `sig { ... }` blocks above each
-# method and contributes the parsed return type at every call
-# site. Run with `bundle exec rigor check` from this directory.
+# Demo: rigor-sorbet picks up `sig { ... }` blocks above each method and contributes the parsed return
+# type at every call site. Run with `bundle exec rigor check` from this directory.
 #
-# Note: this demo intentionally does NOT require `sorbet-runtime`,
-# so we stub `extend T::Sig` and the `sig` method as no-ops.
-# rigor-sorbet only reads the syntactic shape of the `sig`
-# blocks; the runtime implementation is irrelevant to the
-# static analyzer.
+# Note: this demo intentionally does NOT require `sorbet-runtime`, so we stub `extend T::Sig` and the
+# `sig` method as no-ops. rigor-sorbet only reads the syntactic shape of the `sig` blocks; the runtime
+# implementation is irrelevant to the static analyzer.
 
 module T
   module Sig
@@ -16,10 +13,9 @@ module T
     def sig(*, &) = nil
   end
 
-  # Slice 2 assertion stubs so `ruby demo.rb` runs without
-  # `sorbet-runtime` installed. rigor-sorbet only reads the
-  # syntactic shape of the call; the runtime body returns the
-  # inner expression unchanged, mirroring `sorbet-runtime`.
+  # Slice 2 assertion stubs so `ruby demo.rb` runs without `sorbet-runtime` installed. rigor-sorbet only
+  # reads the syntactic shape of the call; the runtime body returns the inner expression unchanged,
+  # mirroring `sorbet-runtime`.
   def self.let(value, _type) = value
   def self.cast(value, _type) = value
   def self.must(value) = value
@@ -40,13 +36,12 @@ class Slug
   end
 end
 
-# rigor-sorbet contributes `Slug.default_length`'s return as
-# `Integer`, so the chained `.even?` resolves through the
-# analyzer's normal Integer dispatch.
+# rigor-sorbet contributes `Slug.default_length`'s return as `Integer`, so the chained `.even?` resolves
+# through the analyzer's normal Integer dispatch.
 length_is_even = Slug.default_length.even?
 
-# Calls on instance receivers also resolve through the catalog
-# when the receiver type is known to be `Nominal["Slug"]`.
+# Calls on instance receivers also resolve through the catalog when the receiver type is known to be
+# `Nominal["Slug"]`.
 slug = Slug.new
 slug_for_alice = slug.normalise("Alice Doe")
 
@@ -54,22 +49,18 @@ slug_for_alice = slug.normalise("Alice Doe")
 puts(slug_for_alice)
 puts(length_is_even.inspect)
 
-# ADR-11 slice 2 — type-assertion calls. T.let / T.cast / T.must
-# / T.unsafe are recognised at the call site and contribute the
-# asserted return type directly.
+# ADR-11 slice 2 — type-assertion calls. T.let / T.cast / T.must / T.unsafe are recognised at the call
+# site and contribute the asserted return type directly.
 counter = T.let(0, Integer)
 counter += 1
 puts(counter.even?.inspect)
 
-# T.must strips nil from a nilable type so chained calls
-# resolve on the inner type alone. The literal initialiser
-# is `42` here so the runtime path also works without nil
-# handling; the rigor-sorbet contribution comes from the
-# `T.let` widening the type to `T.nilable(Integer)`.
+# T.must strips nil from a nilable type so chained calls resolve on the inner type alone. The literal
+# initialiser is `42` here so the runtime path also works without nil handling; the rigor-sorbet
+# contribution comes from the `T.let` widening the type to `T.nilable(Integer)`.
 maybe_id = T.let(42, T.nilable(Integer))
 puts(T.must(maybe_id).bit_length)
 
-# T.unsafe falls back to Dynamic[top] so the analyzer silences
-# call-site existence checks.
+# T.unsafe falls back to Dynamic[top] so the analyzer silences call-site existence checks.
 opaque = T.unsafe(Slug.default_length)
 puts(opaque)

--- a/plugins/rigor-sorbet/demo/errors_demo.rb
+++ b/plugins/rigor-sorbet/demo/errors_demo.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# DO NOT run via `ruby errors_demo.rb` — analyse with
-# `bundle exec rigor check` to see rigor-sorbet's diagnostics.
+# DO NOT run via `ruby errors_demo.rb` — analyse with `bundle exec rigor check` to see rigor-sorbet's
+# diagnostics.
 #
-# Each example is intentionally malformed at the `sig`-syntax
-# level, exercising the `plugin.sorbet.parse-error` warnings.
+# Each example is intentionally malformed at the `sig`-syntax level, exercising the
+# `plugin.sorbet.parse-error` warnings.
 
 module T
   module Sig

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet.rb
@@ -14,46 +14,33 @@ require_relative "sorbet/sigil_detector"
 
 module Rigor
   module Plugin
-    # rigor-sorbet — ingests Sorbet `sig { ... }` blocks as
-    # method-signature contributions to Rigor's analyzer.
+    # rigor-sorbet — ingests Sorbet `sig { ... }` blocks as method-signature contributions to Rigor's
+    # analyzer.
     #
     # ADR-11 slice 1 — first deliverable. Recognises:
     #
-    # - `sig { params(x: Integer).returns(String) }` above a
-    #   `def foo(x)` definition, contributing the parsed return
-    #   type at every call site.
-    # - The `void` terminus and the `abstract` / `override` /
-    #   `overridable` / `final` modifiers (recorded on the
-    #   {MethodSignature} for slice ≥2).
-    # - `class Foo` / `module Foo::Bar` / `class << self`
-    #   nesting; `def self.foo` is recognised as a singleton
-    #   method.
+    # - `sig { params(x: Integer).returns(String) }` above a `def foo(x)` definition, contributing the
+    #   parsed return type at every call site.
+    # - The `void` terminus and the `abstract` / `override` / `overridable` / `final` modifiers (recorded
+    #   on the {MethodSignature} for slice ≥2).
+    # - `class Foo` / `module Foo::Bar` / `class << self` nesting; `def self.foo` is recognised as a
+    #   singleton method.
     #
-    # The {TypeTranslator} table documents coverage. Most of
-    # Sorbet's vocabulary translates; remaining gaps (`T.proc`,
-    # `T::Struct` subclasses, `T.attached_class`, etc.) degrade
-    # silently to `Dynamic[top]`.
+    # The {TypeTranslator} table documents coverage. Most of Sorbet's vocabulary translates; remaining
+    # gaps (`T.proc`, `T::Struct` subclasses, `T.attached_class`, etc.) degrade silently to `Dynamic[top]`.
     #
-    # Architecture: per-run `Catalog` is built lazily on first
-    # access by walking every configured `paths:` entry's `.rb`
-    # files plus every `rbi_paths:` entry's `.rbi` files (slice
-    # 4) via the plugin's `IoBoundary`. The catalog is frozen
-    # after the first build and consulted by the `dynamic_return`
-    # rule at every gated call site. RBI files
-    # share the catalog with project-source sigs — both produce
-    # `MethodSignature` entries keyed by
-    # `(class_name, method_name, kind)`. When a key collides
-    # across files, the last-walked sig wins (ordering is
-    # platform-dependent: `Dir.glob` returns directory entries
-    # in filesystem order). Sorbet's full shim-override
-    # semantics — `sorbet/rbi/shims/` overriding
-    # `sorbet/rbi/gems/` — lands in a later slice once the
-    # catalog gains per-source provenance.
+    # Architecture: per-run `Catalog` is built lazily on first access by walking every configured `paths:`
+    # entry's `.rb` files plus every `rbi_paths:` entry's `.rbi` files (slice 4) via the plugin's
+    # `IoBoundary`. The catalog is frozen after the first build and consulted by the `dynamic_return` rule
+    # at every gated call site. RBI files share the catalog with project-source sigs — both produce
+    # `MethodSignature` entries keyed by `(class_name, method_name, kind)`. When a key collides across
+    # files, the last-walked sig wins (ordering is platform-dependent: `Dir.glob` returns directory
+    # entries in filesystem order). Sorbet's full shim-override semantics — `sorbet/rbi/shims/` overriding
+    # `sorbet/rbi/gems/` — lands in a later slice once the catalog gains per-source provenance.
     #
-    # The plugin emits `plugin.sorbet.parse-error` warnings for
-    # malformed sig blocks (no block / empty block / no
-    # `returns` or `void` terminus / two consecutive sigs / sig
-    # not followed by a def) but never aborts a run.
+    # The plugin emits `plugin.sorbet.parse-error` warnings for malformed sig blocks (no block / empty
+    # block / no `returns` or `void` terminus / two consecutive sigs / sig not followed by a def) but
+    # never aborts a run.
     #
     # ## Configuration
     #
@@ -63,27 +50,23 @@ module Rigor
     #           paths: ["lib", "app"]         # directories to scan for `.rb` sigs; defaults to `paths:`
     #           rbi_paths: ["sorbet/rbi"]     # directories to scan for `.rbi` files; default shown
     #
-    # The `paths:` config key narrows the plugin's `.rb` walk;
-    # omit it to inherit the project-wide `paths:` value. The
-    # `rbi_paths:` key controls where Sorbet's RBI tree is read
-    # from — defaults to `sorbet/rbi/` per Tapioca's standard
-    # layout (`gems/`, `annotations/`, `dsl/`, `shims/`). Set
-    # to `[]` to opt out of RBI loading entirely.
+    # The `paths:` config key narrows the plugin's `.rb` walk; omit it to inherit the project-wide
+    # `paths:` value. The `rbi_paths:` key controls where Sorbet's RBI tree is read from — defaults to
+    # `sorbet/rbi/` per Tapioca's standard layout (`gems/`, `annotations/`, `dsl/`, `shims/`). Set to `[]`
+    # to opt out of RBI loading entirely.
     class Sorbet < Rigor::Plugin::Base
       manifest(
         id: "sorbet",
         version: "0.1.0",
         description: "Ingests Sorbet `sig` blocks as method-signature contributions.",
         config_schema: {
-          # `paths` keeps a `fetch`-with-default in `init` because its
-          # default is dynamic (the project's configured `paths`), not a
-          # static literal the manifest can declare.
+          # `paths` keeps a `fetch`-with-default in `init` because its default is dynamic (the project's
+          # configured `paths`), not a static literal the manifest can declare.
           "paths" => :array,
-          # Default RBI directory tree. Matches the layout `tapioca init`
-          # generates — see Sorbet's `rbi.md`. Slice 4 walks every `.rbi`
-          # file under these roots recursively; the four standard Tapioca
-          # subdirectories (`gems` / `annotations` / `dsl` / `shims`) are
-          # picked up as a side effect of recursing into the parent root.
+          # Default RBI directory tree. Matches the layout `tapioca init` generates — see Sorbet's
+          # `rbi.md`. Slice 4 walks every `.rbi` file under these roots recursively; the four standard
+          # Tapioca subdirectories (`gems` / `annotations` / `dsl` / `shims`) are picked up as a side
+          # effect of recursing into the parent root.
           "rbi_paths" => { kind: :array, default: ["sorbet/rbi"] },
           "enforce_sigil" => { kind: :boolean, default: true }
         }
@@ -93,97 +76,70 @@ module Rigor
         @services = services
         @configured_paths = Array(config.fetch("paths", services.configuration.paths)).map(&:to_s)
         @rbi_paths = Array(config.fetch("rbi_paths")).map(&:to_s)
-        # Schema default `true` — only files marked `# typed: true` /
-        # `:strict` / `:strong` contribute their sigs. Set to
-        # `false` to record every file's sigs regardless of
-        # sigil (current behaviour pre-this-config).
+        # Schema default `true` — only files marked `# typed: true` / `:strict` / `:strong` contribute
+        # their sigs. Set to `false` to record every file's sigs regardless of sigil (current behaviour
+        # pre-this-config).
         @enforce_sigil = config.fetch("enforce_sigil")
-        # Per-call-site assertion gating: `@sigil_by_path` (built
-        # during catalog harvest) is consulted so `T.let` /
-        # `T.cast` / `T.must` / `T.bind` / `T.assert_type!` only
-        # fire in files Sorbet itself would enforce (`:true` /
-        # `:strict` / `:strong`). With `enforce_sigil: false` the
-        # gate is open everywhere. Missing-sigil paths (synthetic
-        # fixtures, out-of-tree call sites) default to enforced —
-        # failing-open suits spec ergonomics better than
-        # failing-closed. See `assertion_enforced_here?`.
+        # Per-call-site assertion gating: `@sigil_by_path` (built during catalog harvest) is consulted so
+        # `T.let` / `T.cast` / `T.must` / `T.bind` / `T.assert_type!` only fire in files Sorbet itself
+        # would enforce (`:true` / `:strict` / `:strong`). With `enforce_sigil: false` the gate is open
+        # everywhere. Missing-sigil paths (synthetic fixtures, out-of-tree call sites) default to enforced
+        # — failing-open suits spec ergonomics better than failing-closed. See `assertion_enforced_here?`.
         @sigil_by_path = {}
         @catalog = nil
         @parse_errors_by_path = {}
         @catalog_built = false
-        # ADR-11 slice 6 — Prism nodes for `T.absurd` calls
-        # we observed in the `dynamic_return` rule to be
-        # *reachable* (i.e., their discriminant didn't narrow
-        # to `bot`). `diagnostics_for_file` walks the per-file
-        # AST and surfaces these as `plugin.sorbet.absurd-reachable`
-        # warnings. Hash is keyed on the Prism node's
-        # `object_id` because the runner only parses each file
-        # once per run, so identity is stable across the two
-        # plugin hooks.
+        # ADR-11 slice 6 — Prism nodes for `T.absurd` calls we observed in the `dynamic_return` rule to be
+        # *reachable* (i.e., their discriminant didn't narrow to `bot`). `diagnostics_for_file` walks the
+        # per-file AST and surfaces these as `plugin.sorbet.absurd-reachable` warnings. Hash is keyed on
+        # the Prism node's `object_id` because the runner only parses each file once per run, so identity
+        # is stable across the two plugin hooks.
         @reachable_absurd_nodes = {}.compare_by_identity
-        # ADR-11 light follow-up — `T.reveal_type` calls
-        # observed in the `dynamic_return` rule, paired with the
-        # display string for the inferred type at the call site.
-        # Mirrors the absurd-node compare-by-identity hash;
-        # `diagnostics_for_file` surfaces each entry as a
+        # ADR-11 light follow-up — `T.reveal_type` calls observed in the `dynamic_return` rule, paired
+        # with the display string for the inferred type at the call site. Mirrors the absurd-node
+        # compare-by-identity hash; `diagnostics_for_file` surfaces each entry as a
         # `plugin.sorbet.reveal-type` `:info` diagnostic.
         @reveal_type_calls = {}.compare_by_identity
-        # T.bind / T.assert_type! priority slice 1 —
-        # `T.assert_type!` calls observed in
-        # the `dynamic_return` rule whose static subtype check
-        # FAILED, paired with the inferred + asserted type
-        # display strings. Same compare-by-identity discipline.
-        # `diagnostics_for_file` walks the file AST for
-        # `T.assert_type!` calls and surfaces matching entries
-        # as `plugin.sorbet.assert-type-mismatch` `:error`
-        # diagnostics.
+        # T.bind / T.assert_type! priority slice 1 — `T.assert_type!` calls observed in the
+        # `dynamic_return` rule whose static subtype check FAILED, paired with the inferred + asserted
+        # type display strings. Same compare-by-identity discipline. `diagnostics_for_file` walks the
+        # file AST for `T.assert_type!` calls and surfaces matching entries as
+        # `plugin.sorbet.assert-type-mismatch` `:error` diagnostics.
         @assert_type_mismatches = {}.compare_by_identity
       end
 
       def diagnostics_for_file(path:, scope:, root:) # rubocop:disable Lint/UnusedMethodArgument
         ensure_catalog
-        # The catalog records errors under the canonicalised
-        # (realpath-resolved) form; the runner may pass the
-        # symlink-bearing form here. Look up under both so the
-        # match is symlink-agnostic.
+        # The catalog records errors under the canonicalised (realpath-resolved) form; the runner may pass
+        # the symlink-bearing form here. Look up under both so the match is symlink-agnostic.
         errors = @parse_errors_by_path[path] || @parse_errors_by_path[canonicalize(path)] || []
         errors.map { |error| parse_error_diagnostic(path, error) }
       end
 
-      # ADR-52 slice 4 — per-call return-type path via the
-      # method-name-gated `dynamic_return` DSL. The recognised name
-      # set is only known at run time (the catalog's `def` names come
-      # from the lazy catalog build), so it is declared as a
-      # callable: the engine `instance_exec`s it once per run on
-      # first dispatch (always after `#prepare`) and memoises the
-      # resolved Symbol Set. The gate is a safe over-approximation —
-      # a project method merely *named* `cast` or `find` passes it
-      # and is declined by the block's own `T.`-receiver / catalog
-      # checks.
+      # ADR-52 slice 4 — per-call return-type path via the method-name-gated `dynamic_return` DSL. The
+      # recognised name set is only known at run time (the catalog's `def` names come from the lazy
+      # catalog build), so it is declared as a callable: the engine `instance_exec`s it once per run on
+      # first dispatch (always after `#prepare`) and memoises the resolved Symbol Set. The gate is a safe
+      # over-approximation — a project method merely *named* `cast` or `find` passes it and is declined by
+      # the block's own `T.`-receiver / catalog checks.
       dynamic_return methods: -> { recognised_method_names } do |call_node, scope|
         contribution_return_type(call_node, scope)
       end
 
-      # ADR-52 slice 4 — `T.bind(self, T)`'s self-narrowing fact,
-      # contributed via the method-gated `narrowing_facts` DSL. The
-      # statement evaluator consults this path for narrowing facts.
-      # The return-type half (`Constant[nil]`) flows through the
-      # `dynamic_return` rule above; the block re-checks the `T.`
-      # receiver via the recogniser, so an unrelated `bind` call
-      # contributes nothing.
+      # ADR-52 slice 4 — `T.bind(self, T)`'s self-narrowing fact, contributed via the method-gated
+      # `narrowing_facts` DSL. The statement evaluator consults this path for narrowing facts. The
+      # return-type half (`Constant[nil]`) flows through the `dynamic_return` rule above; the block
+      # re-checks the `T.` receiver via the recogniser, so an unrelated `bind` call contributes nothing.
       narrowing_facts methods: [:bind] do |call_node, scope|
         bind_post_return_facts(call_node, scope)
       end
 
-      # ADR-37 — the three per-call diagnostics ride the engine-owned
-      # walk instead of three hand-rolled `walk_for_*` recursions. Each
-      # candidate `T.` call is *recorded by object identity* during the
-      # inference pass (the `dynamic_return` / `narrowing_facts` rules
-      # above call `record_*`), so by the time these node rules fire in
-      # the diagnostics phase the sets are populated; the membership
-      # `delete` both gates the emission and pops the entry so a re-run
-      # cannot double-fire. The recorded set is the gate — no per-node
-      # `AbsurdRecognizer` / name check is needed here.
+      # ADR-37 — the three per-call diagnostics ride the engine-owned walk instead of three hand-rolled
+      # `walk_for_*` recursions. Each candidate `T.` call is *recorded by object identity* during the
+      # inference pass (the `dynamic_return` / `narrowing_facts` rules above call `record_*`), so by the
+      # time these node rules fire in the diagnostics phase the sets are populated; the membership
+      # `delete` both gates the emission and pops the entry so a re-run cannot double-fire. The recorded
+      # set is the gate — no per-node `AbsurdRecognizer` / name check is needed here.
       node_rule Prism::CallNode do |node, _scope, path|
         next [] unless @reachable_absurd_nodes.delete(node)
 
@@ -206,10 +162,8 @@ module Rigor
 
       private
 
-      # Run-time method-name gate for the `dynamic_return` rule
-      # (ADR-52 slice 4): the static assertion vocabulary
-      # (`T.let` / `T.cast` / …), `T.absurd`, and every method name
-      # the catalog carries a sig for.
+      # Run-time method-name gate for the `dynamic_return` rule (ADR-52 slice 4): the static assertion
+      # vocabulary (`T.let` / `T.cast` / …), `T.absurd`, and every method name the catalog carries a sig for.
       def recognised_method_names
         ensure_catalog
         names = AssertionRecognizer::SORBET_ASSERTIONS.dup
@@ -218,54 +172,39 @@ module Rigor
         names
       end
 
-      # Main contribution body for the `dynamic_return` rule.
-      # Returns the bare `Rigor::Type` the contract expects.
-      # Resolves the receiver in three passes:
+      # Main contribution body for the `dynamic_return` rule. Returns the bare `Rigor::Type` the contract
+      # expects. Resolves the receiver in three passes:
       #
-      # 1. Constant receiver (`User.find(...)`) → singleton-side
-      #    catalog lookup.
-      # 2. Nominal receiver-type (`user.name` where `user`'s
-      #    inferred type is `Nominal["User"]`) → instance-side
-      #    catalog lookup.
-      # 3. Implicit-self (receiver-less inside a method body) →
-      #    current-class lookup via `implicit_self_lookup`.
+      # 1. Constant receiver (`User.find(...)`) → singleton-side catalog lookup.
+      # 2. Nominal receiver-type (`user.name` where `user`'s inferred type is `Nominal["User"]`) →
+      #    instance-side catalog lookup.
+      # 3. Implicit-self (receiver-less inside a method body) → current-class lookup via
+      #    `implicit_self_lookup`.
       def contribution_return_type(call_node, scope)
         return nil unless call_node.is_a?(Prism::CallNode)
 
-        # ADR-11 slice 6 — `T.absurd(x)` exhaustiveness. Always
-        # contributes a `bot` return (matches Sorbet's runtime
-        # behaviour: `T.absurd` raises, so its value type is `bot`
-        # and the engine's flow analysis treats code after it as
-        # unreachable; the legacy contribution's `exceptional:
-        # :raises` slot was never consumed on the dispatcher path —
-        # only `return_type` survives the merge). When the
-        # discriminant *isn't* narrowed to `bot` at this scope, also
-        # records the call node so `diagnostics_for_file` can surface
-        # a `plugin.sorbet.absurd-reachable` warning.
+        # ADR-11 slice 6 — `T.absurd(x)` exhaustiveness. Always contributes a `bot` return (matches
+        # Sorbet's runtime behaviour: `T.absurd` raises, so its value type is `bot` and the engine's flow
+        # analysis treats code after it as unreachable; the legacy contribution's `exceptional: :raises`
+        # slot was never consumed on the dispatcher path — only `return_type` survives the merge). When
+        # the discriminant *isn't* narrowed to `bot` at this scope, also records the call node so
+        # `diagnostics_for_file` can surface a `plugin.sorbet.absurd-reachable` warning.
         if AbsurdRecognizer.absurd_call?(call_node)
           @reachable_absurd_nodes[call_node] = true unless AbsurdRecognizer.exhaustive?(call_node, scope)
           return Rigor::Type::Combinator.bot
         end
 
-        # ADR-11 slice 2 — `T.let` / `T.cast` / `T.must` /
-        # `T.unsafe` are checked first because they're cheaper
-        # to recognise (no catalog walk required) and they
-        # win over any cataloged signature: the user explicitly
-        # asserted the type at the call site. The light
-        # follow-up extends the recogniser to `T.must_because`
-        # (alias of `T.must`) and `T.reveal_type` (passes the
-        # type through; the human-facing diagnostic is recorded
-        # here for `diagnostics_for_file` to emit).
+        # ADR-11 slice 2 — `T.let` / `T.cast` / `T.must` / `T.unsafe` are checked first because they're
+        # cheaper to recognise (no catalog walk required) and they win over any cataloged signature: the
+        # user explicitly asserted the type at the call site. The light follow-up extends the recogniser
+        # to `T.must_because` (alias of `T.must`) and `T.reveal_type` (passes the type through; the
+        # human-facing diagnostic is recorded here for `diagnostics_for_file` to emit).
         #
-        # Per-call-site sigil gating: with `enforce_sigil: true`
-        # (default), assertions only fire in files Sorbet itself
-        # would enforce. Files at `# typed: false` (or
-        # sigil-less, which Sorbet treats as `:false`) skip the
-        # assertion path entirely so the dispatcher continues
-        # through the next tier as if the wrapper weren't
-        # there. The catalog tier already gates by sigil at
-        # harvest time; this closes the matching gap for
-        # caller-side recognition.
+        # Per-call-site sigil gating: with `enforce_sigil: true` (default), assertions only fire in files
+        # Sorbet itself would enforce. Files at `# typed: false` (or sigil-less, which Sorbet treats as
+        # `:false`) skip the assertion path entirely so the dispatcher continues through the next tier as
+        # if the wrapper weren't there. The catalog tier already gates by sigil at harvest time; this
+        # closes the matching gap for caller-side recognition.
         ensure_catalog
         if assertion_enforced_here?(scope)
           assertion = AssertionRecognizer.recognize(
@@ -283,10 +222,9 @@ module Rigor
         lookup_signature(call_node, scope)&.return_type
       end
 
-      # The `narrowing_facts` body for `T.bind` — same sigil gate as
-      # the return-type path, then the recogniser's
-      # `post_return_facts` (the `Fact(target_kind: :self)` that
-      # narrows `scope.self_type` for the rest of the block).
+      # The `narrowing_facts` body for `T.bind` — same sigil gate as the return-type path, then the
+      # recogniser's `post_return_facts` (the `Fact(target_kind: :self)` that narrows `scope.self_type`
+      # for the rest of the block).
       def bind_post_return_facts(call_node, scope)
         return nil unless call_node.is_a?(Prism::CallNode)
 
@@ -299,24 +237,16 @@ module Rigor
         contribution&.post_return_facts
       end
 
-      # Per-call-site assertion gating (ADR-11). With
-      # `enforce_sigil: false` the gate is fully open. With
-      # `enforce_sigil: true` (default), the caller file's
-      # sigil must reach `:true` / `:strict` / `:strong` for
-      # assertions to fire. Three honest fallbacks:
+      # Per-call-site assertion gating (ADR-11). With `enforce_sigil: false` the gate is fully open. With
+      # `enforce_sigil: true` (default), the caller file's sigil must reach `:true` / `:strict` /
+      # `:strong` for assertions to fire. Three honest fallbacks:
       #
-      # - `scope.source_path` is nil — synthetic call sites
-      #   (specs, virtual-node fixtures) have no file context.
-      #   Default to enforced so existing recogniser tests
-      #   keep working.
-      # - the path is canonicalised to a form not in
-      #   `@sigil_by_path` — the harvest never saw this file
-      #   (out-of-tree call site, or a path the
-      #   `configured_paths` config excluded). Sorbet itself
-      #   has no opinion on such files; default to enforced
-      #   so the recogniser still fires.
-      # - the path IS in `@sigil_by_path` but at `:false` /
-      #   `:ignore` — gate closes.
+      # - `scope.source_path` is nil — synthetic call sites (specs, virtual-node fixtures) have no file
+      #   context. Default to enforced so existing recogniser tests keep working.
+      # - the path is canonicalised to a form not in `@sigil_by_path` — the harvest never saw this file
+      #   (out-of-tree call site, or a path the `configured_paths` config excluded). Sorbet itself has no
+      #   opinion on such files; default to enforced so the recogniser still fires.
+      # - the path IS in `@sigil_by_path` but at `:false` / `:ignore` — gate closes.
       def assertion_enforced_here?(scope)
         return true unless @enforce_sigil
 
@@ -336,8 +266,8 @@ module Rigor
         return nil if method_name.nil?
 
         if (singleton_target = constant_receiver_name(receiver))
-          # `Post.find(...)` — direct singleton method, or
-          # `extend M` lifting `M#find` to the extending class.
+          # `Post.find(...)` — direct singleton method, or `extend M` lifting `M#find` to the extending
+          # class.
           chain_lookup(singleton_target, method_name, anchor_kind: :singleton, mixin_kind: :extend)
         elsif receiver
           instance_chain_lookup(receiver, method_name, scope)
@@ -347,16 +277,13 @@ module Rigor
       end
 
       # ADR-11 slice 2 — implicit-self calls.
-      # A receiver-less call inside a method body resolves against the
-      # engine's own `scope.self_type`: `Nominal[Foo]` inside an
-      # instance method (instance-side lookup), `Singleton[Foo]` inside
-      # a `def self.x` body (singleton-side lookup, `extend` mixins).
-      # Without this, an enforced sig on a sibling method was invisible
-      # to in-class calls — the engine's body-inference tiers then
-      # re-typed the sibling's body, overriding an explicit
-      # `T.untyped` opt-out (the dispatcher's plugin tier had already
-      # run and declined). Anything else (toplevel / Dynamic / DSL
-      # self) contributes nothing and the dispatcher continues.
+      # A receiver-less call inside a method body resolves against the engine's own `scope.self_type`:
+      # `Nominal[Foo]` inside an instance method (instance-side lookup), `Singleton[Foo]` inside a `def
+      # self.x` body (singleton-side lookup, `extend` mixins). Without this, an enforced sig on a sibling
+      # method was invisible to in-class calls — the engine's body-inference tiers then re-typed the
+      # sibling's body, overriding an explicit `T.untyped` opt-out (the dispatcher's plugin tier had
+      # already run and declined). Anything else (toplevel / Dynamic / DSL self) contributes nothing and
+      # the dispatcher continues.
       def implicit_self_lookup(method_name, scope)
         self_type = scope&.self_type
         case self_type
@@ -377,9 +304,8 @@ module Rigor
 
         chain_lookup(receiver_type.class_name, method_name, anchor_kind: :instance, mixin_kind: :include)
       rescue StandardError
-        # `scope.type_of` can raise on unrecognised synthetic
-        # nodes; degrade to "no contribution" rather than
-        # bubbling the failure into the dispatcher.
+        # `scope.type_of` can raise on unrecognised synthetic nodes; degrade to "no contribution" rather
+        # than bubbling the failure into the dispatcher.
         nil
       end
 
@@ -387,15 +313,13 @@ module Rigor
       #
       # For instance-side calls (`post.body`):
       # - `anchor_kind: :instance` (try `Post#body` first)
-      # - `mixin_kind: :include` (then walk Post's `include`d
-      #   modules and try `Foo#body` on each)
+      # - `mixin_kind: :include` (then walk Post's `include`d modules and try `Foo#body` on each)
       #
       # For singleton-side calls (`Post.find`):
       # - `anchor_kind: :singleton` (try `Post.find` first)
-      # - `mixin_kind: :extend` (then walk Post's `extend`ed
-      #   modules and try `Foo#find` *as :instance* — `extend
-      #   Foo` lifts Foo's INSTANCE methods to the extending
-      #   class's SINGLETON methods, matching Ruby's MRO).
+      # - `mixin_kind: :extend` (then walk Post's `extend`ed modules and try `Foo#find` *as :instance* —
+      #   `extend Foo` lifts Foo's INSTANCE methods to the extending class's SINGLETON methods, matching
+      #   Ruby's MRO).
       def chain_lookup(class_name, method_name, anchor_kind:, mixin_kind:)
         each_class_form(class_name).each do |form|
           sig = @catalog.lookup(class_name: form, method_name: method_name, kind: anchor_kind)
@@ -413,8 +337,7 @@ module Rigor
             sig = @catalog.lookup(class_name: form, method_name: method_name, kind: :instance)
             return sig if sig
 
-            # Transitive: an `include` inside the mixed-in
-            # module is also inherited by the host class.
+            # Transitive: an `include` inside the mixed-in module is also inherited by the host class.
             mixin_modules_for(form, :include).each do |inner|
               queue << inner unless visited.include?(inner)
             end
@@ -424,20 +347,16 @@ module Rigor
         nil
       end
 
-      # `Post` and `::Post` are routinely confused at the catalog
-      # boundary (the walker records the lexical name; user code
-      # often writes the rooted form). Try both at every lookup.
+      # `Post` and `::Post` are routinely confused at the catalog boundary (the walker records the lexical
+      # name; user code often writes the rooted form). Try both at every lookup.
       def each_class_form(class_name)
         [class_name, "::#{class_name}"]
       end
 
-      # Resolution forms for a mixed-in module name. Tapioca's
-      # generated DSL RBIs use the nested form
-      # (`class Post; module GeneratedAttributeMethods; ...; end`);
-      # hand-written shims often use the top-level form
-      # (`module GeneratedAttributeMethods; ...; end` outside any
-      # class); explicit rooting (`::GeneratedAttributeMethods`)
-      # is occasionally seen. Try all three.
+      # Resolution forms for a mixed-in module name. Tapioca's generated DSL RBIs use the nested form
+      # (`class Post; module GeneratedAttributeMethods; ...; end`); hand-written shims often use the
+      # top-level form (`module GeneratedAttributeMethods; ...; end` outside any class); explicit rooting
+      # (`::GeneratedAttributeMethods`) is occasionally seen. Try all three.
       def forms_for_mixin(host_class, mixin_name)
         if mixin_name.start_with?("::")
           [mixin_name, mixin_name.delete_prefix("::")]
@@ -486,8 +405,7 @@ module Rigor
 
       # @param root [String] directory or single file.
       # @param catalog [Catalog]
-      # @param extensions [Array<String>] file extensions to
-      #   accept (e.g. `[".rb"]` for project source,
+      # @param extensions [Array<String>] file extensions to accept (e.g. `[".rb"]` for project source,
       #   `[".rbi"]` for Sorbet RBI tree).
       def harvest_path(root, catalog, extensions:)
         absolute = canonicalize(root)
@@ -498,18 +416,15 @@ module Rigor
             end
           end
         elsif File.file?(absolute) && extensions.any? { |ext| absolute.end_with?(ext) }
-          # `paths:` may list individual files (the demos do
-          # this); walk them directly rather than skipping.
+          # `paths:` may list individual files (the demos do this); walk them directly rather than skipping.
           harvest_file(absolute, catalog)
         end
       end
 
-      # Canonicalises a path through `File.realpath` so it
-      # matches the form `Plugin::TrustPolicy#allow_read?` sees
-      # (the runner builds the policy's roots from `Dir.pwd`,
-      # which has symlinks resolved on macOS — `/tmp` →
-      # `/private/tmp` etc.). Falls back to `File.expand_path`
-      # when realpath fails (e.g. the path no longer exists).
+      # Canonicalises a path through `File.realpath` so it matches the form `Plugin::TrustPolicy#allow_read?`
+      # sees (the runner builds the policy's roots from `Dir.pwd`, which has symlinks resolved on macOS —
+      # `/tmp` → `/private/tmp` etc.). Falls back to `File.expand_path` when realpath fails (e.g. the path
+      # no longer exists).
       def canonicalize(path)
         expanded = File.expand_path(path)
         File.exist?(expanded) ? File.realpath(expanded) : expanded
@@ -521,31 +436,23 @@ module Rigor
         contents = io_boundary.read_file(path)
         return if contents.nil?
 
-        # ADR-11 slice 5 — honour Sorbet's `# typed: ignore`
-        # magic comment by skipping the file entirely.
+        # ADR-11 slice 5 — honour Sorbet's `# typed: ignore` magic comment by skipping the file entirely.
         level = SigilDetector.detect(contents)
-        # Per-call-site assertion gating consults this map at
-        # recognition time. Recorded BEFORE the ignored
-        # short-circuit so a `# typed: ignore` file still
-        # reports its level to the gate (the gate then chooses
-        # to suppress assertions there too — `ignore` is
-        # stricter than `false`).
+        # Per-call-site assertion gating consults this map at recognition time. Recorded BEFORE the
+        # ignored short-circuit so a `# typed: ignore` file still reports its level to the gate (the gate
+        # then chooses to suppress assertions there too — `ignore` is stricter than `false`).
         @sigil_by_path[path] = level
         return if SigilDetector.ignored?(level)
 
         result = Prism.parse(contents)
         return unless result.errors.empty?
 
-        # `enforce_sigil` follow-up — when on (default), files
-        # at `:false` (or sigil-less, which Sorbet treats as
-        # `:false`) are STILL walked so parse-error diagnostics
-        # surface, but sigs flow into a discardable catalog
-        # rather than the per-run one. Sorbet itself doesn't
-        # enforce types at `# typed: false`, and Rigor mirrors
-        # that for sig contributions. Assertion recognisers
-        # (`T.let` / `T.cast` / `T.must` / `T.bind` /
-        # `T.assert_type!`) stay live regardless of sigil — the
-        # user wrote those deliberately.
+        # `enforce_sigil` follow-up — when on (default), files at `:false` (or sigil-less, which Sorbet
+        # treats as `:false`) are STILL walked so parse-error diagnostics surface, but sigs flow into a
+        # discardable catalog rather than the per-run one. Sorbet itself doesn't enforce types at `#
+        # typed: false`, and Rigor mirrors that for sig contributions. Assertion recognisers (`T.let` /
+        # `T.cast` / `T.must` / `T.bind` / `T.assert_type!`) stay live regardless of sigil — the user
+        # wrote those deliberately.
         sig_catalog = if @enforce_sigil && !SigilDetector.enforced?(level)
                         Catalog.new
                       else
@@ -555,15 +462,13 @@ module Rigor
         errors = CatalogWalker.walk(root: result.value, catalog: sig_catalog, path: path)
         @parse_errors_by_path[path] = errors unless errors.empty?
       rescue Plugin::AccessDeniedError, Errno::ENOENT
-        # Skip files outside the trusted read scope or that
-        # vanished between glob and read; the plugin produces
-        # no output for them.
+        # Skip files outside the trusted read scope or that vanished between glob and read; the plugin
+        # produces no output for them.
         nil
       end
 
-      # Emits a `plugin.sorbet.absurd-reachable` warning for the
-      # `T.absurd(x)` call recorded in `@reachable_absurd_nodes` during
-      # inference; the node rule above does the identity match and pop.
+      # Emits a `plugin.sorbet.absurd-reachable` warning for the `T.absurd(x)` call recorded in
+      # `@reachable_absurd_nodes` during inference; the node rule above does the identity match and pop.
       def absurd_diagnostic(path, call_node)
         Rigor::Analysis::Diagnostic.from_node(
           call_node,
@@ -576,19 +481,16 @@ module Rigor
         )
       end
 
-      # ADR-11 light follow-up — `T.reveal_type(expr)` records
-      # the inferred type at recogniser time so the per-file
-      # diagnostic hook can surface the human-facing message.
-      # The reveal call's contribution already preserved the
-      # inferred type for downstream chaining; this hash carries
-      # the *display* string that the diagnostic shows.
+      # ADR-11 light follow-up — `T.reveal_type(expr)` records the inferred type at recogniser time so the
+      # per-file diagnostic hook can surface the human-facing message. The reveal call's contribution
+      # already preserved the inferred type for downstream chaining; this hash carries the *display*
+      # string that the diagnostic shows.
       def record_reveal_type_call(call_node, return_type)
         @reveal_type_calls[call_node] = display_for_type(return_type)
       end
 
       def display_for_type(type)
-        # `Type#describe` is the human-facing display contract
-        # used by `rigor type-of`'s text renderer.
+        # `Type#describe` is the human-facing display contract used by `rigor type-of`'s text renderer.
         return "untyped" if type.nil?
 
         type.respond_to?(:describe) ? type.describe : type.inspect
@@ -604,16 +506,11 @@ module Rigor
         )
       end
 
-      # T.bind / T.assert_type! priority slice 1 — runs the
-      # static subtype check at recogniser time and records the
-      # call only when the inferred type is *provably
-      # incompatible* with the asserted type. Gradual
-      # consistency rules (`Type#accepts` mode `:gradual`): a
-      # `Dynamic[top]` inferred type
-      # silences the check; a definite `:no` records for
-      # diagnostic emission; `:maybe` (uncertain) is treated as
-      # "trust the user" and silenced — the runtime check is
-      # there for those cases.
+      # T.bind / T.assert_type! priority slice 1 — runs the static subtype check at recogniser time and
+      # records the call only when the inferred type is *provably incompatible* with the asserted type.
+      # Gradual consistency rules (`Type#accepts` mode `:gradual`): a `Dynamic[top]` inferred type
+      # silences the check; a definite `:no` records for diagnostic emission; `:maybe` (uncertain) is
+      # treated as "trust the user" and silenced — the runtime check is there for those cases.
       def record_assert_type_check(call_node, scope)
         check = AssertionRecognizer.assert_type_check(call_node, scope)
         return if check.nil?

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/absurd_recognizer.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/absurd_recognizer.rb
@@ -7,11 +7,9 @@ require_relative "type_translator"
 module Rigor
   module Plugin
     class Sorbet < Rigor::Plugin::Base
-      # Slice 6 of ADR-11 — recognises `T.absurd(x)` calls and
-      # composes them with the engine's flow-sensitive
-      # narrowing. `T.absurd` asserts that a code branch is
-      # statically unreachable; it's the standard Sorbet idiom
-      # for case/when exhaustiveness:
+      # Slice 6 of ADR-11 — recognises `T.absurd(x)` calls and composes them with the engine's
+      # flow-sensitive narrowing. `T.absurd` asserts that a code branch is statically unreachable; it's
+      # the standard Sorbet idiom for case/when exhaustiveness:
       #
       #   case x
       #   when A then ...
@@ -20,33 +18,23 @@ module Rigor
       #     T.absurd(x)
       #   end
       #
-      # If every case has been handled, `x` at the `else` branch
-      # has been narrowed to `T.noreturn` (Rigor's `Type::Bot`)
-      # and the assertion holds. If the user forgot a case, `x`
-      # narrows to whatever's left and the assertion is wrong —
-      # we surface that mistake as `plugin.sorbet.absurd-reachable`.
+      # If every case has been handled, `x` at the `else` branch has been narrowed to `T.noreturn`
+      # (Rigor's `Type::Bot`) and the assertion holds. If the user forgot a case, `x` narrows to whatever's
+      # left and the assertion is wrong — we surface that mistake as `plugin.sorbet.absurd-reachable`.
       #
       # ## Two-phase mechanism
       #
-      # The recogniser is invoked from the plugin's `dynamic_return` rule
-      # where the per-node `scope:` carries the proper narrowing
-      # context. The rule:
+      # The recogniser is invoked from the plugin's `dynamic_return` rule where the per-node `scope:`
+      # carries the proper narrowing context. The rule:
       #
-      # - Contributes a `bot` return type regardless of
-      #   reachability (faithful to `T.absurd`'s runtime
-      #   behaviour: it always raises). This lets the engine's
-      #   existing flow analysis treat code after `T.absurd` as
-      #   unreachable, matching what users of Sorbet expect.
-      # - When the branch is REACHABLE (the discriminant's type
-      #   isn't `bot`), the recogniser also records the call
-      #   node in a per-plugin set. The plugin's
-      #   `diagnostics_for_file` later walks the AST for
-      #   `T.absurd` calls and emits a
-      #   `plugin.sorbet.absurd-reachable` warning at every
-      #   call_node whose object identity matches the recorded
-      #   set. We rely on the runner only parsing each file
-      #   once per run, so the same Prism node object is seen
-      #   in both the `dynamic_return` rule and
+      # - Contributes a `bot` return type regardless of reachability (faithful to `T.absurd`'s runtime
+      #   behaviour: it always raises). This lets the engine's existing flow analysis treat code after
+      #   `T.absurd` as unreachable, matching what users of Sorbet expect.
+      # - When the branch is REACHABLE (the discriminant's type isn't `bot`), the recogniser also records
+      #   the call node in a per-plugin set. The plugin's `diagnostics_for_file` later walks the AST for
+      #   `T.absurd` calls and emits a `plugin.sorbet.absurd-reachable` warning at every call_node whose
+      #   object identity matches the recorded set. We rely on the runner only parsing each file once per
+      #   run, so the same Prism node object is seen in both the `dynamic_return` rule and
       #   `diagnostics_for_file`.
       module AbsurdRecognizer
         # @param call_node [Prism::CallNode]
@@ -56,19 +44,17 @@ module Rigor
           return false unless call_node.name == :absurd
           return false unless TypeTranslator.sorbet_t_namespaced?(call_node.receiver)
 
-          # Slice 6 only handles single-argument `T.absurd(x)`;
-          # no-arg / multi-arg shapes are syntax errors at
-          # Sorbet's level too.
+          # Slice 6 only handles single-argument `T.absurd(x)`; no-arg / multi-arg shapes are syntax
+          # errors at Sorbet's level too.
           arguments = call_node.arguments&.arguments
           arguments&.size == 1
         end
 
         # @param call_node [Prism::CallNode]
         # @param scope [Rigor::Scope, nil]
-        # @return [Boolean] true when the discriminant has been
-        #   narrowed to `bot` (the branch is unreachable, so
-        #   `T.absurd` is correct). The caller suppresses the
-        #   `absurd-reachable` diagnostic in this case.
+        # @return [Boolean] true when the discriminant has been narrowed to `bot` (the branch is
+        #   unreachable, so `T.absurd` is correct). The caller suppresses the `absurd-reachable` diagnostic
+        #   in this case.
         def self.exhaustive?(call_node, scope)
           return false if scope.nil?
 
@@ -76,9 +62,8 @@ module Rigor
           arg_type = scope.type_of(arg)
           arg_type.equal?(Rigor::Type::Bot.instance) || arg_type.is_a?(Rigor::Type::Bot)
         rescue StandardError
-          # On synthetic / unrecognised nodes the typer may
-          # raise; treat as "can't prove unreachable" so the
-          # diagnostic fires conservatively.
+          # On synthetic / unrecognised nodes the typer may raise; treat as "can't prove unreachable" so
+          # the diagnostic fires conservatively.
           false
         end
       end

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/assertion_recognizer.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/assertion_recognizer.rb
@@ -7,13 +7,10 @@ require_relative "type_translator"
 module Rigor
   module Plugin
     class Sorbet < Rigor::Plugin::Base
-      # Lifts Sorbet's type-assertion calls (`T.let`, `T.cast`,
-      # `T.must`, `T.must_because`, `T.unsafe`, `T.reveal_type`)
-      # into `FlowContribution` return-type contributions.
-      # ADR-11 slice 2 covered the original four; the
-      # `must_because` / `reveal_type` light follow-up extends
-      # the same module rather than splitting into a parallel
-      # recogniser.
+      # Lifts Sorbet's type-assertion calls (`T.let`, `T.cast`, `T.must`, `T.must_because`, `T.unsafe`,
+      # `T.reveal_type`) into `FlowContribution` return-type contributions. ADR-11 slice 2 covered the
+      # original four; the `must_because` / `reveal_type` light follow-up extends the same module rather
+      # than splitting into a parallel recogniser.
       #
       # | Sorbet form                  | Contribution                            |
       # | ---------------------------- | --------------------------------------- |
@@ -26,54 +23,39 @@ module Rigor
       # | `T.assert_type!(expr, T)`    | return type ← translated `T` + static subtype check |
       # | `T.bind(self, T)`            | return type ← `Constant[nil]` + post_return_fact narrowing self to translated `T` |
       #
-      # The Sorbet runtime's `T.let` / `T.cast` actually return
-      # the inner expression unchanged at runtime; their job is
-      # purely to *assert* a static type. From Rigor's static
-      # perspective the simplest faithful translation is "the
-      # call's return type IS the asserted type" — the call
-      # site's downstream uses see that type. This matches what
-      # `%a{rigor:v1:assert: x is T}` would do for an assignment
-      # in the surrounding scope.
+      # The Sorbet runtime's `T.let` / `T.cast` actually return the inner expression unchanged at runtime;
+      # their job is purely to *assert* a static type. From Rigor's static perspective the simplest
+      # faithful translation is "the call's return type IS the asserted type" — the call site's downstream
+      # uses see that type. This matches what `%a{rigor:v1:assert: x is T}` would do for an assignment in
+      # the surrounding scope.
       #
-      # `T.must_because` is `T.must` with a second-argument
-      # string explanation. The static behaviour is identical to
-      # `T.must` — strip `nil` from the inferred type — so the
-      # recogniser dispatches through the same path.
+      # `T.must_because` is `T.must` with a second-argument string explanation. The static behaviour is
+      # identical to `T.must` — strip `nil` from the inferred type — so the recogniser dispatches through
+      # the same path.
       #
-      # `T.reveal_type` is "diagnostic-only" in Sorbet: it
-      # passes the value through unchanged at runtime AND
-      # surfaces the inferred static type as a build-time
-      # message. The recogniser contributes the inferred type
-      # (so chained call sites still resolve as if the
-      # `T.reveal_type` wrapper weren't there); the plugin's
-      # `diagnostics_for_file` hook surfaces the
-      # `plugin.sorbet.reveal-type` `:info` message for human
-      # consumption.
+      # `T.reveal_type` is "diagnostic-only" in Sorbet: it passes the value through unchanged at runtime
+      # AND surfaces the inferred static type as a build-time message. The recogniser contributes the
+      # inferred type (so chained call sites still resolve as if the `T.reveal_type` wrapper weren't
+      # there); the plugin's `diagnostics_for_file` hook surfaces the `plugin.sorbet.reveal-type` `:info`
+      # message for human consumption.
       #
-      # `T.bind(self, T)` is recognised as block-scope self
-      # narrowing. The recogniser returns a contribution whose
-      # `post_return_facts` carries a `Fact(target_kind: :self)`
-      # so the engine's `apply_self_post_return_fact` narrows
-      # `scope.self_type` for the surrounding scope (in a block
-      # body, the rest of the block). The first argument MUST be
-      # a literal `Prism::SelfNode` — Sorbet rejects other
-      # receivers and the recogniser mirrors that. The runtime
-      # call returns nil, so the static return type is
-      # `Constant[nil]`.
+      # `T.bind(self, T)` is recognised as block-scope self narrowing. The recogniser returns a
+      # contribution whose `post_return_facts` carries a `Fact(target_kind: :self)` so the engine's
+      # `apply_self_post_return_fact` narrows `scope.self_type` for the surrounding scope (in a block
+      # body, the rest of the block). The first argument MUST be a literal `Prism::SelfNode` — Sorbet
+      # rejects other receivers and the recogniser mirrors that. The runtime call returns nil, so the
+      # static return type is `Constant[nil]`.
       module AssertionRecognizer
-        # Method names this recogniser claims as Sorbet
-        # assertions. The plugin checks call sites against this
-        # set before any catalog lookup so a `T.let` call
-        # inside an analysed file always resolves through this
-        # module.
+        # Method names this recogniser claims as Sorbet assertions. The plugin checks call sites against
+        # this set before any catalog lookup so a `T.let` call inside an analysed file always resolves
+        # through this module.
         SORBET_ASSERTIONS = %i[let cast must must_because unsafe reveal_type assert_type! bind].freeze
 
         module_function
 
         # @param call_node [Prism::CallNode]
         # @param scope [Rigor::Scope]
-        # @param plugin_id [String] used for the contribution's
-        #   `provenance.source_family`.
+        # @param plugin_id [String] used for the contribution's `provenance.source_family`.
         # @return [Rigor::FlowContribution, nil]
         def recognize(call_node:, scope:, plugin_id:)
           return nil unless TypeTranslator.sorbet_t_namespaced?(call_node.receiver)
@@ -97,20 +79,15 @@ module Rigor
           end
         end
 
-        # `T.bind(self, T)` recognition. Sorbet rejects any
-        # non-`self` receiver argument, and the recogniser
-        # mirrors that — calls like `T.bind(other, X)` fall
-        # through silently. The contribution carries:
+        # `T.bind(self, T)` recognition. Sorbet rejects any non-`self` receiver argument, and the
+        # recogniser mirrors that — calls like `T.bind(other, X)` fall through silently. The contribution
+        # carries:
         #
-        # - `return_type: Constant[nil]` — Sorbet's runtime
-        #   `T.bind` returns nil; chained calls would be a
+        # - `return_type: Constant[nil]` — Sorbet's runtime `T.bind` returns nil; chained calls would be a
         #   bug, but the typing stays accurate.
-        # - `post_return_facts: [Fact(target_kind: :self,
-        #   type: T)]` — the engine's
-        #   `apply_self_post_return_fact` narrows
-        #   `scope.self_type` for the surrounding scope. In a
-        #   block body, that scope is the block's own, so the
-        #   narrowing applies to the rest of the block —
+        # - `post_return_facts: [Fact(target_kind: :self, type: T)]` — the engine's
+        #   `apply_self_post_return_fact` narrows `scope.self_type` for the surrounding scope. In a block
+        #   body, that scope is the block's own, so the narrowing applies to the rest of the block —
         #   matching Sorbet's documented contract.
         def recognize_bind(call_node, plugin_id)
           first_arg = nth_argument(call_node, 0)
@@ -137,15 +114,11 @@ module Rigor
           )
         end
 
-        # `T.assert_type!(expr, T)` shares the typed-assertion
-        # contribution shape with `T.cast` (return is the
-        # asserted type), so the recogniser delegates the
-        # return-type half through `resolve_typed_assertion`.
-        # The static subtype check that distinguishes
-        # `assert_type!` from `cast` lives in the plugin's
-        # `diagnostics_for_file` hook (mirroring the
-        # absurd-recognizer pattern: record the call here, emit
-        # the diagnostic from the per-file walker).
+        # `T.assert_type!(expr, T)` shares the typed-assertion contribution shape with `T.cast` (return is
+        # the asserted type), so the recogniser delegates the return-type half through
+        # `resolve_typed_assertion`. The static subtype check that distinguishes `assert_type!` from
+        # `cast` lives in the plugin's `diagnostics_for_file` hook (mirroring the absurd-recognizer
+        # pattern: record the call here, emit the diagnostic from the per-file walker).
         def assert_type_check(call_node, scope)
           return nil if scope.nil?
 
@@ -162,14 +135,11 @@ module Rigor
           nil
         end
 
-        # `T.reveal_type(expr)` returns `expr` unchanged at
-        # runtime; the Sorbet-side semantics is "make the
-        # inferred static type visible to the user." The
-        # contribution mirrors `T.must` minus the nil-stripping:
-        # the call's return type is the inner expression's
-        # inferred type. The companion diagnostic is emitted by
-        # the plugin's `diagnostics_for_file` hook; this
-        # method handles the contribution only.
+        # `T.reveal_type(expr)` returns `expr` unchanged at runtime; the Sorbet-side semantics is "make
+        # the inferred static type visible to the user." The contribution mirrors `T.must` minus the
+        # nil-stripping: the call's return type is the inner expression's inferred type. The companion
+        # diagnostic is emitted by the plugin's `diagnostics_for_file` hook; this method handles the
+        # contribution only.
         def resolve_reveal_type(call_node, scope)
           inner = nth_argument(call_node, 0)
           return Rigor::Type::Combinator.untyped if inner.nil? || scope.nil?
@@ -177,17 +147,14 @@ module Rigor
           inner_type = scope.type_of(inner)
           inner_type || Rigor::Type::Combinator.untyped
         rescue StandardError
-          # Synthetic / virtual nodes can raise from
-          # `scope.type_of`; degrade gracefully so the dispatcher
+          # Synthetic / virtual nodes can raise from `scope.type_of`; degrade gracefully so the dispatcher
           # can still proceed with a benign untyped envelope.
           Rigor::Type::Combinator.untyped
         end
 
-        # `T.let(expr, T)` and `T.cast(expr, T)` share the same
-        # 2-argument shape: `arguments[1]` is the type
-        # expression. The first argument is opaque to slice 2 —
-        # we don't try to verify it at runtime; that's `srb tc`'s
-        # job and is out of scope per ADR-11.
+        # `T.let(expr, T)` and `T.cast(expr, T)` share the same 2-argument shape: `arguments[1]` is the
+        # type expression. The first argument is opaque to slice 2 — we don't try to verify it at runtime;
+        # that's `srb tc`'s job and is out of scope per ADR-11.
         def resolve_typed_assertion(call_node)
           type_arg = nth_argument(call_node, 1)
           return nil if type_arg.nil?
@@ -195,12 +162,9 @@ module Rigor
           TypeTranslator.translate(type_arg)
         end
 
-        # `T.must(expr)` strips `nil` from `expr`'s inferred
-        # type. The call's target type is therefore
-        # `inferred(expr) - Constant[nil]`. Falls back to the
-        # untyped envelope when the inferred shape is itself
-        # `Dynamic[top]` or when no scope is available
-        # (synthetic / virtual-node call sites).
+        # `T.must(expr)` strips `nil` from `expr`'s inferred type. The call's target type is therefore
+        # `inferred(expr) - Constant[nil]`. Falls back to the untyped envelope when the inferred shape is
+        # itself `Dynamic[top]` or when no scope is available (synthetic / virtual-node call sites).
         def resolve_must(call_node, scope)
           inner = nth_argument(call_node, 0)
           return nil if inner.nil? || scope.nil?
@@ -210,18 +174,15 @@ module Rigor
 
           strip_nil(inner_type)
         rescue StandardError
-          # `scope.type_of` may raise on synthetic nodes; degrade
-          # to "no contribution" rather than crash the dispatcher.
+          # `scope.type_of` may raise on synthetic nodes; degrade to "no contribution" rather than crash
+          # the dispatcher.
           nil
         end
 
-        # Removes `nil` (`Constant[nil]`) from `type` using the
-        # `Difference` carrier. Idempotent on shapes that don't
-        # contain nil — the resulting `Difference[base, removed]`
-        # collapses to `base` if `base` already excludes the
-        # removed value, but the simple form here is good enough
-        # for slice 2; the precise normalisation lands when the
-        # Difference carrier gets full algebraic support.
+        # Removes `nil` (`Constant[nil]`) from `type` using the `Difference` carrier. Idempotent on shapes
+        # that don't contain nil — the resulting `Difference[base, removed]` collapses to `base` if `base`
+        # already excludes the removed value, but the simple form here is good enough for slice 2; the
+        # precise normalisation lands when the Difference carrier gets full algebraic support.
         def strip_nil(type)
           Rigor::Type::Combinator.difference(
             type, Rigor::Type::Combinator.constant_of(nil)

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/catalog.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/catalog.rb
@@ -3,28 +3,22 @@
 module Rigor
   module Plugin
     class Sorbet < Rigor::Plugin::Base
-      # Per-run table of method signatures keyed by the
-      # `(class_name, method_name, kind)` triple. Built by
-      # {CatalogWalker} during the plugin's lazy pre-walk; read
-      # by the plugin's `dynamic_return` rule at every gated call site.
+      # Per-run table of method signatures keyed by the `(class_name, method_name, kind)` triple. Built by
+      # {CatalogWalker} during the plugin's lazy pre-walk; read by the plugin's `dynamic_return` rule at
+      # every gated call site.
       #
-      # The catalog is mutable while it is being built, then
-      # frozen via {#freeze!} before the first read. Construction
-      # mutability is intentional — slice 1 builds the catalog
-      # incrementally as the walker visits each project file —
-      # but consumers MUST treat the catalog as read-only.
+      # The catalog is mutable while it is being built, then frozen via {#freeze!} before the first read.
+      # Construction mutability is intentional — slice 1 builds the catalog incrementally as the walker
+      # visits each project file — but consumers MUST treat the catalog as read-only.
       class Catalog
-        # Frozen empty bucket reused for classes that have no
-        # recorded mixins. Avoids allocating a fresh Hash on
-        # every `mixins_for` query.
+        # Frozen empty bucket reused for classes that have no recorded mixins. Avoids allocating a fresh
+        # Hash on every `mixins_for` query.
         EMPTY_MIXINS = { include: [].freeze, extend: [].freeze }.freeze
 
         def initialize
           @entries = {}
-          # ADR-11 slice 8 — per-class mixin declarations
-          # collected by `CatalogWalker`. Lookup-time chain
-          # traversal lifts sigs declared on a mixed-in
-          # module to call sites on the host class.
+          # ADR-11 slice 8 — per-class mixin declarations collected by `CatalogWalker`. Lookup-time chain
+          # traversal lifts sigs declared on a mixed-in module to call sites on the host class.
           @mixins = {}
           @frozen_after_build = false
         end
@@ -37,13 +31,11 @@ module Rigor
           @entries[key] = signature
         end
 
-        # @param class_name [String] the class / module that
-        #   carries the mixin (`class Post; include Foo; end`
-        #   records under `"Post"`).
+        # @param class_name [String] the class / module that carries the mixin (`class Post; include Foo;
+        #   end` records under `"Post"`).
         # @param kind [:include, :extend]
-        # @param module_name [String] the textual name of the
-        #   mixed-in module as it appeared at the include /
-        #   extend site (`"Foo"`, `"Foo::Bar"`, `"::Foo"`).
+        # @param module_name [String] the textual name of the mixed-in module as it appeared at the
+        #   include / extend site (`"Foo"`, `"Foo::Bar"`, `"::Foo"`).
         def record_mixin(class_name:, kind:, module_name:)
           raise "Catalog already finalised" if @frozen_after_build
 
@@ -69,9 +61,8 @@ module Rigor
         end
 
         # @param class_name [String]
-        # @return [Hash{Symbol => Array<String>}] frozen mapping
-        #   `{ include: [...], extend: [...] }`. Returns
-        #   {EMPTY_MIXINS} when no mixins were recorded.
+        # @return [Hash{Symbol => Array<String>}] frozen mapping `{ include: [...], extend: [...] }`.
+        #   Returns {EMPTY_MIXINS} when no mixins were recorded.
         def mixins_for(class_name)
           @mixins[class_name] || EMPTY_MIXINS
         end
@@ -80,16 +71,12 @@ module Rigor
           @entries.empty?
         end
 
-        # ADR-52 slice 4 — the distinct method names the catalog
-        # carries at least one signature for, across every
-        # `(class_name, kind)` owner. Feeds the plugin's run-time
-        # `dynamic_return methods:` name gate: the engine only
-        # consults the plugin for a call whose name appears here
-        # (or in the static assertion vocabulary), and the
-        # precise `(class, kind)` lookup stays in the rule block.
-        # Computed fresh per call — the plugin memoises the
-        # resolved set, and `freeze!` freezes the catalog itself
-        # so a lazy memo ivar here would raise.
+        # ADR-52 slice 4 — the distinct method names the catalog carries at least one signature for,
+        # across every `(class_name, kind)` owner. Feeds the plugin's run-time `dynamic_return methods:`
+        # name gate: the engine only consults the plugin for a call whose name appears here (or in the
+        # static assertion vocabulary), and the precise `(class, kind)` lookup stays in the rule block.
+        # Computed fresh per call — the plugin memoises the resolved set, and `freeze!` freezes the
+        # catalog itself so a lazy memo ivar here would raise.
         #
         # @return [Array<Symbol>]
         def method_names

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/catalog_walker.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/catalog_walker.rb
@@ -8,35 +8,26 @@ require_relative "sig_parser"
 module Rigor
   module Plugin
     class Sorbet < Rigor::Plugin::Base
-      # Walks a parsed Prism program looking for
-      # `sig { ... }` / `sig do ... end` calls that immediately
-      # precede a `def` (or a `def self.foo` / `class << self;
-      # def foo; end`). Each recognised pair is parsed by
-      # {SigParser} and recorded in the {Catalog} under its
-      # qualified `(class_name, method_name, kind)` key.
+      # Walks a parsed Prism program looking for `sig { ... }` / `sig do ... end` calls that immediately
+      # precede a `def` (or a `def self.foo` / `class << self; def foo; end`). Each recognised pair is
+      # parsed by {SigParser} and recorded in the {Catalog} under its qualified `(class_name, method_name,
+      # kind)` key.
       #
-      # Anything we don't recognise (a stray `sig { ... }` not
-      # followed by a `def`, a `def` with no preceding `sig`,
-      # malformed sig blocks, etc.) is reported back to the
-      # caller through `parse_errors:` so the plugin can emit a
-      # `plugin.sorbet.parse-error` diagnostic. Walking is
-      # otherwise infallible — a bad sig block does not abort
-      # the catalog build for the rest of the file.
+      # Anything we don't recognise (a stray `sig { ... }` not followed by a `def`, a `def` with no
+      # preceding `sig`, malformed sig blocks, etc.) is reported back to the caller through
+      # `parse_errors:` so the plugin can emit a `plugin.sorbet.parse-error` diagnostic. Walking is
+      # otherwise infallible — a bad sig block does not abort the catalog build for the rest of the file.
       module CatalogWalker
-        # Detected error during walking. `kind` is one of:
-        # `:no_block` / `:empty_block` / `:missing_returns_or_void`
-        # / `:duplicate_sig` / `:dangling_sig`.
+        # Detected error during walking. `kind` is one of: `:no_block` / `:empty_block` /
+        # `:missing_returns_or_void` / `:duplicate_sig` / `:dangling_sig`.
         ParseError = Data.define(:kind, :node, :path)
 
         module_function
 
         # @param root [Prism::Node] the file's program node.
-        # @param catalog [Catalog] mutable; signatures are
-        #   recorded into it.
-        # @param path [String] file path used for diagnostic
-        #   provenance.
-        # @return [Array<ParseError>] errors observed during the
-        #   walk; empty when the file is sig-clean.
+        # @param catalog [Catalog] mutable; signatures are recorded into it.
+        # @param path [String] file path used for diagnostic provenance.
+        # @return [Array<ParseError>] errors observed during the walk; empty when the file is sig-clean.
         def walk(root:, catalog:, path:)
           state = State.new(catalog: catalog, path: path)
           walk_node(root, state, lexical_path: [], in_singleton_class: false)
@@ -64,9 +55,8 @@ module Rigor
           when Prism::StatementsNode
             walk_statements(node, state, lexical_path: lexical_path, in_singleton_class: in_singleton_class)
           when Prism::DefNode
-            # A `def` not preceded by a `sig` is fine; we just
-            # don't record anything for it. The interesting case
-            # is in `walk_statements`, which pairs sig+def.
+            # A `def` not preceded by a `sig` is fine; we just don't record anything for it. The
+            # interesting case is in `walk_statements`, which pairs sig+def.
           else
             node.compact_child_nodes.each do |child|
               walk_node(child, state, lexical_path: lexical_path, in_singleton_class: in_singleton_class)
@@ -92,13 +82,10 @@ module Rigor
           end
         end
 
-        # The pair-finding loop. Walks a `StatementsNode`'s
-        # children left-to-right; when it encounters a `sig`
-        # call, it remembers it and consumes the very next
-        # `def` / `def self.foo` as the target. Anything between
-        # a sig and its def (a comment is fine — comments aren't
-        # AST nodes — but a method call would be a problem)
-        # leaves the sig dangling.
+        # The pair-finding loop. Walks a `StatementsNode`'s children left-to-right; when it encounters a
+        # `sig` call, it remembers it and consumes the very next `def` / `def self.foo` as the target.
+        # Anything between a sig and its def (a comment is fine — comments aren't AST nodes — but a
+        # method call would be a problem) leaves the sig dangling.
         def walk_statements(statements, state, lexical_path:, in_singleton_class:)
           pending_sig = nil
 
@@ -107,18 +94,15 @@ module Rigor
               record_def_with_sig(child, pending_sig, state, lexical_path, in_singleton_class)
               pending_sig = nil
             elsif pending_sig && attr_macro_call?(child)
-              # `sig { returns(T) }` above `attr_reader :name` /
-              # `attr_accessor` / `attr_writer` types the generated
-              # accessor(s). This is a first-class Sorbet idiom — not
-              # a dangling sig — so record the accessor signature(s)
-              # instead of warning.
+              # `sig { returns(T) }` above `attr_reader :name` / `attr_accessor` / `attr_writer` types
+              # the generated accessor(s). This is a first-class Sorbet idiom — not a dangling sig — so
+              # record the accessor signature(s) instead of warning.
               record_attr_with_sig(child, pending_sig, state, lexical_path, in_singleton_class)
               pending_sig = nil
             elsif pending_sig && (inner_def = visibility_wrapped_def(child))
-              # `sig { ... }` above `private def foo` /
-              # `private_class_method def self.foo` / `module_function
-              # def bar` — a visibility macro wrapping the very def the
-              # sig types. Record the inner def, not a dangling sig.
+              # `sig { ... }` above `private def foo` / `private_class_method def self.foo` /
+              # `module_function def bar` — a visibility macro wrapping the very def the sig types.
+              # Record the inner def, not a dangling sig.
               record_def_with_sig(inner_def, pending_sig, state, lexical_path, in_singleton_class)
               pending_sig = nil
             elsif sig_call?(child)
@@ -129,10 +113,8 @@ module Rigor
                 state.record_error(:dangling_sig, pending_sig)
                 pending_sig = nil
               end
-              # ADR-11 slice 8 — record `include` / `extend`
-              # declarations alongside the regular walk so the
-              # plugin's chain lookup can lift sigs declared
-              # on a mixed-in module to the host class.
+              # ADR-11 slice 8 — record `include` / `extend` declarations alongside the regular walk so
+              # the plugin's chain lookup can lift sigs declared on a mixed-in module to the host class.
               record_mixin_call(child, state, lexical_path) if mixin_call?(child) && !in_singleton_class
               walk_node(child, state, lexical_path: lexical_path, in_singleton_class: in_singleton_class)
             end
@@ -141,12 +123,9 @@ module Rigor
           state.record_error(:dangling_sig, pending_sig) if pending_sig
         end
 
-        # `include Foo` / `extend Foo` / `include Foo, Bar` —
-        # the `include` and `extend` mixin macros that Tapioca-
-        # generated DSL RBIs depend on. Recognised when the
-        # call has no explicit receiver (top-level inside a
-        # class body) and every argument is a constant
-        # reference.
+        # `include Foo` / `extend Foo` / `include Foo, Bar` — the `include` and `extend` mixin macros that
+        # Tapioca-generated DSL RBIs depend on. Recognised when the call has no explicit receiver
+        # (top-level inside a class body) and every argument is a constant reference.
         def mixin_call?(node)
           return false unless node.is_a?(Prism::CallNode)
           return false unless %i[include extend].include?(node.name)
@@ -191,12 +170,10 @@ module Rigor
           private_class_method public_class_method module_function
         ].freeze
 
-        # `private def foo` / `private_class_method def self.bar` /
-        # `module_function def baz` — a receiverless visibility macro
-        # whose single argument is the `def` it wraps. Returns the
-        # inner `Prism::DefNode` (so a preceding sig types it), or nil.
-        # The def's own receiver still drives instance-vs-singleton, so
-        # `private_class_method def self.bar` records as singleton.
+        # `private def foo` / `private_class_method def self.bar` / `module_function def baz` — a
+        # receiverless visibility macro whose single argument is the `def` it wraps. Returns the inner
+        # `Prism::DefNode` (so a preceding sig types it), or nil. The def's own receiver still drives
+        # instance-vs-singleton, so `private_class_method def self.bar` records as singleton.
         def visibility_wrapped_def(node)
           return nil unless node.is_a?(Prism::CallNode) && node.receiver.nil?
           return nil unless VISIBILITY_MACROS.include?(node.name)
@@ -209,9 +186,8 @@ module Rigor
 
         ATTR_MACROS = %i[attr_reader attr_writer attr_accessor].freeze
 
-        # `attr_reader :a, :b` / `attr_writer` / `attr_accessor` —
-        # a receiverless attribute macro whose arguments are all
-        # symbol literals (the only shape a preceding `sig` types).
+        # `attr_reader :a, :b` / `attr_writer` / `attr_accessor` — a receiverless attribute macro whose
+        # arguments are all symbol literals (the only shape a preceding `sig` types).
         def attr_macro_call?(node)
           return false unless node.is_a?(Prism::CallNode) && node.receiver.nil?
           return false unless ATTR_MACROS.include?(node.name)
@@ -220,11 +196,9 @@ module Rigor
           !args.nil? && !args.empty? && args.all?(Prism::SymbolNode)
         end
 
-        # Records the method signature(s) a `sig` contributes to the
-        # accessor(s) it precedes: the reader `name` and/or the
-        # writer `name=`, each carrying the sig's `returns(...)`
-        # type. `attr_reader` emits the reader, `attr_writer` the
-        # writer, `attr_accessor` both — for every symbol argument.
+        # Records the method signature(s) a `sig` contributes to the accessor(s) it precedes: the reader
+        # `name` and/or the writer `name=`, each carrying the sig's `returns(...)` type. `attr_reader`
+        # emits the reader, `attr_writer` the writer, `attr_accessor` both — for every symbol argument.
         def record_attr_with_sig(attr_node, sig_call, state, lexical_path, in_singleton_class)
           parsed = SigParser.parse(sig_call)
           if parsed.is_a?(SigParser::ParseError)
@@ -273,10 +247,8 @@ module Rigor
           in_singleton_class || def_node.receiver.is_a?(Prism::SelfNode)
         end
 
-        # Resolves a constant-path node (`Foo::Bar`,
-        # `::Foo::Bar`) to its dot-separated name. Returns nil
-        # for the rare dynamic-prefix shape so the walker
-        # doesn't guess a qualified name in that case.
+        # Resolves a constant-path node (`Foo::Bar`, `::Foo::Bar`) to its dot-separated name. Returns nil
+        # for the rare dynamic-prefix shape so the walker doesn't guess a qualified name in that case.
         def qualified_name_for(node)
           case node
           when Prism::ConstantReadNode then node.name.to_s

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/method_signature.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/method_signature.rb
@@ -3,19 +3,15 @@
 module Rigor
   module Plugin
     class Sorbet < Rigor::Plugin::Base
-      # Frozen description of one Sorbet `sig` block as parsed by
-      # {SigParser}. Holds the return type, parameter shape, and
-      # modifier list. Call-site argument-type checking and
-      # override-compatibility validation are deferred; only the
-      # return-type contribution is active.
+      # Frozen description of one Sorbet `sig` block as parsed by {SigParser}. Holds the return type,
+      # parameter shape, and modifier list. Call-site argument-type checking and override-compatibility
+      # validation are deferred; only the return-type contribution is active.
       #
-      # `kind` distinguishes `def foo` (`:instance`) from
-      # `def self.foo` / `class << self; def foo; end`
+      # `kind` distinguishes `def foo` (`:instance`) from `def self.foo` / `class << self; def foo; end`
       # (`:singleton`).
       #
-      # `modifiers` records the `sig`-level flags observed:
-      # `:abstract`, `:override`, `:overridable`, `:final`.
-      # Currently stored but not acted on.
+      # `modifiers` records the `sig`-level flags observed: `:abstract`, `:override`, `:overridable`,
+      # `:final`. Currently stored but not acted on.
       MethodSignature = Data.define(
         :class_name, :method_name, :kind, :params, :return_type, :modifiers
       )

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/sig_parser.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/sig_parser.rb
@@ -7,10 +7,8 @@ require_relative "type_translator"
 module Rigor
   module Plugin
     class Sorbet < Rigor::Plugin::Base
-      # Mini-interpreter for the chained-call expression that
-      # makes up a Sorbet `sig` block. The block body is always
-      # a single expression — Sorbet's docs (`sigs.md`) show the
-      # full grammar:
+      # Mini-interpreter for the chained-call expression that makes up a Sorbet `sig` block. The block
+      # body is always a single expression — Sorbet's docs (`sigs.md`) show the full grammar:
       #
       #   sig { params(x: T, y: T).returns(U) }
       #   sig { void }
@@ -22,26 +20,20 @@ module Rigor
       #     .returns(...)
       #   end
       #
-      # The parser walks the chain right-to-left, gathering
-      # whatever it recognises (`params` / `returns` / `void` /
-      # `abstract` / `override` / `overridable` / `final` /
-      # `type_parameters` / `checked` / `on_failure`) into a
-      # frozen result hash stored in {MethodSignature}. Modifiers
-      # and `type_parameters` are recorded but not yet acted on.
+      # The parser walks the chain right-to-left, gathering whatever it recognises (`params` / `returns` /
+      # `void` / `abstract` / `override` / `overridable` / `final` / `type_parameters` / `checked` /
+      # `on_failure`) into a frozen result hash stored in {MethodSignature}. Modifiers and
+      # `type_parameters` are recorded but not yet acted on.
       #
-      # The parser is intentionally tolerant — unknown chain
-      # nodes degrade to "the rest of the chain is opaque" rather
-      # than raising. The plugin emits a diagnostic
-      # (`plugin.sorbet.parse-error`) only when the entire chain
-      # fails to yield either a `returns` or a `void`.
+      # The parser is intentionally tolerant — unknown chain nodes degrade to "the rest of the chain is
+      # opaque" rather than raising. The plugin emits a diagnostic (`plugin.sorbet.parse-error`) only when
+      # the entire chain fails to yield either a `returns` or a `void`.
       module SigParser
-        # Modifiers we recognise at any position in the chain.
-        # Stored in `:modifiers` on the parse result.
+        # Modifiers we recognise at any position in the chain. Stored in `:modifiers` on the parse result.
         RECOGNISED_MODIFIERS = %i[abstract override overridable final].freeze
 
-        # Sorbet runtime-only chain steps. Recognised so the
-        # parser doesn't degrade the whole sig when it sees them,
-        # but their payload is intentionally discarded.
+        # Sorbet runtime-only chain steps. Recognised so the parser doesn't degrade the whole sig when it
+        # sees them, but their payload is intentionally discarded.
         RUNTIME_ONLY_STEPS = %i[checked on_failure].freeze
 
         ParseResult = Data.define(:return_type, :params, :modifiers, :void) do
@@ -52,8 +44,7 @@ module Rigor
 
         module_function
 
-        # @param sig_call [Prism::CallNode] the `sig { ... }` /
-        #   `sig do ... end` call.
+        # @param sig_call [Prism::CallNode] the `sig { ... }` / `sig do ... end` call.
         # @return [ParseResult, ParseError]
         def parse(sig_call)
           return ParseError.new(reason: :no_block, node: sig_call) if sig_call.block.nil?
@@ -72,11 +63,9 @@ module Rigor
           end
         end
 
-        # Walks the chain bottom-up. Each chain link is a
-        # `Prism::CallNode` whose receiver is the next link;
-        # `params` / `returns` / `void` may appear at any
-        # position, so we accumulate their effect into a
-        # mutable hash and freeze on the way out.
+        # Walks the chain bottom-up. Each chain link is a `Prism::CallNode` whose receiver is the next
+        # link; `params` / `returns` / `void` may appear at any position, so we accumulate their effect
+        # into a mutable hash and freeze on the way out.
         def fold_chain(node, sig_call)
           accumulator = { return_type: nil, params: {}, modifiers: [], void: false, terminus_kind: nil }
           current = node
@@ -92,15 +81,13 @@ module Rigor
             when :params
               accumulator[:params].merge!(parse_params(current))
             when :type_parameters
-              # Recognised to suppress the degraded path;
-              # payload intentionally discarded (deferred).
+              # Recognised to suppress the degraded path; payload intentionally discarded (deferred).
             when *RECOGNISED_MODIFIERS
               accumulator[:modifiers] << current.name
             when *RUNTIME_ONLY_STEPS
               # Discard payload; runtime-only.
             else
-              # Unknown chain link — stop folding and treat
-              # whatever we accumulated so far as the result.
+              # Unknown chain link — stop folding and treat whatever we accumulated so far as the result.
               break
             end
             current = current.receiver
@@ -116,20 +103,16 @@ module Rigor
           )
         end
 
-        # `void` and `returns(T)` share the slot; if both are
-        # present (unusual but parseable), `returns(T)` wins
-        # because Sorbet's static side treats `void` as
-        # "discard the value" — when the user explicitly named
-        # `T`, that's the more informative shape.
+        # `void` and `returns(T)` share the slot; if both are present (unusual but parseable), `returns(T)`
+        # wins because Sorbet's static side treats `void` as "discard the value" — when the user
+        # explicitly named `T`, that's the more informative shape.
         def resolve_return_type(accumulator)
           accumulator[:return_type] || Rigor::Type::Combinator.untyped
         end
 
-        # `params(x: Integer, y: T.nilable(String))` — extracts
-        # the `KeywordHashNode` AST and translates each value.
-        # The result is `{ Symbol => Rigor::Type }`. Splat /
-        # double-splat / unrecognised keys degrade silently
-        # (slice 1 behaviour).
+        # `params(x: Integer, y: T.nilable(String))` — extracts the `KeywordHashNode` AST and translates
+        # each value. The result is `{ Symbol => Rigor::Type }`. Splat / double-splat / unrecognised keys
+        # degrade silently (slice 1 behaviour).
         def parse_params(call_node)
           args = call_node.arguments&.arguments || []
           first = args.first

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/sigil_detector.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/sigil_detector.rb
@@ -3,49 +3,36 @@
 module Rigor
   module Plugin
     class Sorbet < Rigor::Plugin::Base
-      # Reads Sorbet's `# typed: <level>` magic comment from the
-      # head of a file. Sorbet's own contract (per
-      # [`static.md`](https://sorbet.org/docs/static)) requires
-      # the sigil to appear at the top of the file before any
-      # Ruby code. We're slightly more lenient here — the sigil
-      # may appear after a few comment / blank lines (matching
-      # what Sorbet itself accepts in practice) but we stop
-      # scanning once we hit a non-comment, non-blank line.
+      # Reads Sorbet's `# typed: <level>` magic comment from the head of a file. Sorbet's own contract (per
+      # [`static.md`](https://sorbet.org/docs/static)) requires the sigil to appear at the top of the file
+      # before any Ruby code. We're slightly more lenient here — the sigil may appear after a few comment
+      # / blank lines (matching what Sorbet itself accepts in practice) but we stop scanning once we hit a
+      # non-comment, non-blank line.
       #
-      # Recognised levels: `:ignore` / `:false` / `:true` /
-      # `:strict` / `:strong`. Falls back to `:false` (Sorbet's
-      # default) when no sigil is present, matching how Sorbet
-      # treats sigil-less files.
+      # Recognised levels: `:ignore` / `:false` / `:true` / `:strict` / `:strong`. Falls back to `:false`
+      # (Sorbet's default) when no sigil is present, matching how Sorbet treats sigil-less files.
       #
-      # ADR-11 slice 5 uses this at catalog-harvest time:
-      # `# typed: ignore` files are skipped entirely; other
-      # levels gate both sig contributions (`:true`/`:strict`/
-      # `:strong` only) and per-call assertion recognition
-      # (`T.let` / `T.cast` / `T.must` / etc.) via
-      # `Sorbet#assertion_enforced_here?`.
+      # ADR-11 slice 5 uses this at catalog-harvest time: `# typed: ignore` files are skipped entirely;
+      # other levels gate both sig contributions (`:true`/`:strict`/`:strong` only) and per-call assertion
+      # recognition (`T.let` / `T.cast` / `T.must` / etc.) via `Sorbet#assertion_enforced_here?`.
       module SigilDetector
-        # Sorbet's strictness-level names. Stored as symbols to
-        # match the analyzer's existing convention for level
-        # identifiers; the `:true` / `:false` symbols here are
-        # level *names* (the textual sigil values) and are
-        # intentionally distinct from the `true` / `false`
-        # boolean literals.
+        # Sorbet's strictness-level names. Stored as symbols to match the analyzer's existing convention
+        # for level identifiers; the `:true` / `:false` symbols here are level *names* (the textual sigil
+        # values) and are intentionally distinct from the `true` / `false` boolean literals.
         VALID_LEVELS = %i[ignore false true strict strong].freeze
         DEFAULT_LEVEL = :false # rubocop:disable Lint/BooleanSymbol
         SIGIL_REGEX = /\A\s*#\s*typed\s*:\s*(ignore|false|true|strict|strong)\s*\z/
 
-        # Cap on how many lines we scan before giving up. Sorbet
-        # doesn't formally specify a cap, but the sigil
-        # convention is "near the top of the file"; 10 lines is
-        # generous and bounds the parse cost on enormous files.
+        # Cap on how many lines we scan before giving up. Sorbet doesn't formally specify a cap, but the
+        # sigil convention is "near the top of the file"; 10 lines is generous and bounds the parse cost
+        # on enormous files.
         MAX_HEAD_LINES = 10
 
         module_function
 
         # @param contents [String] raw file contents.
-        # @return [Symbol] one of {VALID_LEVELS}; defaults to
-        #   {DEFAULT_LEVEL} for sigil-less or malformed-sigil
-        #   files.
+        # @return [Symbol] one of {VALID_LEVELS}; defaults to {DEFAULT_LEVEL} for sigil-less or
+        #   malformed-sigil files.
         def detect(contents)
           return DEFAULT_LEVEL if contents.nil? || contents.empty?
 
@@ -57,9 +44,8 @@ module Rigor
 
             match = SIGIL_REGEX.match(stripped)
             return match[1].to_sym if match
-            # First non-blank line that isn't a sigil-shaped
-            # comment ends the scan: Sorbet's parser stops at
-            # the first directive-or-code line.
+            # First non-blank line that isn't a sigil-shaped comment ends the scan: Sorbet's parser stops
+            # at the first directive-or-code line.
             break unless stripped.start_with?("#")
           end
 
@@ -67,27 +53,20 @@ module Rigor
         end
 
         # @param level [Symbol]
-        # @return [Boolean] true when `# typed: ignore`. The
-        #   harvest pipeline calls this to short-circuit
+        # @return [Boolean] true when `# typed: ignore`. The harvest pipeline calls this to short-circuit
         #   walking the file's AST.
         def ignored?(level)
           level == :ignore
         end
 
-        # @return [Boolean] true when `level` is at or above the
-        #   `# typed: true` mark. Used by the
-        #   `enforce_sigil` config gate (default `true`): with
-        #   the gate on, only files marked `:true` / `:strict` /
-        #   `:strong` contribute their sigs to the catalog. The
-        #   `:false` (and sigil-less) levels still get walked
-        #   (so RBI files outside the project can be loaded
-        #   regardless), but their sig-derived narrowing is
-        #   suppressed — matching how Sorbet itself only
-        #   enforces type errors at `# typed: true`+. Assertion
-        #   recognisers (`T.let` / `T.cast` / `T.must` /
-        #   `T.bind` / `T.assert_type!`) are NOT gated by this:
-        #   the user wrote them deliberately, so the
-        #   recogniser still fires regardless of sigil.
+        # @return [Boolean] true when `level` is at or above the `# typed: true` mark. Used by the
+        #   `enforce_sigil` config gate (default `true`): with the gate on, only files marked `:true` /
+        #   `:strict` / `:strong` contribute their sigs to the catalog. The `:false` (and sigil-less)
+        #   levels still get walked (so RBI files outside the project can be loaded regardless), but their
+        #   sig-derived narrowing is suppressed — matching how Sorbet itself only enforces type errors at
+        #   `# typed: true`+. Assertion recognisers (`T.let` / `T.cast` / `T.must` / `T.bind` /
+        #   `T.assert_type!`) are NOT gated by this: the user wrote them deliberately, so the recogniser
+        #   still fires regardless of sigil.
         def enforced?(level)
           %i[true strict strong].include?(level)
         end

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/type_translator.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/type_translator.rb
@@ -5,9 +5,8 @@ require "prism"
 module Rigor
   module Plugin
     class Sorbet < Rigor::Plugin::Base
-      # Maps Sorbet's type expressions (the AST inside a `sig`
-      # block's `params(...)` and `returns(...)` clauses) into
-      # Rigor's internal type carriers.
+      # Maps Sorbet's type expressions (the AST inside a `sig` block's `params(...)` and `returns(...)`
+      # clauses) into Rigor's internal type carriers.
       #
       # | Sorbet form              | Rigor carrier                            |
       # | ------------------------ | ---------------------------------------- |
@@ -32,18 +31,14 @@ module Rigor
       # | `{a: A, b: B}` (shape)   | `HashShape{a: A, b: B}` (closed)         |
       # | `Foo::Bar[A, B]` (user)  | `Nominal["Foo::Bar", [A, B]]`            |
       #
-      # Anything else (`T.proc`, `T.attached_class`,
-      # `T.self_type`, `T.type_parameter`, `T::Struct` / `T::Enum`
-      # subclasses, …) degrades silently to `Dynamic[top]`. The
-      # `dynamic.sorbet.unsupported` diagnostic for degraded
-      # forms is deferred.
+      # Anything else (`T.proc`, `T.attached_class`, `T.self_type`, `T.type_parameter`, `T::Struct` /
+      # `T::Enum` subclasses, …) degrades silently to `Dynamic[top]`. The `dynamic.sorbet.unsupported`
+      # diagnostic for degraded forms is deferred.
       module TypeTranslator
         BOOLEAN_NAME = "Boolean"
 
-        # `T::*` constants whose `[]` application maps directly
-        # onto a Rigor `Nominal` with the matching standard-
-        # library class name. Ordering matches the table above
-        # for ease of reading.
+        # `T::*` constants whose `[]` application maps directly onto a Rigor `Nominal` with the matching
+        # standard-library class name. Ordering matches the table above for ease of reading.
         T_GENERIC_CLASSES = {
           "Array" => "Array",
           "Hash" => "Hash",
@@ -58,8 +53,7 @@ module Rigor
         module_function
 
         # @param node [Prism::Node, nil]
-        # @return [Rigor::Type] never `nil`; unrecognised forms
-        #   degrade to `Type::Combinator.untyped`.
+        # @return [Rigor::Type] never `nil`; unrecognised forms degrade to `Type::Combinator.untyped`.
         def translate(node)
           return Rigor::Type::Combinator.untyped if node.nil?
 
@@ -86,8 +80,8 @@ module Rigor
           name = constant_path_name(node)
           return degraded if name.nil?
 
-          # Sorbet's `T::Boolean` is a special alias rather than a
-          # nominal class, expressed as the Boolean type alias.
+          # Sorbet's `T::Boolean` is a special alias rather than a nominal class, expressed as the Boolean
+          # type alias.
           return boolean_type if name == "T::Boolean"
 
           Rigor::Type::Combinator.nominal_of(name)
@@ -95,20 +89,16 @@ module Rigor
 
         # `Prism::CallNode` covers three distinct surfaces:
         #
-        # 1. `T.something(...)` — `untyped` / `anything` /
-        #    `noreturn` / `nilable` / `any` / `all` / `class_of`.
-        # 2. `T::SomeClass[...]` — the `[]` method on a generic
-        #    `T::*` constant (slice 3 widening). Maps to
-        #    `Nominal[name, type_args]`.
-        # 3. `Some::User::Generic[...]` — the `[]` method on any
-        #    OTHER constant (a user-defined generic application,
-        #    e.g. `Mangrove::Result::Ok[String, StandardError]`).
-        #    Maps to `Nominal[name, type_args]` so generic carriers
-        #    authored outside Sorbet's `T::*` set round-trip with
-        #    their instantiation intact (the unwrap-site receiver a
-        #    plugin like rigor-mangrove reads `type_args` from).
-        #    Without this branch such forms degraded to `untyped`,
-        #    silently dropping the receiver's generic arguments.
+        # 1. `T.something(...)` — `untyped` / `anything` / `noreturn` / `nilable` / `any` / `all` /
+        #    `class_of`.
+        # 2. `T::SomeClass[...]` — the `[]` method on a generic `T::*` constant (slice 3 widening). Maps
+        #    to `Nominal[name, type_args]`.
+        # 3. `Some::User::Generic[...]` — the `[]` method on any OTHER constant (a user-defined generic
+        #    application, e.g. `Mangrove::Result::Ok[String, StandardError]`). Maps to `Nominal[name,
+        #    type_args]` so generic carriers authored outside Sorbet's `T::*` set round-trip with their
+        #    instantiation intact (the unwrap-site receiver a plugin like rigor-mangrove reads `type_args`
+        #    from). Without this branch such forms degraded to `untyped`, silently dropping the
+        #    receiver's generic arguments.
         def translate_call(node)
           return translate_t_method(node) if sorbet_t_namespaced?(node.receiver)
           return translate_t_subscript(node) if sorbet_subscript?(node)
@@ -154,11 +144,9 @@ module Rigor
           Rigor::Type::Combinator.intersection(*args.map { |arg| translate(arg) })
         end
 
-        # `T.class_of(C)` — singleton-class type for a single
-        # constant. Sorbet docs note `T.class_of(MyInterface)`
-        # rarely means what users expect (it's the singleton
-        # class of `MyInterface`, not "any class implementing
-        # the interface"); we honour the literal meaning here
+        # `T.class_of(C)` — singleton-class type for a single constant. Sorbet docs note
+        # `T.class_of(MyInterface)` rarely means what users expect (it's the singleton class of
+        # `MyInterface`, not "any class implementing the interface"); we honour the literal meaning here
         # and translate to `Singleton[C]`.
         def translate_class_of(node)
           target = first_argument(node)
@@ -168,14 +156,10 @@ module Rigor
           Rigor::Type::Combinator.singleton_of(name)
         end
 
-        # Handles `T::Array[E]`, `T::Hash[K, V]`, etc. The Prism
-        # AST for `T::Array[Integer]` is a `CallNode` whose
-        # receiver is the `T::Array` `ConstantPathNode` and
-        # whose `name` is `:[]`. `T::Class[T]` lands here too;
-        # we collapse it to `Singleton[name]` (a deliberate
-        # narrowing — `T::Class` is structurally generic in
-        # Sorbet, but Rigor's `Singleton` carries class identity
-        # only).
+        # Handles `T::Array[E]`, `T::Hash[K, V]`, etc. The Prism AST for `T::Array[Integer]` is a
+        # `CallNode` whose receiver is the `T::Array` `ConstantPathNode` and whose `name` is `:[]`.
+        # `T::Class[T]` lands here too; we collapse it to `Singleton[name]` (a deliberate narrowing —
+        # `T::Class` is structurally generic in Sorbet, but Rigor's `Singleton` carries class identity only).
         def translate_t_subscript(node)
           base_name = sorbet_subscript_base(node.receiver)
           args = call_arguments(node).map { |arg| translate(arg) }
@@ -190,14 +174,11 @@ module Rigor
           end
         end
 
-        # A user-defined generic application — a `[]` call on a
-        # constant that is NOT `T`-rooted, e.g.
-        # `Mangrove::Result::Ok[String, StandardError]` or a
-        # top-level `Box[Integer]`. Translates to
-        # `Nominal[name, type_args]`, recursively translating each
-        # argument (so nested `T::Array[...]` inside a user generic
-        # still resolves). Ordered AFTER `translate_t_subscript` in
-        # `translate_call`, so the `T::*` forms never reach here.
+        # A user-defined generic application — a `[]` call on a constant that is NOT `T`-rooted, e.g.
+        # `Mangrove::Result::Ok[String, StandardError]` or a top-level `Box[Integer]`. Translates to
+        # `Nominal[name, type_args]`, recursively translating each argument (so nested `T::Array[...]`
+        # inside a user generic still resolves). Ordered AFTER `translate_t_subscript` in `translate_call`,
+        # so the `T::*` forms never reach here.
         def user_generic_subscript?(node)
           return false unless node.name == :[]
 
@@ -205,15 +186,14 @@ module Rigor
           return false unless receiver.is_a?(Prism::ConstantReadNode) ||
                               receiver.is_a?(Prism::ConstantPathNode)
 
-          # `T::Foo[...]` is handled by translate_t_subscript; only
-          # non-`T`-rooted constants are user generics.
+          # `T::Foo[...]` is handled by translate_t_subscript; only non-`T`-rooted constants are user
+          # generics.
           !sorbet_t_qualified?(receiver)
         end
 
         def translate_user_subscript(node)
-          # Parity with translate_constant_path: the constant's
-          # rendered name (carrying a leading `::` for absolute
-          # paths) becomes the nominal class name.
+          # Parity with translate_constant_path: the constant's rendered name (carrying a leading `::` for
+          # absolute paths) becomes the nominal class name.
           name = constant_path_name(node.receiver)
           return degraded if name.nil?
 
@@ -221,13 +201,10 @@ module Rigor
           Rigor::Type::Combinator.nominal_of(name, type_args: args)
         end
 
-        # `T::Class[T]` — Sorbet's "any class object whose
-        # instances are at least `T`". Rigor has no exact
-        # analogue (Singleton names a specific class); the
-        # closest faithful translation is `Singleton[name]`
-        # when `T` is a constant, or `Singleton[Object]` for
-        # broader applications. Lossy — the `dynamic.sorbet.degraded`
-        # diagnostic for this case is deferred.
+        # `T::Class[T]` — Sorbet's "any class object whose instances are at least `T`". Rigor has no exact
+        # analogue (Singleton names a specific class); the closest faithful translation is `Singleton[name]`
+        # when `T` is a constant, or `Singleton[Object]` for broader applications. Lossy — the
+        # `dynamic.sorbet.degraded` diagnostic for this case is deferred.
         def translate_t_class_subscript(args)
           inner = args.first
           return Rigor::Type::Combinator.singleton_of("Class") if inner.nil?
@@ -238,20 +215,16 @@ module Rigor
           end
         end
 
-        # Tuple types in `sig` position appear as bare array
-        # literals: `sig { returns([String, Integer]) }`. Each
-        # element is itself a type expression we translate
-        # recursively.
+        # Tuple types in `sig` position appear as bare array literals: `sig { returns([String, Integer]) }`.
+        # Each element is itself a type expression we translate recursively.
         def translate_tuple(node)
           elements = node.elements.map { |element| translate(element) }
           Rigor::Type::Combinator.tuple_of(*elements)
         end
 
-        # Shape types in `sig` position appear as bare hash
-        # literals with symbol keys:
-        # `sig { returns({a: Integer, b: String}) }`. Each
-        # value is a type expression; the resulting `HashShape`
-        # is closed (no extra keys allowed).
+        # Shape types in `sig` position appear as bare hash literals with symbol keys:
+        # `sig { returns({a: Integer, b: String}) }`. Each value is a type expression; the resulting
+        # `HashShape` is closed (no extra keys allowed).
         def translate_shape(node)
           pairs = []
           node.elements.each do |element|
@@ -263,9 +236,8 @@ module Rigor
           Rigor::Type::Combinator.hash_shape_of(pairs)
         end
 
-        # Renders a constant-path node (`Foo::Bar`, `::Foo::Bar`)
-        # as a `::`-joined String. Mirrors the helper used by
-        # rigor-activerecord's ModelDiscoverer for parity.
+        # Renders a constant-path node (`Foo::Bar`, `::Foo::Bar`) as a `::`-joined String. Mirrors the
+        # helper used by rigor-activerecord's ModelDiscoverer for parity.
         def constant_path_name(node)
           return nil if node.nil?
 
@@ -294,9 +266,8 @@ module Rigor
           receiver.is_a?(Prism::ConstantReadNode) && receiver.name == :T
         end
 
-        # `T::Array[Integer]` parses as `CallNode(receiver: T::Array, name: :[])`.
-        # The receiver is a `ConstantPathNode` rooted at the
-        # `T` constant.
+        # `T::Array[Integer]` parses as `CallNode(receiver: T::Array, name: :[])`. The receiver is a
+        # `ConstantPathNode` rooted at the `T` constant.
         def sorbet_subscript?(node)
           node.name == :[] && sorbet_t_qualified?(node.receiver)
         end
@@ -304,16 +275,14 @@ module Rigor
         def sorbet_t_qualified?(node)
           return false unless node.is_a?(Prism::ConstantPathNode)
 
-          # Walk to the root; require that it terminates at a
-          # `T` ConstantReadNode (not an absolute `::T`).
+          # Walk to the root; require that it terminates at a `T` ConstantReadNode (not an absolute `::T`).
           current = node
           current = current.parent while current.is_a?(Prism::ConstantPathNode)
           current.is_a?(Prism::ConstantReadNode) && current.name == :T
         end
 
-        # Strips the leading `T::` from a `T::Foo::Bar`
-        # constant-path node, returning `"Foo::Bar"`. Returns
-        # nil for shapes that aren't `T`-rooted.
+        # Strips the leading `T::` from a `T::Foo::Bar` constant-path node, returning `"Foo::Bar"`.
+        # Returns nil for shapes that aren't `T`-rooted.
         def sorbet_subscript_base(node)
           return nil unless sorbet_t_qualified?(node)
 
@@ -338,11 +307,9 @@ module Rigor
           Rigor::Type::Combinator.untyped
         end
 
-        # `T::Boolean` corresponds to the union of the singleton
-        # `true` / `false` values, matching how RBS's `bool`
-        # would translate. Built from `Constant[true]` /
-        # `Constant[false]` so the analyzer's flow-sensitive
-        # narrowing recognises the discriminating shape.
+        # `T::Boolean` corresponds to the union of the singleton `true` / `false` values, matching how
+        # RBS's `bool` would translate. Built from `Constant[true]` / `Constant[false]` so the analyzer's
+        # flow-sensitive narrowing recognises the discriminating shape.
         def boolean_type
           Rigor::Type::Combinator.union(
             Rigor::Type::Combinator.constant_of(true),

--- a/plugins/rigor-statesman/demo/demo.rb
+++ b/plugins/rigor-statesman/demo/demo.rb
@@ -7,10 +7,8 @@ require_relative "lib/runtime"
 #   RUBYLIB=$PWD/../lib bundle exec rigor check
 #
 # rigor-statesman performs a two-pass analysis on each file:
-#   pass 1 — collect every `state :name` declaration inside
-#            `state_machine do ... end` blocks.
-#   pass 2 — validate every `transition_to(:sym)` call site
-#            against the collected state set.
+#   pass 1 — collect every `state :name` declaration inside `state_machine do ... end` blocks.
+#   pass 2 — validate every `transition_to(:sym)` call site against the collected state set.
 
 class Order
   state_machine do
@@ -33,7 +31,7 @@ order.transition_to(:approved)
 order.transition_to(:rejected)
 order.transition_to(:draft)
 
-# Non-Symbol arguments stay silent (the plugin can't statically
-# know which state value the variable resolves to).
+# Non-Symbol arguments stay silent (the plugin can't statically know which state value the variable
+# resolves to).
 target = :submitted
 order.transition_to(target)

--- a/plugins/rigor-statesman/demo/errors_demo.rb
+++ b/plugins/rigor-statesman/demo/errors_demo.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 
-# Intentionally ill-typed file — demonstrates the diagnostics
-# rigor-statesman emits for unknown state references. DO NOT
-# run via `ruby errors_demo.rb` — the unknown states would
-# raise at runtime. Run `rigor check` instead.
+# Intentionally ill-typed file — demonstrates the diagnostics rigor-statesman emits for unknown state
+# references. DO NOT run via `ruby errors_demo.rb` — the unknown states would raise at runtime. Run
+# `rigor check` instead.
 
 require_relative "lib/runtime"
 
-# The plugin scopes states to the file. Repeat the
-# state_machine declaration here so the validator has
-# something to compare against — same shape a real Statesman
-# user would write in their `app/models/order.rb`.
+# The plugin scopes states to the file. Repeat the state_machine declaration here so the validator has
+# something to compare against — same shape a real Statesman user would write in their
+# `app/models/order.rb`.
 class Order
   state_machine do
     state :draft, initial: true

--- a/plugins/rigor-statesman/demo/lib/runtime.rb
+++ b/plugins/rigor-statesman/demo/lib/runtime.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# Tiny state-machine runtime. Just enough to make demo.rb
-# runnable; the plugin's value is in the lint-time check
-# of the `transition_to(:state)` calls below.
+# Tiny state-machine runtime. Just enough to make demo.rb runnable; the plugin's value is in the lint-time
+# check of the `transition_to(:state)` calls below.
 
 class Class
   def state_machine(&)
@@ -35,9 +34,8 @@ class StateMachine
     @initial_state = name if initial
   end
 
-  # Runtime stub for `event :name do ... end`. The plugin does
-  # NOT yet introspect events; real DSL plugins would extend
-  # the collector to track per-event from/to declarations.
+  # Runtime stub for `event :name do ... end`. The plugin does NOT yet introspect events; real DSL
+  # plugins would extend the collector to track per-event from/to declarations.
   def event(_name, &)
     nil
   end

--- a/plugins/rigor-statesman/lib/rigor-statesman.rb
+++ b/plugins/rigor-statesman/lib/rigor-statesman.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-statesman` under `plugins:`. The
-# loader expects this `require` to side-effect a call to
-# `Rigor::Plugin.register`, which the body of
-# `lib/rigor/plugin/statesman.rb` performs at load time.
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists `rigor-statesman` under
+# `plugins:`. The loader expects this `require` to side-effect a call to `Rigor::Plugin.register`, which
+# the body of `lib/rigor/plugin/statesman.rb` performs at load time.
 require_relative "rigor/plugin/statesman"

--- a/plugins/rigor-statesman/lib/rigor/plugin/statesman.rb
+++ b/plugins/rigor-statesman/lib/rigor/plugin/statesman.rb
@@ -6,29 +6,24 @@ require "rigor/source/literals"
 
 module Rigor
   module Plugin
-    # Example plugin: validates state-machine references.
-    # Demonstrates the **two-pass DSL analysis** pattern many
-    # plugins reuse:
+    # Example plugin: validates state-machine references. Demonstrates the **two-pass DSL analysis**
+    # pattern many plugins reuse:
     #
-    #   1. **Collect pass.** Walk the file once to gather every
-    #      state name declared inside a `state_machine do ... end`
-    #      block (`state :draft`, `state :submitted`, ...).
-    #   2. **Validate pass.** Walk the file again, validating each
-    #      `transition_to(:sym)` and `event :sym` reference against
-    #      the collected state set. Levenshtein distance ≤ 3 drives
-    #      the did-you-mean suggestions.
+    #   1. **Collect pass.** Walk the file once to gather every state name declared inside a
+    #      `state_machine do ... end` block (`state :draft`, `state :submitted`, ...).
+    #   2. **Validate pass.** Walk the file again, validating each `transition_to(:sym)` and `event :sym`
+    #      reference against the collected state set. Levenshtein distance ≤ 3 drives the did-you-mean
+    #      suggestions.
     #
-    # Useful for `aasm` / `statesman` / hand-rolled DSLs and any
-    # framework where declarations and uses live in the same
-    # file. The same skeleton lifts to GraphQL types,
-    # ActiveModel validations, route declarations — anywhere a
-    # declarative DSL produces a closed namespace and the rest
-    # of the file references that namespace by literal symbol.
+    # Useful for `aasm` / `statesman` / hand-rolled DSLs and any framework where declarations and uses
+    # live in the same file. The same skeleton lifts to GraphQL types, ActiveModel validations, route
+    # declarations — anywhere a declarative DSL produces a closed namespace and the rest of the file
+    # references that namespace by literal symbol.
     #
     # ## Configuration
     #
-    # Defaults match the `Statesman::Machine` API; override via
-    # `.rigor.yml` if your DSL uses different names:
+    # Defaults match the `Statesman::Machine` API; override via `.rigor.yml` if your DSL uses different
+    # names:
     #
     #     plugins:
     #       - gem: rigor-statesman
@@ -63,13 +58,11 @@ module Rigor
         @transition_method = config.fetch("transition_method").to_sym
       end
 
-      # ADR-37 — the two-pass shape made explicit. The collect pass
-      # (pass 1) runs once per file as the node-rule file context: it
-      # MUST complete before validation because a `transition_to` may
-      # precede the `state` that declares its target, so it cannot be a
-      # per-node rule in the engine's single forward walk. The validate
-      # pass (pass 2) is then a per-`CallNode` rule over the
-      # engine-owned walk — no hand-rolled traversal.
+      # ADR-37 — the two-pass shape made explicit. The collect pass (pass 1) runs once per file as the
+      # node-rule file context: it MUST complete before validation because a `transition_to` may precede
+      # the `state` that declares its target, so it cannot be a per-node rule in the engine's single
+      # forward walk. The validate pass (pass 2) is then a per-`CallNode` rule over the engine-owned walk
+      # — no hand-rolled traversal.
       node_file_context do |root, _scope|
         collect_states(root)
       end
@@ -86,10 +79,9 @@ module Rigor
 
       private
 
-      # Pass 1 — every `state :foo` declaration inside a
-      # `<dsl_method> do ... end` block on the file. Returns a
-      # frozen Set of state name Symbols. Walks via the engine's
-      # shared `Source::NodeWalker` rather than a hand-rolled traversal.
+      # Pass 1 — every `state :foo` declaration inside a `<dsl_method> do ... end` block on the file.
+      # Returns a frozen Set of state name Symbols. Walks via the engine's shared `Source::NodeWalker`
+      # rather than a hand-rolled traversal.
       def collect_states(root)
         states = Set.new
         Source::NodeWalker.each(root) do |node|

--- a/plugins/rigor-typescript-utility-types/lib/rigor-typescript-utility-types.rb
+++ b/plugins/rigor-typescript-utility-types/lib/rigor-typescript-utility-types.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-# Gem entry point. Required by Rigor's plugin loader when
-# `.rigor.yml` lists `rigor-typescript-utility-types` under
-# `plugins:`. The loader expects this `require` to side-effect
-# a call to `Rigor::Plugin.register`, which the body of
-# `lib/rigor/plugin/typescript_utility_types.rb` performs at
-# load time.
+# Gem entry point. Required by Rigor's plugin loader when `.rigor.yml` lists
+# `rigor-typescript-utility-types` under `plugins:`. The loader expects this `require` to side-effect a
+# call to `Rigor::Plugin.register`, which the body of `lib/rigor/plugin/typescript_utility_types.rb`
+# performs at load time.
 require_relative "rigor/plugin/typescript_utility_types"

--- a/plugins/rigor-typescript-utility-types/lib/rigor/plugin/typescript_utility_types.rb
+++ b/plugins/rigor-typescript-utility-types/lib/rigor/plugin/typescript_utility_types.rb
@@ -4,36 +4,27 @@ require "rigor/plugin"
 
 module Rigor
   module Plugin
-    # Example plugin: ships the TypeScript-canonical utility-type
-    # aliases (`Pick<T, K>`, `Omit<T, K>`, `Partial<T>`,
-    # `Required<T>`, `Readonly<T>`) as opt-in vocabulary that
-    # resolves to the Rigor-canonical shape-projection type
-    # functions introduced in ADR-13.
+    # Example plugin: ships the TypeScript-canonical utility-type aliases (`Pick<T, K>`, `Omit<T, K>`,
+    # `Partial<T>`, `Required<T>`, `Readonly<T>`) as opt-in vocabulary that resolves to the Rigor-canonical
+    # shape-projection type functions introduced in ADR-13.
     #
-    # Background. `docs/type-specification/imported-built-in-types.md`
-    # § "Deferred or rejected imports" deliberately rejects
-    # TypeScript-canonical names from the Rigor core surface: the
-    # core stays RBS-canonical per ADR-0 / ADR-1, and the shape
-    # semantics live in core under `pick_of[T, K]` /
-    # `omit_of[T, K]` / `partial_of[T]` / `required_of[T]` /
-    # `readonly_of[T]` (added in ADR-13 slice 4). This plugin
-    # ships the TS spellings as an opt-in translation layer for
-    # users migrating from TypeScript / Sorbet / Flow-style RBI.
+    # Background. `docs/type-specification/imported-built-in-types.md` § "Deferred or rejected imports"
+    # deliberately rejects TypeScript-canonical names from the Rigor core surface: the core stays
+    # RBS-canonical per ADR-0 / ADR-1, and the shape semantics live in core under `pick_of[T, K]` /
+    # `omit_of[T, K]` / `partial_of[T]` / `required_of[T]` / `readonly_of[T]` (added in ADR-13 slice 4).
+    # This plugin ships the TS spellings as an opt-in translation layer for users migrating from
+    # TypeScript / Sorbet / Flow-style RBI.
     #
-    # Off by default — users add the gem to their `.rigor.yml`
-    # plugins list to enable.
+    # Off by default — users add the gem to their `.rigor.yml` plugins list to enable.
     #
     # @example .rigor.yml
     #   plugins:
     #     - gem: rigor-typescript-utility-types
     #
-    # Once loaded, an RBS::Extended payload such as
-    # `%a{rigor:v1:return: Pick[Foo, :a | :b]}` resolves through
-    # the chain: the parser builds a `Generic("Pick", …)` AST,
-    # the registry / built-in parametric builders decline, the
-    # chain consults `Resolvers::Pick`, which recursively
-    # resolves the two arguments to Rigor types and calls
-    # `Type::Combinator.pick_of` on them.
+    # Once loaded, an RBS::Extended payload such as `%a{rigor:v1:return: Pick[Foo, :a | :b]}` resolves
+    # through the chain: the parser builds a `Generic("Pick", …)` AST, the registry / built-in parametric
+    # builders decline, the chain consults `Resolvers::Pick`, which recursively resolves the two arguments
+    # to Rigor types and calls `Type::Combinator.pick_of` on them.
     #
     # ## Translation table
     #
@@ -47,22 +38,17 @@ module Rigor
     #
     # ## Deferred TypeScript utility names
     #
-    # `Parameters<F>` / `ReturnType<F>` / `InstanceType<C>` /
-    # `Awaited<P>` / `Uppercase<S>` / `Lowercase<S>` /
-    # `Capitalize<S>` / `Uncapitalize<S>` / `ThisParameterType<F>`
-    # / `OmitThisParameter<F>` / `ConstructorParameters<C>` /
-    # `NoInfer<T>` are NOT mapped today. The plugin returns `nil`
-    # from `#resolve` for those heads, leaving the parser's
-    # default Nominal-fallback to produce `Nominal[ReturnType, …]`
-    # etc. Function-type projection operators (`params_of[F]` /
-    # `return_of[F]`) and class projections (`instance_type[C]`)
-    # would unlock these — they remain deferred in core.
+    # `Parameters<F>` / `ReturnType<F>` / `InstanceType<C>` / `Awaited<P>` / `Uppercase<S>` /
+    # `Lowercase<S>` / `Capitalize<S>` / `Uncapitalize<S>` / `ThisParameterType<F>` /
+    # `OmitThisParameter<F>` / `ConstructorParameters<C>` / `NoInfer<T>` are NOT mapped today. The plugin
+    # returns `nil` from `#resolve` for those heads, leaving the parser's default Nominal-fallback to
+    # produce `Nominal[ReturnType, …]` etc. Function-type projection operators (`params_of[F]` /
+    # `return_of[F]`) and class projections (`instance_type[C]`) would unlock these — they remain
+    # deferred in core.
     class TypescriptUtilityTypes < Rigor::Plugin::Base
       module Resolvers
-        # Common helper: extract a single-arg utility-type Generic
-        # whose head matches `name`. Returns the resolved
-        # argument's `Rigor::Type` or `nil` (so the chain falls
-        # through).
+        # Common helper: extract a single-arg utility-type Generic whose head matches `name`. Returns the
+        # resolved argument's `Rigor::Type` or `nil` (so the chain falls through).
         module SingleArg
           def self.resolve(node, scope, name)
             return nil unless node.is_a?(Rigor::TypeNode::Generic)

--- a/spec/docs/handbook_snippets_spec.rb
+++ b/spec/docs/handbook_snippets_spec.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 
-# Verify that every executable code block in docs/handbook/ stays
-# accurate as the engine evolves.  "Executable" means the block
-# contains an `assert_type(...)` or `dump_type(...)` call — the two
-# Rigor introspection helpers that pin inferred types in prose.
+# Verify that every executable code block in docs/handbook/ stays accurate as the engine evolves.
+# "Executable" means the block contains an `assert_type(...)` or `dump_type(...)` call — the two Rigor
+# introspection helpers that pin inferred types in prose.
 #
-# A block that fires `assert.type-mismatch` is a documentation error:
-# the prose claims a type that the engine no longer produces.
+# A block that fires `assert.type-mismatch` is a documentation error: the prose claims a type that the engine
+# no longer produces.
 #
-# Blocks that use only the `#=> dump_type: TypeString` annotation
-# convention (documentation-only comments, not method calls) are not
-# tested here — they are presentation markers for `rigor annotate`.
+# Blocks that use only the `#=> dump_type: TypeString` annotation convention (documentation-only comments, not
+# method calls) are not tested here — they are presentation markers for `rigor annotate`.
 
 require "spec_helper"
 

--- a/spec/docs/link_integrity_spec.rb
+++ b/spec/docs/link_integrity_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-# Verify that every relative markdown link in docs/handbook/ and
-# docs/manual/ resolves to an existing file.
+# Verify that every relative markdown link in docs/handbook/ and docs/manual/ resolves to an existing file.
 #
-# External links (http/https) and pure in-page anchors (#section)
-# are not checked — only relative file references.
+# External links (http/https) and pure in-page anchors (#section) are not checked — only relative file references.
 
 require "spec_helper"
 
@@ -17,8 +15,7 @@ LINK_INTEGRITY_DOC_DIRS = [
 
 module LinkIntegrityHelpers
   def extract_relative_links(content, base_dir)
-    # Strip fenced code blocks and inline code spans to avoid matching
-    # code like `[T any](x T)` as a markdown link.
+    # Strip fenced code blocks and inline code spans to avoid matching code like `[T any](x T)` as a markdown link.
     stripped = content
                .gsub(/```.*?```/m, "")
                .gsub(/`[^`\n]+`/, "")

--- a/spec/docs/manual_drift_spec.rb
+++ b/spec/docs/manual_drift_spec.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
-# Catch drift between docs/manual/ prose and the implementation it
-# describes.  Three axes:
+# Catch drift between docs/manual/ prose and the implementation it describes.  Three axes:
 #
-#   1. CLI subcommands — every key in CLI::HANDLERS must appear in
-#      the CLI reference, and vice versa.
-#   2. Config keys — every top-level key in Configuration::DEFAULTS
-#      must be mentioned in the configuration reference.
-#   3. Rule IDs — every ID in CheckRules::ALL_RULES must appear in
-#      the diagnostic catalogue or the handbook errors chapter.
+#   1. CLI subcommands — every key in CLI::HANDLERS must appear in the CLI reference, and vice versa.
+#   2. Config keys — every top-level key in Configuration::DEFAULTS must be mentioned in the configuration reference.
+#   3. Rule IDs — every ID in CheckRules::ALL_RULES must appear in the diagnostic catalogue or the handbook
+#      errors chapter.
 #
 # These checks are purely textual — no Rigor analysis needed.
 
@@ -23,8 +20,8 @@ MANUAL_DRIFT_DOCS_ROOT    = File.expand_path("../../docs", __dir__)
 MANUAL_DRIFT_MANUAL_DIR   = File.join(MANUAL_DRIFT_DOCS_ROOT, "manual")
 MANUAL_DRIFT_HANDBOOK_DIR = File.join(MANUAL_DRIFT_DOCS_ROOT, "handbook")
 
-# Introspection helpers: emitted by the engine but documented in the
-# handbook type-inspection chapter (05), not the diagnostic catalogue.
+# Introspection helpers: emitted by the engine but documented in the handbook type-inspection chapter (05),
+# not the diagnostic catalogue.
 MANUAL_DRIFT_INTROSPECTION_RULES = %w[dump.type assert.type-mismatch].freeze
 
 RSpec.describe "manual accuracy" do
@@ -52,8 +49,7 @@ RSpec.describe "manual accuracy" do
 
     it "every DEFAULTS top-level key is mentioned in the reference" do
       missing = top_level_keys.reject do |key|
-        # Accept backtick forms, YAML-key form (key:), or dot-notation
-        # prefix (cache.path, bundler.lockfile, …).
+        # Accept backtick forms, YAML-key form (key:), or dot-notation prefix (cache.path, bundler.lockfile, …).
         config_doc.include?("`#{key}`") ||
           config_doc.include?("`#{key}:`") ||
           config_doc.include?("#{key}:") ||

--- a/spec/integration/all_plugins_load_spec.rb
+++ b/spec/integration/all_plugins_load_spec.rb
@@ -2,50 +2,41 @@
 
 require "spec_helper"
 
-# Structural guard: EVERY bundled plugin (`plugins/*`) and example
-# (`examples/*`) must load and register a valid plugin. The per-plugin
-# integration specs cover *behaviour*, but nothing enumerates the whole
-# set — so a newly-added plugin with no spec of its own, or one whose
-# gem entry / manifest breaks, could slip through CI unnoticed. This
-# spec globs both trees so no plugin escapes a load attempt, and is the
-# companion to `external_plugin_spec.rb` (which proves the *out-of-tree*
-# load path): together they guard that the plugin contract keeps working
-# for every shipped plugin and for third-party authors.
+# Structural guard: EVERY bundled plugin (`plugins/*`) and example (`examples/*`) must load and register a
+# valid plugin. The per-plugin integration specs cover *behaviour*, but nothing enumerates the whole set — so a
+# newly-added plugin with no spec of its own, or one whose gem entry / manifest breaks, could slip through CI
+# unnoticed. This spec globs both trees so no plugin escapes a load attempt, and is the companion to
+# `external_plugin_spec.rb` (which proves the *out-of-tree* load path): together they guard that the plugin
+# contract keeps working for every shipped plugin and for third-party authors.
 #
-# Loadability is exercised by `require`-ing each gem entry. `require` is
-# idempotent: a broken entry raises here when no other spec loaded it
-# first, and a loadable one never falsely fails — so "every entry is
-# loadable" holds regardless of which worker/order runs this file under
-# `make test-parallel`. Registration + manifest validity are then
-# asserted against the public `Rigor::Plugin` surface.
+# Loadability is exercised by `require`-ing each gem entry. `require` is idempotent: a broken entry raises here
+# when no other spec loaded it first, and a loadable one never falsely fails — so "every entry is loadable"
+# holds regardless of which worker/order runs this file under `make test-parallel`. Registration + manifest
+# validity are then asserted against the public `Rigor::Plugin` surface.
 
 # Repo root from spec/integration/.
 ALL_PLUGINS_REPO_ROOT = File.expand_path("../..", __dir__)
 
-# Directories under plugins/ and examples/ (trailing slash → dirs only,
-# so the README.md files are not picked up).
+# Directories under plugins/ and examples/ (trailing slash → dirs only, so the README.md files are not picked up).
 ALL_PLUGINS_DIRS = (
   Dir[File.join(ALL_PLUGINS_REPO_ROOT, "plugins", "*", "")] +
   Dir[File.join(ALL_PLUGINS_REPO_ROOT, "examples", "*", "")]
 ).sort.freeze
 
-# `rigor-playground` is a standalone Rack application, not a Rigor
-# plugin — it has no `lib/rigor-playground.rb` entry and registers no
-# `Plugin::Base`, so it is out of scope for this guard.
+# `rigor-playground` is a standalone Rack application, not a Rigor plugin — it has no `lib/rigor-playground.rb`
+# entry and registers no `Plugin::Base`, so it is out of scope for this guard.
 ALL_PLUGINS_SKIP = %w[rigor-playground].freeze
 
 ALL_PLUGINS_LOADABLE_DIRS = ALL_PLUGINS_DIRS.reject do |dir|
   ALL_PLUGINS_SKIP.include?(File.basename(dir))
 end.freeze
 
-# Meta-gems aggregate other plugins' entry points (`require
-# "rigor-rails-routes"` …) and register no checker plugin of their own,
-# so they are asserted only for clean loading, not for registration.
+# Meta-gems aggregate other plugins' entry points (`require "rigor-rails-routes"` …) and register no checker
+# plugin of their own, so they are asserted only for clean loading, not for registration.
 ALL_PLUGINS_META_GEM_IDS = %w[rails].freeze
 
-# Put every plugin's lib on the load path up front so a meta-gem entry
-# (which requires its sub-plugins by gem name) resolves regardless of
-# example order.
+# Put every plugin's lib on the load path up front so a meta-gem entry (which requires its sub-plugins by gem
+# name) resolves regardless of example order.
 ALL_PLUGINS_LOADABLE_DIRS.each do |dir|
   lib = File.join(dir, "lib")
   $LOAD_PATH.unshift(lib) if Dir.exist?(lib) && !$LOAD_PATH.include?(lib)
@@ -60,11 +51,10 @@ RSpec.describe "bundled plugins and examples all load (structural guard)" do
     File.basename(dir).sub(/\Arigor-/, "")
   end
 
-  # Every `Rigor::Plugin::*` constant that is a concrete plugin class
-  # whose declared manifest id matches `id`. Scanning the namespace
-  # (rather than the loader registry) keeps the assertion robust to other
-  # specs' `Rigor::Plugin.unregister!` calls — a required plugin's class
-  # constant persists even when the registry is cleared.
+  # Every `Rigor::Plugin::*` constant that is a concrete plugin class whose declared manifest id matches `id`.
+  # Scanning the namespace (rather than the loader registry) keeps the assertion robust to other specs'
+  # `Rigor::Plugin.unregister!` calls — a required plugin's class constant persists even when the registry is
+  # cleared.
   def plugin_class_for(id)
     Rigor::Plugin.constants
                  .map { |const| Rigor::Plugin.const_get(const) }
@@ -72,9 +62,8 @@ RSpec.describe "bundled plugins and examples all load (structural guard)" do
                  .find { |klass| safe_manifest_id(klass) == id }
   end
 
-  # A `Plugin::Base` subclass that never declared a manifest raises
-  # `ArgumentError` from `.manifest`; treat that as "not this id" rather
-  # than letting the scan blow up on an unrelated class.
+  # A `Plugin::Base` subclass that never declared a manifest raises `ArgumentError` from `.manifest`; treat that
+  # as "not this id" rather than letting the scan blow up on an unrelated class.
   def safe_manifest_id(klass)
     klass.manifest.id
   rescue ArgumentError
@@ -107,9 +96,8 @@ RSpec.describe "bundled plugins and examples all load (structural guard)" do
   end
 
   it "covers every plugins/* and examples/* directory" do
-    # Guards the guard: if a new top-level directory appears with no gem
-    # entry (and it is not the known Rack-app exception), surface it so
-    # the omission is a deliberate decision, not an oversight.
+    # Guards the guard: if a new top-level directory appears with no gem entry (and it is not the known
+    # Rack-app exception), surface it so the omission is a deliberate decision, not an oversight.
     skipped = ALL_PLUGINS_DIRS.map { |dir| File.basename(dir) } -
               ALL_PLUGINS_LOADABLE_DIRS.map { |dir| File.basename(dir) }
     expect(skipped).to eq(ALL_PLUGINS_SKIP)

--- a/spec/integration/demos_run_spec.rb
+++ b/spec/integration/demos_run_spec.rb
@@ -5,44 +5,32 @@ require "open3"
 require "json"
 require "rbconfig"
 
-# Behavioural guard (option B): EVERY bundled plugin / example `demo/`
-# project must run end-to-end under the real `rigor check` CLI without
-# crashing. `all_plugins_load_spec.rb` proves each plugin *loads*; this
-# proves each shipped demo — the runnable artefact a user copies — still
-# *analyses* cleanly.
+# Behavioural guard (option B): EVERY bundled plugin / example `demo/` project must run end-to-end under the
+# real `rigor check` CLI without crashing. `all_plugins_load_spec.rb` proves each plugin *loads*; this proves
+# each shipped demo — the runnable artefact a user copies — still *analyses* cleanly.
 #
 # ## Why a subprocess (and why that is the CI-reliable choice)
 #
-# Each demo is run via a fresh `ruby exe/rigor check` subprocess rather
-# than in-process, for two reasons that together make it deterministic
-# in GitHub Actions:
+# Each demo is run via a fresh `ruby exe/rigor check` subprocess rather than in-process, for two reasons that
+# together make it deterministic in GitHub Actions:
 #
-#   1. **Fresh process = real plugin load.** The Rigor plugin loader
-#      keys "did this gem register a plugin?" on the registry diff across
-#      its `require`. In one long-lived test process that `require` is
-#      cached after the first spec touches the gem, so an in-process run
-#      could silently fail-soft (plugin not re-registered) and test
-#      nothing. A subprocess loads every plugin for real, exactly as a
-#      user's `rigor check` does.
-#   2. **No locale/encoding surface in the assertion.** Demo diagnostics
-#      contain non-ASCII (e.g. the `—` in statesman's messages). Ruby's
-#      JSON generator emits raw UTF-8 under a UTF-8 locale and ASCII
-#      `\uXXXX` escapes under a C locale, so `rigor` itself never crashes
-#      on output regardless of `LANG` (verified under `LC_ALL=C`). The
-#      test reads the captured bytes back as UTF-8 explicitly, so the
-#      assertion is locale-independent on the CI runner too.
+#   1. **Fresh process = real plugin load.** The Rigor plugin loader keys "did this gem register a plugin?" on
+#      the registry diff across its `require`. In one long-lived test process that `require` is cached after
+#      the first spec touches the gem, so an in-process run could silently fail-soft (plugin not re-registered)
+#      and test nothing. A subprocess loads every plugin for real, exactly as a user's `rigor check` does.
+#   2. **No locale/encoding surface in the assertion.** Demo diagnostics contain non-ASCII (e.g. the `—` in
+#      statesman's messages). Ruby's JSON generator emits raw UTF-8 under a UTF-8 locale and ASCII `\uXXXX`
+#      escapes under a C locale, so `rigor` itself never crashes on output regardless of `LANG` (verified under
+#      `LC_ALL=C`). The test reads the captured bytes back as UTF-8 explicitly, so the assertion is
+#      locale-independent on the CI runner too.
 #
-# The subprocess inherits the parent's environment — under
-# `make test-parallel` (which CI runs) that is a `bundle exec` context,
-# so `RUBYOPT=-rbundler/setup` carries the gem environment into the
-# child. `--no-cache` keeps each run hermetic (no cache writes into the
-# repo tree, no stale-cache cross-run coupling).
+# The subprocess inherits the parent's environment — under `make test-parallel` (which CI runs) that is a
+# `bundle exec` context, so `RUBYOPT=-rbundler/setup` carries the gem environment into the child. `--no-cache`
+# keeps each run hermetic (no cache writes into the repo tree, no stale-cache cross-run coupling).
 #
-# A "crash" is any of: a terminating signal (segfault), a non
-# {0 (clean), 1 (diagnostics found)} exit (e.g. 64 usage error or an
-# uncaught-exception exit), a Ruby backtrace on stderr, or stdout that
-# is not the expected JSON report. A demo that merely *reports*
-# diagnostics (exit 1) is working, not crashing.
+# A "crash" is any of: a terminating signal (segfault), a non {0 (clean), 1 (diagnostics found)} exit (e.g. 64
+# usage error or an uncaught-exception exit), a Ruby backtrace on stderr, or stdout that is not the expected
+# JSON report. A demo that merely *reports* diagnostics (exit 1) is working, not crashing.
 
 DEMO_REPO_ROOT = File.expand_path("../..", __dir__)
 DEMO_RIGOR_EXE = File.join(DEMO_REPO_ROOT, "exe", "rigor")
@@ -52,8 +40,7 @@ DEMO_DIRS = (
 ).select { |dir| File.directory?(dir) }.sort.freeze
 
 RSpec.describe "bundled plugin / example demos all run (no-crash guard)" do
-  # Run `rigor check` over a demo dir in a fresh subprocess; return
-  # [stdout(UTF-8), stderr(UTF-8), Process::Status].
+  # Run `rigor check` over a demo dir in a fresh subprocess; return [stdout(UTF-8), stderr(UTF-8), Process::Status].
   def run_demo_check(demo_dir)
     out, err, status = Open3.capture3(
       RbConfig.ruby, DEMO_RIGOR_EXE, "check", "--no-cache", "--format", "json",
@@ -67,8 +54,8 @@ RSpec.describe "bundled plugin / example demos all run (no-crash guard)" do
   end
 
   it "finds demo projects to exercise" do
-    # Guards the glob itself: a path regression that found no demos would
-    # otherwise make every generated example silently vanish.
+    # Guards the glob itself: a path regression that found no demos would otherwise make every generated
+    # example silently vanish.
     expect(DEMO_DIRS).not_to be_empty
   end
 

--- a/spec/integration/examples/deprecations_plugin_spec.rb
+++ b/spec/integration/examples/deprecations_plugin_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Integration spec for `examples/rigor-deprecations/`.
-# Reference coverage for config-driven plugin rules.
+# Integration spec for `examples/rigor-deprecations/`. Reference coverage for config-driven plugin rules.
 
 require "spec_helper"
 

--- a/spec/integration/examples/lisp_eval_plugin_spec.rb
+++ b/spec/integration/examples/lisp_eval_plugin_spec.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
-# Integration spec for `examples/rigor-lisp-eval/`. Loads the
-# example plugin source, drives a real `Analysis::Runner` over
-# the demo, and asserts the diagnostics the plugin emits per
-# call site. Treat the spec as the executable contract for the
-# README's "What the plugin recognises" section.
+# Integration spec for `examples/rigor-lisp-eval/`. Loads the example plugin source, drives a real
+# `Analysis::Runner` over the demo, and asserts the diagnostics the plugin emits per call site. Treat the spec
+# as the executable contract for the README's "What the plugin recognises" section.
 #
-# Boilerplate (`run_plugin`, `plugin_diagnostics`, requirer) is
-# in `spec/integration/examples/support/plugin_helpers.rb`.
-# Auto-included for every `*_plugin_spec.rb` file under this
-# directory.
+# Boilerplate (`run_plugin`, `plugin_diagnostics`, requirer) is in
+# `spec/integration/examples/support/plugin_helpers.rb`. Auto-included for every `*_plugin_spec.rb` file under
+# this directory.
 
 require "spec_helper"
 
@@ -89,10 +86,8 @@ RSpec.describe "examples/rigor-lisp-eval" do
   end
 
   describe "dynamic_return return-type contribution (v0.1.2)" do
-    # The plugin narrows `Lisp.eval(literal)` to a precise
-    # carrier so downstream call sites resolve against the
-    # inferred class — without the contribution, the RBS
-    # `untyped` return would silence every downstream miss.
+    # The plugin narrows `Lisp.eval(literal)` to a precise carrier so downstream call sites resolve against the
+    # inferred class — without the contribution, the RBS `untyped` return would silence every downstream miss.
     it "narrows the result so a non-Integer call surfaces a method-undefined diagnostic" do
       result = run_plugin(source: <<~RUBY)
         sum = Lisp.eval([:+, 1, 2])

--- a/spec/integration/examples/pattern_plugin_spec.rb
+++ b/spec/integration/examples/pattern_plugin_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-# Integration spec for `examples/rigor-pattern/`. Reference
-# coverage for the plugin -> analyzer collaboration pattern:
-# the plugin queries `Scope#type_of` and Rigor's
-# `Type::Combinator.literal_string_compatible?` predicate
-# rather than reimplementing literal-string tracking.
+# Integration spec for `examples/rigor-pattern/`. Reference coverage for the plugin -> analyzer collaboration
+# pattern: the plugin queries `Scope#type_of` and Rigor's `Type::Combinator.literal_string_compatible?`
+# predicate rather than reimplementing literal-string tracking.
 
 require "spec_helper"
 
@@ -69,13 +67,10 @@ RSpec.describe "examples/rigor-pattern" do
     end
 
     it "still recognises interpolated literal strings as literal-string-compatible" do
-      # Interpolation may not constant-fold all the way to a
-      # `Constant<String>` (depending on Rigor's interpolation
-      # tier), but the literal-string carrier still publishes
-      # the fact, so the plugin emits either `literal-match`
-      # (exact value known) or `literal-unknown` (carrier
-      # detected, exact value not Constant). Either rule
-      # demonstrates the engine collaboration.
+      # Interpolation may not constant-fold all the way to a `Constant<String>` (depending on Rigor's
+      # interpolation tier), but the literal-string carrier still publishes the fact, so the plugin emits
+      # either `literal-match` (exact value known) or `literal-unknown` (carrier detected, exact value not
+      # Constant). Either rule demonstrates the engine collaboration.
       diags = plugin_diagnostics(with_pattern_config('validate(:email, "user@#{"example.com"}")')) # rubocop:disable Lint/InterpolationCheck
       info = diags.find { |d| %w[literal-match literal-unknown].include?(d.rule) }
       expect(info).not_to be_nil
@@ -136,11 +131,9 @@ RSpec.describe "examples/rigor-pattern" do
   end
 
   describe "dynamic_return return-type contribution (v0.1.2)" do
-    # On a successful match the runtime `validate` returns its
-    # value argument unchanged, so the plugin contributes the
-    # argument's type (typically `Constant<String>`) as the
-    # call site's return type. Downstream calls then resolve
-    # against `String` instead of the RBS-level untyped.
+    # On a successful match the runtime `validate` returns its value argument unchanged, so the plugin
+    # contributes the argument's type (typically `Constant<String>`) as the call site's return type.
+    # Downstream calls then resolve against `String` instead of the RBS-level untyped.
     it "narrows a matching literal so downstream non-String calls surface" do
       result = with_pattern_config(<<~RUBY)
         result = validate(:email, "user@example.com")

--- a/spec/integration/examples/routes_plugin_spec.rb
+++ b/spec/integration/examples/routes_plugin_spec.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# Integration spec for `examples/rigor-routes/`. Reference
-# coverage for the v0.1.0 slice 2 (`Plugin::IoBoundary`) and
-# slice 6 (`Plugin::Base.producer` / `#cache_for`) surfaces.
+# Integration spec for `examples/rigor-routes/`. Reference coverage for the v0.1.0 slice 2 (`Plugin::IoBoundary`)
+# and slice 6 (`Plugin::Base.producer` / `#cache_for`) surfaces.
 
 require "spec_helper"
 require "fileutils"
@@ -124,26 +123,20 @@ RSpec.describe "examples/rigor-routes" do
       expect(stats[:by_producer]["plugin.routes.route_table"][:writes]).to eq(1)
     end
 
-    # The runner-internal plugin loader diffs the global
-    # `Rigor::Plugin.registered` set across `require_gem!` to
-    # discover newly-registered plugins. Two consecutive
-    # `Runner.run` calls in the same test must therefore drop
-    # the registry between them, so the requirer's
-    # re-registration looks like a fresh registration to the
-    # loader. `run_plugin_in_dir` does NOT auto-unregister on
-    # entry (unlike `run_plugin`), so this helper handles the
-    # lifecycle explicitly.
+    # The runner-internal plugin loader diffs the global `Rigor::Plugin.registered` set across `require_gem!`
+    # to discover newly-registered plugins. Two consecutive `Runner.run` calls in the same test must therefore
+    # drop the registry between them, so the requirer's re-registration looks like a fresh registration to the
+    # loader. `run_plugin_in_dir` does NOT auto-unregister on entry (unlike `run_plugin`), so this helper
+    # handles the lifecycle explicitly.
     def run_routes_in_dir_twice(dir, source:, routes_yaml: DEFAULT_ROUTES_YAML)
       results = []
       2.times do |i|
         Rigor::Plugin.unregister!
         results << run_plugin_in_dir(
           dir: dir,
-          # Vary the analyzed source on the second run so the ADR-45
-          # whole-run result cache misses (a content change) and the
-          # per-producer `route_table` cache is actually re-consulted —
-          # otherwise the run-level hit shadows it. `routes.yml` is
-          # identical across runs, so the producer itself still hits.
+          # Vary the analyzed source on the second run so the ADR-45 whole-run result cache misses (a content
+          # change) and the per-producer `route_table` cache is actually re-consulted — otherwise the
+          # run-level hit shadows it. `routes.yml` is identical across runs, so the producer itself still hits.
           source: i.zero? ? source : "#{source}# run #{i}\n",
           cache_store: cache_store,
           files: { "config/routes.yml" => routes_yaml }

--- a/spec/integration/examples/units_plugin_spec.rb
+++ b/spec/integration/examples/units_plugin_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-# Integration spec for `examples/rigor-units/`. Loads the
-# example plugin source, drives a real `Analysis::Runner` over
-# inline source snippets, and pins the diagnostic shape per
-# recognised event. Treat the spec as the executable contract
-# for the README's "What the plugin recognises" section.
+# Integration spec for `examples/rigor-units/`. Loads the example plugin source, drives a real
+# `Analysis::Runner` over inline source snippets, and pins the diagnostic shape per recognised event. Treat the
+# spec as the executable contract for the README's "What the plugin recognises" section.
 
 require "spec_helper"
 
@@ -184,16 +182,12 @@ RSpec.describe "examples/rigor-units" do
   end
 
   describe "dynamic_return return-type contribution (v0.1.2)" do
-    # The plugin's MethodTable resolves `Distance / Time -> Speed`,
-    # `Distance + Distance -> Distance`, `Speed * Time -> Distance`,
-    # etc. The demo's RBS annotates these methods as `untyped`,
-    # so without the contribution downstream calls never surface
-    # dimensional errors. With the contribution, mis-using the
-    # result against the wrong dimension trips
-    # `call.undefined-method`. The unit-class declarations live
-    # in the demo's `sig/units.rbs`; the helpers re-materialise
-    # that file under a tmpdir so the test runs without leaking
-    # the demo's working directory.
+    # The plugin's MethodTable resolves `Distance / Time -> Speed`, `Distance + Distance -> Distance`,
+    # `Speed * Time -> Distance`, etc. The demo's RBS annotates these methods as `untyped`, so without the
+    # contribution downstream calls never surface dimensional errors. With the contribution, mis-using the
+    # result against the wrong dimension trips `call.undefined-method`. The unit-class declarations live in
+    # the demo's `sig/units.rbs`; the helpers re-materialise that file under a tmpdir so the test runs without
+    # leaking the demo's working directory.
     let(:units_rbs) { File.read(File.expand_path("../../../examples/rigor-units/demo/sig/units.rbs", __dir__)) }
 
     def with_units_sigs(source)

--- a/spec/integration/examples/web_plugin_spec.rb
+++ b/spec/integration/examples/web_plugin_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-# Integration spec for `examples/rigor-web/`. Reference coverage
-# for the ADR-28 path-scoped method-protocol contract surface:
-# the engine *provides* the contract's parameter type into a
-# matching method body, and the plugin *checks* method presence
-# plus return-type conformance.
+# Integration spec for `examples/rigor-web/`. Reference coverage for the ADR-28 path-scoped method-protocol
+# contract surface: the engine *provides* the contract's parameter type into a matching method body, and the
+# plugin *checks* method presence plus return-type conformance.
 
 require "spec_helper"
 
@@ -18,9 +16,8 @@ RSpec.describe "examples/rigor-web" do
 
   let(:plugin_class) { Rigor::Plugin::Web }
 
-  # Materialises `files` into a tmpdir and analyses `paths`. The
-  # plugin contributes its own Rack RBS via `signature_paths:`, so
-  # the spec does not pass any signatures itself.
+  # Materialises `files` into a tmpdir and analyses `paths`. The plugin contributes its own Rack RBS via
+  # `signature_paths:`, so the spec does not pass any signatures itself.
   def run_web(files:, paths:, config: nil)
     plugin_entry = config ? { "gem" => "rigor-web", "config" => config } : "rigor-web"
     run_plugin(source: "# entry point unused\n", files: files, paths: paths, plugin_entry: plugin_entry)
@@ -104,11 +101,9 @@ RSpec.describe "examples/rigor-web" do
     end
   end
 
-  # The provide half of the contract: inside a controller `#get`,
-  # the parameter is typed `Rack::Request`. The same body misusing
-  # the request surfaces a core diagnostic ONLY when the file is
-  # under the contract path — that difference proves the engine
-  # provides the parameter type.
+  # The provide half of the contract: inside a controller `#get`, the parameter is typed `Rack::Request`. The
+  # same body misusing the request surfaces a core diagnostic ONLY when the file is under the contract path —
+  # that difference proves the engine provides the parameter type.
   describe "parameter-type provision" do
     let(:body) do
       <<~RUBY

--- a/spec/integration/external_plugin_spec.rb
+++ b/spec/integration/external_plugin_spec.rb
@@ -7,19 +7,15 @@ require "tmpdir"
 require "rigor/analysis/runner"
 require "rigor/configuration"
 
-# v0.2.0 gate-1 evidence (ROADMAP § "v0.2.0 — first evaluation release"):
-# a plugin that lives OUTSIDE the monorepo — a third-party `rigor-*` gem
-# in its own repo per ADR-31 WD4 — loads via the REAL `require`
-# mechanism and runs end-to-end through `Analysis::Runner`, depending
-# only on the public plugin contract.
+# v0.2.0 gate-1 evidence (ROADMAP § "v0.2.0 — first evaluation release"): a plugin that lives OUTSIDE the
+# monorepo — a third-party `rigor-*` gem in its own repo per ADR-31 WD4 — loads via the REAL `require` mechanism
+# and runs end-to-end through `Analysis::Runner`, depending only on the public plugin contract.
 #
-# Unlike the bundled-plugin integration specs (which stub the loader's
-# `requirer` to register the class directly), this spec drives the
-# Runner with no `plugin_requirer`, so the loader uses its real
-# `->(name) { require name }` and the genuine gem-load path is
-# exercised. Break what an external author can depend on (the ADR-2
-# surface, `node_rule`, `#diagnostic`, ADR-40 `config_schema` defaults,
-# `Source::Literals`) and this fails.
+# Unlike the bundled-plugin integration specs (which stub the loader's `requirer` to register the class
+# directly), this spec drives the Runner with no `plugin_requirer`, so the loader uses its real
+# `->(name) { require name }` and the genuine gem-load path is exercised. Break what an external author can
+# depend on (the ADR-2 surface, `node_rule`, `#diagnostic`, ADR-40 `config_schema` defaults, `Source::Literals`)
+# and this fails.
 EXTERNAL_PLUGIN_LIB = File.expand_path(
   "../fixtures/external_plugin/rigor-external-demo/lib", __dir__
 )
@@ -47,20 +43,17 @@ RSpec.describe "external (out-of-tree) plugin contract" do
       )
 
       result = Dir.chdir(dir) do
-        # No `plugin_requirer:` — the loader falls back to the real
-        # `require`, so this loads the fixture gem from $LOAD_PATH for
-        # real rather than via a test stub.
+        # No `plugin_requirer:` — the loader falls back to the real `require`, so this loads the fixture gem
+        # from $LOAD_PATH for real rather than via a test stub.
         Rigor::Analysis::Runner.new(configuration: configuration).run
       end
 
-      # The plugin registered and produced its diagnostic: proof the
-      # out-of-tree gem loaded and ran.
+      # The plugin registered and produced its diagnostic: proof the out-of-tree gem loaded and ran.
       diagnostics = result.diagnostics.select { |d| d.source_family == "plugin.external-demo" }
       expect(diagnostics.map(&:rule)).to eq(["flagged-call"])
 
-      # ADR-40 default (`flagged_method` → "legacy_call") drove the match
-      # without any user config, and `Source::Literals.symbol` named the
-      # literal argument — both public surfaces exercised through the
+      # ADR-40 default (`flagged_method` → "legacy_call") drove the match without any user config, and
+      # `Source::Literals.symbol` named the literal argument — both public surfaces exercised through the
       # real load.
       diagnostic = diagnostics.first
       expect(diagnostic.message).to include("`legacy_call`")

--- a/spec/integration/fold_runtime_parity_spec.rb
+++ b/spec/integration/fold_runtime_parity_spec.rb
@@ -1,24 +1,19 @@
 # frozen_string_literal: true
 
-# Integration spec: runtime-value parity for the precision folds
-# catalogued by the `rigor-type-coverage-uplift` skill.
+# Integration spec: runtime-value parity for the precision folds catalogued by the `rigor-type-coverage-uplift`
+# skill.
 #
-# Every fold the skill adds (`ConstantFolding`, `ShapeDispatch`,
-# the `*_folding` singleton modules) claims a *precise* result
-# type for a statically-known call. This spec closes the loop:
-# for each catalogued expression it
+# Every fold the skill adds (`ConstantFolding`, `ShapeDispatch`, the `*_folding` singleton modules) claims a
+# *precise* result type for a statically-known call. This spec closes the loop: for each catalogued expression it
 #
 #   1. infers the type with the engine, and
 #   2. evaluates the SAME source with MRI,
 #
-# then asserts the inferred type is consistent with the value the
-# program actually produces. A fold that returns `Constant[4]`
-# when Ruby yields `5`, or `Array[Elem]` when Ruby yields an
-# `Enumerator`, fails here — the exact bug class that motivated
-# the block-less-overload fix in `OverloadSelector`.
+# then asserts the inferred type is consistent with the value the program actually produces. A fold that
+# returns `Constant[4]` when Ruby yields `5`, or `Array[Elem]` when Ruby yields an `Enumerator`, fails here —
+# the exact bug class that motivated the block-less-overload fix in `OverloadSelector`.
 #
-# Adding a new fold means adding one expression string to the
-# `FOLD_PARITY_CASES` table; no other wiring is needed.
+# Adding a new fold means adding one expression string to the `FOLD_PARITY_CASES` table; no other wiring is needed.
 
 require "spec_helper"
 require "tmpdir"
@@ -27,17 +22,14 @@ require "cgi"
 require "uri"
 require "date"
 
-# One environment for the whole file. `for_project` loads
-# `DEFAULT_LIBRARIES` (shellwords / cgi / uri / digest / ...),
-# which the stdlib-module folds need; RBS itself loads lazily on
-# the first inference query.
+# One environment for the whole file. `for_project` loads `DEFAULT_LIBRARIES` (shellwords / cgi / uri / digest /
+# ...), which the stdlib-module folds need; RBS itself loads lazily on the first inference query.
 FOLD_PARITY_SCOPE = Rigor::Scope.empty(
   environment: Rigor::Environment.for_project(root: Dir.mktmpdir)
 )
 
-# method group => list of expression sources. Each source is
-# parsed + typed by the engine AND `eval`-ed by MRI; the two
-# results must agree.
+# method group => list of expression sources. Each source is parsed + typed by the engine AND `eval`-ed by MRI;
+# the two results must agree.
 FOLD_PARITY_CASES = {
   "String — ConstantFolding unary/binary" => [
     '"Hello".upcase', '"Hello".downcase', '"hello".capitalize', '"hello".swapcase',
@@ -123,20 +115,17 @@ FOLD_PARITY_CASES = {
 }.freeze
 
 RSpec.describe "Fold runtime-value parity (integration)" do
-  # Infers the type of a single Ruby expression by typing the
-  # last statement of its parse tree under a pristine scope.
+  # Infers the type of a single Ruby expression by typing the last statement of its parse tree under a pristine
+  # scope.
   def infer(source)
     node = Prism.parse(source).value.statements.body.last
     FOLD_PARITY_SCOPE.type_of(node)
   end
 
-  # True when `value` (a real MRI runtime value) is a member of
-  # the inferred `type`. Precise carriers are compared
-  # structurally so a mismatch names the offending element; a
-  # `Nominal` carrier (e.g. an `Enumerator` from a block-less
-  # iteration call, or a still-imprecise `File.*` fold) is
-  # checked by class membership; a refinement carrier
-  # (`non-empty-string` and friends) is checked via `accepts`.
+  # True when `value` (a real MRI runtime value) is a member of the inferred `type`. Precise carriers are
+  # compared structurally so a mismatch names the offending element; a `Nominal` carrier (e.g. an `Enumerator`
+  # from a block-less iteration call, or a still-imprecise `File.*` fold) is checked by class membership; a
+  # refinement carrier (`non-empty-string` and friends) is checked via `accepts`.
   def value_consistent_with_type?(type, value)
     case type
     when Rigor::Type::Constant  then constant_matches?(type, value)
@@ -169,8 +158,7 @@ RSpec.describe "Fold runtime-value parity (integration)" do
     !klass.nil? && value.is_a?(klass)
   end
 
-  # Refinement / range carriers (`Difference`, `IntegerRange`,
-  # `Refined`): the scalar runtime value must be accepted.
+  # Refinement / range carriers (`Difference`, `IntegerRange`, `Refined`): the scalar runtime value must be accepted.
   def refinement_matches?(type, value)
     literal = scalar_literal_for(value)
     !literal.nil? && type.accepts(literal, mode: :gradual).yes?

--- a/spec/integration/macro_block_self_type_integration_spec.rb
+++ b/spec/integration/macro_block_self_type_integration_spec.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 
-# Integration coverage for ADR-16 Tier A (block-as-method) engine
-# hook, slice 1b. Demonstrates the floor contract pinned by WD13:
-# when a registered plugin declares `block_as_methods:` for a class
-# that the user's app subclasses, bare identifiers inside the
-# matching DSL block resolve through the receiver's RBS rather
+# Integration coverage for ADR-16 Tier A (block-as-method) engine hook, slice 1b. Demonstrates the floor
+# contract pinned by WD13: when a registered plugin declares `block_as_methods:` for a class that the user's
+# app subclasses, bare identifiers inside the matching DSL block resolve through the receiver's RBS rather
 # than producing `call.undefined-method`.
 #
-# The Sinatra-flavoured fixture is the canonical real-world target
-# for Tier A. It uses an in-spec plugin class with a minimal RBS
-# stub for `Sinatra::Base` so the Tier A contract is observable
-# independent of `plugins/rigor-sinatra/` (slice 1c, now shipped).
+# The Sinatra-flavoured fixture is the canonical real-world target for Tier A. It uses an in-spec plugin class
+# with a minimal RBS stub for `Sinatra::Base` so the Tier A contract is observable independent of
+# `plugins/rigor-sinatra/` (slice 1c, now shipped).
 
 require "spec_helper"
 require "fileutils"
@@ -21,10 +18,8 @@ require "rigor/cache/store"
 require "rigor/configuration"
 
 RSpec.describe "ADR-16 Tier A — block-as-method engine hook" do
-  # Plugin under test. Declares the Tier A contract for
-  # `Sinatra::Base`'s `get` / `post` verbs. No diagnostics-of-its-
-  # own; the substrate's `self_type` narrowing is the entire
-  # delivery.
+  # Plugin under test. Declares the Tier A contract for `Sinatra::Base`'s `get` / `post` verbs. No
+  # diagnostics-of-its-own; the substrate's `self_type` narrowing is the entire delivery.
   let(:tier_a_plugin) do
     klass = Class.new(Rigor::Plugin::Base) do
       manifest(
@@ -42,10 +37,9 @@ RSpec.describe "ADR-16 Tier A — block-as-method engine hook" do
     klass
   end
 
-  # Minimal RBS for the fixture. `Sinatra::Base` exposes `redirect`,
-  # `params`, `halt`. The class method `get` accepts a path String
-  # and an optional block returning untyped — leaving the block's
-  # actual `self` to the Tier A hook to pin.
+  # Minimal RBS for the fixture. `Sinatra::Base` exposes `redirect`, `params`, `halt`. The class method `get`
+  # accepts a path String and an optional block returning untyped — leaving the block's actual `self` to the
+  # Tier A hook to pin.
   let(:sinatra_base_rbs) do
     <<~RBS
       module Sinatra
@@ -112,25 +106,19 @@ RSpec.describe "ADR-16 Tier A — block-as-method engine hook" do
       )
     end
 
-    # NOTE: "missing-method-on-substrate-narrowed-self surfaces as
-    # a diagnostic" is a separate analyzer-rule concern (the
-    # `call.undefined-method` rule is opt-in via the severity
-    # profile, not always-on). Tier A's contract is the *narrowing*;
-    # the downstream diagnostic policy is unchanged. The unit spec
-    # at `spec/rigor/inference/macro_block_self_type_spec.rb` covers
-    # the helper's positive and negative match cases; the
-    # integration here proves the engine consumes the helper's
-    # output for actual block-body resolution.
+    # NOTE: "missing-method-on-substrate-narrowed-self surfaces as a diagnostic" is a separate analyzer-rule
+    # concern (the `call.undefined-method` rule is opt-in via the severity profile, not always-on). Tier A's
+    # contract is the *narrowing*; the downstream diagnostic policy is unchanged. The unit spec at
+    # `spec/rigor/inference/macro_block_self_type_spec.rb` covers the helper's positive and negative match
+    # cases; the integration here proves the engine consumes the helper's output for actual block-body resolution.
   end
 
   describe "non-matching call shapes" do
-    # The substrate's correctness model is "Tier A narrows self_type
-    # only when (receiver_constraint matches, verb matches)." The
-    # negative-side observable is the *inference effect* — Type::Singleton
-    # of the outer class body is preserved inside the block — rather
-    # than a particular diagnostic. The unit-spec already proves the
-    # narrowing rules at the helper level; here we drive the engine
-    # through the same paths to confirm the wiring respects them.
+    # The substrate's correctness model is "Tier A narrows self_type only when (receiver_constraint matches,
+    # verb matches)." The negative-side observable is the *inference effect* — Type::Singleton of the outer
+    # class body is preserved inside the block — rather than a particular diagnostic. The unit-spec already
+    # proves the narrowing rules at the helper level; here we drive the engine through the same paths to
+    # confirm the wiring respects them.
 
     it "leaves verbs outside the manifest's `method_names:` list alone (Tier A does not fire)" do
       source = <<~RUBY
@@ -140,11 +128,9 @@ RSpec.describe "ADR-16 Tier A — block-as-method engine hook" do
           end
         end
       RUBY
-      # The engine produces SOME diagnostic about the unknown call
-      # path. The Tier A invariant we care about is that the helper's
-      # narrow_self_type_for returned nil for the `delete` verb;
-      # that's verified at the unit-spec layer. The integration spec
-      # here just exercises the end-to-end runner to confirm no
+      # The engine produces SOME diagnostic about the unknown call path. The Tier A invariant we care about is
+      # that the helper's narrow_self_type_for returned nil for the `delete` verb; that's verified at the
+      # unit-spec layer. The integration spec here just exercises the end-to-end runner to confirm no
       # exception is raised when Tier A declines.
       expect { run_analysis(source, plugin_class: tier_a_plugin) }.not_to raise_error
     end

--- a/spec/integration/plugin_contract_conformance_spec.rb
+++ b/spec/integration/plugin_contract_conformance_spec.rb
@@ -2,34 +2,26 @@
 
 require "spec_helper"
 
-# Structural guard: EVERY bundled plugin (`plugins/*`) and example
-# (`examples/*`) that overrides a `Rigor::Plugin::Base` contract hook
-# must override it with a *call-compatible* signature — one the engine
-# can actually invoke the way it invokes the base method.
+# Structural guard: EVERY bundled plugin (`plugins/*`) and example (`examples/*`) that overrides a
+# `Rigor::Plugin::Base` contract hook must override it with a *call-compatible* signature — one the engine can
+# actually invoke the way it invokes the base method.
 #
-# This is the rule-based half of "constrain plugin files with the
-# contract" (ADR-37). The RBS half (`sig/rigor/plugin/base.rbs`) lets
-# Steep / `rigor check lib` check Base's own implementation, but neither
-# tool enforces override compatibility on a plugin subclass that ships
-# no RBS of its own: Steep types `self` as the bare `Base` (so it would
-# false-positive on every call to the plugin's *own* un-RBS'd helper
-# methods, which is why a strict Steep target over the plugin tree is
-# not viable), and `rigor check` does not exercise the plugin tree.
+# This is the rule-based half of "constrain plugin files with the contract" (ADR-37). The RBS half
+# (`sig/rigor/plugin/base.rbs`) lets Steep / `rigor check lib` check Base's own implementation, but neither
+# tool enforces override compatibility on a plugin subclass that ships no RBS of its own: Steep types `self` as
+# the bare `Base` (so it would false-positive on every call to the plugin's *own* un-RBS'd helper methods,
+# which is why a strict Steep target over the plugin tree is not viable), and `rigor check` does not exercise
+# the plugin tree.
 #
-# A pure-Ruby `Method#parameters` comparison sidesteps both problems: it
-# needs no per-plugin RBS, raises no false positive on a plugin's own
-# methods, and catches the one violation that actually breaks a plugin
-# at runtime — an override that cannot receive the engine's call (e.g.
-# `def diagnostics_for_file(path:)` dropping the required `scope:` /
-# `root:` keywords, which raises `ArgumentError` the moment the runner
-# dispatches the file).
+# A pure-Ruby `Method#parameters` comparison sidesteps both problems: it needs no per-plugin RBS, raises no
+# false positive on a plugin's own methods, and catches the one violation that actually breaks a plugin at
+# runtime — an override that cannot receive the engine's call (e.g. `def diagnostics_for_file(path:)` dropping
+# the required `scope:` / `root:` keywords, which raises `ArgumentError` the moment the runner dispatches the file).
 #
-# The check is deliberately lenient on the override side per the
-# robustness principle (ADR-5, Postel's law for types): a wider override
-# — extra optional positionals, a `*rest`, extra optional keywords, or a
-# `**keyrest` catch-all — is always accepted. Only a *narrower* override
-# (one that omits a parameter the engine supplies, or demands one it
-# does not) fails.
+# The check is deliberately lenient on the override side per the robustness principle (ADR-5, Postel's law for
+# types): a wider override — extra optional positionals, a `*rest`, extra optional keywords, or a `**keyrest`
+# catch-all — is always accepted. Only a *narrower* override (one that omits a parameter the engine supplies,
+# or demands one it does not) fails.
 
 CONTRACT_REPO_ROOT = File.expand_path("../..", __dir__)
 
@@ -38,30 +30,28 @@ CONTRACT_PLUGIN_DIRS = (
   Dir[File.join(CONTRACT_REPO_ROOT, "examples", "*", "")]
 ).sort.freeze
 
-# `rigor-playground` is a Rack app, not a plugin (mirrors
-# `all_plugins_load_spec.rb`).
+# `rigor-playground` is a Rack app, not a plugin (mirrors `all_plugins_load_spec.rb`).
 CONTRACT_PLUGIN_SKIP = %w[rigor-playground].freeze
 
 CONTRACT_LOADABLE_DIRS = CONTRACT_PLUGIN_DIRS.reject do |dir|
   CONTRACT_PLUGIN_SKIP.include?(File.basename(dir))
 end.freeze
 
-# The author-overridable hooks on `Plugin::Base`. The engine invokes
-# each with a fixed argument shape; an override must stay callable with
-# it. The required shape is derived from Base's *own* parameters at run
-# time, so changing Base's signature carries the contract automatically.
+# The author-overridable hooks on `Plugin::Base`. The engine invokes each with a fixed argument shape; an
+# override must stay callable with it. The required shape is derived from Base's *own* parameters at run time,
+# so changing Base's signature carries the contract automatically.
 CONTRACT_OVERRIDABLE_HOOKS = %i[init prepare diagnostics_for_file].freeze
 
-# Put every plugin's lib on the load path so meta-gem entries resolve
-# regardless of example order (same prelude as the load guard).
+# Put every plugin's lib on the load path so meta-gem entries resolve regardless of example order (same
+# prelude as the load guard).
 CONTRACT_LOADABLE_DIRS.each do |dir|
   lib = File.join(dir, "lib")
   $LOAD_PATH.unshift(lib) if Dir.exist?(lib) && !$LOAD_PATH.include?(lib)
 end
 
 RSpec.describe "plugin contract hook-override conformance (structural guard)" do
-  # Decompose a `Method#parameters` list into the call surface we need.
-  # `params` is an Array of `[kind, name]` pairs, not a Hash.
+  # Decompose a `Method#parameters` list into the call surface we need. `params` is an Array of `[kind, name]`
+  # pairs, not a Hash.
   def parameter_shape(params)
     {
       req_positional: params.count { |kind, _| kind == :req },
@@ -73,28 +63,26 @@ RSpec.describe "plugin contract hook-override conformance (structural guard)" do
     }
   end
 
-  # True when a method with `override` parameters can receive a call that
-  # passes `positional` positional arguments and exactly the `keywords`
-  # set — the call the engine makes (read off Base's own signature).
+  # True when a method with `override` parameters can receive a call that passes `positional` positional
+  # arguments and exactly the `keywords` set — the call the engine makes (read off Base's own signature).
   def callable_with?(override, positional:, keywords:)
     shape = parameter_shape(override)
 
-    # Positional: the override must not demand more than supplied, and
-    # (absent a *rest) must have room for all supplied.
+    # Positional: the override must not demand more than supplied, and (absent a *rest) must have room for
+    # all supplied.
     return false if shape[:req_positional] > positional
     return false if !shape[:rest] && (shape[:req_positional] + shape[:opt_positional]) < positional
 
-    # Keywords: every keyword the override *requires* must be supplied,
-    # and every keyword the engine supplies must be accepted (named or
-    # absorbed by **keyrest).
+    # Keywords: every keyword the override *requires* must be supplied, and every keyword the engine supplies
+    # must be accepted (named or absorbed by **keyrest).
     return false unless (shape[:req_keywords] - keywords).empty?
     return false if !shape[:keyrest] && !(keywords - (shape[:req_keywords] + shape[:opt_keywords])).empty?
 
     true
   end
 
-  # The engine's call shape for `hook`, derived from Base's signature:
-  # the positional count and the union of keyword names Base declares.
+  # The engine's call shape for `hook`, derived from Base's signature: the positional count and the union of
+  # keyword names Base declares.
   def engine_call_shape(hook)
     base = parameter_shape(Rigor::Plugin::Base.instance_method(hook).parameters)
     {
@@ -109,8 +97,8 @@ RSpec.describe "plugin contract hook-override conformance (structural guard)" do
                  .select { |value| value.is_a?(Class) && value < Rigor::Plugin::Base }
   end
 
-  # Idempotent: `require` no-ops after the first load, so calling this
-  # per example is cheap and avoids a state-leaking `before(:all)`.
+  # Idempotent: `require` no-ops after the first load, so calling this per example is cheap and avoids a
+  # state-leaking `before(:all)`.
   before do
     CONTRACT_LOADABLE_DIRS.each do |dir|
       entry = File.join(dir, "lib", "#{File.basename(dir)}.rb")
@@ -125,8 +113,7 @@ RSpec.describe "plugin contract hook-override conformance (structural guard)" do
 
         offenders = plugin_classes.filter_map do |klass|
           method = klass.instance_method(hook)
-          # Only check classes that actually OVERRIDE the hook — an
-          # inherited Base method trivially conforms.
+          # Only check classes that actually OVERRIDE the hook — an inherited Base method trivially conforms.
           next if method.owner == Rigor::Plugin::Base
 
           next if callable_with?(method.parameters, positional: call[:positional], keywords: call[:keywords])

--- a/spec/integration/plugin_operator_dynamic_return_spec.rb
+++ b/spec/integration/plugin_operator_dynamic_return_spec.rb
@@ -1,28 +1,21 @@
 # frozen_string_literal: true
 
-# Executable contract for the note
-# `docs/notes/20260603-phpstan-type-algebra-comparison.md` (§3 G1) and
-# ADR-42: a Ruby binary operator (`a + b`) is a `Prism::CallNode` named
-# `:+`, so it flows through the ordinary dispatch path where the plugin
-# `dynamic_return` tier (receiver-gated, method-name-agnostic) sits
-# between `ConstantFolding` and RBS. A plugin can therefore specify the
-# result type of a binary operation on a plugin-owned receiver WITHOUT
-# any operator-specific extension point — which is why ADR-42 records the
-# self/left-operand case as "already works" and scopes itself to the
-# coerce direction only.
+# Executable contract for the note `docs/notes/20260603-phpstan-type-algebra-comparison.md` (§3 G1) and ADR-42:
+# a Ruby binary operator (`a + b`) is a `Prism::CallNode` named `:+`, so it flows through the ordinary dispatch
+# path where the plugin `dynamic_return` tier (receiver-gated, method-name-agnostic) sits between
+# `ConstantFolding` and RBS. A plugin can therefore specify the result type of a binary operation on a
+# plugin-owned receiver WITHOUT any operator-specific extension point — which is why ADR-42 records the
+# self/left-operand case as "already works" and scopes itself to the coerce direction only.
 #
-# Observation method: the plugin contributes a CORE return type
-# (`String`) for the operator, because Rigor (by false-positive
-# discipline) does not raise `undefined-method` on bare user classes —
-# only on classes it fully models (core/RBS). So a downstream
-# `.nope_zzz` on the contributed type surfaces `undefined method
-# 'nope_zzz' for String` exactly when the contribution took effect.
+# Observation method: the plugin contributes a CORE return type (`String`) for the operator, because Rigor (by
+# false-positive discipline) does not raise `undefined-method` on bare user classes — only on classes it fully
+# models (core/RBS). So a downstream `.nope_zzz` on the contributed type surfaces `undefined method 'nope_zzz'
+# for String` exactly when the contribution took effect.
 #
-# The same spec pins the coerce-direction LIMITATION (ADR-42's subject):
-# `1 + money` dispatches on `Integer`, so a `receivers: ["Money"]` rule
-# does not fire; the result types as the left operand `Integer` (NOT the
-# contributed type and NOT `Dynamic`). That left-biased result is the
-# narrow false-positive surface ADR-42 scopes itself to.
+# The same spec pins the coerce-direction LIMITATION (ADR-42's subject): `1 + money` dispatches on `Integer`,
+# so a `receivers: ["Money"]` rule does not fire; the result types as the left operand `Integer` (NOT the
+# contributed type and NOT `Dynamic`). That left-biased result is the narrow false-positive surface ADR-42
+# scopes itself to.
 
 require "spec_helper"
 require "fileutils"
@@ -32,11 +25,10 @@ require "rigor/analysis/runner"
 require "rigor/configuration"
 
 RSpec.describe "plugin dynamic_return captures binary-operator sugar (ADR-42)" do
-  # A minimal plugin that contributes a return type for arithmetic
-  # operators on a plugin-owned `Money` receiver. It returns `String`
-  # (a core type) purely as an observable sentinel — `Money <op> Money`
-  # is not semantically a String; the point is that a core return type
-  # makes the contribution visible via downstream method resolution.
+  # A minimal plugin that contributes a return type for arithmetic operators on a plugin-owned `Money`
+  # receiver. It returns `String` (a core type) purely as an observable sentinel — `Money <op> Money` is not
+  # semantically a String; the point is that a core return type makes the contribution visible via downstream
+  # method resolution.
   let(:operator_plugin) do
     klass = Class.new(Rigor::Plugin::Base) do
       manifest(id: "optest", version: "0.1.0")
@@ -115,9 +107,8 @@ RSpec.describe "plugin dynamic_return captures binary-operator sugar (ADR-42)" d
     end
 
     it "declines (returns nil) for an operator outside its set, falling through to normal dispatch" do
-      # `==` is not in the rule's operator set, so the block returns nil
-      # and the engine resolves `Money == Money` itself (-> bool). The
-      # String contribution must NOT appear.
+      # `==` is not in the rule's operator set, so the block returns nil and the engine resolves
+      # `Money == Money` itself (-> bool). The String contribution must NOT appear.
       result = run_analysis(<<~RUBY)
         class Money; end
         a = Money.new
@@ -131,14 +122,11 @@ RSpec.describe "plugin dynamic_return captures binary-operator sugar (ADR-42)" d
 
   describe "coerce direction (ADR-42's scoped gap — NOT supported)" do
     it "does not fire for `Integer + Money`; the result types left-biased as Integer" do
-      # `1 + b` dispatches on Integer, so a `receivers: ["Money"]` rule
-      # cannot intervene. Rigor types the result as the left operand
-      # (Integer), NOT the contributed String and NOT Dynamic. Calling
-      # `.nope_zzz` therefore resolves against Integer. This left-biased
-      # result is the narrow false-positive surface ADR-42 addresses:
-      # had `b` defined a real method, calling it on `(1 + b)` would be
-      # flagged undefined-for-Integer despite working at runtime via
-      # `b.coerce`.
+      # `1 + b` dispatches on Integer, so a `receivers: ["Money"]` rule cannot intervene. Rigor types the
+      # result as the left operand (Integer), NOT the contributed String and NOT Dynamic. Calling `.nope_zzz`
+      # therefore resolves against Integer. This left-biased result is the narrow false-positive surface
+      # ADR-42 addresses: had `b` defined a real method, calling it on `(1 + b)` would be flagged
+      # undefined-for-Integer despite working at runtime via `b.coerce`.
       result = run_analysis(<<~RUBY)
         class Money; end
         b = Money.new

--- a/spec/integration/plugins/actioncable_plugin_spec.rb
+++ b/spec/integration/plugins/actioncable_plugin_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-actioncable/`.
-# Tier 3F of the Rails plugins roadmap. Discovers channel
-# classes by walking `app/channels/` and validates
-# `<Channel>.broadcast_to(...)` and
+# Integration spec for `plugins/rigor-actioncable/`. Tier 3F of the Rails plugins roadmap. Discovers channel
+# classes by walking `app/channels/` and validates `<Channel>.broadcast_to(...)` and
 # `ActionCable.server.broadcast(stream_name, ...)` calls.
 
 require "spec_helper"
@@ -58,14 +56,11 @@ RSpec.describe "plugins/rigor-actioncable" do
 
   let(:plugin_class) { Rigor::Plugin::Actioncable }
 
-  # Opt into the shared per-process `Cache::Store`. The plugin's
-  # `:channel_index` producer now passes an explicit
-  # `glob_descriptor` covering `app/channels/**/*.rb`, so cache
-  # entries invalidate correctly when channel files differ between
-  # examples. Without that descriptor fix the shared cache served
-  # stale `ChannelIndex` data across examples (see
-  # `docs/CURRENT_WORK.md` § Open Engineering Items for the
-  # session that surfaced the bug).
+  # Opt into the shared per-process `Cache::Store`. The plugin's `:channel_index` producer now passes an
+  # explicit `glob_descriptor` covering `app/channels/**/*.rb`, so cache entries invalidate correctly when
+  # channel files differ between examples. Without that descriptor fix the shared cache served stale
+  # `ChannelIndex` data across examples (see `docs/CURRENT_WORK.md` § Open Engineering Items for the session
+  # that surfaced the bug).
   let(:default_run_plugin_cache_store) { :shared }
 
   describe "broadcast_to recognition" do
@@ -180,8 +175,7 @@ RSpec.describe "plugins/rigor-actioncable" do
         files: files_with_stream_for_channel,
         plugin_entry: DEFAULT_PLUGIN_ENTRY
       )
-      # No unknown-stream warning — the dynamic
-      # registration via `stream_for` suppresses it.
+      # No unknown-stream warning — the dynamic registration via `stream_for` suppresses it.
       diags = plugin_diagnostics(result)
       expect(diags.select { |d| d.rule == "unknown-stream" }).to be_empty
     end

--- a/spec/integration/plugins/actionmailer_plugin_spec.rb
+++ b/spec/integration/plugins/actionmailer_plugin_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-actionmailer/`.
-# Tier 1C of the Rails plugins roadmap. Discovers
-# ActionMailer subclasses by walking `app/mailers/` and
-# validates `Mailer.action(args)` call shape (method exists,
-# arity matches) and view template existence.
+# Integration spec for `plugins/rigor-actionmailer/`. Tier 1C of the Rails plugins roadmap. Discovers
+# ActionMailer subclasses by walking `app/mailers/` and validates `Mailer.action(args)` call shape (method
+# exists, arity matches) and view template existence.
 
 require "spec_helper"
 
@@ -42,13 +40,10 @@ RSpec.describe "plugins/rigor-actionmailer" do
 
   let(:plugin_class) { Rigor::Plugin::Actionmailer }
 
-  # Opt into the shared per-process `Cache::Store`. The plugin's
-  # `:mailer_index` producer now passes an explicit composed
-  # `glob_descriptor` covering both `app/mailers/**/*.rb` and
-  # every file under `app/views/`, so cache entries invalidate on
-  # mailer or view changes between examples. Without that fix the
-  # shared cache served stale `MailerIndex` data (missing-view
-  # discovery hid views added in later examples).
+  # Opt into the shared per-process `Cache::Store`. The plugin's `:mailer_index` producer now passes an
+  # explicit composed `glob_descriptor` covering both `app/mailers/**/*.rb` and every file under `app/views/`,
+  # so cache entries invalidate on mailer or view changes between examples. Without that fix the shared cache
+  # served stale `MailerIndex` data (missing-view discovery hid views added in later examples).
   let(:default_run_plugin_cache_store) { :shared }
 
   describe "recognised mailer calls" do
@@ -145,12 +140,9 @@ RSpec.describe "plugins/rigor-actionmailer" do
     end
 
     it "skips methods that follow a bare `private` (Mastodon AdminMailer shape)" do
-      # Mastodon's AdminMailer has `before_action :set_instance`
-      # plus `private` followed by `set_instance` /
-      # `process_params` / `set_locale` / `set_important_headers!`.
-      # None of those are mailer actions; pre-fix they surfaced
-      # as missing-view because the discoverer treated every
-      # instance `def` as an action.
+      # Mastodon's AdminMailer has `before_action :set_instance` plus `private` followed by `set_instance` /
+      # `process_params` / `set_locale` / `set_important_headers!`. None of those are mailer actions; pre-fix
+      # they surfaced as missing-view because the discoverer treated every instance `def` as an action.
       files = {
         "app/mailers/admin_mailer.rb" => <<~RUBY,
           class AdminMailer < ApplicationMailer
@@ -220,8 +212,7 @@ RSpec.describe "plugins/rigor-actionmailer" do
     end
 
     it "doesn't validate framework methods that happen to be called on the mailer" do
-      # `UserMailer.deliver_later` (no preceding action) is
-      # a framework-level call; we don't try to validate it
+      # `UserMailer.deliver_later` (no preceding action) is a framework-level call; we don't try to validate it
       # as an action.
       result = run_plugin(
         source: "UserMailer.deliver_later\n",

--- a/spec/integration/plugins/actionpack_plugin_spec.rb
+++ b/spec/integration/plugins/actionpack_plugin_spec.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-actionpack/` (Phase 4
-# — route-helper consumption). Tests the cross-plugin
-# integration end to end: rigor-rails-routes parses
-# `config/routes.rb` and publishes the helper table; the
-# loader's ADR-9 topo sort runs `prepare` first; then
-# rigor-actionpack reads the published helper table and
+# Integration spec for `plugins/rigor-actionpack/` (Phase 4 — route-helper consumption). Tests the cross-plugin
+# integration end to end: rigor-rails-routes parses `config/routes.rb` and publishes the helper table; the
+# loader's ADR-9 topo sort runs `prepare` first; then rigor-actionpack reads the published helper table and
 # validates `*_path` / `*_url` calls inside controller files.
 
 require "spec_helper"
@@ -199,13 +196,10 @@ RSpec.describe "plugins/rigor-actionpack" do
   end
 
   describe "helper-call error diagnostics (canonically delegated to rigor-rails-routes)" do
-    # rigor-actionpack and rigor-rails-routes both consume the same
-    # `:helper_table` fact. To avoid every typo'd / wrong-arity
-    # helper call surfacing twice (once per plugin) on every
-    # Rails project, the actionpack plugin emits only the
-    # info-level route-resolution (`helper-call`) and defers
-    # `unknown-helper` / `wrong-helper-arity` to rigor-rails-routes.
-    # Mastodon pre-fix saw +301 duplicate errors from this overlap.
+    # rigor-actionpack and rigor-rails-routes both consume the same `:helper_table` fact. To avoid every
+    # typo'd / wrong-arity helper call surfacing twice (once per plugin) on every Rails project, the actionpack
+    # plugin emits only the info-level route-resolution (`helper-call`) and defers `unknown-helper` /
+    # `wrong-helper-arity` to rigor-rails-routes. Mastodon pre-fix saw +301 duplicate errors from this overlap.
     # These specs assert the new contract: rails-routes still fires.
     it "rigor-rails-routes fires `unknown-helper` with a did-you-mean suggestion on a typo" do
       source = "class C\n  def show\n    usres_path\n  end\nend\n"
@@ -229,12 +223,9 @@ RSpec.describe "plugins/rigor-actionpack" do
     end
 
     it "rigor-rails-routes fires the arity-mismatch diagnostic on overflow" do
-      # `about_path` is arity 0 — `accepts_arity?` allows
-      # `arity + 1` for the trailing-options-hash idiom, so we
-      # pass 2 explicit args to overflow past the `0 + 1`
-      # tolerance. Underflow (passing 0 args to a non-zero-arity
-      # helper) is silenced inside controller paths because of
-      # Rails' implicit-params-fill pattern.
+      # `about_path` is arity 0 — `accepts_arity?` allows `arity + 1` for the trailing-options-hash idiom, so
+      # we pass 2 explicit args to overflow past the `0 + 1` tolerance. Underflow (passing 0 args to a
+      # non-zero-arity helper) is silenced inside controller paths because of Rails' implicit-params-fill pattern.
       source = "class C\n  def show\n    about_path(1, 2)\n  end\nend\n"
       with_demo(source) do |result|
         err = result.diagnostics.find do |d|
@@ -282,9 +273,8 @@ RSpec.describe "plugins/rigor-actionpack" do
             end
           )
           result = runner.run
-          # The rails-routes plugin still validates the `usres_path`
-          # call (its own walker doesn't filter by path), but
-          # actionpack's path filter must skip the lib/ file.
+          # The rails-routes plugin still validates the `usres_path` call (its own walker doesn't filter by
+          # path), but actionpack's path filter must skip the lib/ file.
           ap_diags = result.diagnostics.select { |d| d.source_family == "plugin.actionpack" }
           expect(ap_diags).to be_empty
         end
@@ -384,10 +374,8 @@ RSpec.describe "plugins/rigor-actionpack" do
                            end
                          RUBY
                        }) do |result|
-        # `:show` and `:edit` are action names, NOT filter
-        # names — Phase 2 must NOT flag them as unknown
-        # filters. (Phase 2.5 will validate the action-name
-        # arguments separately.)
+        # `:show` and `:edit` are action names, NOT filter names — Phase 2 must NOT flag them as unknown
+        # filters. (Phase 2.5 will validate the action-name arguments separately.)
         unknown = actionpack_diagnostics(result).select { |d| d.rule == "unknown-filter-method" }
         expect(unknown).to be_empty
       end
@@ -412,11 +400,9 @@ RSpec.describe "plugins/rigor-actionpack" do
     end
 
     it "resolves filter methods transitively through `include` chains (Mastodon shape)" do
-      # AccountsController includes SignatureAuthentication,
-      # SignatureAuthentication includes SignatureVerification,
-      # SignatureVerification defines `require_account_signature!`.
-      # Pre-fix all 177 such Mastodon call sites surfaced as
-      # `unknown-filter-method`.
+      # AccountsController includes SignatureAuthentication, SignatureAuthentication includes
+      # SignatureVerification, SignatureVerification defines `require_account_signature!`. Pre-fix all 177
+      # such Mastodon call sites surfaced as `unknown-filter-method`.
       with_controllers(controllers: {
                          "concerns/signature_verification.rb" => <<~RUBY,
                            module SignatureVerification
@@ -443,13 +429,10 @@ RSpec.describe "plugins/rigor-actionpack" do
     end
 
     # ──────────────────────────────────────────────────────
-    # Mastodon shape: `module Admin; class AccountsController
-    # < BaseController; end; end` (nested-module form).
-    # Pre-fix this registered the inner class as bare
-    # `AccountsController`, clobbering the top-level
-    # `app/controllers/accounts_controller.rb` entry. The fix
-    # threads the enclosing module qualifier through the AST
-    # walk so the entry's `class_name` is fully qualified.
+    # Mastodon shape: `module Admin; class AccountsController < BaseController; end; end` (nested-module form).
+    # Pre-fix this registered the inner class as bare `AccountsController`, clobbering the top-level
+    # `app/controllers/accounts_controller.rb` entry. The fix threads the enclosing module qualifier through
+    # the AST walk so the entry's `class_name` is fully qualified.
     # ──────────────────────────────────────────────────────
 
     it "qualifies a nested-module class declaration with its enclosing scope" do
@@ -477,10 +460,8 @@ RSpec.describe "plugins/rigor-actionpack" do
     end
 
     it "walks the full ancestor chain (multi-level inheritance)" do
-      # `Admin::AccountsController < Admin::BaseController <
-      # ApplicationController` — `require_user!` is defined on
-      # the GRANDPARENT. Pre-fix only the immediate parent was
-      # walked, so this case false-fired.
+      # `Admin::AccountsController < Admin::BaseController < ApplicationController` — `require_user!` is
+      # defined on the GRANDPARENT. Pre-fix only the immediate parent was walked, so this case false-fired.
       with_controllers(controllers: {
                          "application_controller.rb" => <<~RUBY,
                            class ApplicationController
@@ -534,9 +515,8 @@ RSpec.describe "plugins/rigor-actionpack" do
     end
 
     it "resolves skip_before_action :name through the ancestor chain" do
-      # The dominant Mastodon case (13 of 42 errors pre-fix):
-      # `skip_before_action :require_functional!` references
-      # a filter declared on the parent.
+      # The dominant Mastodon case (13 of 42 errors pre-fix): `skip_before_action :require_functional!`
+      # references a filter declared on the parent.
       with_controllers(controllers: {
                          "application_controller.rb" => <<~RUBY,
                            class ApplicationController
@@ -556,12 +536,9 @@ RSpec.describe "plugins/rigor-actionpack" do
     end
 
     it "suppresses unknown-filter-method when the controller includes a gem-shipped (unresolved) concern" do
-      # Devise / Pundit-style: the controller `include`s a module
-      # whose source isn't in `app/controllers/`. We can't see
-      # what methods that module provides, so an unrecognized
-      # `before_action :authenticate_user!` MUST stay silent —
-      # the method could legitimately come from the unresolved
-      # include.
+      # Devise / Pundit-style: the controller `include`s a module whose source isn't in `app/controllers/`. We
+      # can't see what methods that module provides, so an unrecognized `before_action :authenticate_user!`
+      # MUST stay silent — the method could legitimately come from the unresolved include.
       with_controllers(controllers: {
                          "application_controller.rb" => <<~RUBY
                            class ApplicationController
@@ -579,11 +556,9 @@ RSpec.describe "plugins/rigor-actionpack" do
     it "suppresses unknown-filter-method when the controller inherits from a gem-shipped (unresolved) parent" do
       # Devise/Doorkeeper-style:
       #   class Auth::ConfirmationsController < Devise::ConfirmationsController
-      # The gem-shipped parent's own ancestor chain is invisible
-      # to us, so a `skip_before_action :check_self_destruct!`
-      # against a filter that the parent's ancestors might
-      # legitimately define MUST stay silent — same rationale as
-      # the unresolved-include case above.
+      # The gem-shipped parent's own ancestor chain is invisible to us, so a `skip_before_action
+      # :check_self_destruct!` against a filter that the parent's ancestors might legitimately define MUST
+      # stay silent — same rationale as the unresolved-include case above.
       with_controllers(controllers: {
                          "auth/confirmations_controller.rb" => <<~RUBY
                            class Auth::ConfirmationsController < Devise::ConfirmationsController
@@ -805,13 +780,10 @@ RSpec.describe "plugins/rigor-actionpack" do
   end
 
   describe "nested-module controllers — analyzer matches discoverer qualification" do
-    # The `ControllerDiscoverer` (separate slice) qualifies a
-    # nested-module declaration as `Admin::DomainBlocksController`.
-    # The analyzer's `diagnose_filters` / `diagnose_renders`
-    # MUST resolve the same qualified name from the AST, or
-    # filter validation silently no-ops and render-target
-    # paths point at the wrong directory (`domain_blocks/` vs
-    # `admin/domain_blocks/`).
+    # The `ControllerDiscoverer` (separate slice) qualifies a nested-module declaration as
+    # `Admin::DomainBlocksController`. The analyzer's `diagnose_filters` / `diagnose_renders` MUST resolve the
+    # same qualified name from the AST, or filter validation silently no-ops and render-target paths point at
+    # the wrong directory (`domain_blocks/` vs `admin/domain_blocks/`).
 
     def with_nested_module_controller(path:, contents:, views: {})
       Dir.mktmpdir do |dir|

--- a/spec/integration/plugins/activejob_plugin_spec.rb
+++ b/spec/integration/plugins/activejob_plugin_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-activejob/`.
-# Tier 1D of the Rails plugins roadmap. Discovers
-# ActiveJob subclasses by walking `app/jobs/` and validates
-# `Job.perform_later` / `.perform_now` / `.perform`
-# argument arity against each class's `#perform`.
+# Integration spec for `plugins/rigor-activejob/`. Tier 1D of the Rails plugins roadmap. Discovers ActiveJob
+# subclasses by walking `app/jobs/` and validates `Job.perform_later` / `.perform_now` / `.perform` argument
+# arity against each class's `#perform`.
 
 require "spec_helper"
 
@@ -98,8 +96,7 @@ RSpec.describe "plugins/rigor-activejob" do
 
   describe "edge cases" do
     it "ignores `Job.perform_later` calls when `Job` is not in `app/jobs/`" do
-      # `UnrelatedKlass.perform_later(1)` doesn't trigger a
-      # diagnostic — the plugin only validates calls whose
+      # `UnrelatedKlass.perform_later(1)` doesn't trigger a diagnostic — the plugin only validates calls whose
       # receiver is a discovered job class.
       result = run_plugin(
         source: "UnrelatedKlass.perform_later(1)\n",

--- a/spec/integration/plugins/activerecord_plugin_spec.rb
+++ b/spec/integration/plugins/activerecord_plugin_spec.rb
@@ -1,21 +1,17 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-activerecord/`. Reference
-# coverage for the most architecturally complete v0.1.0 plugin
-# example — combines `rigor-routes`-style IoBoundary + cache
-# producer (twice — schema and model index), `rigor-lisp-eval`-
-# style Prism DSL interpretation (the schema parser), and
-# `rigor-statesman`-style two-pass discover-then-validate.
+# Integration spec for `plugins/rigor-activerecord/`. Reference coverage for the most architecturally complete
+# v0.1.0 plugin example — combines `rigor-routes`-style IoBoundary + cache producer (twice — schema and model
+# index), `rigor-lisp-eval`-style Prism DSL interpretation (the schema parser), and `rigor-statesman`-style
+# two-pass discover-then-validate.
 
 require "spec_helper"
 require "fileutils"
 require "tmpdir"
 
-# `ACTIVERECORD_PLUGIN_LIB` is also defined by
-# `factorybot_plugin_spec.rb` (which consumes the activerecord
-# plugin's `:model_index` facts). Guard against the double
-# definition so running both specs in the same process does
-# not warn `already initialized constant`.
+# `ACTIVERECORD_PLUGIN_LIB` is also defined by `factorybot_plugin_spec.rb` (which consumes the activerecord
+# plugin's `:model_index` facts). Guard against the double definition so running both specs in the same
+# process does not warn `already initialized constant`.
 unless defined?(ACTIVERECORD_PLUGIN_LIB)
   ACTIVERECORD_PLUGIN_LIB = File.expand_path("../../../plugins/rigor-activerecord/lib", __dir__)
 end
@@ -74,13 +70,10 @@ RSpec.describe "plugins/rigor-activerecord" do
     run_plugin(source: source, plugin_entry: plugin_entry, files: files)
   end
 
-  # Materialises the project files, runs the analyser
-  # directly, and returns `[result, model_index]` so the
-  # AR-extension specs can assert against BOTH the diagnostic
-  # stream and the structured per-model state (enums /
-  # scopes / validations / callbacks). The `model_index`
-  # accessor isn't surfaced through `run_plugin` because the
-  # other plugin examples don't need it.
+  # Materialises the project files, runs the analyser directly, and returns `[result, model_index]` so the
+  # AR-extension specs can assert against BOTH the diagnostic stream and the structured per-model state (enums
+  # / scopes / validations / callbacks). The `model_index` accessor isn't surfaced through `run_plugin` because
+  # the other plugin examples don't need it.
   def run_ar_with_index(source, models:, schema:)
     files = { "db/schema.rb" => schema, "demo.rb" => source }.merge(models)
     Dir.mktmpdir do |dir|
@@ -133,14 +126,10 @@ RSpec.describe "plugins/rigor-activerecord" do
   end
 
   describe "migration files are excluded from column validation" do
-    # Rails migration files (`db/migrate/<timestamp>_*.rb`)
-    # and post-migration files reference the EVOLVING schema
-    # at the time the migration ran. The current `db/schema.rb`
-    # may not have the columns those files mention (the
-    # migration's purpose was often to add/remove them).
-    # Validating these files against the current schema is a
-    # category error — the AR plugin must stay silent on
-    # them.
+    # Rails migration files (`db/migrate/<timestamp>_*.rb`) and post-migration files reference the EVOLVING
+    # schema at the time the migration ran. The current `db/schema.rb` may not have the columns those files
+    # mention (the migration's purpose was often to add/remove them). Validating these files against the
+    # current schema is a category error — the AR plugin must stay silent on them.
 
     let(:migration_source) { "Account.where(suspended: true)\n" }
 
@@ -165,9 +154,7 @@ RSpec.describe "plugins/rigor-activerecord" do
           )
           result = runner.run
           ar_diags = result.diagnostics.select { |d| d.source_family == "plugin.activerecord" }
-          # Only the schema-loading info / load-error
-          # diagnostics may pass through; no per-file column
-          # errors.
+          # Only the schema-loading info / load-error diagnostics may pass through; no per-file column errors.
           expect(ar_diags.select { |d| d.rule == "unknown-column" }).to be_empty
         end
       end
@@ -199,8 +186,7 @@ RSpec.describe "plugins/rigor-activerecord" do
     end
 
     it "still fires unknown-column on a regular app/ file (precision floor)" do
-      # `:emial` typo on User — pattern from the surrounding
-      # `unknown-column diagnostics` block, known to fire.
+      # `:emial` typo on User — pattern from the surrounding `unknown-column diagnostics` block, known to fire.
       diags = plugin_diagnostics(run_ar("User.where(emial: 'a')\n"))
       err = diags.find { |d| d.rule == "unknown-column" }
       expect(err).not_to be_nil
@@ -317,10 +303,8 @@ RSpec.describe "plugins/rigor-activerecord" do
     end
 
     it "emits the load-error warning at most once across many analyzed files" do
-      # Solidus monorepo / Redmine (migrations-only) scale: hundreds
-      # of files, but `db/schema.rb` absence is a single
-      # project-global root cause. Pre-fix the plugin emitted
-      # `load-error` per file (346× on Redmine).
+      # Solidus monorepo / Redmine (migrations-only) scale: hundreds of files, but `db/schema.rb` absence is a
+      # single project-global root cause. Pre-fix the plugin emitted `load-error` per file (346× on Redmine).
       result = run_plugin(
         source: "User.find(1)\n",
         files: { "extra1.rb" => "stuff\n", "extra2.rb" => "more\n", "extra3.rb" => "again\n" }
@@ -330,12 +314,10 @@ RSpec.describe "plugins/rigor-activerecord" do
     end
 
     it "attempts the missing-schema read only once across many AR call sites" do
-      # Regression: `schema_table_or_nil` is invoked per AR call site via
-      # `model_index`; before memoizing the *failure* it re-read the
-      # missing schema and appended a fresh interpolated error string to
-      # `@load_errors` on every call, growing it without bound (measured:
-      # 4.2 M retained strings / ~1.5 GB on Redmine). The internal error
-      # list must stay at one entry no matter how many call sites run.
+      # Regression: `schema_table_or_nil` is invoked per AR call site via `model_index`; before memoizing the
+      # *failure* it re-read the missing schema and appended a fresh interpolated error string to
+      # `@load_errors` on every call, growing it without bound (measured: 4.2 M retained strings / ~1.5 GB on
+      # Redmine). The internal error list must stay at one entry no matter how many call sites run.
       source = (1..40).map { |i| "User.where(id: #{i})\n" }.join
       Dir.mktmpdir do |dir|
         materialize_files(dir, { "demo.rb" => source }) # no db/schema.rb
@@ -356,14 +338,11 @@ RSpec.describe "plugins/rigor-activerecord" do
   end
 
   describe "dynamic_return / #dynamic_return_type return-type contribution (v0.1.2)" do
-    # The plugin's `Model.find(id)` rule contributes
-    # `Nominal[Model]` so chained call sites resolve through
-    # the analyzer's normal dispatch — without the contribution
-    # the RBS-level untyped return would let any chained method
-    # name through silently. The `call.undefined-method` rule
-    # only fires when the receiver class is known to RBS, so the
-    # tests below ship an RBS sig for User (top-level
-    # `USER_RBS_FOR_NARROWING`) declaring its columns.
+    # The plugin's `Model.find(id)` rule contributes `Nominal[Model]` so chained call sites resolve through the
+    # analyzer's normal dispatch — without the contribution the RBS-level untyped return would let any chained
+    # method name through silently. The `call.undefined-method` rule only fires when the receiver class is
+    # known to RBS, so the tests below ship an RBS sig for User (top-level `USER_RBS_FOR_NARROWING`) declaring
+    # its columns.
     def run_ar_with_user_sig(source, schema: DEFAULT_SCHEMA, models: DEFAULT_MODELS)
       files = { "db/schema.rb" => schema, "sig/user.rbs" => USER_RBS_FOR_NARROWING }.merge(models)
       run_plugin(
@@ -387,10 +366,9 @@ RSpec.describe "plugins/rigor-activerecord" do
     end
 
     it "narrows `Model.where` to a relation whose `.find` extracts the element" do
-      # `where` → `ActiveRecord::Relation[User]`; `.find` → `User`,
-      # so a bad method on the extracted element surfaces on `User`.
-      # (`bit_length` is NOT flagged on the relation itself —
-      # `ActiveRecord::Relation` is an ADR-26 open receiver.)
+      # `where` → `ActiveRecord::Relation[User]`; `.find` → `User`, so a bad method on the extracted element
+      # surfaces on `User`. (`bit_length` is NOT flagged on the relation itself — `ActiveRecord::Relation` is
+      # an ADR-26 open receiver.)
       result = run_ar_with_user_sig(<<~RUBY)
         user = User.where(admin: true).find(1)
         user.bit_length
@@ -407,8 +385,7 @@ RSpec.describe "plugins/rigor-activerecord" do
         x = Object.find(1)
         x.upcase
       RUBY
-      # Object.find isn't a model — no contribution; the call
-      # falls through to the analyzer's normal dispatch.
+      # Object.find isn't a model — no contribution; the call falls through to the analyzer's normal dispatch.
       method_undefined = result.diagnostics.select do |d|
         d.path.end_with?("demo.rb") && d.rule == "call.undefined-method" && d.message.include?("upcase")
       end
@@ -417,14 +394,10 @@ RSpec.describe "plugins/rigor-activerecord" do
   end
 
   describe "associations (has_many / belongs_to / has_one) — v0.1.5" do
-    # rigor-activerecord now records `has_many` / `belongs_to`
-    # / `has_one` declarations in the ModelIndex (and
-    # contributes `Nominal[Target] | nil` for the singular
-    # cases via `dynamic_return`). The integration
-    # spec asserts via the model-index lookup that the right
-    # rows landed; the singular return-type contribution is covered
-    # via direct unit specs on the plugin classes
-    # (`spec/examples/activerecord/` — not bundled here).
+    # rigor-activerecord now records `has_many` / `belongs_to` / `has_one` declarations in the ModelIndex (and
+    # contributes `Nominal[Target] | nil` for the singular cases via `dynamic_return`). The integration spec
+    # asserts via the model-index lookup that the right rows landed; the singular return-type contribution is
+    # covered via direct unit specs on the plugin classes (`spec/examples/activerecord/` — not bundled here).
 
     # rubocop:disable Lint/ConstantDefinitionInBlock, RSpec/LeakyConstantDeclaration
     POST_USER_MODELS = {
@@ -531,11 +504,9 @@ RSpec.describe "plugins/rigor-activerecord" do
     end
 
     it "publishes a non-nullable `Nominal[Target]` for a required belongs_to" do
-      # `belongs_to` is required (non-`nil`) by default since
-      # Rails 5, so `post.user` narrows to `Nominal[User]` with no
-      # nil arm. Spec the return type directly on the plugin
-      # instance — Rigor's diagnostic rule contract for chained
-      # calls is independent of the plugin's return-type publication.
+      # `belongs_to` is required (non-`nil`) by default since Rails 5, so `post.user` narrows to
+      # `Nominal[User]` with no nil arm. Spec the return type directly on the plugin instance — Rigor's
+      # diagnostic rule contract for chained calls is independent of the plugin's return-type publication.
       index = model_index_after_run(models: POST_USER_MODELS)
       runner_plugin = Rigor::Plugin::Activerecord.allocate
       runner_plugin.instance_variable_set(:@model_index, index)
@@ -555,8 +526,7 @@ RSpec.describe "plugins/rigor-activerecord" do
     end
 
     it "publishes a nullable `Nominal[Target] | nil` for has_one" do
-      # `has_one` genuinely returns `nil` when no associated
-      # record exists, so `user.profile` keeps the nil arm.
+      # `has_one` genuinely returns `nil` when no associated record exists, so `user.profile` keeps the nil arm.
       index = model_index_after_run(models: POST_USER_MODELS)
       runner_plugin = Rigor::Plugin::Activerecord.allocate
       runner_plugin.instance_variable_set(:@model_index, index)
@@ -638,11 +608,9 @@ RSpec.describe "plugins/rigor-activerecord" do
     end
 
     it "accepts a singular association name as a `find_by` / `where` key alias" do
-      # Mastodon-derived regression: `AccountPin.find_by(account: x)`
-      # passes the belongs_to association name `:account` instead of
-      # the FK column `:account_id`. ActiveRecord accepts both; the
-      # plugin should match. Pre-fix this was 100+ FPs on Mastodon's
-      # API controllers.
+      # Mastodon-derived regression: `AccountPin.find_by(account: x)` passes the belongs_to association name
+      # `:account` instead of the FK column `:account_id`. ActiveRecord accepts both; the plugin should match.
+      # Pre-fix this was 100+ FPs on Mastodon's API controllers.
       result = run_plugin(
         source: "Post.find_by(user: x); Post.where(user: y)\n",
         files: {
@@ -663,9 +631,8 @@ RSpec.describe "plugins/rigor-activerecord" do
         }
       )
       diags = plugin_diagnostics(result)
-      # `posts` would be a has_many (collection) association on a
-      # hypothetical reverse relationship; it's not declared here at
-      # all, so the plugin should still error.
+      # `posts` would be a has_many (collection) association on a hypothetical reverse relationship; it's not
+      # declared here at all, so the plugin should still error.
       expect(diags.find { |d| d.rule == "unknown-column" && d.message.include?("`posts`") }).not_to be_nil
     end
   end
@@ -767,10 +734,8 @@ RSpec.describe "plugins/rigor-activerecord" do
     end
 
     it "types an implicit-self `select(...)` inside a scope lambda as Relation[Model]" do
-      # The lambda body's `self_type` is `Singleton[Post]`, so
-      # `select(:title).group(:title)` opens a relation via the
-      # AR plugin instead of falling through to `Kernel#select`'s
-      # IO-multiplexer return (`Array[String]`).
+      # The lambda body's `self_type` is `Singleton[Post]`, so `select(:title).group(:title)` opens a relation
+      # via the AR plugin instead of falling through to `Kernel#select`'s IO-multiplexer return (`Array[String]`).
       source = <<~RUBY
         Post.published.merge(Post.where(title: 'x'))
       RUBY
@@ -865,13 +830,10 @@ RSpec.describe "plugins/rigor-activerecord" do
   end
 
   describe "ADR-9 :model_index publication" do
-    # Loads rigor-activerecord (the producer) alongside a
-    # synthetic consumer plugin that reads the published
-    # :model_index in its `prepare(services)` hook and emits
-    # a diagnostic naming the column set it sees. This is the
-    # same shape rigor-actionpack Phase 1 / rigor-factorybot
-    # Phase 1 (c) will use; the test pins the publication
-    # contract.
+    # Loads rigor-activerecord (the producer) alongside a synthetic consumer plugin that reads the published
+    # :model_index in its `prepare(services)` hook and emits a diagnostic naming the column set it sees. This
+    # is the same shape rigor-actionpack Phase 1 / rigor-factorybot Phase 1 (c) will use; the test pins the
+    # publication contract.
     let(:consumer_plugin) do
       klass = Class.new(Rigor::Plugin::Base) do
         manifest(
@@ -975,8 +937,7 @@ RSpec.describe "plugins/rigor-activerecord" do
     end
 
     it "adds only `<name>_id` for a non-polymorphic reference" do
-      # DEFAULT_SCHEMA's `posts` table has a plain
-      # `t.references "user"` — no `user_type` column exists.
+      # DEFAULT_SCHEMA's `posts` table has a plain `t.references "user"` — no `user_type` column exists.
       diags = plugin_diagnostics(run_ar("Post.where(user_type: 'x')\n"))
       expect(diags.find { |d| d.rule == "unknown-column" && d.message.include?("user_type") }).not_to be_nil
     end
@@ -1247,8 +1208,8 @@ RSpec.describe "plugins/rigor-activerecord" do
     end
 
     it "inherits the parent model's associations on the STI subclass" do
-      # `belongs_to :company` is declared on User; the child must
-      # accept `:company` as a query key or it is a false positive.
+      # `belongs_to :company` is declared on User; the child must accept `:company` as a query key or it is a
+      # false positive.
       diags = plugin_diagnostics(run_ar("Admin.find_by(company: x)\n", models: sti_models))
       expect(diags.select { |d| d.rule == "unknown-column" }).to be_empty
     end
@@ -1500,11 +1461,9 @@ RSpec.describe "plugins/rigor-activerecord" do
     end
 
     it "accepts the nested association name as a query key" do
-      # Mastodon-derived regression: `Report` declares its
-      # account belongs_to associations inside a
-      # `with_options class_name: 'Account'` block. Before the
-      # `with_options` descent every `Report.where(target_account:
-      # ...)` surfaced as a false `unknown-column`.
+      # Mastodon-derived regression: `Report` declares its account belongs_to associations inside a
+      # `with_options class_name: 'Account'` block. Before the `with_options` descent every
+      # `Report.where(target_account: ...)` surfaced as a false `unknown-column`.
       diags = plugin_diagnostics(
         run_ar("Report.where(target_account: a)\n", models: with_options_models, schema: reports_schema)
       )
@@ -1584,9 +1543,8 @@ RSpec.describe "plugins/rigor-activerecord" do
     end
 
     it "re-contributes the relation type for a scope invoked ON a relation" do
-      # `Post.where(...).published` — the receiver of `.published`
-      # is `ActiveRecord::Relation[Post]`; the scope keeps the
-      # element type through the chain.
+      # `Post.where(...).published` — the receiver of `.published` is `ActiveRecord::Relation[Post]`; the
+      # scope keeps the element type through the chain.
       _result, index = run_ar_with_index("x = 1\n", models: scope_models, schema: scope_schema)
       plugin = Rigor::Plugin::Activerecord.allocate
       plugin.instance_variable_set(:@model_index, index)
@@ -1604,9 +1562,8 @@ RSpec.describe "plugins/rigor-activerecord" do
     end
 
     it "keeps a chained relation query method type-checking cleanly" do
-      # `where` opens the relation; every chained query method
-      # resolves through the bundled `ActiveRecord::Relation` RBS,
-      # so the whole chain stays `Relation[User]`.
+      # `where` opens the relation; every chained query method resolves through the bundled
+      # `ActiveRecord::Relation` RBS, so the whole chain stays `Relation[User]`.
       result = run_ar(<<~RUBY)
         users = User.where(admin: true).order(:name).limit(10)
         users.first
@@ -1618,10 +1575,8 @@ RSpec.describe "plugins/rigor-activerecord" do
     end
 
     it "does not flag an unknown scope called on a typed relation (ADR-26 open receiver)" do
-      # `Post.where(...).some_undeclared_scope` — the relation is
-      # typed, but `ActiveRecord::Relation` is an open receiver, so
-      # an unenumerable scope call must NOT surface as
-      # `call.undefined-method`.
+      # `Post.where(...).some_undeclared_scope` — the relation is typed, but `ActiveRecord::Relation` is an
+      # open receiver, so an unenumerable scope call must NOT surface as `call.undefined-method`.
       result = run_ar(
         "Post.where(published: true).some_undeclared_scope\n",
         models: scope_models, schema: scope_schema
@@ -1633,9 +1588,8 @@ RSpec.describe "plugins/rigor-activerecord" do
     end
 
     it "resolves the block element type through the relation end-to-end" do
-      # `where` → Relation[User] → Enumerable[User]#each yields
-      # User → the column accessor types `u.name` as String →
-      # `bit_length` is undefined on String.
+      # `where` → Relation[User] → Enumerable[User]#each yields User → the column accessor types `u.name` as
+      # String → `bit_length` is undefined on String.
       result = run_ar("User.where(admin: true).each { |u| u.name.bit_length }\n")
       undefined = result.diagnostics.find do |d|
         d.path.end_with?("demo.rb") && d.rule == "call.undefined-method" && d.message.include?("bit_length")

--- a/spec/integration/plugins/activestorage_plugin_spec.rb
+++ b/spec/integration/plugins/activestorage_plugin_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-activestorage/`.
-# Mirrors the structure of the `rigor-activerecord` spec —
-# materialises model files on disk, runs the analyser, and
-# asserts both the diagnostic stream and the per-model
-# attachment index.
+# Integration spec for `plugins/rigor-activestorage/`. Mirrors the structure of the `rigor-activerecord` spec
+# — materialises model files on disk, runs the analyser, and asserts both the diagnostic stream and the
+# per-model attachment index.
 
 require "spec_helper"
 require "fileutils"
@@ -38,10 +36,9 @@ RSpec.describe "plugins/rigor-activestorage" do
   RBS
   # rubocop:enable Lint/ConstantDefinitionInBlock, RSpec/LeakyConstantDeclaration
 
-  # Materialises a project tree on disk + runs `rigor check`
-  # against `demo.rb`; returns `[result, attachment_index]`
-  # so specs can assert against the diagnostic stream AND
-  # the structured per-model state captured by the plugin.
+  # Materialises a project tree on disk + runs `rigor check` against `demo.rb`; returns
+  # `[result, attachment_index]` so specs can assert against the diagnostic stream AND the structured per-model
+  # state captured by the plugin.
   def run_as(source, models: { "app/models/application_record.rb" => APPLICATION_RECORD,
                                "app/models/user.rb" => USER_WITH_ATTACHMENTS,
                                "app/models/post.rb" => POST_WITHOUT_ATTACHMENTS },

--- a/spec/integration/plugins/activesupport_core_ext_plugin_spec.rb
+++ b/spec/integration/plugins/activesupport_core_ext_plugin_spec.rb
@@ -2,12 +2,9 @@
 
 # Integration spec for `plugins/rigor-activesupport-core-ext/`.
 #
-# ADR-25 — the bundle is a pure RBS-bundle plugin: its manifest
-# declares `signature_paths: ["sig"]` and the plugin loader feeds
-# that directory into the RBS environment. This spec proves the
-# end-to-end path: with the plugin active, ActiveSupport
-# `core_ext` selectors type-check instead of producing
-# `call.undefined-method` diagnostics.
+# ADR-25 — the bundle is a pure RBS-bundle plugin: its manifest declares `signature_paths: ["sig"]` and the
+# plugin loader feeds that directory into the RBS environment. This spec proves the end-to-end path: with the
+# plugin active, ActiveSupport `core_ext` selectors type-check instead of producing `call.undefined-method` diagnostics.
 
 require "spec_helper"
 

--- a/spec/integration/plugins/devise_plugin_spec.rb
+++ b/spec/integration/plugins/devise_plugin_spec.rb
@@ -1,18 +1,15 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-devise/`. ADR-16 slice 3c.
-# Exercises the substrate's Tier B path end-to-end:
+# Integration spec for `plugins/rigor-devise/`. ADR-16 slice 3c. Exercises the substrate's Tier B path end-to-end:
 #
 # 1. Load the example plugin via the `rigor-devise` entry point.
-# 2. Run rigor against a multi-file fixture with a User model
-#    using `devise :database_authenticatable, :recoverable` plus a
-#    consumer file calling the synthesised methods cross-file.
-# 3. Assert that bare reader calls resolve through the substrate
-#    (no `call.undefined-method` for Devise module methods).
+# 2. Run rigor against a multi-file fixture with a User model using `devise :database_authenticatable,
+#    :recoverable` plus a consumer file calling the synthesised methods cross-file.
+# 3. Assert that bare reader calls resolve through the substrate (no `call.undefined-method` for Devise
+#    module methods).
 #
-# Per WD13 floor — the synthesised methods return `Dynamic[T]`;
-# this spec verifies the *name resolution* path, not precise
-# return typing (which is slice-6 ceiling).
+# Per WD13 floor — the synthesised methods return `Dynamic[T]`; this spec verifies the *name resolution* path,
+# not precise return typing (which is slice-6 ceiling).
 
 require "spec_helper"
 

--- a/spec/integration/plugins/dry_schema_plugin_spec.rb
+++ b/spec/integration/plugins/dry_schema_plugin_spec.rb
@@ -1,17 +1,13 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-dry-schema/`.
-# ADR-12 + the slicing plan in
+# Integration spec for `plugins/rigor-dry-schema/`. ADR-12 + the slicing plan in
 # `docs/design/20260517-dry-validation-slicing.md`.
 #
 # Slice 1 contract:
 #
-# 1. Walk the project for `Foo = Dry::Schema.{Params,JSON,define} { ... }`
-#    assignments.
-# 2. Inside each block, extract `required(:key).<predicate>(...)` and
-#    `optional(:key).<predicate>(...)` rows.
-# 3. Publish the resulting per-schema typed-key table as the
-#    `:dry_schema_table` ADR-9 cross-plugin fact.
+# 1. Walk the project for `Foo = Dry::Schema.{Params,JSON,define} { ... }` assignments.
+# 2. Inside each block, extract `required(:key).<predicate>(...)` and `optional(:key).<predicate>(...)` rows.
+# 3. Publish the resulting per-schema typed-key table as the `:dry_schema_table` ADR-9 cross-plugin fact.
 
 require "spec_helper"
 
@@ -160,8 +156,7 @@ RSpec.describe "rigor-dry-schema integration" do
         required(:name).filled(:string)
       end
     RUBY
-    # No `Types` module + no rigor-dry-types loaded → the constant
-    # reference doesn't resolve, key drops.
+    # No `Types` module + no rigor-dry-types loaded → the constant reference doesn't resolve, key drops.
     shape = run_and_read_fact(demo: demo).fetch("UnresolvedSchema")
     expect(shape.fetch(:required)).to eq(name: { type: "String", list: false })
   end
@@ -191,9 +186,8 @@ RSpec.describe "rigor-dry-schema integration" do
     expect(run_and_read_fact(demo: demo)).to be_nil
   end
 
-  # Runs the plugin(s) against a single-file project and returns
-  # the `:dry_schema_table` fact value. Optionally also loads
-  # rigor-dry-types (for the cross-plugin fact-resolution test).
+  # Runs the plugin(s) against a single-file project and returns the `:dry_schema_table` fact value. Optionally
+  # also loads rigor-dry-types (for the cross-plugin fact-resolution test).
   def run_and_read_fact(demo:, with_dry_types: false)
     Rigor::Plugin.unregister!
     captured_store = capture_fact_store!

--- a/spec/integration/plugins/dry_struct_plugin_spec.rb
+++ b/spec/integration/plugins/dry_struct_plugin_spec.rb
@@ -1,18 +1,14 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-dry-struct/`. ADR-16 slice 2c.
-# Exercises the substrate's Tier C path end-to-end:
+# Integration spec for `plugins/rigor-dry-struct/`. ADR-16 slice 2c. Exercises the substrate's Tier C path end-to-end:
 #
 # 1. Load the example plugin via the `rigor-dry-struct` entry point.
-# 2. Run rigor against a multi-file Dry::Struct fixture with a
-#    minimal Dry::Struct RBS stub.
-# 3. Assert that cross-file dispatch through the synthesised
-#    readers resolves (no `call.undefined-method` for
+# 2. Run rigor against a multi-file Dry::Struct fixture with a minimal Dry::Struct RBS stub.
+# 3. Assert that cross-file dispatch through the synthesised readers resolves (no `call.undefined-method` for
 #    `address.city` / `user.name` etc.).
 #
-# Per WD13 floor — the synthetic readers return `Dynamic[T]`;
-# this spec verifies the *name resolution* path, not precise
-# return typing (which is the slice-6 ceiling).
+# Per WD13 floor — the synthetic readers return `Dynamic[T]`; this spec verifies the *name resolution* path,
+# not precise return typing (which is the slice-6 ceiling).
 
 require "spec_helper"
 
@@ -126,11 +122,9 @@ RSpec.describe "rigor-dry-struct integration" do
           end
         RBS
 
-        # Capture the synthesised methods directly so we can
-        # assert on their `return_type` instead of relying on
-        # downstream call-site narrowing (which would need
-        # `Types::String` to resolve at the constant-typing
-        # tier — separate work).
+        # Capture the synthesised methods directly so we can assert on their `return_type` instead of relying
+        # on downstream call-site narrowing (which would need `Types::String` to resolve at the
+        # constant-typing tier — separate work).
         captured_index = nil
         allow(Rigor::Inference::SyntheticMethodIndex).to receive(:new).and_wrap_original do |original, **kwargs|
           captured_index = original.call(**kwargs)

--- a/spec/integration/plugins/dry_types_plugin_spec.rb
+++ b/spec/integration/plugins/dry_types_plugin_spec.rb
@@ -1,18 +1,13 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-dry-types/`. ADR-12 slice 1.
-# Exercises the Tier A foundation plugin end-to-end:
+# Integration spec for `plugins/rigor-dry-types/`. ADR-12 slice 1. Exercises the Tier A foundation plugin end-to-end:
 #
 # 1. Load the example plugin via the `rigor-dry-types` entry point.
-# 2. Run rigor against a project that declares
-#    `module Types; include Dry.Types(); end`.
-# 3. Assert that the plugin publishes the `:dry_type_aliases`
-#    fact via the ADR-9 cross-plugin fact store.
+# 2. Run rigor against a project that declares `module Types; include Dry.Types(); end`.
+# 3. Assert that the plugin publishes the `:dry_type_aliases` fact via the ADR-9 cross-plugin fact store.
 #
-# Slice 1 has no user-facing diagnostics — the contract is
-# fact-publication. Downstream uplifts (rigor-dry-struct's
-# slice-6 precision promotion) consume the fact in later
-# slices.
+# Slice 1 has no user-facing diagnostics — the contract is fact-publication. Downstream uplifts
+# (rigor-dry-struct's slice-6 precision promotion) consume the fact in later slices.
 
 require "spec_helper"
 
@@ -162,12 +157,9 @@ RSpec.describe "rigor-dry-types integration" do
     expect(aliases).to be_nil
   end
 
-  # Runs the plugin against a single-file project and returns
-  # the `:dry_type_aliases` fact value (or `nil` if the plugin
-  # didn't publish it). Captures the per-run `Plugin::Services`
-  # instance via `wrap_original` so we can read the fact store
-  # after `prepare(services)` ran — same pattern as the
-  # rigor-rails-routes integration spec.
+  # Runs the plugin against a single-file project and returns the `:dry_type_aliases` fact value (or `nil` if
+  # the plugin didn't publish it). Captures the per-run `Plugin::Services` instance via `wrap_original` so we
+  # can read the fact store after `prepare(services)` ran — same pattern as the rigor-rails-routes integration spec.
   def run_and_read_fact(demo:)
     Rigor::Plugin.unregister!
     captured_store = nil

--- a/spec/integration/plugins/dry_validation_plugin_spec.rb
+++ b/spec/integration/plugins/dry_validation_plugin_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-dry-validation/`.
-# ADR-12 Tier A per the slicing plan in
+# Integration spec for `plugins/rigor-dry-validation/`. ADR-12 Tier A per the slicing plan in
 # `docs/design/20260517-dry-validation-slicing.md`.
 
 require "spec_helper"

--- a/spec/integration/plugins/factorybot_plugin_spec.rb
+++ b/spec/integration/plugins/factorybot_plugin_spec.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-factorybot/`. Phase 1
-# (a) — self-contained validation of FactoryBot entry calls
-# against a per-run factory index.
+# Integration spec for `plugins/rigor-factorybot/`. Phase 1 (a) — self-contained validation of FactoryBot
+# entry calls against a per-run factory index.
 
 require "spec_helper"
 
 FACTORYBOT_PLUGIN_LIB = File.expand_path("../../../plugins/rigor-factorybot/lib", __dir__)
-# `ACTIVERECORD_PLUGIN_LIB` is also defined by
-# `activerecord_plugin_spec.rb`. Guard against the double
-# definition so running both specs in the same process does
-# not warn `already initialized constant`.
+# `ACTIVERECORD_PLUGIN_LIB` is also defined by `activerecord_plugin_spec.rb`. Guard against the double
+# definition so running both specs in the same process does not warn `already initialized constant`.
 unless defined?(ACTIVERECORD_PLUGIN_LIB)
   ACTIVERECORD_PLUGIN_LIB = File.expand_path("../../../plugins/rigor-activerecord/lib", __dir__)
 end
@@ -181,8 +178,7 @@ RSpec.describe "plugins/rigor-factorybot" do
           RUBY
         }
       )
-      # `:only_in_trait` is declared inside `trait :admin do
-      # ... end`, which Phase 1 (a) doesn't recurse into.
+      # `:only_in_trait` is declared inside `trait :admin do ... end`, which Phase 1 (a) doesn't recurse into.
       # Hence the kwarg surfaces as `unknown-attribute`.
       err = plugin_diagnostics(result).find { |d| d.rule == "unknown-attribute" }
       expect(err).not_to be_nil
@@ -223,10 +219,8 @@ RSpec.describe "plugins/rigor-factorybot" do
     end
 
     it "accepts a column-only kwarg that's NOT in the factory's declared attributes" do
-      # The factory only declares `:name`. Without the AR
-      # cross-check, `:email` would surface as
-      # unknown-attribute. With Phase 1 (c) the email column
-      # is in the model's index, so the kwarg is accepted.
+      # The factory only declares `:name`. Without the AR cross-check, `:email` would surface as
+      # unknown-attribute. With Phase 1 (c) the email column is in the model's index, so the kwarg is accepted.
       run_factorybot_with_ar("FactoryBot.create(:user, email: \"x@y.z\")\n") do |result|
         unknown = result.diagnostics.select do |d|
           d.source_family == "plugin.factorybot" && d.rule == "unknown-attribute"
@@ -255,19 +249,13 @@ RSpec.describe "plugins/rigor-factorybot" do
     end
   end
 
-  # Pillar 2 Slice 3 — factory definitions as struct-shape
-  # facts. The `:factory_index` ADR-9 publication now carries
-  # per-factory `model_class` so downstream consumers (Slice
-  # 2's `let(:user) { create(:user) }` SUT binding, future
-  # `rigor-shoulda-matchers`-style cross-checks) can map a
-  # factory name to a Ruby class.
+  # Pillar 2 Slice 3 — factory definitions as struct-shape facts. The `:factory_index` ADR-9 publication now
+  # carries per-factory `model_class` so downstream consumers (Slice 2's `let(:user) { create(:user) }` SUT
+  # binding, future `rigor-shoulda-matchers`-style cross-checks) can map a factory name to a Ruby class.
   describe "Pillar 2 Slice 3 — factory entry model_class" do
-    # Drives the FactoryDiscoverer directly via a temp dir.
-    # The full integration through `producer :factory_index`
-    # is exercised by every downstream consumer spec (e.g.
-    # rspec_plugin_spec / shoulda_matchers_plugin_spec
-    # patterns) — these focused tests pin the Entry shape
-    # change.
+    # Drives the FactoryDiscoverer directly via a temp dir. The full integration through `producer
+    # :factory_index` is exercised by every downstream consumer spec (e.g. rspec_plugin_spec /
+    # shoulda_matchers_plugin_spec patterns) — these focused tests pin the Entry shape change.
     def factory_index_for(files)
       Dir.mktmpdir do |dir|
         files.each do |relative, contents|

--- a/spec/integration/plugins/graphql_plugin_spec.rb
+++ b/spec/integration/plugins/graphql_plugin_spec.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-graphql/`.
-# Tier 3D per the Rails plugins roadmap.
+# Integration spec for `plugins/rigor-graphql/`. Tier 3D per the Rails plugins roadmap.
 #
 # Slice 1 contract:
 #
-# 1. Walk the project for `class T < GraphQL::Schema::Object`
-#    subclasses (including nested `module Types; class User < ...; end`).
+# 1. Walk the project for `class T < GraphQL::Schema::Object` subclasses (including nested `module Types;
+#    class User < ...; end`).
 # 2. Inside each, extract `field :name, Type, null: ...` declarations.
-# 3. Publish the resulting `{type_class_fqn => {field_name => {type:, nullable:}}}`
-#    table as the `:graphql_type_table` ADR-9 cross-plugin fact.
+# 3. Publish the resulting `{type_class_fqn => {field_name => {type:, nullable:}}}` table as the
+#    `:graphql_type_table` ADR-9 cross-plugin fact.
 
 require "spec_helper"
 
@@ -449,8 +448,7 @@ RSpec.describe "rigor-graphql integration" do
         field :name, String, null: false
       end
     RUBY
-    # `Container::Object` has the right tail name but wrong
-    # parent — must not register as a GraphQL type.
+    # `Container::Object` has the right tail name but wrong parent — must not register as a GraphQL type.
     expect(run_and_read_fact(demo: demo)).to be_nil
   end
 

--- a/spec/integration/plugins/hanami_plugin_spec.rb
+++ b/spec/integration/plugins/hanami_plugin_spec.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-hanami/`.
-# Validates the ADR-28 provide-and-check pair for Hanami
-# actions: the engine provides `Hanami::Action::Request` /
-# `Hanami::Action::Response` into `#handle` bodies, and the
-# plugin checks that every class under `app/actions/` defines
-# `#handle`.
+# Integration spec for `plugins/rigor-hanami/`. Validates the ADR-28 provide-and-check pair for Hanami
+# actions: the engine provides `Hanami::Action::Request` / `Hanami::Action::Response` into `#handle` bodies,
+# and the plugin checks that every class under `app/actions/` defines `#handle`.
 
 require "spec_helper"
 
@@ -19,9 +16,8 @@ RSpec.describe "plugins/rigor-hanami" do
 
   let(:plugin_class) { Rigor::Plugin::Hanami }
 
-  # Materialises `files` into a tmpdir and analyses `paths`.
-  # The plugin contributes Hanami Action RBS via `signature_paths:`
-  # so no external sig is needed.
+  # Materialises `files` into a tmpdir and analyses `paths`. The plugin contributes Hanami Action RBS via
+  # `signature_paths:` so no external sig is needed.
   def run_hanami(files:, paths:, config: nil)
     plugin_entry = config ? { "gem" => "rigor-hanami", "config" => config } : "rigor-hanami"
     run_plugin(source: "# entry point\n", files: files, paths: paths, plugin_entry: plugin_entry)
@@ -96,10 +92,9 @@ RSpec.describe "plugins/rigor-hanami" do
     end
   end
 
-  # Proves the engine provides Hanami::Action::Request / Response
-  # types into the #handle body: calling a non-existent method on
-  # request surfaces a core diagnostic when the file is under the
-  # action path, but stays silent when it is outside.
+  # Proves the engine provides Hanami::Action::Request / Response types into the #handle body: calling a
+  # non-existent method on request surfaces a core diagnostic when the file is under the action path, but
+  # stays silent when it is outside.
   describe "parameter-type provision" do
     let(:body) do
       <<~RUBY

--- a/spec/integration/plugins/mangrove_plugin_spec.rb
+++ b/spec/integration/plugins/mangrove_plugin_spec.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-mangrove/`. Slice 1:
-# instantiates the Mangrove Result/Option carrier generic at the
-# unwrap call site, contributing `type_args[0]` (the OkType /
-# InnerType) as the unwrap call's return type.
+# Integration spec for `plugins/rigor-mangrove/`. Slice 1: instantiates the Mangrove Result/Option carrier
+# generic at the unwrap call site, contributing `type_args[0]` (the OkType / InnerType) as the unwrap call's
+# return type.
 #
-# The carriers are declared as applied generics in RBS but their
-# unwrap methods return `untyped` — mirroring a generic-unaware
-# sig source. Without the plugin every unwrap is `untyped` and a
-# typo'd chained call goes unnoticed; with the plugin the unwrap
-# resolves to the carried type and the typo surfaces as
+# The carriers are declared as applied generics in RBS but their unwrap methods return `untyped` — mirroring a
+# generic-unaware sig source. Without the plugin every unwrap is `untyped` and a typo'd chained call goes
+# unnoticed; with the plugin the unwrap resolves to the carried type and the typo surfaces as
 # `call.undefined-method`.
 
 require "spec_helper"
@@ -18,8 +15,7 @@ MANGROVE_PLUGIN_LIB = File.expand_path("../../../plugins/rigor-mangrove/lib", __
 $LOAD_PATH.unshift(MANGROVE_PLUGIN_LIB) unless $LOAD_PATH.include?(MANGROVE_PLUGIN_LIB)
 require "rigor-mangrove"
 
-# Carriers as applied generics; a `Session` producer whose
-# declared return types make the receiver carry `type_args`.
+# Carriers as applied generics; a `Session` producer whose declared return types make the receiver carry `type_args`.
 MANGROVE_RBS = <<~RBS
   module Mangrove
     module Result
@@ -121,10 +117,8 @@ RSpec.describe "plugins/rigor-mangrove" do
 
   describe "conservative floor — never invents precision" do
     it "no-ops on a raw carrier with no type_args (constructor shape)" do
-      # `Result::Ok.new("x")` yields a raw Nominal (the engine
-      # does not infer generics from constructor args), so the
-      # plugin contributes nothing and the typo'd chain stays
-      # `untyped` — no false positive.
+      # `Result::Ok.new("x")` yields a raw Nominal (the engine does not infer generics from constructor args),
+      # so the plugin contributes nothing and the typo'd chain stays `untyped` — no false positive.
       source = <<~RUBY
         def demo
           Mangrove::Result::Ok.new("x").unwrap!.uppercaze
@@ -147,8 +141,8 @@ RSpec.describe "plugins/rigor-mangrove" do
     end
   end
 
-  # ADR-36 nested-class emission — the `variants do … end` Enum DSL
-  # mints a nested subclass per variant with a typed `#inner` reader.
+  # ADR-36 nested-class emission — the `variants do … end` Enum DSL mints a nested subclass per variant with a
+  # typed `#inner` reader.
   describe "Enum variant synthesis (ADR-36)" do
     it "resolves the variant constant + `.new` + a payload-typed `#inner`" do
       source = <<~RUBY

--- a/spec/integration/plugins/minitest_plugin_spec.rb
+++ b/spec/integration/plugins/minitest_plugin_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-minitest/`.
-# Pillar 2 Slice 1 (sibling to rigor-rspec's matcher
-# narrowing) — extends spec-derived flow facts to the
-# Minitest / Test::Unit assertion API plus the Minitest/spec
+# Integration spec for `plugins/rigor-minitest/`. Pillar 2 Slice 1 (sibling to rigor-rspec's matcher narrowing)
+# — extends spec-derived flow facts to the Minitest / Test::Unit assertion API plus the Minitest/spec
 # `_(x).must_*` / `.wont_*` matchers.
 
 require "spec_helper"

--- a/spec/integration/plugins/pundit_plugin_spec.rb
+++ b/spec/integration/plugins/pundit_plugin_spec.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-pundit/`.
-# Tier 3B of the Rails plugins roadmap. Discovers Pundit
-# policy classes by walking `app/policies/` and validates
-# `authorize(record, :action)` / `policy(record)` /
-# `policy_scope(scope)` call sites against the discovered
-# policies.
+# Integration spec for `plugins/rigor-pundit/`. Tier 3B of the Rails plugins roadmap. Discovers Pundit policy
+# classes by walking `app/policies/` and validates `authorize(record, :action)` / `policy(record)` /
+# `policy_scope(scope)` call sites against the discovered policies.
 
 require "spec_helper"
 
@@ -41,9 +38,8 @@ DEFAULT_POLICIES = {
   RUBY
 }.freeze
 
-# Two revisions of the same policy file, used by the
-# cross-process cache-invalidation regression below. The second
-# adds an `archive?` predicate.
+# Two revisions of the same policy file, used by the cross-process cache-invalidation regression below. The
+# second adds an `archive?` predicate.
 POLICY_WITHOUT_ARCHIVE = <<~RUBY
   class ApplicationPolicy; end
   class PostPolicy < ApplicationPolicy
@@ -104,13 +100,10 @@ RSpec.describe "plugins/rigor-pundit" do
     end
 
     it "validates the policy class via the inferred type when the receiver is Nominal[T]" do
-      # `String.new("hi")` returns `Nominal[String]` (RBS
-      # gives us this for free); the plugin should map
-      # that to `StringPolicy`. There's no `StringPolicy`
-      # in the default fixtures, so we expect an
-      # `unknown-policy-class` rather than a successful
-      # `policy-call`. This shows the inferred-type path
-      # *does* fire when the type is statically known.
+      # `String.new("hi")` returns `Nominal[String]` (RBS gives us this for free); the plugin should map that
+      # to `StringPolicy`. There's no `StringPolicy` in the default fixtures, so we expect an
+      # `unknown-policy-class` rather than a successful `policy-call`. This shows the inferred-type path *does*
+      # fire when the type is statically known.
       result = run_plugin(
         source: %(authorize(String.new("hi"), :show)\n),
         files: DEFAULT_POLICIES
@@ -179,8 +172,7 @@ RSpec.describe "plugins/rigor-pundit" do
     end
 
     it "skips action validation when `authorize` has no second argument" do
-      # The implicit form: pundit looks up the action from
-      # the controller. We can still check the policy
+      # The implicit form: pundit looks up the action from the controller. We can still check the policy
       # class exists.
       result = run_plugin(
         source: "authorize(Post)\n",
@@ -230,24 +222,16 @@ RSpec.describe "plugins/rigor-pundit" do
     end
   end
 
-  # Regression: the `:policy_index` producer must pass an
-  # explicit `glob_descriptor(@policy_search_paths, "**/*.rb")`
-  # to `cache_for`. Without it the cache key only reflects files
-  # the `IoBoundary` happened to read in-process — empty at the
-  # producer's first call in a fresh process — so a persistent
-  # `Cache::Store` shared across `rigor check` runs served a
-  # STALE policy index when a policy file changed between
-  # processes (editing a policy returned the same cache key, a
-  # warm hit, and last session's predicates). See
-  # `docs/design/20260601-plugin-mechanism-pre-1.0-review.md`
-  # § 2.1.
+  # Regression: the `:policy_index` producer must pass an explicit `glob_descriptor(@policy_search_paths,
+  # "**/*.rb")` to `cache_for`. Without it the cache key only reflects files the `IoBoundary` happened to read
+  # in-process — empty at the producer's first call in a fresh process — so a persistent `Cache::Store` shared
+  # across `rigor check` runs served a STALE policy index when a policy file changed between processes (editing
+  # a policy returned the same cache key, a warm hit, and last session's predicates). See
+  # `docs/design/20260601-plugin-mechanism-pre-1.0-review.md` § 2.1.
   describe "cross-process cache invalidation" do
-    # Runs the pundit analyzer against `dir` using a FRESH
-    # `Cache::Store` rooted at `cache_root`. A fresh store with
-    # an empty in-process memo is the faithful simulation of a
-    # second `rigor check` process reading the same on-disk
-    # cache — the only configuration in which the missing
-    # descriptor surfaces as stale output.
+    # Runs the pundit analyzer against `dir` using a FRESH `Cache::Store` rooted at `cache_root`. A fresh store
+    # with an empty in-process memo is the faithful simulation of a second `rigor check` process reading the
+    # same on-disk cache — the only configuration in which the missing descriptor surfaces as stale output.
     def run_pundit(dir:, cache_root:, source:)
       Rigor::Plugin.unregister!
       File.write(File.join(dir, "demo.rb"), source)
@@ -282,18 +266,15 @@ RSpec.describe "plugins/rigor-pundit" do
           FileUtils.mkdir_p(File.dirname(policy_path))
           source = "authorize(Post, :archive)\n"
 
-          # Process 1: PostPolicy defines no `archive?`, so the
-          # call flags `unknown-policy-method`. This warms the
-          # on-disk cache.
+          # Process 1: PostPolicy defines no `archive?`, so the call flags `unknown-policy-method`. This warms
+          # the on-disk cache.
           File.write(policy_path, POLICY_WITHOUT_ARCHIVE)
           first = run_pundit(dir: dir, cache_root: cache_root, source: source)
           expect(unknown_policy_method(first)).not_to be_nil
 
-          # Add `archive?` to the policy, then run a fresh process
-          # against the same on-disk cache. With the
-          # `glob_descriptor` fix the changed digest invalidates
-          # the cached index and the call is now recognised;
-          # without it the stale index keeps flagging `archive`.
+          # Add `archive?` to the policy, then run a fresh process against the same on-disk cache. With the
+          # `glob_descriptor` fix the changed digest invalidates the cached index and the call is now
+          # recognised; without it the stale index keeps flagging `archive`.
           File.write(policy_path, POLICY_WITH_ARCHIVE)
           second = run_pundit(dir: dir, cache_root: cache_root, source: source)
           expect(unknown_policy_method(second)).to be_nil

--- a/spec/integration/plugins/rails_i18n_plugin_spec.rb
+++ b/spec/integration/plugins/rails_i18n_plugin_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-rails-i18n/`.
-# Tier 1B of the Rails plugins roadmap. Reads
-# `config/locales/*.yml`, builds a flat `dotted_key`
-# catalogue per locale, and validates every literal-string
+# Integration spec for `plugins/rigor-rails-i18n/`. Tier 1B of the Rails plugins roadmap. Reads
+# `config/locales/*.yml`, builds a flat `dotted_key` catalogue per locale, and validates every literal-string
 # `t(...)` / `I18n.t(...)` call site.
 
 require "spec_helper"
@@ -12,10 +10,8 @@ RAILS_I18N_PLUGIN_LIB = File.expand_path("../../../plugins/rigor-rails-i18n/lib"
 $LOAD_PATH.unshift(RAILS_I18N_PLUGIN_LIB) unless $LOAD_PATH.include?(RAILS_I18N_PLUGIN_LIB)
 require "rigor-rails-i18n"
 
-# `%{name}` is the I18n interpolation placeholder syntax —
-# RuboCop's `Style/FormatStringToken` would prefer
-# `%<name>s`, but here the YAML payload is data the plugin
-# parses, not a Ruby format string.
+# `%{name}` is the I18n interpolation placeholder syntax — RuboCop's `Style/FormatStringToken` would prefer
+# `%<name>s`, but here the YAML payload is data the plugin parses, not a Ruby format string.
 # rubocop:disable Style/FormatStringToken
 DEFAULT_LOCALES = {
   "config/locales/en.yml" => <<~YAML,
@@ -42,13 +38,10 @@ RSpec.describe "plugins/rigor-rails-i18n" do
 
   let(:plugin_class) { Rigor::Plugin::RailsI18n }
 
-  # Opt into the shared per-process `Cache::Store`. The plugin's
-  # `:locale_index` producer now passes an explicit
-  # `glob_descriptor` covering `config/locales/**/*.{yml,yaml}`,
-  # so cache entries invalidate when locale YAML files differ
-  # between examples — letting the malformed-YAML test surface a
-  # fresh load error rather than reading a healthy cache entry
-  # left over from a prior valid-YAML example.
+  # Opt into the shared per-process `Cache::Store`. The plugin's `:locale_index` producer now passes an
+  # explicit `glob_descriptor` covering `config/locales/**/*.{yml,yaml}`, so cache entries invalidate when
+  # locale YAML files differ between examples — letting the malformed-YAML test surface a fresh load error
+  # rather than reading a healthy cache entry left over from a prior valid-YAML example.
   let(:default_run_plugin_cache_store) { :shared }
 
   describe "recognised translation calls" do
@@ -98,10 +91,8 @@ RSpec.describe "plugins/rigor-rails-i18n" do
     end
 
     it "accepts a pluralization namespace whose CLDR subkeys exist" do
-      # Mastodon-derived regression: `t('accounts.posts', count: n)`
-      # resolves through `accounts.posts.{one,other}`. The parent
-      # `accounts.posts` itself has no leaf value, but it IS a
-      # valid pluralization namespace.
+      # Mastodon-derived regression: `t('accounts.posts', count: n)` resolves through `accounts.posts.{one,other}`.
+      # The parent `accounts.posts` itself has no leaf value, but it IS a valid pluralization namespace.
       result = run_plugin(
         source: "t('accounts.posts', count: 3)\n",
         files: {
@@ -281,10 +272,8 @@ RSpec.describe "plugins/rigor-rails-i18n" do
   end
 
   describe "view template lazy key expansion" do
-    # Use per-test cache to avoid cross-test pollution from the
-    # shared cache store (view_diagnostics is a new producer and
-    # the shared cache doesn't know how to invalidate it across
-    # different tmpdir-based tests).
+    # Use per-test cache to avoid cross-test pollution from the shared cache store (view_diagnostics is a new
+    # producer and the shared cache doesn't know how to invalidate it across different tmpdir-based tests).
     let(:default_run_plugin_cache_store) { nil }
 
     # rubocop:disable Style/FormatStringToken

--- a/spec/integration/plugins/rails_meta_spec.rb
+++ b/spec/integration/plugins/rails_meta_spec.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-rails/`. Verifies the
-# Tier 1+2 Rails meta-gem's contract:
+# Integration spec for `plugins/rigor-rails/`. Verifies the Tier 1+2 Rails meta-gem's contract:
 #
-# Requiring `rigor-rails` side-effects a `Rigor::Plugin.register`
-# call for every Tier 1+2 plugin class — so the plugin loader can
-# later look them up by id when `.rigor.yml` enumerates them.
+# Requiring `rigor-rails` side-effects a `Rigor::Plugin.register` call for every Tier 1+2 plugin class — so the
+# plugin loader can later look them up by id when `.rigor.yml` enumerates them.
 #
-# All sub-plugins ship bundled in the `rigortype` gem; no separate
-# $LOAD_PATH manipulation or gemspec loading is needed.
+# All sub-plugins ship bundled in the `rigortype` gem; no separate $LOAD_PATH manipulation or gemspec loading
+# is needed.
 
 require "spec_helper"
 require "rigor-rails"

--- a/spec/integration/plugins/rails_routes_plugin_spec.rb
+++ b/spec/integration/plugins/rails_routes_plugin_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-rails-routes/`.
-# Tier 1A of the Rails plugins roadmap. Statically interprets
-# `config/routes.rb`'s DSL via Prism and validates every
-# `*_path` / `*_url` call site against the resulting helper
-# table.
+# Integration spec for `plugins/rigor-rails-routes/`. Tier 1A of the Rails plugins roadmap. Statically
+# interprets `config/routes.rb`'s DSL via Prism and validates every `*_path` / `*_url` call site against the
+# resulting helper table.
 
 require "spec_helper"
 
@@ -65,9 +63,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "generates `new_admin_widget_path` not `admin_new_widget_path` (prefix before new/edit)" do
-      # Rails convention: new_ / edit_ prefix comes FIRST, then the namespace prefix.
-      # `namespace :admin { resources :widgets }` → `new_admin_widget_path`,
-      # not `admin_new_widget_path`.
+      # Rails convention: new_ / edit_ prefix comes FIRST, then the namespace prefix. `namespace :admin {
+      # resources :widgets }` → `new_admin_widget_path`, not `admin_new_widget_path`.
       result = run_plugin(
         source: "new_admin_widget_path\nedit_admin_widget_path(1)\n",
         files: { "config/routes.rb" => DEFAULT_ROUTES_RB }
@@ -87,8 +84,7 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "recognises an anonymous `get` route by path-derived name (`login_path`)" do
-      # `get "/login", to: "sessions#new"` — no `as:` key; Rails derives
-      # the helper name from the path string.
+      # `get "/login", to: "sessions#new"` — no `as:` key; Rails derives the helper name from the path string.
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
           get "/login", to: "sessions#new"
@@ -179,9 +175,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "emits the load-error warning at most once across many analyzed files" do
-      # Solidus / Mastodon scale: hundreds of files, but `routes.rb`
-      # absence is a single project-global root cause. Pre-fix, the
-      # plugin emitted `load-error` per file (999× on Solidus).
+      # Solidus / Mastodon scale: hundreds of files, but `routes.rb` absence is a single project-global root
+      # cause. Pre-fix, the plugin emitted `load-error` per file (999× on Solidus).
       result = run_plugin(
         source: "users_path\n",
         files: { "extra1.rb" => "stuff\n", "extra2.rb" => "more\n", "extra3.rb" => "again\n" }
@@ -192,16 +187,11 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "handles uncountable-noun resources (`resources :news`, _index_ on index helper)" do
-      # `resources :news` with `singular == plural`: Rails
-      # generates `news_index_path` (collection / index, arity 0)
-      # and `news_path(:id)` (show, arity 1). The `_index_`
-      # suffix on the index helper disambiguates the two — it is
-      # added whenever `singular == plural`, INCLUDING for
-      # uncountable nouns. Redmine's
-      # `app/controllers/news_controller.rb` calls
-      # `news_index_path` and `project_news_index_path(@project)`
-      # for the index form; legitimate `news_path(@news)` calls
-      # the show.
+      # `resources :news` with `singular == plural`: Rails generates `news_index_path` (collection / index,
+      # arity 0) and `news_path(:id)` (show, arity 1). The `_index_` suffix on the index helper disambiguates
+      # the two — it is added whenever `singular == plural`, INCLUDING for uncountable nouns. Redmine's
+      # `app/controllers/news_controller.rb` calls `news_index_path` and `project_news_index_path(@project)`
+      # for the index form; legitimate `news_path(@news)` calls the show.
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
           resources :news, only: [:index, :show, :new, :edit]
@@ -222,8 +212,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
           resources :news, only: [:index, :show]
         end
       RUBY
-      # news_path accepts 0 (index) or 1 (show), plus one trailing options hash.
-      # 3 args exceeds even the most permissive interpretation.
+      # news_path accepts 0 (index) or 1 (show), plus one trailing options hash. 3 args exceeds even the most
+      # permissive interpretation.
       result = run_plugin(
         source: "news_path(1, 2, 3)\n",
         files: { "config/routes.rb" => routes_rb }
@@ -233,12 +223,10 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "registers the `as:` alias on root, both new and hash-rocket forms" do
-      # Redmine uses `root :to => 'welcome#index', :as => 'home'`
-      # at line 26 of config/routes.rb — the hash-rocket form is
-      # the legacy Ruby 1.8 idiom that still works in modern
-      # Rails. Pre-fix the parser registered only `root_path`,
-      # so all 230 call sites to `home_path` / `home_url` across
-      # Redmine surfaced as `unknown-helper`.
+      # Redmine uses `root :to => 'welcome#index', :as => 'home'` at line 26 of config/routes.rb — the
+      # hash-rocket form is the legacy Ruby 1.8 idiom that still works in modern Rails. Pre-fix the parser
+      # registered only `root_path`, so all 230 call sites to `home_path` / `home_url` across Redmine surfaced
+      # as `unknown-helper`.
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
           root :to => 'welcome#index', :as => 'home'
@@ -254,11 +242,9 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "accepts `only:` / `except:` as a single Symbol (not just Array)" do
-      # Mastodon, Solidus and many other Rails apps use the shorthand
-      # `resources :foo, only: :show` (Symbol) interchangeably with
-      # `only: [:show]` (Array). The parser must accept both — pre-fix,
-      # `Symbol#&` raised `NoMethodError` and the entire routes file
-      # failed to parse, bubbling up as a load-error against every
+      # Mastodon, Solidus and many other Rails apps use the shorthand `resources :foo, only: :show` (Symbol)
+      # interchangeably with `only: [:show]` (Array). The parser must accept both — pre-fix, `Symbol#&` raised
+      # `NoMethodError` and the entire routes file failed to parse, bubbling up as a load-error against every
       # analyzed file in the project.
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
@@ -272,8 +258,7 @@ RSpec.describe "plugins/rigor-rails-routes" do
       )
       diags = plugin_diagnostics(result)
       expect(diags.find { |d| d.rule == "load-error" }).to be_nil
-      # Both helpers should be recognised (info-level), proving the
-      # restrict_actions table built cleanly.
+      # Both helpers should be recognised (info-level), proving the restrict_actions table built cleanly.
       helper_names = diags.map(&:message).join("\n")
       expect(helper_names).to include("custom_css_path")
       expect(helper_names).to include("statuses_path")
@@ -291,9 +276,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "accepts user_path(1, 2) as valid (second arg can be options hash)" do
-      # Rails: `user_path(@user, anchor: 'top')` is arity 1 + options.
-      # Since Rigor cannot tell an options hash from a positional arg at
-      # the type level, it allows expected+1 args for every helper.
+      # Rails: `user_path(@user, anchor: 'top')` is arity 1 + options. Since Rigor cannot tell an options hash
+      # from a positional arg at the type level, it allows expected+1 args for every helper.
       result = run_plugin(
         source: "user_path(1, 2)\n",
         files: { "config/routes.rb" => DEFAULT_ROUTES_RB }
@@ -303,8 +287,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "still catches a genuinely wrong arity (expected+2 args)" do
-      # user_path expects 1 segment; user_path(1, 2, 3) has 3 args —
-      # even allowing one trailing options hash, that is still one too many.
+      # user_path expects 1 segment; user_path(1, 2, 3) has 3 args — even allowing one trailing options hash,
+      # that is still one too many.
       result = run_plugin(
         source: "user_path(1, 2, 3)\n",
         files: { "config/routes.rb" => DEFAULT_ROUTES_RB }
@@ -385,10 +369,9 @@ RSpec.describe "plugins/rigor-rails-routes" do
 
   describe "scope routing" do
     it "generates prefixed helpers for `scope as:` blocks" do
-      # `scope "/:event_slug", as: "event" do; resources :talks; end`
-      # is the conference-app kaigionrails pattern. Without the fix
-      # the parser ignored the `as:` prefix and registered `talks_path`
-      # instead of `event_talks_path`, producing unknown-helper FPs.
+      # `scope "/:event_slug", as: "event" do; resources :talks; end` is the conference-app kaigionrails
+      # pattern. Without the fix the parser ignored the `as:` prefix and registered `talks_path` instead of
+      # `event_talks_path`, producing unknown-helper FPs.
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
           scope "/:event_slug", as: "event" do
@@ -405,9 +388,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "does not register un-prefixed helpers for scope-body resources" do
-      # Pre-fix the parser processed the scope block as a plain block,
-      # registering `talks_path` / `talk_path` as if the resources were
-      # top-level — those helpers don't actually exist.
+      # Pre-fix the parser processed the scope block as a plain block, registering `talks_path` / `talk_path`
+      # as if the resources were top-level — those helpers don't actually exist.
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
           scope "/:event_slug", as: "event" do
@@ -490,9 +472,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "skips `get '/'` inside a scope (would produce an empty path-derived name)" do
-      # `get "/"` inside a scope derives as_name "" which, combined with
-      # a scope prefix, would produce a `event__path` double-underscore entry.
-      # The parser now returns early on empty derived names.
+      # `get "/"` inside a scope derives as_name "" which, combined with a scope prefix, would produce a
+      # `event__path` double-underscore entry. The parser now returns early on empty derived names.
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
           scope "/:event_slug", as: "event" do
@@ -507,10 +488,9 @@ RSpec.describe "plugins/rigor-rails-routes" do
   end
 
   describe "only: with non-show actions still registers the path helper" do
-    # Mastodon shape: `resource :inbox, only: [:create]` —
-    # Rails registers POST /inbox under the same `inbox_path`
-    # helper Rails uses for show forms; the plugin must too,
-    # otherwise the caller's `inbox_path` reads as unknown.
+    # Mastodon shape: `resource :inbox, only: [:create]` — Rails registers POST /inbox under the same
+    # `inbox_path` helper Rails uses for show forms; the plugin must too, otherwise the caller's `inbox_path`
+    # reads as unknown.
     it "registers the path helper for a singular resource with `only: [:create]`" do
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
@@ -523,9 +503,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "registers the show-shape path helper for plural resources with `except: [:show]`" do
-      # Mastodon `resources :roles, except: [:show]` — Rails
-      # generates PATCH / PUT / DELETE under `admin_role_path(id)`
-      # even though :show is excluded.
+      # Mastodon `resources :roles, except: [:show]` — Rails generates PATCH / PUT / DELETE under
+      # `admin_role_path(id)` even though :show is excluded.
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
           namespace :admin do
@@ -551,10 +530,9 @@ RSpec.describe "plugins/rigor-rails-routes" do
   end
 
   describe "singular resource with plural-looking name keeps the as-given name" do
-    # Mastodon shape: `resource :relationships, only: [:show, :update]`
-    # — singular DSL with a plural-looking name. Rails generates
-    # `relationships_path` (no singularising); the parser used
-    # to mangle this to `relationship_path`.
+    # Mastodon shape: `resource :relationships, only: [:show, :update]` — singular DSL with a plural-looking
+    # name. Rails generates `relationships_path` (no singularising); the parser used to mangle this to
+    # `relationship_path`.
     it "does not singularise a singular-resource's helper" do
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
@@ -567,8 +545,7 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "still derives the singular form from a plural-resources declaration" do
-      # Make sure the Bug B fix does not break the normal
-      # `resources :foos` → `foo_path(id)` derivation.
+      # Make sure the Bug B fix does not break the normal `resources :foos` → `foo_path(id)` derivation.
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
           resources :widgets
@@ -610,9 +587,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "finds a `private _url` method declared in a controller" do
-      # Mastodon's exact shape:
-      # `app/controllers/follower_accounts_controller.rb` has
-      # `private; def page_url(page) ... end`.
+      # Mastodon's exact shape: `app/controllers/follower_accounts_controller.rb` has `private; def
+      # page_url(page) ... end`.
       result = run_plugin(
         source: "page_url(1)\n",
         files: {
@@ -671,8 +647,7 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "still flags a misspelt helper that is neither in routes nor in app/helpers/" do
-      # Name MUST end in `_path` / `_url` to reach the rule
-      # at all — pick a name not present in either source.
+      # Name MUST end in `_path` / `_url` to reach the rule at all — pick a name not present in either source.
       result = run_plugin(
         source: "definitely_not_real_url('foo.png')\n",
         files: {
@@ -686,12 +661,9 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "includes `_path` / `_url` methods marked private (visibility-agnostic by design)" do
-      # Visibility-agnostic discovery: a `private def
-      # internal_path(arg)` IS registered so a paired view or
-      # cross-controller call site does not false-fire
-      # `unknown-helper`. The core engine's
-      # `call.undefined-method` rule still catches the case
-      # where the call's receiver genuinely cannot see the
+      # Visibility-agnostic discovery: a `private def internal_path(arg)` IS registered so a paired view or
+      # cross-controller call site does not false-fire `unknown-helper`. The core engine's
+      # `call.undefined-method` rule still catches the case where the call's receiver genuinely cannot see the
       # method.
       result = run_plugin(
         source: "internal_path('x')\n",
@@ -820,8 +792,7 @@ RSpec.describe "plugins/rigor-rails-routes" do
   end
 
   describe "with_options applies defaults to inner resources" do
-    # Mastodon's `with_options only: [:index], concerns:
-    # :batch do resources :links; resources :tags; ... end`
+    # Mastodon's `with_options only: [:index], concerns: :batch do resources :links; resources :tags; ... end`
     # — inner declarations inherit `only:` + `concerns:`.
 
     it "applies `only:` to a bare `resources :foo` inside the block" do
@@ -842,10 +813,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "applies `concerns:` defaults so concern bodies replay for inner resources" do
-      # The Mastodon shape: `concern :batch do collection {
-      # post :batch }; end` + `with_options only: [:index],
-      # concerns: :batch do resources :links; ... end` →
-      # `batch_links_path` registers.
+      # The Mastodon shape: `concern :batch do collection { post :batch }; end` + `with_options only: [:index],
+      # concerns: :batch do resources :links; ... end` → `batch_links_path` registers.
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
           namespace :admin do
@@ -917,10 +886,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
 
   describe "resources `as:` overrides the helper name root" do
     it "uses :as for the show helper when `only: [:show]`" do
-      # `resources :collections, only: [:show], as:
-      # :actor_collections` — Rails' show helper becomes
-      # `actor_collection_path(id)` (the URL stays
-      # `/collections/:id`).
+      # `resources :collections, only: [:show], as: :actor_collections` — Rails' show helper becomes
+      # `actor_collection_path(id)` (the URL stays `/collections/:id`).
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
           resources :collections, only: [:show], as: :actor_collections
@@ -965,10 +932,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "silently skips a `mount` without `as:`" do
-      # `mount LetterOpenerWeb::Engine, at: 'letter_opener'`
-      # — no `as:`, so we don't fabricate a helper name.
-      # Include `resources :users` so the helper table isn't
-      # empty (the plugin silences all diagnostics on an
+      # `mount LetterOpenerWeb::Engine, at: 'letter_opener'` — no `as:`, so we don't fabricate a helper name.
+      # Include `resources :users` so the helper table isn't empty (the plugin silences all diagnostics on an
       # empty table to avoid noise on routes-less files).
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
@@ -1032,8 +997,7 @@ RSpec.describe "plugins/rigor-rails-routes" do
 
   describe "irregular singulars (Latin / Greek plurals)" do
     it "singularises `media` to `medium` for `resources :media`" do
-      # Mastodon's `resources :media, only: [:show]` →
-      # `medium_path(id)` (arity 1). Pre-fix `media` was in
+      # Mastodon's `resources :media, only: [:show]` → `medium_path(id)` (arity 1). Pre-fix `media` was in
       # UNCOUNTABLE and the helper resolved as `media_path`.
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
@@ -1050,13 +1014,10 @@ RSpec.describe "plugins/rigor-rails-routes" do
   end
 
   describe "concern-injected route bodies" do
-    # Mastodon shape: `concern :account_resources do ...
-    # end` then `resources :accounts, concerns:
-    # :account_resources do ... end` injects the concern body
-    # inside the accounts resource block. Pre-fix the parser
-    # silently skipped concern bodies (per v0.1.11's
-    # `:concern` no-op) — so every helper defined ONLY inside
-    # a concern surfaced as `unknown-helper` at the call site.
+    # Mastodon shape: `concern :account_resources do ... end` then `resources :accounts, concerns:
+    # :account_resources do ... end` injects the concern body inside the accounts resource block. Pre-fix the
+    # parser silently skipped concern bodies (per v0.1.11's `:concern` no-op) — so every helper defined ONLY
+    # inside a concern surfaced as `unknown-helper` at the call site.
 
     it "replays a single concern's body inside `concerns: :name`" do
       routes_rb = <<~RUBY
@@ -1098,9 +1059,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "replays the concern body with the resource's arity context" do
-      # `resources :accounts do concern body { resource :inbox } end`
-      # → `account_inbox_path(account_id)` arity 1 (the
-      # concern's resource picks up the outer `:account_id`).
+      # `resources :accounts do concern body { resource :inbox } end` → `account_inbox_path(account_id)`
+      # arity 1 (the concern's resource picks up the outer `:account_id`).
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
           concern :inbox_target do
@@ -1119,8 +1079,7 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "still fires unknown-helper for a misspelt concern reference (precision floor)" do
-      # Concern not declared → bodies aren't replayed →
-      # call to a helper that would have come from a missing
+      # Concern not declared → bodies aren't replayed → call to a helper that would have come from a missing
       # concern still surfaces as unknown-helper.
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
@@ -1137,10 +1096,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
   end
 
   describe "singular `resource` adds the name to helper prefix for nested declarations" do
-    # Mastodon shape: `resource :instance, only: [:show] do
-    # scope module: :instances do resources :domain_blocks
-    # only: [:index]; end; end` — generates
-    # `api_v1_instance_domain_blocks_path` (NOT
+    # Mastodon shape: `resource :instance, only: [:show] do scope module: :instances do resources
+    # :domain_blocks only: [:index]; end; end` — generates `api_v1_instance_domain_blocks_path` (NOT
     # `api_v1_domain_blocks_path`).
 
     it "prefixes nested resources helpers with the singular resource's name" do
@@ -1182,10 +1139,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "does NOT contribute a `:id` arity segment for the singular parent" do
-      # `resource :instance do resources :domain_blocks end`
-      # → index helper takes 0 args (instance has no :id,
-      # domain_blocks index has no :id either). Precision
-      # floor against accidentally adding 1 to arity.
+      # `resource :instance do resources :domain_blocks end` → index helper takes 0 args (instance has no :id,
+      # domain_blocks index has no :id either). Precision floor against accidentally adding 1 to arity.
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
           resource :instance, only: [:show] do
@@ -1203,10 +1158,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
   end
 
   describe "same-singular-plural names get the `_index_` suffix" do
-    # Rails appends `_index_` to the index helper when the
-    # singular form equals the plural form AND the name is not
-    # in the canonical UNCOUNTABLE list. The disambiguation
-    # exists because show/index would otherwise collide.
+    # Rails appends `_index_` to the index helper when the singular form equals the plural form AND the name
+    # is not in the canonical UNCOUNTABLE list. The disambiguation exists because show/index would otherwise collide.
 
     it "registers `<name>_index_path` for `resources :reblogged_by`" do
       routes_rb = <<~RUBY
@@ -1239,8 +1192,7 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "keeps UNCOUNTABLE-noun index under the bare name (no `_index_` suffix)" do
-      # `resources :news` → `news_path` for both index AND
-      # show (Rails-compatible). Precision floor against
+      # `resources :news` → `news_path` for both index AND show (Rails-compatible). Precision floor against
       # over-eager `_index_` suffixing.
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
@@ -1257,13 +1209,10 @@ RSpec.describe "plugins/rigor-rails-routes" do
   end
 
   describe "member/collection block shorthand routes" do
-    # Mastodon shape: `resources :accounts do; member { post
-    # :memorialize }; end` inside a namespace. Rails generates
-    # `memorialize_admin_account_path(id)` (member) and
-    # `memorialize_admin_accounts_path` (collection). Pre-fix
-    # the parser silently skipped these because
-    # `handle_explicit_route` rejected the symbol-only call
-    # shape (`post :memorialize` with no path arg).
+    # Mastodon shape: `resources :accounts do; member { post :memorialize }; end` inside a namespace. Rails
+    # generates `memorialize_admin_account_path(id)` (member) and `memorialize_admin_accounts_path`
+    # (collection). Pre-fix the parser silently skipped these because `handle_explicit_route` rejected the
+    # symbol-only call shape (`post :memorialize` with no path arg).
 
     it "registers a member action helper inside `resources do member { post :action } end`" do
       routes_rb = <<~RUBY
@@ -1326,8 +1275,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "applies the correct arity to member actions (parent resource segments only)" do
-      # `resources :users do; resources :accounts do; member { post :memorialize }; end; end`
-      # → `memorialize_user_account_path(user_id, id)` arity 2.
+      # `resources :users do; resources :accounts do; member { post :memorialize }; end; end` →
+      # `memorialize_user_account_path(user_id, id)` arity 2.
       routes_rb = <<~RUBY
         Rails.application.routes.draw do
           resources :users do
@@ -1349,13 +1298,10 @@ RSpec.describe "plugins/rigor-rails-routes" do
   end
 
   describe "shadowing locals suppress diagnostics" do
-    # When a file declares a local that shadows a route helper
-    # name (`let(:foo_url)`, `def foo_path`, `foo_url = ...`),
-    # the analyzer MUST treat the call as the local, not the
-    # registered helper. Mastodon's `spec/` has 200+ such
-    # patterns that pre-fix surfaced as bogus `unknown-helper`
-    # / `wrong-arity` against route helpers that happen to
-    # share the name.
+    # When a file declares a local that shadows a route helper name (`let(:foo_url)`, `def foo_path`, `foo_url
+    # = ...`), the analyzer MUST treat the call as the local, not the registered helper. Mastodon's `spec/` has
+    # 200+ such patterns that pre-fix surfaced as bogus `unknown-helper` / `wrong-arity` against route helpers
+    # that happen to share the name.
 
     it "skips unknown-helper for a `let(:foo_url)`-shadowed call" do
       result = run_plugin(
@@ -1372,8 +1318,7 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "skips wrong-arity for a `let(:helper_path)` that shadows a known route helper" do
-      # `resources :users` registers `user_path(id)` with
-      # arity 1; a `let(:user_path) { ... }` followed by
+      # `resources :users` registers `user_path(id)` with arity 1; a `let(:user_path) { ... }` followed by
       # `user_path` (no args) used to fire `wrong-arity`.
       result = run_plugin(
         source: <<~RUBY,
@@ -1420,8 +1365,7 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "still fires unknown-helper for a non-shadowed unknown name" do
-      # Precision floor — make sure the shadow check doesn't
-      # silently swallow real typos.
+      # Precision floor — make sure the shadow check doesn't silently swallow real typos.
       result = run_plugin(
         source: "definitely_not_a_real_path\n",
         files: { "config/routes.rb" => DEFAULT_ROUTES_RB }
@@ -1432,11 +1376,9 @@ RSpec.describe "plugins/rigor-rails-routes" do
   end
 
   describe "arity check accepts kwargs-only call shapes" do
-    # Mastodon shape: a multi-segment route called via
-    # keyword args carrying every segment name —
-    # `short_account_status_url(account_username: u, id: i)`
-    # for `/@:account_username/:id`. Rails accepts this form;
-    # our strict positional-arity check used to false-fire.
+    # Mastodon shape: a multi-segment route called via keyword args carrying every segment name —
+    # `short_account_status_url(account_username: u, id: i)` for `/@:account_username/:id`. Rails accepts this
+    # form; our strict positional-arity check used to false-fire.
 
     let(:routes_with_kwargs_helper) do
       <<~RUBY
@@ -1465,8 +1407,7 @@ RSpec.describe "plugins/rigor-rails-routes" do
     end
 
     it "still fires wrong-arity when actual positional exceeds expected even with kwargs" do
-      # Precision floor: 3 positionals (over expected 2) plus
-      # trailing kwargs is still wrong.
+      # Precision floor: 3 positionals (over expected 2) plus trailing kwargs is still wrong.
       result = run_plugin(
         source: "short_account_status_url('a', 'b', 'c', id: 1)\n",
         files: { "config/routes.rb" => routes_with_kwargs_helper }
@@ -1478,9 +1419,8 @@ RSpec.describe "plugins/rigor-rails-routes" do
 
   describe "ADR-9 cross-plugin fact publication" do
     it "publishes the `:helper_table` fact during prepare" do
-      # FactStore is constructed once per Services / per run;
-      # capture it as the runner builds Services so we can
-      # read the fact back after `prepare` has fired.
+      # FactStore is constructed once per Services / per run; capture it as the runner builds Services so we
+      # can read the fact back after `prepare` has fired.
       captured_store = nil
       allow(Rigor::Plugin::Services).to receive(:new).and_wrap_original do |original, **kwargs|
         services = original.call(**kwargs)

--- a/spec/integration/plugins/rbs_inline_plugin_spec.rb
+++ b/spec/integration/plugins/rbs_inline_plugin_spec.rb
@@ -2,14 +2,10 @@
 
 # Integration spec for `plugins/rigor-rbs-inline/`.
 #
-# ADR-32 — the plugin calls the upstream `rbs-inline` library
-# to synthesise RBS from Ruby source files carrying
-# rbs-inline-shaped comments and contributes the result to the
-# RBS environment via the `source_rbs_synthesizer:` manifest
-# hook. This spec proves the end-to-end path: with the plugin
-# active, a `# @rbs name: T`-shaped parameter annotation
-# enforces the contract just like a hand-written `.rbs`
-# signature would.
+# ADR-32 — the plugin calls the upstream `rbs-inline` library to synthesise RBS from Ruby source files carrying
+# rbs-inline-shaped comments and contributes the result to the RBS environment via the
+# `source_rbs_synthesizer:` manifest hook. This spec proves the end-to-end path: with the plugin active, a
+# `# @rbs name: T`-shaped parameter annotation enforces the contract just like a hand-written `.rbs` signature would.
 
 require "spec_helper"
 
@@ -119,12 +115,10 @@ RSpec.describe "plugins/rigor-rbs-inline" do
       RUBY
       result = run_plugin(source: source)
       info_diagnostics = result.diagnostics.select { |d| d.qualified_rule == "source-rbs-synthesis-failed" }
-      # NOTE: rbs-inline is generally permissive and may not raise on
-      # every garbage input. The contract this test asserts is: IF
-      # the synthesizer hits an error, THE engine surfaces it as an
-      # info diagnostic (and analysis continues). If rbs-inline
-      # accepts our garbage silently, this is a no-op assertion path
-      # and the test reverts to verifying no crash + no rule violation.
+      # NOTE: rbs-inline is generally permissive and may not raise on every garbage input. The contract this
+      # test asserts is: IF the synthesizer hits an error, THE engine surfaces it as an info diagnostic (and
+      # analysis continues). If rbs-inline accepts our garbage silently, this is a no-op assertion path and the
+      # test reverts to verifying no crash + no rule violation.
       expect(info_diagnostics.all? { |d| d.severity == :info }).to be(true)
       # In either branch, analysis must complete cleanly.
       expect(result.diagnostics).to all(have_attributes(severity: be_a(Symbol)))
@@ -153,8 +147,8 @@ RSpec.describe "plugins/rigor-rbs-inline" do
 
         AscDesc.new.ascdesc(:bad)
       RUBY
-      # Re-use the same `project_dir` across both runs so the
-      # cache key (which includes the source file path) is stable.
+      # Re-use the same `project_dir` across both runs so the cache key (which includes the source file path)
+      # is stable.
       Rigor::Plugin.unregister!
       run_plugin_in_dir(dir: project_dir, source: source, cache_store: cache_store)
       writes_before = cache_store.stats.fetch(:writes)

--- a/spec/integration/plugins/rspec_plugin_spec.rb
+++ b/spec/integration/plugins/rspec_plugin_spec.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-rspec/`.
-# Tier 3A of the Rails plugins roadmap. Deliberately
-# scoped — only flags duplicate `let` / `subject`
-# declarations and self-referencing let blocks. The
-# heavier mock-target / let-typo detection is out of scope
-# for v0.1.0.
+# Integration spec for `plugins/rigor-rspec/`. Tier 3A of the Rails plugins roadmap. Deliberately scoped — only
+# flags duplicate `let` / `subject` declarations and self-referencing let blocks. The heavier mock-target /
+# let-typo detection is out of scope for v0.1.0.
 
 require "spec_helper"
 
@@ -133,13 +130,10 @@ RSpec.describe "plugins/rigor-rspec" do
     end
   end
 
-  # Pillar 2 Slice 1 — `expect(x).to MATCHER` narrows `x`
-  # downstream in the same `it` body. The plugin's
-  # `narrowing_facts` (method-gated on `to` / `not_to` / `to_not`,
-  # ADR-37 slice 2) recognises the call shape and emits a
-  # `post_return_fact` targeting local `x`; the engine's
-  # `apply_plugin_assertions` → `:local` target_kind branch
-  # narrows the local in the surrounding scope.
+  # Pillar 2 Slice 1 — `expect(x).to MATCHER` narrows `x` downstream in the same `it` body. The plugin's
+  # `narrowing_facts` (method-gated on `to` / `not_to` / `to_not`, ADR-37 slice 2) recognises the call shape
+  # and emits a `post_return_fact` targeting local `x`; the engine's `apply_plugin_assertions` → `:local`
+  # target_kind branch narrows the local in the surrounding scope.
   describe "matcher narrowing (Pillar 2 Slice 1)" do
     def parse_call_node(source)
       Prism.parse(source, scopes: [[:x]]).value.statements.body.first
@@ -279,15 +273,14 @@ RSpec.describe "plugins/rigor-rspec" do
 
     context "with non-matching call shapes" do
       it "is silent for expect(non_local).to MATCHER" do
-        # expect(foo.bar) — the arg isn't a LocalVariableReadNode,
-        # so the analyzer cannot name a narrowing target.
+        # expect(foo.bar) — the arg isn't a LocalVariableReadNode, so the analyzer cannot name a narrowing target.
         call_node = parse_call_node("expect(foo.bar).to be_a(String)")
         expect(plugin.type_specifier_facts(call_node: call_node, scope: nil)).to be_empty
       end
 
       it "is silent for expect { block }.to raise_error(...)" do
-        # Block form doesn't match the call shape; future slices
-        # might add support, but for now the analyzer drops out.
+        # Block form doesn't match the call shape; future slices might add support, but for now the analyzer
+        # drops out.
         call_node = parse_call_node("expect { foo }.to raise_error(StandardError)")
         expect(plugin.type_specifier_facts(call_node: call_node, scope: nil)).to be_empty
       end
@@ -303,10 +296,8 @@ RSpec.describe "plugins/rigor-rspec" do
       end
     end
 
-    # End-to-end: the plugin's contribution flows through the
-    # engine's `apply_plugin_assertions` → `:local` branch and
-    # narrows the local so a downstream `.upcase` / `.+` /
-    # etc. resolves cleanly.
+    # End-to-end: the plugin's contribution flows through the engine's `apply_plugin_assertions` → `:local`
+    # branch and narrows the local so a downstream `.upcase` / `.+` / etc. resolves cleanly.
     context "when running end-to-end through the engine" do
       it "removes the possible-nil-receiver after expect(x).to be_a(String)" do
         result = run_plugin(
@@ -338,12 +329,9 @@ RSpec.describe "plugins/rigor-rspec" do
     end
   end
 
-  # Pillar 2 Slice 2 — let / subject locals in `it` bodies
-  # are bound to their inferred return type. Tests exercise
-  # the LetScopeIndex + LetTypeResolver directly with a stub
-  # factory_index where applicable; the end-to-end run goes
-  # through `dynamic_return` to prove the engine
-  # actually narrows the local.
+  # Pillar 2 Slice 2 — let / subject locals in `it` bodies are bound to their inferred return type. Tests
+  # exercise the LetScopeIndex + LetTypeResolver directly with a stub factory_index where applicable; the
+  # end-to-end run goes through `dynamic_return` to prove the engine actually narrows the local.
   describe "let / subject binding (Pillar 2 Slice 2)" do
     describe "LetScopeIndex" do
       def build_index(source)
@@ -370,8 +358,7 @@ RSpec.describe "plugins/rigor-rspec" do
             end
           end
         RUBY
-        # Two records: outer (User, lets [:user]) and inner
-        # (anchor inherits User, lets [:filter]).
+        # Two records: outer (User, lets [:user]) and inner (anchor inherits User, lets [:filter]).
         expect(index.records.size).to eq(2)
         const_anchors = index.records.map(&:describe_const)
         expect(const_anchors).to eq(%w[User User])
@@ -390,8 +377,7 @@ RSpec.describe "plugins/rigor-rspec" do
           end
         RUBY
         index = build_index(source)
-        # The `name` read inside the inner `it` block is line
-        # 6; the inner-record's `:name` let wins.
+        # The `name` read inside the inner `it` block is line 6; the inner-record's `:name` let wins.
         block = index.let_block_at(6, :name)
         expect(block).not_to be_nil
         expect(block.body.body.first.unescaped).to eq("inner")
@@ -517,10 +503,8 @@ RSpec.describe "plugins/rigor-rspec" do
             end
           RUBY
         )
-        # No undefined-method diagnostics — `user` resolved
-        # through the let binding rather than as an unknown
-        # method call. The engine's matcher narrowing (Slice
-        # 1) plus the let binding (Slice 2) compose cleanly.
+        # No undefined-method diagnostics — `user` resolved through the let binding rather than as an unknown
+        # method call. The engine's matcher narrowing (Slice 1) plus the let binding (Slice 2) compose cleanly.
         undefined = result.diagnostics.select { |d| d.rule == "call.undefined-method" }
         expect(undefined).to be_empty
       end
@@ -545,8 +529,7 @@ RSpec.describe "plugins/rigor-rspec" do
     end
 
     it "handles `subject` with no name (the implicit subject)" do
-      # Two `subject { ... }` calls at the same scope are
-      # still duplicates of the implicit `:subject`.
+      # Two `subject { ... }` calls at the same scope are still duplicates of the implicit `:subject`.
       result = run_plugin(
         source: <<~RUBY
           RSpec.describe "X" do

--- a/spec/integration/plugins/rspec_rails_http_status_codes_spec.rb
+++ b/spec/integration/plugins/rspec_rails_http_status_codes_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-# ADR-39 — `have_http_status` symbol validation reads the REAL
-# `Rack::Utils::SYMBOL_TO_STATUS_CODE` (the repo bundle carries `rack` as
-# a development dependency), never a vendored snapshot that could go
-# stale. When Rack is unavailable the accepted set is unknowable, so the
-# check declines rather than emitting a false `unknown-symbol`.
+# ADR-39 — `have_http_status` symbol validation reads the REAL `Rack::Utils::SYMBOL_TO_STATUS_CODE` (the repo
+# bundle carries `rack` as a development dependency), never a vendored snapshot that could go stale. When Rack
+# is unavailable the accepted set is unknowable, so the check declines rather than emitting a false `unknown-symbol`.
 
 require "spec_helper"
 

--- a/spec/integration/plugins/rspec_rails_plugin_spec.rb
+++ b/spec/integration/plugins/rspec_rails_plugin_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-rspec-rails/`.
-# v0.1.0 covers `have_http_status(int_or_symbol)` validation
-# only — the larger behavioral matcher surface (render_template
-# / route_to / redirect_to / have_enqueued_job / have_received)
-# is deferred per the README's "Deferred matchers" section.
+# Integration spec for `plugins/rigor-rspec-rails/`. v0.1.0 covers `have_http_status(int_or_symbol)` validation
+# only — the larger behavioral matcher surface (render_template / route_to / redirect_to / have_enqueued_job /
+# have_received) is deferred per the README's "Deferred matchers" section.
 
 require "spec_helper"
 
@@ -96,8 +94,7 @@ RSpec.describe "plugins/rigor-rspec-rails" do
     end
 
     it "is silent for the new :unprocessable_content alias (Rails 7.2+)" do
-      # Newer Rails uses `:unprocessable_content` as a synonym
-      # of `:unprocessable_entity` (422); recognise both.
+      # Newer Rails uses `:unprocessable_content` as a synonym of `:unprocessable_entity` (422); recognise both.
       diags = diagnostics_for("expect(response).to have_http_status(:unprocessable_content)\n")
       expect(diags).to be_empty
     end
@@ -135,8 +132,7 @@ RSpec.describe "plugins/rigor-rspec-rails" do
     end
 
     it "is silent for a String arg (Rails accepts string literals too)" do
-      # The plugin intentionally skips the String form rather
-      # than parse / validate the numeric content.
+      # The plugin intentionally skips the String form rather than parse / validate the numeric content.
       diags = diagnostics_for("expect(response).to have_http_status(\"200\")\n")
       have_diags = diags.select { |d| d.rule.start_with?("have_http_status") }
       expect(have_diags).to be_empty
@@ -145,11 +141,9 @@ RSpec.describe "plugins/rigor-rspec-rails" do
 
   describe "matcher invocation context" do
     it "fires on the bare `have_http_status(arg)` matcher form" do
-      # Some specs call `should have_http_status(404)` or use
-      # the matcher inside a custom matcher composition. The
-      # diagnostic should still fire because the matcher
-      # itself is recognised regardless of the surrounding
-      # chain.
+      # Some specs call `should have_http_status(404)` or use the matcher inside a custom matcher composition.
+      # The diagnostic should still fire because the matcher itself is recognised regardless of the
+      # surrounding chain.
       diags = diagnostics_for("should have_http_status(700)\n")
       err = diags.find { |d| d.rule == "have_http_status.out-of-range" }
       expect(err).not_to be_nil

--- a/spec/integration/plugins/shoulda_matchers_plugin_spec.rb
+++ b/spec/integration/plugins/shoulda_matchers_plugin_spec.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-shoulda-matchers/`.
-# Validates shoulda matchers against the :model_index
+# Integration spec for `plugins/rigor-shoulda-matchers/`. Validates shoulda matchers against the :model_index
 # cross-plugin fact (ADR-9) published by rigor-activerecord.
 #
-# Tests exercise the Analyzer module directly with a stub
-# model_index — the full integration through
-# rigor-activerecord's producer is covered by the
-# activerecord plugin spec; here we pin the matcher
-# recogniser shape independently so a future rigor-activerecord
-# refactor can't accidentally break the matcher contract.
+# Tests exercise the Analyzer module directly with a stub model_index — the full integration through
+# rigor-activerecord's producer is covered by the activerecord plugin spec; here we pin the matcher recogniser
+# shape independently so a future rigor-activerecord refactor can't accidentally break the matcher contract.
 
 require "spec_helper"
 
@@ -23,10 +19,8 @@ RSpec.describe "plugins/rigor-shoulda-matchers" do
 
   let(:plugin_class) { Rigor::Plugin::ShouldaMatchers }
 
-  # Minimal stub model_index. Mirrors the surface
-  # rigor-activerecord's ModelIndex exposes (`find` returning
-  # an Entry that responds to `column?` / `association?` /
-  # `association` / `column_names` / `association_names`).
+  # Minimal stub model_index. Mirrors the surface rigor-activerecord's ModelIndex exposes (`find` returning an
+  # Entry that responds to `column?` / `association?` / `association` / `column_names` / `association_names`).
   let(:user_entry) do
     Class.new do
       def initialize(columns:, associations:)
@@ -57,11 +51,10 @@ RSpec.describe "plugins/rigor-shoulda-matchers" do
     end.new(entries)
   end
 
-  # Drives the plugin's per-node path (ADR-37): the engine walks with
-  # ancestors and the Analyzer's per-node `violations_for` validates each
-  # matcher against the (innermost enclosing) describe-model anchor. This
-  # mirrors exactly what `node_rule` + `Base#diagnostic` do, returning
-  # real `Diagnostic` rows so the assertions below are unchanged.
+  # Drives the plugin's per-node path (ADR-37): the engine walks with ancestors and the Analyzer's per-node
+  # `violations_for` validates each matcher against the (innermost enclosing) describe-model anchor. This
+  # mirrors exactly what `node_rule` + `Base#diagnostic` do, returning real `Diagnostic` rows so the assertions
+  # below are unchanged.
   def diagnose(source, index: model_index)
     root = Prism.parse(source).value
     diagnostics = []
@@ -159,8 +152,7 @@ RSpec.describe "plugins/rigor-shoulda-matchers" do
     end
 
     it "fires association-kind-mismatch for belong_to on a :collection" do
-      # `posts` is a :collection association; `belong_to`
-      # expects :singular.
+      # `posts` is a :collection association; `belong_to` expects :singular.
       diags = diagnose(<<~RUBY)
         RSpec.describe User do
           it { should belong_to(:posts) }
@@ -205,8 +197,7 @@ RSpec.describe "plugins/rigor-shoulda-matchers" do
 
   describe "describe anchor resolution" do
     it "inherits the outer model anchor through a nested describe" do
-      # `describe ".active"` doesn't change the anchor; the
-      # column lookup still targets User.
+      # `describe ".active"` doesn't change the anchor; the column lookup still targets User.
       diags = diagnose(<<~RUBY)
         RSpec.describe User do
           describe ".active" do
@@ -220,10 +211,8 @@ RSpec.describe "plugins/rigor-shoulda-matchers" do
     end
 
     it "uses the nested model anchor when one is supplied" do
-      # Synthetic case: nested `describe Comment` inside
-      # `describe User`. Inside Comment's body, the anchor is
-      # Comment. We don't have Comment in the stub index, so
-      # nothing fires.
+      # Synthetic case: nested `describe Comment` inside `describe User`. Inside Comment's body, the anchor is
+      # Comment. We don't have Comment in the stub index, so nothing fires.
       diags = diagnose(<<~RUBY)
         RSpec.describe User do
           describe Comment do

--- a/spec/integration/plugins/sidekiq_plugin_spec.rb
+++ b/spec/integration/plugins/sidekiq_plugin_spec.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-sidekiq/`.
-# Tier 3C of the Rails plugins roadmap. Discovers Sidekiq
-# workers by walking `app/workers/` and validates
-# `Worker.perform_async(...)` / `.perform_in(...)` /
-# `.perform_at(...)` / `.perform_inline(...)` argument
-# count against each class's `#perform`.
+# Integration spec for `plugins/rigor-sidekiq/`. Tier 3C of the Rails plugins roadmap. Discovers Sidekiq
+# workers by walking `app/workers/` and validates `Worker.perform_async(...)` / `.perform_in(...)` /
+# `.perform_at(...)` / `.perform_inline(...)` argument count against each class's `#perform`.
 
 require "spec_helper"
 
@@ -80,8 +77,7 @@ RSpec.describe "plugins/rigor-sidekiq" do
 
   describe "scheduled entry points" do
     it "treats the first argument of `perform_in` as the schedule" do
-      # `perform_in(60, user_id)` — `60` is the schedule,
-      # `user_id` is the only forwarded arg → matches
+      # `perform_in(60, user_id)` — `60` is the schedule, `user_id` is the only forwarded arg → matches
       # `WelcomeEmailWorker#perform`'s 1..2 envelope.
       result = run_plugin(
         source: "WelcomeEmailWorker.perform_in(60, 1)\n",
@@ -94,8 +90,7 @@ RSpec.describe "plugins/rigor-sidekiq" do
     end
 
     it "flags wrong arity AFTER consuming the schedule arg" do
-      # `perform_in(60)` — `60` is the schedule, 0 args
-      # forwarded → fewer than `WelcomeEmailWorker#perform`'s
+      # `perform_in(60)` — `60` is the schedule, 0 args forwarded → fewer than `WelcomeEmailWorker#perform`'s
       # required min (1).
       result = run_plugin(
         source: "WelcomeEmailWorker.perform_in(60)\n",

--- a/spec/integration/plugins/sinatra_plugin_spec.rb
+++ b/spec/integration/plugins/sinatra_plugin_spec.rb
@@ -1,20 +1,15 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-sinatra/`. ADR-16 slice 1c.
-# Exercises the substrate's Tier A path end-to-end:
+# Integration spec for `plugins/rigor-sinatra/`. ADR-16 slice 1c. Exercises the substrate's Tier A path end-to-end:
 #
 # 1. Load the example plugin via `rigor-sinatra`'s entry point.
-# 2. Run rigor against a Sinatra-flavoured fixture with a minimal
-#    Sinatra::Base RBS stub.
-# 3. Assert that bare identifiers inside the route block
-#    (`params`, `redirect`, `halt`) resolve through Sinatra::Base's
-#    RBS — i.e. the substrate has narrowed the block's self_type.
+# 2. Run rigor against a Sinatra-flavoured fixture with a minimal Sinatra::Base RBS stub.
+# 3. Assert that bare identifiers inside the route block (`params`, `redirect`, `halt`) resolve through
+#    Sinatra::Base's RBS — i.e. the substrate has narrowed the block's self_type.
 #
-# The integration spec at `spec/integration/macro_block_self_type_integration_spec.rb`
-# already proves the engine hook against an *in-spec* fake plugin;
-# this spec confirms the same path works through the *real example
-# plugin gem entry point* and that the manifest declaration is
-# wired correctly.
+# The integration spec at `spec/integration/macro_block_self_type_integration_spec.rb` already proves the
+# engine hook against an *in-spec* fake plugin; this spec confirms the same path works through the *real
+# example plugin gem entry point* and that the manifest declaration is wired correctly.
 
 require "spec_helper"
 

--- a/spec/integration/plugins/sorbet_plugin_spec.rb
+++ b/spec/integration/plugins/sorbet_plugin_spec.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-sorbet/`. Slice 1 of
-# ADR-11: ingests Sorbet `sig { ... }` blocks and contributes
-# the parsed return type at every call site.
+# Integration spec for `plugins/rigor-sorbet/`. Slice 1 of ADR-11: ingests Sorbet `sig { ... }` blocks and
+# contributes the parsed return type at every call site.
 
 require "spec_helper"
 
@@ -10,10 +9,9 @@ SORBET_PLUGIN_LIB = File.expand_path("../../../plugins/rigor-sorbet/lib", __dir_
 $LOAD_PATH.unshift(SORBET_PLUGIN_LIB) unless $LOAD_PATH.include?(SORBET_PLUGIN_LIB)
 require "rigor-sorbet"
 
-# Stub stamp every demo source uses — `sorbet-runtime` is not
-# loaded in the test environment, so the spec defines `sig` /
-# `T::Sig` as no-ops at runtime. The plugin only reads the
-# syntactic shape; the runtime gem is independent.
+# Stub stamp every demo source uses — `sorbet-runtime` is not loaded in the test environment, so the spec
+# defines `sig` / `T::Sig` as no-ops at runtime. The plugin only reads the syntactic shape; the runtime gem is
+# independent.
 SIG_STUB = <<~RUBY
   module T
     module Sig
@@ -28,15 +26,11 @@ RSpec.describe "plugins/rigor-sorbet" do
 
   let(:plugin_class) { Rigor::Plugin::Sorbet }
 
-  # Opt into the shared per-process `Cache::Store`. This file
-  # has 48 `run_plugin` examples and the warm-cache savings
-  # dominate the cache I/O overhead: spec wall time drops
-  # 13.1 s → 3.9 s isolated (≈3× faster). Other plugin specs
-  # with fewer examples (typically 4–11) see net-neutral or
-  # net-negative parallel-mode behaviour from the shared cache
-  # because the cache I/O overhead exceeds the per-call env
-  # build savings; the shared-cache default in `plugin_helpers`
-  # stays opt-in for that reason.
+  # Opt into the shared per-process `Cache::Store`. This file has 48 `run_plugin` examples and the warm-cache
+  # savings dominate the cache I/O overhead: spec wall time drops 13.1 s → 3.9 s isolated (≈3× faster). Other
+  # plugin specs with fewer examples (typically 4–11) see net-neutral or net-negative parallel-mode behaviour
+  # from the shared cache because the cache I/O overhead exceeds the per-call env build savings; the
+  # shared-cache default in `plugin_helpers` stays opt-in for that reason.
   let(:default_run_plugin_cache_store) { :shared }
 
   describe "method signature contributions (slice 1)" do
@@ -142,11 +136,9 @@ RSpec.describe "plugins/rigor-sorbet" do
     end
   end
 
-  # A `sig { returns(T) }` above an `attr_reader` / `attr_writer` /
-  # `attr_accessor` types the generated accessor — a first-class
-  # Sorbet idiom (dependabot-core uses it pervasively). It must NOT
-  # warn as a dangling sig, and SHOULD contribute the accessor's
-  # type at call sites.
+  # A `sig { returns(T) }` above an `attr_reader` / `attr_writer` / `attr_accessor` types the generated
+  # accessor — a first-class Sorbet idiom (dependabot-core uses it pervasively). It must NOT warn as a dangling
+  # sig, and SHOULD contribute the accessor's type at call sites.
   describe "attribute-accessor sigs" do
     it "does not warn when a sig precedes an attr_reader" do
       source = <<~RUBY
@@ -214,11 +206,9 @@ RSpec.describe "plugins/rigor-sorbet" do
     end
   end
 
-  # A `sig { ... }` above a visibility-wrapped def — `private def foo`,
-  # `private_class_method def self.bar`, `module_function def baz` — is a
-  # common Ruby/Sorbet idiom (dependabot-core uses `private_class_method def
-  # self.x`). It must NOT warn as a dangling sig, and SHOULD type the wrapped
-  # method.
+  # A `sig { ... }` above a visibility-wrapped def — `private def foo`, `private_class_method def self.bar`,
+  # `module_function def baz` — is a common Ruby/Sorbet idiom (dependabot-core uses `private_class_method def
+  # self.x`). It must NOT warn as a dangling sig, and SHOULD type the wrapped method.
   describe "visibility-wrapped def sigs" do
     %w[private public protected private_class_method public_class_method module_function].each do |macro|
       it "does not warn for `#{macro} def`" do
@@ -290,15 +280,12 @@ RSpec.describe "plugins/rigor-sorbet" do
       expect(result.diagnostics.select { |d| d.rule == "call.undefined-method" }).to be_empty
     end
 
-    # An enforced `sig { returns(T.untyped) }` is the author's explicit
-    # opt-out of return typing. The plugin's `dynamic_return` tier sits
-    # ahead of the engine's body-inference tiers in `MethodDispatcher`,
-    # so the contributed `Dynamic[top]` wins even when the body would
-    # fold to a precise value (`def thing; 1; end` → `Constant[1]`) —
-    # per the false-positive discipline, the opt-out outranks the
-    # foldable body's precision. The sigil gate still applies: in a
-    # sigil-less / `# typed: false` file Sorbet itself ignores the sig,
-    # so the engine's fold stands there (see the contrast example).
+    # An enforced `sig { returns(T.untyped) }` is the author's explicit opt-out of return typing. The plugin's
+    # `dynamic_return` tier sits ahead of the engine's body-inference tiers in `MethodDispatcher`, so the
+    # contributed `Dynamic[top]` wins even when the body would fold to a precise value (`def thing; 1; end` →
+    # `Constant[1]`) — per the false-positive discipline, the opt-out outranks the foldable body's precision.
+    # The sigil gate still applies: in a sigil-less / `# typed: false` file Sorbet itself ignores the sig, so
+    # the engine's fold stands there (see the contrast example).
     describe "`T.untyped` opt-out over a foldable body" do
       it "suppresses engine body-folding for an instance method (explicit receiver)" do
         source = <<~RUBY
@@ -443,14 +430,10 @@ RSpec.describe "plugins/rigor-sorbet" do
       expect(result.diagnostics.select { |d| d.rule == "call.undefined-method" }).to be_empty
     end
 
-    # The fix that unblocks rigor-mangrove on the real
-    # Sorbet-sig chain: a non-`T::`-namespaced generic
-    # application in sig position now maps to
-    # `Nominal[name, type_args]` instead of degrading to
-    # `untyped`, so the receiver's generic arguments survive to
-    # the call site. Verified directly against the translator —
-    # the end-to-end chain (sig → translation → rigor-mangrove
-    # unwrap) is exercised by the survey fixture in
+    # The fix that unblocks rigor-mangrove on the real Sorbet-sig chain: a non-`T::`-namespaced generic
+    # application in sig position now maps to `Nominal[name, type_args]` instead of degrading to `untyped`, so
+    # the receiver's generic arguments survive to the call site. Verified directly against the translator — the
+    # end-to-end chain (sig → translation → rigor-mangrove unwrap) is exercised by the survey fixture in
     # `docs/notes/20260530-mangrove-library-survey.md`.
     describe "user-defined generic application (non-`T::`)" do
       def translate_sig_type(expr)
@@ -557,9 +540,8 @@ RSpec.describe "plugins/rigor-sorbet" do
   end
 
   describe "mixin chain resolution (ADR-11 slice 8)" do
-    # Tapioca's standard DSL RBI shape. Slice 8 lifts sigs
-    # declared on a `Generated*` module up to the host class
-    # via the recorded `include` / `extend` chain.
+    # Tapioca's standard DSL RBI shape. Slice 8 lifts sigs declared on a `Generated*` module up to the host
+    # class via the recorded `include` / `extend` chain.
 
     let(:tapioca_include_rbi) do
       <<~RBI
@@ -615,8 +597,7 @@ RSpec.describe "plugins/rigor-sorbet" do
         },
         paths: ["demo.rb", "app/models/post.rb"]
       )
-      # Plugin contributed `String` for `post.body`, so the
-      # chained `.upcase` resolves through String's RBS.
+      # Plugin contributed `String` for `post.body`, so the chained `.upcase` resolves through String's RBS.
       expect(result.diagnostics.select { |d| d.rule == "call.undefined-method" }).to be_empty
     end
 
@@ -629,8 +610,7 @@ RSpec.describe "plugins/rigor-sorbet" do
         },
         paths: ["demo.rb", "app/models/post.rb"]
       )
-      # `extend M` lifts M's instance methods to singleton
-      # methods on the extending class. `Post.find` resolves
+      # `extend M` lifts M's instance methods to singleton methods on the extending class. `Post.find` resolves
       # via `GeneratedClassMethods#find`, returning `String`.
       expect(result.diagnostics.select { |d| d.rule == "call.undefined-method" }).to be_empty
     end
@@ -656,10 +636,8 @@ RSpec.describe "plugins/rigor-sorbet" do
         },
         paths: ["demo.rb", "app/models/post.rb"]
       )
-      # `bogus` isn't in any chained module — the plugin
-      # contributes nothing and no spurious sig lands on the
-      # method. (`call.undefined-method` is silenced
-      # separately by Post being a non-RBS-known class.)
+      # `bogus` isn't in any chained module — the plugin contributes nothing and no spurious sig lands on the
+      # method. (`call.undefined-method` is silenced separately by Post being a non-RBS-known class.)
       expect(plugin_diagnostics(result)).to be_empty
     end
   end
@@ -681,8 +659,7 @@ RSpec.describe "plugins/rigor-sorbet" do
     end
 
     let(:mixed_rbi) do
-      # Adjacent malformed (no terminus) + well-formed sigs.
-      # Slice 4 contract: malformed silently degrades; the
+      # Adjacent malformed (no terminus) + well-formed sigs. Slice 4 contract: malformed silently degrades; the
       # well-formed sig in the same file is still recorded.
       <<~RBI
         # typed: true
@@ -716,8 +693,7 @@ RSpec.describe "plugins/rigor-sorbet" do
     end
 
     it "respects an empty `rbi_paths` to opt out of RBI loading entirely" do
-      # With rbi_paths: [] the plugin doesn't walk the RBI;
-      # the RBI's sig is therefore never recorded. We only
+      # With rbi_paths: [] the plugin doesn't walk the RBI; the RBI's sig is therefore never recorded. We only
       # assert that the opt-out doesn't crash the plugin.
       result = run_plugin(
         source: "#{SIG_STUB}Gem::Connection.open\n",
@@ -730,12 +706,10 @@ RSpec.describe "plugins/rigor-sorbet" do
 
   describe "sigil honoring (ADR-11 slice 5)" do
     it "skips a file marked `# typed: ignore` during catalog harvest" do
-      # The RBI declares Slug.default_length, but the file is
-      # `# typed: ignore` so rigor-sorbet must not record the
-      # sig. Without the contribution, the chained `.even?`
-      # call on the receiver wouldn't carry an Integer type;
-      # we assert the silent-degradation outcome (no plugin
-      # diagnostic about the missing contribution, no crash).
+      # The RBI declares Slug.default_length, but the file is `# typed: ignore` so rigor-sorbet must not record
+      # the sig. Without the contribution, the chained `.even?` call on the receiver wouldn't carry an Integer
+      # type; we assert the silent-degradation outcome (no plugin diagnostic about the missing contribution,
+      # no crash).
       ignored_rbi = <<~RBI
         # typed: ignore
         class Slug
@@ -753,12 +727,9 @@ RSpec.describe "plugins/rigor-sorbet" do
     end
 
     it "skips `# typed: false` sigs when enforce_sigil is on (default)" do
-      # Sorbet itself doesn't enforce types at `# typed: false`
-      # — sigs are parsed but not used to surface errors. Rigor
-      # mirrors that under the default `enforce_sigil: true`:
-      # the file's catalog entry is not recorded, so the
-      # chained `.bit_length` call falls back to RBS / nominal
-      # dispatch as if the sig wasn't there.
+      # Sorbet itself doesn't enforce types at `# typed: false` — sigs are parsed but not used to surface
+      # errors. Rigor mirrors that under the default `enforce_sigil: true`: the file's catalog entry is not
+      # recorded, so the chained `.bit_length` call falls back to RBS / nominal dispatch as if the sig wasn't there.
       typed_false_rbi = <<~RBI
         # typed: false
         class Greeter
@@ -768,10 +739,8 @@ RSpec.describe "plugins/rigor-sorbet" do
         end
       RBI
 
-      # Without the sig contribution, `Greeter.count.bit_length`
-      # has no inferred Integer return at the chained call —
-      # we ASSERT no plugin recognised the sig (the
-      # diagnostic-trace check stays empty), not that the
+      # Without the sig contribution, `Greeter.count.bit_length` has no inferred Integer return at the chained
+      # call — we ASSERT no plugin recognised the sig (the diagnostic-trace check stays empty), not that the
       # downstream call resolves.
       result = run_plugin(
         source: "#{SIG_STUB}Greeter.count\n",
@@ -823,9 +792,8 @@ RSpec.describe "plugins/rigor-sorbet" do
         end
       RBI
 
-      # Override default `enforce_sigil: true` via the plugin
-      # entry's config block. Now the `# typed: false` file's
-      # sig DOES contribute, so the chained `.even?` resolves.
+      # Override default `enforce_sigil: true` via the plugin entry's config block. Now the `# typed: false`
+      # file's sig DOES contribute, so the chained `.even?` resolves.
       result = run_plugin(
         source: "#{SIG_STUB}Lenient.value.even?\n",
         files: { "sorbet/rbi/shims/lenient.rbi" => typed_false_rbi },
@@ -836,17 +804,13 @@ RSpec.describe "plugins/rigor-sorbet" do
   end
 
   describe "per-call-site assertion gating (ADR-11 deferred follow-up)" do
-    # Sorbet itself only enforces type errors at `# typed: true`
-    # and above. The harvest-time `enforce_sigil` gate already
-    # mirrors that for cataloged sigs; this gate extends the
-    # same discipline to caller-side assertion recognisers
-    # (`T.let` / `T.cast` / `T.must` / `T.bind` /
-    # `T.assert_type!` / `T.reveal_type` / `T.unsafe`).
+    # Sorbet itself only enforces type errors at `# typed: true` and above. The harvest-time `enforce_sigil`
+    # gate already mirrors that for cataloged sigs; this gate extends the same discipline to caller-side
+    # assertion recognisers (`T.let` / `T.cast` / `T.must` / `T.bind` / `T.assert_type!` / `T.reveal_type` /
+    # `T.unsafe`).
     #
-    # Behaviour observability: the suppressed `T.reveal_type`
-    # never records a `record_reveal_type_call`, so
-    # `diagnostics_for_file` emits no `reveal-type` :info
-    # diagnostic. We use that as the smoke signal: the
+    # Behaviour observability: the suppressed `T.reveal_type` never records a `record_reveal_type_call`, so
+    # `diagnostics_for_file` emits no `reveal-type` :info diagnostic. We use that as the smoke signal: the
     # diagnostic IS / IS-NOT present.
 
     it "fires assertion recognisers at `# typed: true` files (default enforce_sigil)" do
@@ -901,17 +865,13 @@ RSpec.describe "plugins/rigor-sorbet" do
   end
 
   describe "T.absurd exhaustiveness (ADR-11 slice 6)" do
-    # Slice 6 relies on Rigor's existing flow-sensitive
-    # narrowing to decide whether the discriminant has been
-    # narrowed to `bot` at the absurd call. `is_a?` narrowing
-    # is precise; `case`/`when` over symbols isn't (as of
-    # v0.1.3 — covered by an open-question in ADR-11). Tests
-    # use the precise pattern so they exercise the plugin's
-    # logic, not the engine's narrowing strength.
+    # Slice 6 relies on Rigor's existing flow-sensitive narrowing to decide whether the discriminant has been
+    # narrowed to `bot` at the absurd call. `is_a?` narrowing is precise; `case`/`when` over symbols isn't (as
+    # of v0.1.3 — covered by an open-question in ADR-11). Tests use the precise pattern so they exercise the
+    # plugin's logic, not the engine's narrowing strength.
 
     it "stays silent when the discriminant narrows to bot via `is_a?`" do
-      # `Constant<1>` minus `Integer` collapses to `bot`, so
-      # the else branch is unreachable and `T.absurd` is
+      # `Constant<1>` minus `Integer` collapses to `bot`, so the else branch is unreachable and `T.absurd` is
       # correct.
       source = <<~RUBY
         #{SIG_STUB}
@@ -927,8 +887,7 @@ RSpec.describe "plugins/rigor-sorbet" do
     end
 
     it "emits `absurd-reachable` when the discriminant remains reachable" do
-      # `Integer` minus `String` is `Integer`, not `bot`, so
-      # the else branch IS reachable — `T.absurd` is wrong.
+      # `Integer` minus `String` is `Integer`, not `bot`, so the else branch IS reachable — `T.absurd` is wrong.
       source = <<~RUBY
         #{SIG_STUB}
         val = T.let(1, Integer)
@@ -944,10 +903,8 @@ RSpec.describe "plugins/rigor-sorbet" do
     end
 
     it "stays silent when the engine determines the entire else branch is dead before typing" do
-      # `nil.nil?` is statically `true`, so the engine prunes
-      # the else branch entirely — the dynamic_return hook is
-      # never called for the `T.absurd` and our recorded set
-      # stays empty.
+      # `nil.nil?` is statically `true`, so the engine prunes the else branch entirely — the dynamic_return
+      # hook is never called for the `T.absurd` and our recorded set stays empty.
       source = <<~RUBY
         #{SIG_STUB}
         val = nil
@@ -1028,10 +985,9 @@ RSpec.describe "plugins/rigor-sorbet" do
     end
 
     it "leaves a non-Sorbet `T.let`-shaped call alone (different receiver)" do
-      # If the user's project defines its own `T` constant that
-      # is NOT Sorbet's, the plugin should not interfere. The
-      # recognizer keys on receiver name `T`; a renamed
-      # constant doesn't match and the call falls through.
+      # If the user's project defines its own `T` constant that is NOT Sorbet's, the plugin should not
+      # interfere. The recognizer keys on receiver name `T`; a renamed constant doesn't match and the call
+      # falls through.
       source = <<~RUBY
         #{SIG_STUB}
         module NotSorbet
@@ -1077,10 +1033,8 @@ RSpec.describe "plugins/rigor-sorbet" do
     end
 
     it "emits a `plugin.sorbet.reveal-type` :info diagnostic naming the inferred type" do
-      # Per-call-site assertion gating (ADR-11 deferred
-      # follow-up): the `T.reveal_type` recogniser only fires
-      # at files Sorbet itself would enforce. The sigil is
-      # required so the gate stays open.
+      # Per-call-site assertion gating (ADR-11 deferred follow-up): the `T.reveal_type` recogniser only fires
+      # at files Sorbet itself would enforce. The sigil is required so the gate stays open.
       source = <<~RUBY
         # typed: true
         #{SIG_STUB}
@@ -1113,8 +1067,7 @@ RSpec.describe "plugins/rigor-sorbet" do
     end
 
     it "emits `plugin.sorbet.assert-type-mismatch` when the inferred type is provably incompatible" do
-      # Per-call-site assertion gating (ADR-11 deferred
-      # follow-up): the `T.assert_type!` mismatch check only
+      # Per-call-site assertion gating (ADR-11 deferred follow-up): the `T.assert_type!` mismatch check only
       # fires at files Sorbet itself would enforce.
       source = <<~RUBY
         # typed: true
@@ -1162,11 +1115,9 @@ RSpec.describe "plugins/rigor-sorbet" do
 
   describe "T.bind (T.bind / T.assert_type! priority slice 3)" do
     it "narrows self in a block via post_return_facts(target_kind: :self)" do
-      # Without T.bind, an implicit-self call to `upcase` at top
-      # level would emit `call.undefined-method` (default self
-      # is Object). After `T.bind(self, String)`, the engine
-      # narrows self to String, and `upcase` resolves on the
-      # narrowed self via the standard String method dispatch.
+      # Without T.bind, an implicit-self call to `upcase` at top level would emit `call.undefined-method`
+      # (default self is Object). After `T.bind(self, String)`, the engine narrows self to String, and
+      # `upcase` resolves on the narrowed self via the standard String method dispatch.
       source = <<~RUBY
         #{SIG_STUB}
         T.bind(self, String)

--- a/spec/integration/plugins/statesman_plugin_spec.rb
+++ b/spec/integration/plugins/statesman_plugin_spec.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-statesman/`. Reference
-# coverage for the two-pass DSL analysis pattern (collect
-# declarations, then validate references).
+# Integration spec for `plugins/rigor-statesman/`. Reference coverage for the two-pass DSL analysis pattern
+# (collect declarations, then validate references).
 
 require "spec_helper"
 

--- a/spec/integration/plugins/typescript_utility_types_plugin_spec.rb
+++ b/spec/integration/plugins/typescript_utility_types_plugin_spec.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-# Integration spec for `plugins/rigor-typescript-utility-types/`.
-# Covers ADR-13's intended end-to-end flow: an RBS::Extended
-# payload using TypeScript-canonical spellings (`Pick`, `Omit`,
-# `Partial`, `Required`, `Readonly`) reaches the parser, the
-# plugin chain resolves it through the recursive Resolver, and
-# the result is the same Type carrier the canonical core
-# spellings (`pick_of`, etc.) would produce.
+# Integration spec for `plugins/rigor-typescript-utility-types/`. Covers ADR-13's intended end-to-end flow: an
+# RBS::Extended payload using TypeScript-canonical spellings (`Pick`, `Omit`, `Partial`, `Required`,
+# `Readonly`) reaches the parser, the plugin chain resolves it through the recursive Resolver, and the result
+# is the same Type carrier the canonical core spellings (`pick_of`, etc.) would produce.
 
 require "spec_helper"
 
@@ -29,18 +26,14 @@ RSpec.describe "plugins/rigor-typescript-utility-types" do
 
   describe "Pick<T, K>" do
     it "fires the Pick resolver and returns the lossy-degraded result for Nominal inputs" do
-      # `Address` resolves to Nominal[Address] (no shape
-      # evidence); `NameKey` resolves to Nominal[NameKey] (not
-      # a Constant<Symbol|String> or Union of such), so pick_of
-      # degrades to "input unchanged" per ADR-13 phase A. The
-      # observable difference from "chain declined → Nominal
-      # fallback" is the ABSENCE of `Pick` in the result.
+      # `Address` resolves to Nominal[Address] (no shape evidence); `NameKey` resolves to Nominal[NameKey] (not
+      # a Constant<Symbol|String> or Union of such), so pick_of degrades to "input unchanged" per ADR-13 phase
+      # A. The observable difference from "chain declined → Nominal fallback" is the ABSENCE of `Pick` in the result.
       expect(parse("Pick[Address, NameKey]")).to eq(Rigor::Type::Combinator.nominal_of("Address"))
     end
 
     it "falls back to Nominal[Pick, …] when the resolver declines on arity mismatch" do
-      # 1-arg / 3-arg Pick: plugin returns nil → parser's RBS
-      # fallback builds Nominal[Pick, …].
+      # 1-arg / 3-arg Pick: plugin returns nil → parser's RBS fallback builds Nominal[Pick, …].
       expected_one = Rigor::Type::Combinator.nominal_of("Pick", type_args: [Rigor::Type::Combinator.nominal_of("Address")])
       expect(parse("Pick[Address]")).to eq(expected_one)
     end
@@ -94,10 +87,8 @@ RSpec.describe "plugins/rigor-typescript-utility-types" do
 
   describe "recursive resolution via scope.resolver.resolve" do
     it "Pick<Address, non-empty-string> resolves the K arg through the built-in registry" do
-      # Pick<X, K> where K is a refinement name — the K arg
-      # resolves through built-in registry, not through the
-      # chain. The plugin returns pick_of(Nominal[Address],
-      # non-empty-string refinement carrier).
+      # Pick<X, K> where K is a refinement name — the K arg resolves through built-in registry, not through the
+      # chain. The plugin returns pick_of(Nominal[Address], non-empty-string refinement carrier).
       result = parse("Pick[Address, non-empty-string]")
       expected = Rigor::Type::Combinator.pick_of(
         Rigor::Type::Combinator.nominal_of("Address"),
@@ -108,15 +99,11 @@ RSpec.describe "plugins/rigor-typescript-utility-types" do
   end
 
   describe "resolver-level semantics (synthetic AST + scope)" do
-    # The RBS::Extended payload grammar doesn't yet accept Symbol /
-    # String literal tokens (`:name` / `"name"`), so end-to-end
-    # parsing of Pick<HashShape, :a | :b> isn't reachable through
-    # `ImportedRefinements.parse` yet. To prove the plugin's
-    # resolvers produce the right pick_of / partial_of / etc. on
-    # actual shape inputs, we invoke the resolver directly with a
-    # synthetic AST and a `NameScope` whose `resolver:` is a
-    # hand-rolled stub that knows how to map specific identifiers
-    # to the shape carriers under test.
+    # The RBS::Extended payload grammar doesn't yet accept Symbol / String literal tokens (`:name` / `"name"`),
+    # so end-to-end parsing of Pick<HashShape, :a | :b> isn't reachable through `ImportedRefinements.parse`
+    # yet. To prove the plugin's resolvers produce the right pick_of / partial_of / etc. on actual shape
+    # inputs, we invoke the resolver directly with a synthetic AST and a `NameScope` whose `resolver:` is a
+    # hand-rolled stub that knows how to map specific identifiers to the shape carriers under test.
 
     let(:string_t)  { Rigor::Type::Combinator.nominal_of("String") }
     let(:integer_t) { Rigor::Type::Combinator.nominal_of("Integer") }
@@ -185,10 +172,8 @@ RSpec.describe "plugins/rigor-typescript-utility-types" do
                                     "Address" => hash_shape,
                                     "KeysProxy" => Rigor::Type::Combinator.nominal_of("KeysProxy")
                                   ))
-      # K isn't a Constant<Symbol> / Union[Constant<Symbol>, …],
-      # so pick_of degrades to "input unchanged" — but the plugin
-      # DID fire (the result is the HashShape, not a Nominal[Pick, …]
-      # fallback).
+      # K isn't a Constant<Symbol> / Union[Constant<Symbol>, …], so pick_of degrades to "input unchanged" — but
+      # the plugin DID fire (the result is the HashShape, not a Nominal[Pick, …] fallback).
       expect(result).to eq(hash_shape)
     end
   end

--- a/spec/integration/precision_snapshot_spec.rb
+++ b/spec/integration/precision_snapshot_spec.rb
@@ -4,20 +4,17 @@
 #
 # For every fixture under `spec/integration/fixtures/` this spec:
 #   1. Runs the engine end-to-end via `FixtureHarness`.
-#   2. Captures the type string (`Type#describe(:short)`) of every top-level
-#      local variable in the evaluated scope.
+#   2. Captures the type string (`Type#describe(:short)`) of every top-level local variable in the evaluated scope.
 #   3. Compares the result to a YAML golden file under `spec/integration/snapshots/`.
 #
-# A failed example means a type CHANGED — either it became more precise
-# (good — update the snapshot) or it degraded (bad — investigate and fix).
-# In both cases the developer consciously reviews the diff before accepting.
+# A failed example means a type CHANGED — either it became more precise (good — update the snapshot) or it
+# degraded (bad — investigate and fix). In both cases the developer consciously reviews the diff before accepting.
 #
 # Regenerating golden files:
 #
 #   UPDATE_SNAPSHOTS=1 bundle exec rspec spec/integration/precision_snapshot_spec.rb
 #
-# The spec never deletes stale snapshot files automatically; remove them by hand
-# when a fixture is deleted.
+# The spec never deletes stale snapshot files automatically; remove them by hand when a fixture is deleted.
 
 require "spec_helper"
 require "yaml"
@@ -29,8 +26,7 @@ FIXTURE_DIR   = File.expand_path("fixtures",  __dir__)
 
 UPDATE_SNAPSHOTS = ENV.fetch("UPDATE_SNAPSHOTS", "0") == "1"
 
-# Enumerate fixture names: flat .rb files → name without extension,
-# directory fixtures → directory name.
+# Enumerate fixture names: flat .rb files → name without extension, directory fixtures → directory name.
 SNAPSHOT_FIXTURE_NAMES = (
   Dir.children(FIXTURE_DIR).sort.filter_map do |entry|
     path = File.join(FIXTURE_DIR, entry)
@@ -78,8 +74,7 @@ RSpec.describe "Precision snapshots (inference regression gate)" do
 
           golden = YAML.load_file(snap_path)
 
-          # Build a human-readable diff before failing so the engineer
-          # immediately sees which locals changed and how.
+          # Build a human-readable diff before failing so the engineer immediately sees which locals changed and how.
           changed = []
           (golden["locals"] || {}).each do |var, expected_type|
             actual_type = actual.dig("locals", var)

--- a/spec/integration/support/fixture_harness.rb
+++ b/spec/integration/support/fixture_harness.rb
@@ -4,26 +4,19 @@ require "prism"
 
 module Rigor
   module IntegrationSupport
-    # Loads a fixture under `spec/integration/fixtures/` and runs
-    # the engine end-to-end against it. Each fixture is a
-    # self-contained Ruby snippet — readable on its own, runnable
-    # under MRI, and independently inspectable through the
-    # `rigor type-of` CLI.
+    # Loads a fixture under `spec/integration/fixtures/` and runs the engine end-to-end against it. Each
+    # fixture is a self-contained Ruby snippet — readable on its own, runnable under MRI, and independently
+    # inspectable through the `rigor type-of` CLI.
     #
     # Two layouts are supported:
     #
-    # - **Flat fixture**: `fixtures/<name>.rb`. Parsed and
-    #   evaluated under `Rigor::Scope.empty`. No project sig is
-    #   loaded, so only `Environment.default` (RBS-core +
-    #   bundled stdlib) is visible.
-    # - **Project fixture**: `fixtures/<name>/` directory
-    #   containing `<entry>.rb` (default: `demo.rb`) and a sibling
-    #   `sig/` directory. The harness `chdir`s into the directory
-    #   and uses `Environment.for_project` so the project sig is
-    #   merged with the bundled stdlib.
+    # - **Flat fixture**: `fixtures/<name>.rb`. Parsed and evaluated under `Rigor::Scope.empty`. No project sig
+    #   is loaded, so only `Environment.default` (RBS-core + bundled stdlib) is visible.
+    # - **Project fixture**: `fixtures/<name>/` directory containing `<entry>.rb` (default: `demo.rb`) and a
+    #   sibling `sig/` directory. The harness `chdir`s into the directory and uses `Environment.for_project` so
+    #   the project sig is merged with the bundled stdlib.
     #
-    # Each `evaluate` / `type_at` returns plain Rigor values so
-    # the surrounding RSpec `expect` calls stay declarative.
+    # Each `evaluate` / `type_at` returns plain Rigor values so the surrounding RSpec `expect` calls stay declarative.
     class FixtureHarness
       FIXTURES_ROOT = File.expand_path("../fixtures", __dir__)
 
@@ -35,34 +28,28 @@ module Rigor
         load_fixture
       end
 
-      # Evaluates the fixture top to bottom under the harness
-      # scope and returns the post-scope so callers can inspect
-      # `local(:foo)` / `ivar(:@bar)` bindings.
+      # Evaluates the fixture top to bottom under the harness scope and returns the post-scope so callers can
+      # inspect `local(:foo)` / `ivar(:@bar)` bindings.
       def post_scope
         @post_scope ||= scope.evaluate(tree).last
       end
 
-      # Resolves the type at a 1-indexed `(line, column)` pair
-      # by routing through the per-node scope index. The position
-      # MAY land on any node Prism produces; callers usually
-      # target a `LocalVariableReadNode` or write target.
+      # Resolves the type at a 1-indexed `(line, column)` pair by routing through the per-node scope index. The
+      # position MAY land on any node Prism produces; callers usually target a `LocalVariableReadNode` or
+      # write target.
       def type_at(line:, column:)
         node = locator.at_position(line: line, column: column)
         index[node].type_of(node)
       end
 
-      # Convenience: returns the type bound to a top-level local
-      # in the fully-evaluated post-scope.
+      # Convenience: returns the type bound to a top-level local in the fully-evaluated post-scope.
       def local(name)
         post_scope.local(name)
       end
 
-      # Runs the full `Rigor::Analysis::CheckRules` catalogue
-      # against the fixture and returns the resulting
-      # diagnostics. Used by the self-asserting fixtures
-      # (e.g. `assertions.rb`) — `harness.diagnostics` should
-      # be empty when the fixture's `assert_type(...)` calls
-      # all match the engine's inference.
+      # Runs the full `Rigor::Analysis::CheckRules` catalogue against the fixture and returns the resulting
+      # diagnostics. Used by the self-asserting fixtures (e.g. `assertions.rb`) — `harness.diagnostics` should
+      # be empty when the fixture's `assert_type(...)` calls all match the engine's inference.
       def diagnostics
         @diagnostics ||= Rigor::Analysis::CheckRules.diagnose(
           path: name,
@@ -105,8 +92,7 @@ module Rigor
       def load_project(dir)
         entry_path = File.join(dir, @entry)
         @source = File.read(entry_path)
-        # `for_project` auto-detects `<dir>/sig` so the fixture's
-        # sig files are merged with the bundled stdlib.
+        # `for_project` auto-detects `<dir>/sig` so the fixture's sig files are merged with the bundled stdlib.
         env = Rigor::Environment.for_project(root: dir)
         @scope = Rigor::Scope.empty(environment: env)
       end

--- a/spec/integration/support/plugin_helpers.rb
+++ b/spec/integration/support/plugin_helpers.rb
@@ -5,13 +5,10 @@ require "tmpdir"
 
 module Rigor
   module IntegrationSupport
-    # Shared helpers for the plugin integration specs under
-    # `spec/integration/plugins/` (production plugins) and
-    # `spec/integration/examples/` (walkthrough samples).
-    # Auto-included for files that
-    # match the path pattern (see RSpec.configure block at the
-    # bottom of this file). Specs explicitly `include` this
-    # module if they live elsewhere.
+    # Shared helpers for the plugin integration specs under `spec/integration/plugins/` (production plugins)
+    # and `spec/integration/examples/` (walkthrough samples). Auto-included for files that match the path
+    # pattern (see RSpec.configure block at the bottom of this file). Specs explicitly `include` this module if
+    # they live elsewhere.
     #
     # ## Required `let` bindings
     #
@@ -19,58 +16,38 @@ module Rigor
     #
     #     let(:plugin_class) { Rigor::Plugin::SomePluginClass }
     #
-    # The helpers read `plugin_class` via RSpec's `let` /
-    # method-resolution surface, so subsequent calls do NOT
-    # repeat the class on each invocation. Plugin id is derived
-    # from `plugin_class.manifest.id`.
+    # The helpers read `plugin_class` via RSpec's `let` / method-resolution surface, so subsequent calls do NOT
+    # repeat the class on each invocation. Plugin id is derived from `plugin_class.manifest.id`.
     #
     # ## What each helper does
     #
-    # - `run_plugin(source:, ...)` — materialises a tmpdir
-    #   containing `demo.rb` (and optionally extra `files:`),
-    #   builds a `Rigor::Configuration` listing the plugin,
-    #   runs `Rigor::Analysis::Runner` against it, and returns
-    #   the `Rigor::Analysis::Result`. Auto-`unregister!`s the
-    #   plugin registry before each invocation so the loader's
-    #   newly-registered diff sees a fresh state.
-    # - `plugin_diagnostics(result)` — filters a result down to
-    #   diagnostics whose `source_family` matches the plugin's
-    #   manifest id (`"plugin.<id>"`).
-    # - `build_plugin_requirer` — returns the `requirer` lambda
-    #   the plugin loader expects. Specs that drive
-    #   `Analysis::Runner` themselves (e.g. routes' multi-run
-    #   cache test) call this directly.
-    # - `materialize_files(dir, files)` — convenience for specs
-    #   that build their tmpdir manually.
-    # - `run_plugin_in_dir(dir:, source:, ...)` — lower-level
-    #   variant that accepts an existing tmpdir, for specs that
-    #   need to run multiple analyses against the same project
-    #   (e.g. cache invalidation tests).
+    # - `run_plugin(source:, ...)` — materialises a tmpdir containing `demo.rb` (and optionally extra
+    #   `files:`), builds a `Rigor::Configuration` listing the plugin, runs `Rigor::Analysis::Runner` against
+    #   it, and returns the `Rigor::Analysis::Result`. Auto-`unregister!`s the plugin registry before each
+    #   invocation so the loader's newly-registered diff sees a fresh state.
+    # - `plugin_diagnostics(result)` — filters a result down to diagnostics whose `source_family` matches the
+    #   plugin's manifest id (`"plugin.<id>"`).
+    # - `build_plugin_requirer` — returns the `requirer` lambda the plugin loader expects. Specs that drive
+    #   `Analysis::Runner` themselves (e.g. routes' multi-run cache test) call this directly.
+    # - `materialize_files(dir, files)` — convenience for specs that build their tmpdir manually.
+    # - `run_plugin_in_dir(dir:, source:, ...)` — lower-level variant that accepts an existing tmpdir, for
+    #   specs that need to run multiple analyses against the same project (e.g. cache invalidation tests).
     #
     # ## Why not `before { unregister! }` automation?
     #
-    # `run_plugin` calls `Rigor::Plugin.unregister!` at the
-    # start of every invocation. Specs may STILL declare
-    # `before { Rigor::Plugin.unregister! }` /
-    # `after { Rigor::Plugin.unregister! }` for visibility — the
-    # belt-and-braces is harmless and surfaces the lifecycle
-    # for readers.
+    # `run_plugin` calls `Rigor::Plugin.unregister!` at the start of every invocation. Specs may STILL declare
+    # `before { Rigor::Plugin.unregister! }` / `after { Rigor::Plugin.unregister! }` for visibility — the
+    # belt-and-braces is harmless and surfaces the lifecycle for readers.
     #
     # ## Why `cache_store: :shared` is the default
     #
-    # The persistent `Cache::Store` caches the per-run RBS
-    # environment, constant table, instance/singleton
-    # definitions, and known-class set. With `cache_store: nil`
-    # every call paid the full ~250ms cold env build; using one
-    # process-wide store warms the cache after the first call so
-    # subsequent calls are ~30ms each (≈7× faster). The
-    # descriptor's `gems` / `files` / `configs` / `plugins`
-    # slots key the entries so different plugins, sigs, and
-    # libraries automatically land in separate slots —
-    # cross-test contamination is impossible. Tests that need to
-    # assert cache behaviour explicitly (e.g.
-    # `routes_plugin_spec`'s invalidation surface) pass an
-    # explicit `cache_store:` to opt out.
+    # The persistent `Cache::Store` caches the per-run RBS environment, constant table, instance/singleton
+    # definitions, and known-class set. With `cache_store: nil` every call paid the full ~250ms cold env build;
+    # using one process-wide store warms the cache after the first call so subsequent calls are ~30ms each
+    # (≈7× faster). The descriptor's `gems` / `files` / `configs` / `plugins` slots key the entries so
+    # different plugins, sigs, and libraries automatically land in separate slots — cross-test contamination is
+    # impossible. Tests that need to assert cache behaviour explicitly (e.g. `routes_plugin_spec`'s
+    # invalidation surface) pass an explicit `cache_store:` to opt out.
     module PluginHelpers
       class << self
         def shared_cache_store
@@ -82,24 +59,16 @@ module Rigor
         end
       end
 
-      # Sentinel default. Callers can pass `:shared` for the
-      # process-wide store, an explicit `Cache::Store`, or `nil`
-      # for no caching (the historical default — every call pays
-      # the cold ~250ms env build). The process-wide store is
-      # opt-in per spec file via `cache_store: :shared` (or via
-      # the `default_run_plugin_cache_store` let override) because
-      # it is only a net win for spec files with many `run_plugin`
-      # calls: cache I/O overhead exceeds the per-call env build
-      # savings up to and including ≈17 examples per spec file
-      # (measured: a 17-example file got ~12 % slower under
-      # shared cache). The crossover sits closer to the high end
-      # of plugin-spec example counts, so only the heaviest files
-      # opt in today — sorbet's 48 examples shrink from 13.1 s to
-      # 4.7 s with the shared cache (≈3× faster). Spec files
-      # whose plugin's `cache_for(...)` descriptor is incomplete
-      # (does not include the project files the producer reads
-      # from) MUST avoid the shared cache because stale producer
-      # output leaks between examples.
+      # Sentinel default. Callers can pass `:shared` for the process-wide store, an explicit `Cache::Store`, or
+      # `nil` for no caching (the historical default — every call pays the cold ~250ms env build). The
+      # process-wide store is opt-in per spec file via `cache_store: :shared` (or via the
+      # `default_run_plugin_cache_store` let override) because it is only a net win for spec files with many
+      # `run_plugin` calls: cache I/O overhead exceeds the per-call env build savings up to and including ≈17
+      # examples per spec file (measured: a 17-example file got ~12 % slower under shared cache). The crossover
+      # sits closer to the high end of plugin-spec example counts, so only the heaviest files opt in today —
+      # sorbet's 48 examples shrink from 13.1 s to 4.7 s with the shared cache (≈3× faster). Spec files whose
+      # plugin's `cache_for(...)` descriptor is incomplete (does not include the project files the producer
+      # reads from) MUST avoid the shared cache because stale producer output leaks between examples.
       DEFAULT_CACHE_STORE = :default
 
       def default_run_plugin_cache_store
@@ -152,10 +121,8 @@ module Rigor
       end
 
       def build_plugin_requirer
-        # Capture plugin_class in a local so the lambda doesn't
-        # close over `self` (specs may share a `let`-resolved
-        # binding across nested describes; capturing avoids
-        # surprising re-evaluation).
+        # Capture plugin_class in a local so the lambda doesn't close over `self` (specs may share a
+        # `let`-resolved binding across nested describes; capturing avoids surprising re-evaluation).
         plugin_class_local = plugin_class
         lambda do |_name|
           Rigor::Plugin.register(plugin_class_local)

--- a/spec/integration/type_construction_spec.rb
+++ b/spec/integration/type_construction_spec.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-# Integration spec: the engine should construct precise types
-# for small but realistic Ruby snippets. Each example is a
-# self-contained Ruby fixture under `spec/integration/fixtures/`
-# — readable on its own, runnable under MRI, and inspectable
-# through the `rigor type-of` CLI. The spec body uses a shared
-# `FixtureHarness` helper so adding a new scenario means
-# dropping a `.rb` file under `fixtures/` and adding a few
-# `expect` lines here.
+# Integration spec: the engine should construct precise types for small but realistic Ruby snippets. Each
+# example is a self-contained Ruby fixture under `spec/integration/fixtures/` — readable on its own, runnable
+# under MRI, and inspectable through the `rigor type-of` CLI. The spec body uses a shared `FixtureHarness`
+# helper so adding a new scenario means dropping a `.rb` file under `fixtures/` and adding a few `expect` lines here.
 
 require "spec_helper"
 require_relative "support/fixture_harness"
@@ -25,12 +21,9 @@ RSpec.describe "Rigor type construction (integration)" do
     let(:harness) { harness_for("parity") }
 
     it "binds `result` to the live-branch `Constant[:even]` when the predicate folds to true" do
-      # `4.even?` constant-folds to `Constant[true]`, so the
-      # else-branch is dead and the if-expression resolves to
-      # `Constant[:even]` only. The bool-valued path (when the
-      # receiver is a non-literal Integer) joins both edges into
-      # `Constant[:even] | Constant[:odd]` — the fixture itself
-      # `assert_type`s that case.
+      # `4.even?` constant-folds to `Constant[true]`, so the else-branch is dead and the if-expression resolves
+      # to `Constant[:even]` only. The bool-valued path (when the receiver is a non-literal Integer) joins both
+      # edges into `Constant[:even] | Constant[:odd]` — the fixture itself `assert_type`s that case.
       expect(harness.local(:result)).to eq(constant(:even))
     end
 
@@ -43,12 +36,10 @@ RSpec.describe "Rigor type construction (integration)" do
   describe "fixtures/module_singleton_call.rb — module/class singleton-method call resolution" do
     let(:harness) { harness_for("module_singleton_call") }
 
-    # Module-singleton call resolution (ADR-57 follow-up): a `def self.x` /
-    # `module_function` call on a module/class constant re-types the body
-    # with the call's args bound (constant args fold; a singleton helper
-    # called via implicit self resolves against the same singleton table),
-    # while a foreign / RBS-known singleton (`Math.sqrt`) stays
-    # catalog-typed. The fixture's `assert_type(...)` lines self-check.
+    # Module-singleton call resolution (ADR-57 follow-up): a `def self.x` / `module_function` call on a
+    # module/class constant re-types the body with the call's args bound (constant args fold; a singleton
+    # helper called via implicit self resolves against the same singleton table), while a foreign / RBS-known
+    # singleton (`Math.sqrt`) stays catalog-typed. The fixture's `assert_type(...)` lines self-check.
     it "resolves singleton-method calls (def self / module_function / implicit-self helper)" do
       mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
       expect(mismatches).to be_empty
@@ -58,13 +49,11 @@ RSpec.describe "Rigor type construction (integration)" do
   describe "fixtures/constant_reduce_fold.rb — constant reduce/inject folding" do
     let(:harness) { harness_for("constant_reduce_fold") }
 
-    # Folds a fully-constant `reduce`/`inject` to its exact value. The
-    # fact2 chain (Range-literal bound-type folding → ReduceFolding's
-    # constant tier → ADR-57 per-call adoption) makes
-    # `def range_fact(n) = (1..n).reduce(1, :*); range_fact(5)` fold to
-    # `120` / `range_fact(0)` to `1` — the bound `(1..n)` types as
-    # `Constant[Range]` once `n` is pinned, even though the bound is a
-    # variable read rather than a literal IntegerNode.
+    # Folds a fully-constant `reduce`/`inject` to its exact value. The fact2 chain (Range-literal bound-type
+    # folding → ReduceFolding's constant tier → ADR-57 per-call adoption) makes
+    # `def range_fact(n) = (1..n).reduce(1, :*); range_fact(5)` fold to `120` / `range_fact(0)` to `1` — the
+    # bound `(1..n)` types as `Constant[Range]` once `n` is pinned, even though the bound is a variable read
+    # rather than a literal IntegerNode.
     it "produces no assert_type mismatches" do
       mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
       expect(mismatches).to be_empty
@@ -239,8 +228,7 @@ RSpec.describe "Rigor type construction (integration)" do
     end
 
     it "composes Phase 2 + filter_map + ternary branch elision into a precise survivor Tuple" do
-      # `[1,2,3].filter_map { |n| n.even? ? n.to_s : nil }`
-      # — only n=2 survives the per-position fold, so the
+      # `[1,2,3].filter_map { |n| n.even? ? n.to_s : nil }` — only n=2 survives the per-position fold, so the
       # answer is `Tuple[Constant["2"]]`.
       filter_mapped_evens = harness.local(:filter_mapped_evens)
       expect(filter_mapped_evens).to be_a(Rigor::Type::Tuple)
@@ -260,18 +248,16 @@ RSpec.describe "Rigor type construction (integration)" do
     end
 
     it "treats per-position Constant scalars as single-element contributions in flat_map" do
-      # `[1, 2, 3].flat_map { |n| n.to_s }` — each per-position
-      # result is a `Constant<String>`, which contributes one
-      # element to the assembled Tuple.
+      # `[1, 2, 3].flat_map { |n| n.to_s }` — each per-position result is a `Constant<String>`, which
+      # contributes one element to the assembled Tuple.
       flat_scalar = harness.local(:flat_scalar)
       expect(flat_scalar).to be_a(Rigor::Type::Tuple)
       expect(flat_scalar.elements.map(&:value)).to eq(%w[1 2 3])
     end
 
     it "concatenates all-empty per-position Tuples into the empty Tuple" do
-      # `[1, 2, 3].flat_map { |_n| [] }` — every per-position
-      # result is `Tuple[]`, so the assembled answer is also `Tuple[]`.
-      # (`[]` resolves to `Tuple[]`, not `Nominal[Array]`.)
+      # `[1, 2, 3].flat_map { |_n| [] }` — every per-position result is `Tuple[]`, so the assembled answer is
+      # also `Tuple[]`. (`[]` resolves to `Tuple[]`, not `Nominal[Array]`.)
       flat_all_empty = harness.local(:flat_all_empty)
       expect(flat_all_empty).to be_a(Rigor::Type::Tuple)
       expect(flat_all_empty.elements).to be_empty
@@ -339,11 +325,9 @@ RSpec.describe "Rigor type construction (integration)" do
     let(:harness) { harness_for("block_map") }
 
     it "binds `strings` to a per-position Tuple of stringified literals" do
-      # `[1,2,3].map { |n| n.to_s }` folds to
-      # `Tuple[Constant["1"], Constant["2"], Constant["3"]]`,
-      # strictly tighter than the Array[union] projection.
-      # Wider receivers (e.g. `Nominal[Integer]`) still widen back
-      # to `Array[String]` via the RBS tier.
+      # `[1,2,3].map { |n| n.to_s }` folds to `Tuple[Constant["1"], Constant["2"], Constant["3"]]`, strictly
+      # tighter than the Array[union] projection. Wider receivers (e.g. `Nominal[Integer]`) still widen back to
+      # `Array[String]` via the RBS tier.
       strings = harness.local(:strings)
       expect(strings).to be_a(Rigor::Type::Tuple)
       expect(strings.elements.map(&:value)).to eq(%w[1 2 3])
@@ -405,11 +389,9 @@ RSpec.describe "Rigor type construction (integration)" do
     end
 
     it "exposes every `dump_type` call as an `:info` diagnostic the user can read" do
-      # The fixture intentionally uses only `assert_type` (no
-      # bare `dump_type` calls), so the info-severity dump
-      # surface starts empty here. The presence of the rule
-      # is what we are asserting; future fixtures may add
-      # dump_type calls.
+      # The fixture intentionally uses only `assert_type` (no bare `dump_type` calls), so the info-severity
+      # dump surface starts empty here. The presence of the rule is what we are asserting; future fixtures may
+      # add dump_type calls.
       info_dumps = harness.diagnostics.select { |d| d.severity == :info }
       expect(info_dumps).to be_an(Array)
     end
@@ -641,20 +623,16 @@ RSpec.describe "Rigor type construction (integration)" do
     let(:harness) { harness_for("param_extended") }
 
     it "flags exactly the call site whose argument fails the refinement (suppression verifies identification)" do
-      # The fixture uses `# rigor:disable argument-type-mismatch`
-      # on the offending call, so a clean run proves both that
-      # the rule fired against the override AND that the
-      # suppression-comment matches.
+      # The fixture uses `# rigor:disable argument-type-mismatch` on the offending call, so a clean run proves
+      # both that the rule fired against the override AND that the suppression-comment matches.
       arg_errors = harness.errors.select { |d| d.message.start_with?("argument type mismatch") }
       expect(arg_errors).to be_empty
     end
 
     it "applies the override inside the method body via MethodParameterBinder" do
-      # `assert_type` calls inside `normalise(id)` exercise the
-      # body-side narrowing: the binder must read the same
-      # override map and bind `id` to `non-empty-string` rather
-      # than the RBS-declared `String`. A miss surfaces as an
-      # `assert_type mismatch` diagnostic.
+      # `assert_type` calls inside `normalise(id)` exercise the body-side narrowing: the binder must read the
+      # same override map and bind `id` to `non-empty-string` rather than the RBS-declared `String`. A miss
+      # surfaces as an `assert_type mismatch` diagnostic.
       mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
       expect(mismatches).to be_empty
     end
@@ -754,9 +732,8 @@ RSpec.describe "Rigor type construction (integration)" do
     let(:harness) { harness_for("always_raises") }
 
     it "flags every Integer-by-zero call (suppressions in the fixture verify identification)" do
-      # The fixture uses `# rigor:disable always-raises` on each
-      # raising line, so a clean run proves both that the rule
-      # fired AND that the suppression comment matches.
+      # The fixture uses `# rigor:disable always-raises` on each raising line, so a clean run proves both that
+      # the rule fired AND that the suppression comment matches.
       raises = harness.errors.select { |d| d.rule == "flow.always-raises" }
       expect(raises).to be_empty
     end
@@ -888,12 +865,9 @@ RSpec.describe "Rigor type construction (integration)" do
     end
   end
 
-  # The fixtures below carry both an `assert_type` self-check
-  # (so the file is readable as documentation) and the
-  # finer-grained `harness.local` assertions above. The shared
-  # spec here only verifies the assert_type path; the type-
-  # specific assertions for each fixture live in their own
-  # `describe` block.
+  # The fixtures below carry both an `assert_type` self-check (so the file is readable as documentation) and
+  # the finer-grained `harness.local` assertions above. The shared spec here only verifies the assert_type
+  # path; the type-specific assertions for each fixture live in their own `describe` block.
   describe "self-asserting `assert_type` calls in converted fixtures" do
     %w[parity case_when compound_writes tuple_access hash_shape block_map block_filter tuple_map
        per_element_filter].each do |name|
@@ -1046,9 +1020,8 @@ RSpec.describe "Rigor type construction (integration)" do
     describe "fixtures/recursive_constant_fold.rb — ADR-55 slice 1 constant-arg unroll" do
       let(:harness) { harness_for("recursive_constant_fold") }
 
-      # factorial(5) → 120, the string builder → "***", and the
-      # constant-arg mutual recursion all fold; factorial(100) exhausts
-      # the 32-frame fuel and degrades to today's widened `Integer`.
+      # factorial(5) → 120, the string builder → "***", and the constant-arg mutual recursion all fold;
+      # factorial(100) exhausts the 32-frame fuel and degrades to today's widened `Integer`.
       it "folds constant-arg recursion and degrades gracefully on fuel exhaustion" do
         mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
         expect(mismatches).to be_empty
@@ -1067,9 +1040,8 @@ RSpec.describe "Rigor type construction (integration)" do
     describe "fixtures/recursive_unroll_clamp.rb — ADR-55 WD1 precision-envelope clamps" do
       let(:harness) { harness_for("recursive_unroll_clamp") }
 
-      # (1) value-pinned self-call adoption is inert outside an unroll;
-      # (2) a guarded re-entry whose body folds to a non-pinned type
-      #     clamps back to the plain guard's `untyped`.
+      # (1) value-pinned self-call adoption is inert outside an unroll; (2) a guarded re-entry whose body folds
+      # to a non-pinned type clamps back to the plain guard's `untyped`.
       it "confines value-pinned adoption to the unroll envelope" do
         mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
         expect(mismatches).to be_empty
@@ -1079,14 +1051,12 @@ RSpec.describe "Rigor type construction (integration)" do
     describe "fixtures/recursive_fixpoint_summary.rb — ADR-55 slice 2 fixpoint return summaries" do
       let(:harness) { harness_for("recursive_fixpoint_summary") }
 
-      # A non-constant-arg recursive method's in-cycle contribution is the
-      # method's real return type, not `Dynamic[top]`. The discriminating
-      # cases are the bare-self-call recursions: `passthrough → :done` (the
-      # fixpoint discovers the base case) and `pick → Dynamic[top]` (the
-      # bot-collapse floor for an explicit-return base case); an
-      # only-recursing method → `bot` (without hanging); mutual recursion
-      # terminates. Factorial / Builder are RBS-absorption anchors, not
-      # fixpoint discriminators (see the fixture's note).
+      # A non-constant-arg recursive method's in-cycle contribution is the method's real return type, not
+      # `Dynamic[top]`. The discriminating cases are the bare-self-call recursions: `passthrough → :done` (the
+      # fixpoint discovers the base case) and `pick → Dynamic[top]` (the bot-collapse floor for an
+      # explicit-return base case); an only-recursing method → `bot` (without hanging); mutual recursion
+      # terminates. Factorial / Builder are RBS-absorption anchors, not fixpoint discriminators (see the
+      # fixture's note).
       it "computes Dynamic-free recursive return summaries and terminates" do
         mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
         expect(mismatches).to be_empty
@@ -1096,10 +1066,9 @@ RSpec.describe "Rigor type construction (integration)" do
     describe "fixtures/explicit_return_contribution.rb — ADR-57 slice 2 explicit-return inference" do
       let(:harness) { harness_for("explicit_return_contribution") }
 
-      # Explicit `return value` nodes (early returns, bare returns, and
-      # block-internal returns that exit the enclosing method) join the
-      # tail type in method-return inference; nested `def`/lambda are
-      # return barriers. Predicate helpers infer `bool`, not `Constant[true]`.
+      # Explicit `return value` nodes (early returns, bare returns, and block-internal returns that exit the
+      # enclosing method) join the tail type in method-return inference; nested `def`/lambda are return
+      # barriers. Predicate helpers infer `bool`, not `Constant[true]`.
       it "joins explicit returns into the inferred method return type" do
         mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
         expect(mismatches).to be_empty
@@ -1109,19 +1078,17 @@ RSpec.describe "Rigor type construction (integration)" do
     describe "fixtures/overridable_method_no_fold.rb — ADR-57 N5 overridable-method adoption gate" do
       let(:harness) { harness_for("overridable_method_no_fold") }
 
-      # An implicit-self call to a method whose owner has a discovered
-      # subclass / includer redefining it degrades the adopted return to
-      # `Dynamic[top]` (template-method default is not a flow constant),
-      # while a method with no discovered override keeps folding to its
-      # base literal. The fixture's `assert_type`s pin both halves.
+      # An implicit-self call to a method whose owner has a discovered subclass / includer redefining it
+      # degrades the adopted return to `Dynamic[top]` (template-method default is not a flow constant), while
+      # a method with no discovered override keeps folding to its base literal. The fixture's `assert_type`s
+      # pin both halves.
       it "degrades the overridden self-call return but preserves the final-method fold" do
         mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
         expect(mismatches).to be_empty
       end
 
-      # No always-truthy/falsey FP fires on the `directed?`-style template
-      # method: the guard read is `Dynamic[top]`, which the flow-constant
-      # rule never fires on (rgl's entire warning set).
+      # No always-truthy/falsey FP fires on the `directed?`-style template method: the guard read is
+      # `Dynamic[top]`, which the flow-constant rule never fires on (rgl's entire warning set).
       it "fires no flow.always-truthy-condition on the overridden template read" do
         flow_constants = harness.diagnostics.select { |d| d.rule == "flow.always-truthy-condition" }
         expect(flow_constants).to be_empty
@@ -1131,11 +1098,9 @@ RSpec.describe "Rigor type construction (integration)" do
     describe "fixtures/escaping_content_capture.rb — ADR-57 slice 2 escaping-block content widening" do
       let(:harness) { harness_for("escaping_content_capture") }
 
-      # An escaping / unknown block that content-mutates a captured outer
-      # local widens that local to its bare-collection floor (Hash →
-      # Hash[untyped, untyped], String → String, Array → Array[Dynamic[top]])
-      # instead of keeping the unsoundly-precise empty seed. A read-only
-      # capture is untouched.
+      # An escaping / unknown block that content-mutates a captured outer local widens that local to its
+      # bare-collection floor (Hash → Hash[untyped, untyped], String → String, Array → Array[Dynamic[top]])
+      # instead of keeping the unsoundly-precise empty seed. A read-only capture is untouched.
       it "widens content-mutated escaping captures to the Dynamic floor" do
         mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
         expect(mismatches).to be_empty
@@ -1145,11 +1110,9 @@ RSpec.describe "Rigor type construction (integration)" do
     describe "fixtures/optional_tuple_destructure.rb — ADR-57 slice 3 optional-slot softening" do
       let(:harness) { harness_for("optional_tuple_destructure") }
 
-      # Destructuring a tuple slot flow typed as optional (`X | nil`) softens
-      # that slot to its non-`nil` part (FP discipline: a nil-able slot is
-      # almost always guarded by a correlated invariant flow cannot prove),
-      # while a pure slot keeps its precise type and a bare `nil` slot stays
-      # `nil`.
+      # Destructuring a tuple slot flow typed as optional (`X | nil`) softens that slot to its non-`nil` part
+      # (FP discipline: a nil-able slot is almost always guarded by a correlated invariant flow cannot prove),
+      # while a pure slot keeps its precise type and a bare `nil` slot stays `nil`.
       it "softens optional destructured slots without over-widening" do
         mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
         expect(mismatches).to be_empty
@@ -1159,14 +1122,11 @@ RSpec.describe "Rigor type construction (integration)" do
     describe "fixtures/block_captured_writeback.rb — ADR-56 slice A captured-local write-back" do
       let(:harness) { harness_for("block_captured_writeback") }
 
-      # A non-escaping block that rebinds an outer local writes the
-      # continuation binding back (the capped fixpoint): accumulators widen
-      # to a base, a distinct-constant rebind keeps both pinned
-      # constituents (0-iteration soundness), `||=` keeps the pre-call
-      # `nil`, a no-write block keeps its exact constant (fast path), a
-      # compounding shape floors to `Dynamic[top]` at the cap, and an
-      # escaping block is unchanged. Before this slice every accumulator
-      # kept its WRONG pre-call constant — a spec-MUST violation.
+      # A non-escaping block that rebinds an outer local writes the continuation binding back (the capped
+      # fixpoint): accumulators widen to a base, a distinct-constant rebind keeps both pinned constituents
+      # (0-iteration soundness), `||=` keeps the pre-call `nil`, a no-write block keeps its exact constant
+      # (fast path), a compounding shape floors to `Dynamic[top]` at the cap, and an escaping block is
+      # unchanged. Before this slice every accumulator kept its WRONG pre-call constant — a spec-MUST violation.
       it "folds written captured locals back, soundly, without touching unwritten ones" do
         mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
         expect(mismatches).to be_empty
@@ -1184,23 +1144,20 @@ RSpec.describe "Rigor type construction (integration)" do
     describe "fixtures/loop_body_fixpoint.rb — ADR-56 slice B loop-body fixpoint" do
       let(:harness) { harness_for("loop_body_fixpoint") }
 
-      # A `while` / `until` body that rebinds a loop-carried local folds its
-      # continuation binding through the same capped fixpoint slice A uses:
-      # accumulators widen to a base (never the historical unsound
-      # `1 | 2`), a body-first-assignment local degrades to `T | nil` for
-      # the 0-iteration path, and a compounding shape floors to
-      # `Dynamic[top]` at the cap. Before this slice every accumulator kept
-      # its WRONG single-pass constant — a spec-MUST violation.
+      # A `while` / `until` body that rebinds a loop-carried local folds its continuation binding through the
+      # same capped fixpoint slice A uses: accumulators widen to a base (never the historical unsound `1 | 2`),
+      # a body-first-assignment local degrades to `T | nil` for the 0-iteration path, and a compounding shape
+      # floors to `Dynamic[top]` at the cap. Before this slice every accumulator kept its WRONG single-pass
+      # constant — a spec-MUST violation.
       it "folds loop-carried locals back, soundly, across while / until / do-loop shapes" do
         mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
         expect(mismatches).to be_empty
       end
 
       it "joins the pushed element type of a receiver-content-mutated non-rebound local (slice C)" do
-        # `acc.push(m)` widens `acc`'s Tuple AND the slice-C content
-        # writeback joins the pushed `m` (→ `Integer`) into the element
-        # parameter, so the continuation is `Array[Integer]` — sounder and
-        # more precise than the pre-slice-C `Array[Dynamic[top]] | []`.
+        # `acc.push(m)` widens `acc`'s Tuple AND the slice-C content writeback joins the pushed `m` (→
+        # `Integer`) into the element parameter, so the continuation is `Array[Integer]` — sounder and more
+        # precise than the pre-slice-C `Array[Dynamic[top]] | []`.
         expect(harness.local(:acc)).to eq(
           Rigor::Type::Combinator.nominal_of("Array", type_args: [Rigor::Type::Combinator.nominal_of("Integer")])
         )
@@ -1214,12 +1171,10 @@ RSpec.describe "Rigor type construction (integration)" do
     describe "fixtures/reduce_symbol.rb — Symbol-form reduce / inject return types" do
       let(:harness) { harness_for("reduce_symbol") }
 
-      # `(1..n).reduce(1, :*)`, `[1,2,3].reduce(:+)`, and friends carry no
-      # block, so the call used to fall to `Enumerable#reduce`'s
-      # `(untyped, Symbol) -> untyped` RBS overload and widen to
-      # `Dynamic[top]`. ReduceFolding dispatches the named operator on the
-      # accumulated element type and recovers the precise carrier
-      # (`Integer` / `String`) — strictly more informative, no diagnostic.
+      # `(1..n).reduce(1, :*)`, `[1,2,3].reduce(:+)`, and friends carry no block, so the call used to fall to
+      # `Enumerable#reduce`'s `(untyped, Symbol) -> untyped` RBS overload and widen to `Dynamic[top]`.
+      # ReduceFolding dispatches the named operator on the accumulated element type and recovers the precise
+      # carrier (`Integer` / `String`) — strictly more informative, no diagnostic.
       it "recovers a precise carrier for every Symbol-operand fold shape" do
         mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
         expect(mismatches).to be_empty

--- a/spec/rigor/analysis/baseline_spec.rb
+++ b/spec/rigor/analysis/baseline_spec.rb
@@ -194,10 +194,8 @@ RSpec.describe Rigor::Analysis::Baseline do
 
       merge_bucket = baseline.buckets.find { |b| b.message_regex.source.include?("merge") }
       expect(merge_bucket.count).to eq(2)
-      # Confirm the regex round-trips correctly through escape +
-      # match — the literal backtick / apostrophe / square-
-      # brackets in the original message must NOT be
-      # regex-interpreted.
+      # Confirm the regex round-trips correctly through escape + match — the literal backtick / apostrophe / square-
+      # brackets in the original message must NOT be regex-interpreted.
       expect(merge_bucket.message_regex.match?("undefined method `merge' for Array")).to be(true)
     end
 
@@ -384,9 +382,8 @@ RSpec.describe Rigor::Analysis::Baseline do
       rows = baseline.audit([
                               diagnostic(path: "a.rb", rule: "call.undefined-method", message: "undefined method `foo'")
                             ])
-      # Two distinct messages → two buckets, each keyed by its own regex source
-      # (bucket_key reads message_regex.source); the foo bucket matches once, bar
-      # matches nothing, so the two counts must not collide.
+      # Two distinct messages → two buckets, each keyed by its own regex source (bucket_key reads message_regex.source);
+      # the foo bucket matches once, bar matches nothing, so the two counts must not collide.
       expect(rows.size).to eq(2)
       foo_row = rows.find { |r| r.bucket.message_regex.source.include?("foo") }
       bar_row = rows.find { |r| r.bucket.message_regex.source.include?("bar") }

--- a/spec/rigor/analysis/check_rules/nil_argument_mismatch_spec.rb
+++ b/spec/rigor/analysis/check_rules/nil_argument_mismatch_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe "nil argument-type-mismatch" do
   end
 
   it "fires on a single-overload interface-alias param that rejects nil (Gap B)" do
-    # "a" + nil and "a".include?(nil) raise TypeError; String#+/#include? take
-    # `string` (String | _ToStr), and nil implements neither.
+    # "a" + nil and "a".include?(nil) raise TypeError; String#+/#include? take `string` (String | _ToStr), and nil
+    # implements neither.
     expect(arg_mismatches(%(s = "a"\ns + nil\n))).to include(a_string_matching(/`\+' on String.*got nil/))
     expect(arg_mismatches(%(s = "a"\ns.include?(nil)\n)))
       .to include(a_string_matching(/`include\?' on String.*got nil/))
@@ -37,9 +37,8 @@ RSpec.describe "nil argument-type-mismatch" do
     expect(arg_mismatches("x = 5\nx * nil\n")).to include(a_string_matching(/`\*' on Integer.*got nil/))
     # Array#fetch is multi-overload with an interface-alias `int` param.
     expect(arg_mismatches("a = [1, 2, 3]\na.fetch(nil)\n")).to include(a_string_matching(/`fetch' on Array.*got nil/))
-    # MatchData#[] has a `range[int?]` GENERIC-alias overload; resolving it
-    # (not bailing to "admits") lets every overload reject nil so `m[nil]`
-    # fires.
+    # MatchData#[] has a `range[int?]` GENERIC-alias overload; resolving it (not bailing to "admits") lets every
+    # overload reject nil so `m[nil]` fires.
     expect(arg_mismatches(%(m = "abc".match(/b/)\nunless m.nil?\n  m[nil]\nend\n)))
       .to include(a_string_matching(/`\[\]' on MatchData.*got nil/))
   end
@@ -55,8 +54,8 @@ RSpec.describe "nil argument-type-mismatch" do
   end
 
   it "does not fire on a non-nil mismatched argument (nil-only restriction — coerce-safety)" do
-    # 5 * "x" raises too, but a non-nil receiver may be valid via `coerce`,
-    # so the rule is deliberately restricted to nil.
+    # 5 * "x" raises too, but a non-nil receiver may be valid via `coerce`, so the rule is deliberately restricted to
+    # nil.
     expect(arg_mismatches(%(x = 5\nx * "y"\n))).to be_empty
   end
 

--- a/spec/rigor/analysis/check_rules/non_nil_argument_mismatch_spec.rb
+++ b/spec/rigor/analysis/check_rules/non_nil_argument_mismatch_spec.rb
@@ -2,14 +2,12 @@
 
 require "spec_helper"
 
-# ADR-64 — the non-nil channel of `call.argument-type-mismatch`. The nil
-# channel ([nil_argument_mismatch_spec]) fires on a pure-`nil` argument every
-# overload rejects; this channel extends that to a non-nil argument that types
-# to a single concrete, RBS-known class no overload admits — on a *non-coerce*
-# method. The coerce-dispatch operators (`+ - * / < …`) are excluded because a
-# user type may rescue a non-`Numeric` argument via `coerce` (`5 + Money.new`),
-# which `nil` can never do. Acceptance is decided on the RBS parameter type so
-# the `int` / `string` interface-aliases the translator degrades are resolved.
+# ADR-64 — the non-nil channel of `call.argument-type-mismatch`. The nil channel ([nil_argument_mismatch_spec]) fires on
+# a pure-`nil` argument every overload rejects; this channel extends that to a non-nil argument that types to a single
+# concrete, RBS-known class no overload admits — on a *non-coerce* method. The coerce-dispatch operators (`+ - * / < …`)
+# are excluded because a user type may rescue a non-`Numeric` argument via `coerce` (`5 + Money.new`), which `nil` can
+# never do. Acceptance is decided on the RBS parameter type so the `int` / `string` interface-aliases the translator
+# degrades are resolved.
 RSpec.describe "non-nil argument-type-mismatch (ADR-64)" do
   def diagnostics_for(source)
     Rigor::Analysis::Runner.new(configuration: Rigor::Configuration.new("paths" => []), cache_store: nil)
@@ -22,8 +20,8 @@ RSpec.describe "non-nil argument-type-mismatch (ADR-64)" do
   end
 
   it "fires when a single-concrete-class arg is rejected by every overload (interface-alias param)" do
-    # Array#fetch is multi-overload; its index param is `int` (Integer | _ToInt).
-    # A String is neither an Integer nor `_ToInt` (no #to_int) → TypeError at runtime.
+    # Array#fetch is multi-overload; its index param is `int` (Integer | _ToInt). A String is neither an Integer nor
+    # `_ToInt` (no #to_int) → TypeError at runtime.
     expect(arg_mismatches("a = [1, 2, 3]\na.fetch(\"x\")\n"))
       .to include(a_string_matching(/`fetch' on Array.*expected int.*got "x"/))
     # A Symbol likewise has no #to_int.
@@ -32,18 +30,16 @@ RSpec.describe "non-nil argument-type-mismatch (ADR-64)" do
   end
 
   it "resolves the interface so a class that DOES implement it stays clean" do
-    # Float has #to_int, so `_ToInt` admits it — `[1,2,3].fetch(2.0)` is valid
-    # (2.0.to_int → 2). The interface resolution must accept it.
+    # Float has #to_int, so `_ToInt` admits it — `[1,2,3].fetch(2.0)` is valid (2.0.to_int → 2). The interface
+    # resolution must accept it.
     expect(arg_mismatches("a = [1, 2, 3]\na.fetch(2.0)\n")).to be_empty
   end
 
   it "excludes the coerce-dispatch operators (a non-Numeric arg may coerce)" do
-    # 5 * "y" / 5 + "y" raise at runtime, but the rule cannot know a user type
-    # would not define #coerce, so the multi-overload arithmetic operators
-    # (`Integer#+` / `#*` each have four numeric overloads) are excluded. The
-    # single-overload comparison operators (`Integer#< : (Numeric) -> bool`)
-    # are governed by the pre-existing per-overload acceptance check, not this
-    # multi-overload channel.
+    # 5 * "y" / 5 + "y" raise at runtime, but the rule cannot know a user type would not define #coerce, so the
+    # multi-overload arithmetic operators (`Integer#+` / `#*` each have four numeric overloads) are excluded. The
+    # single-overload comparison operators (`Integer#< : (Numeric) -> bool`) are governed by the pre-existing
+    # per-overload acceptance check, not this multi-overload channel.
     expect(arg_mismatches("x = 5\nx * \"y\"\n")).to be_empty
     expect(arg_mismatches("x = 5\nx + \"y\"\n")).to be_empty
     expect(arg_mismatches("x = 5\nx - \"y\"\n")).to be_empty
@@ -55,8 +51,8 @@ RSpec.describe "non-nil argument-type-mismatch (ADR-64)" do
   end
 
   it "does not fire across an overload arity divergence" do
-    # `fetch(0, "default")`: the second positional has no matching param in the
-    # single-arg overload, so the wrong-arity rule owns it, not this one.
+    # `fetch(0, "default")`: the second positional has no matching param in the single-arg overload, so the wrong-arity
+    # rule owns it, not this one.
     expect(arg_mismatches("a = [1, 2, 3]\na.fetch(0, \"default\")\n")).to be_empty
   end
 
@@ -65,8 +61,8 @@ RSpec.describe "non-nil argument-type-mismatch (ADR-64)" do
   end
 
   it "defers a union argument (WD3 — single concrete class only)" do
-    # `x` is `String | nil` at the call site; a union arg is left to the
-    # union-receiver story, like the nil channel's pure-nil restriction.
+    # `x` is `String | nil` at the call site; a union arg is left to the union-receiver story, like the nil channel's
+    # pure-nil restriction.
     expect(arg_mismatches("def f(flag)\n  x = \"s\" if flag\n  [1, 2, 3].fetch(x)\nend\n")).to be_empty
   end
 

--- a/spec/rigor/analysis/check_rules/refined_receiver_dispatch_spec.rb
+++ b/spec/rigor/analysis/check_rules/refined_receiver_dispatch_spec.rb
@@ -2,12 +2,10 @@
 
 require "spec_helper"
 
-# A refinement receiver (`non-negative-int` = `Type::IntegerRange`,
-# `non-empty-string` = `Type::Refined`) IS its base class for method dispatch.
-# `concrete_class_name` resolves it to the base so the call rules
-# (undefined-method / wrong-arity / argument-type-mismatch) reason about it
-# instead of bailing on "no single concrete class". Surfaced by the
-# tool/mutation teeth sweep (the `non-negative-int#>=` cluster).
+# A refinement receiver (`non-negative-int` = `Type::IntegerRange`, `non-empty-string` = `Type::Refined`) IS its base
+# class for method dispatch. `concrete_class_name` resolves it to the base so the call rules (undefined-method /
+# wrong-arity / argument-type-mismatch) reason about it instead of bailing on "no single concrete class". Surfaced by
+# the tool/mutation teeth sweep (the `non-negative-int#>=` cluster).
 RSpec.describe "refined-receiver call-rule dispatch" do
   def diagnostics_for(source)
     Rigor::Analysis::Runner.new(configuration: Rigor::Configuration.new("paths" => []), cache_store: nil)
@@ -19,8 +17,7 @@ RSpec.describe "refined-receiver call-rule dispatch" do
     diagnostics_for(source).select { |d| d.rule == rule }.map(&:message)
   end
 
-  # `[…].select { }.size` is a non-negative-int of unknown value (a literal
-  # tuple's size would constant-fold instead).
+  # `[…].select { }.size` is a non-negative-int of unknown value (a literal tuple's size would constant-fold instead).
   def refined_int(expr)
     <<~RUBY
       def f(x)
@@ -46,9 +43,8 @@ RSpec.describe "refined-receiver call-rule dispatch" do
     expect(diagnostics_for(source).select(&:error?)).to be_empty
   end
 
-  # The non-empty / non-zero refinements are `Type::Difference` (`Array - []`,
-  # `String - ""`, `Integer - 0`), a different carrier from `Type::Refined` /
-  # `Type::IntegerRange`. A difference dispatches as its base (minuend) class —
+  # The non-empty / non-zero refinements are `Type::Difference` (`Array - []`, `String - ""`, `Integer - 0`), a
+  # different carrier from `Type::Refined` / `Type::IntegerRange`. A difference dispatches as its base (minuend) class —
   # subtracting values never changes the method surface.
   def non_empty_array(expr)
     <<~RUBY

--- a/spec/rigor/analysis/check_rules/rule_walk_equivalence_spec.rb
+++ b/spec/rigor/analysis/check_rules/rule_walk_equivalence_spec.rb
@@ -2,19 +2,15 @@
 
 require "spec_helper"
 
-# ADR-53 Track B — the permanent equivalence harness for the engine-owned
-# CheckRules::RuleWalk. Every collector hosted on the walk keeps its
-# legacy single-collector walk as the oracle; this spec runs both over
-# sources that exercise the shared traversal contract (loop / block
-# suppression, nesting, firing and non-firing shapes) plus the whole
-# integration fixture corpus, and requires identical per-collector
-# results. A collector may only migrate onto the walk while this oracle
-# comparison holds; the corpus-scale companion is the
-# `RIGOR_SHADOW_RULE_WALK=1` mode in `CheckRules.run_node_collectors`.
+# ADR-53 Track B — the permanent equivalence harness for the engine-owned CheckRules::RuleWalk. Every collector hosted
+# on the walk keeps its legacy single-collector walk as the oracle; this spec runs both over sources that exercise the
+# shared traversal contract (loop / block suppression, nesting, firing and non-firing shapes) plus the whole integration
+# fixture corpus, and requires identical per-collector results. A collector may only migrate onto the walk while this
+# oracle comparison holds; the corpus-scale companion is the `RIGOR_SHADOW_RULE_WALK=1` mode in
+# `CheckRules.run_node_collectors`.
 module RuleWalkEquivalenceCases
-  # Curated shapes: each exercises a distinct part of the traversal
-  # contract. Firing shapes are present for BOTH collectors so the
-  # harness can never pass vacuously (asserted in the spec).
+  # Curated shapes: each exercises a distinct part of the traversal contract. Firing shapes are present for BOTH
+  # collectors so the harness can never pass vacuously (asserted in the spec).
   CURATED = {
     "top-level firing if (always-truthy)" => <<~RUBY,
       x = 1
@@ -206,8 +202,8 @@ module RuleWalkEquivalenceCases
 
   FIXTURE_FILES = Dir[File.expand_path("../../../integration/fixtures/*.rb", __dir__)].freeze
 
-  # Every {RuleWalk}-hosted collector, in the order it is added to the
-  # shared walk. Each keeps its legacy `#collect` walk as the oracle.
+  # Every {RuleWalk}-hosted collector, in the order it is added to the shared walk. Each keeps its legacy `#collect`
+  # walk as the oracle.
   HOSTED_COLLECTOR_CLASSES = [
     Rigor::Analysis::CheckRules::AlwaysTruthyConditionCollector,
     Rigor::Analysis::CheckRules::UnreachableClauseCollector,
@@ -235,11 +231,9 @@ RSpec.describe Rigor::Analysis::CheckRules::RuleWalk do
     collectors.map(&:results)
   end
 
-  # ADR-53 B4 — drive the SAME collectors through the converged
-  # {Plugin::NodeRuleWalk} traversal (with no plugins, so only the
-  # built-in {CollectorDriver} runs) instead of the standalone
-  # `RuleWalk.run`. Asserts the convergence preserves per-collector
-  # results byte-for-byte against the legacy oracle.
+  # ADR-53 B4 — drive the SAME collectors through the converged {Plugin::NodeRuleWalk} traversal (with no plugins, so
+  # only the built-in {CollectorDriver} runs) instead of the standalone `RuleWalk.run`. Asserts the convergence
+  # preserves per-collector results byte-for-byte against the legacy oracle.
   def converged_walk_results(root, scope_index)
     collectors = RuleWalkEquivalenceCases::HOSTED_COLLECTOR_CLASSES.map { |klass| klass.new(scope_index) }
     driver = described_class::CollectorDriver.new(collectors)
@@ -269,9 +263,8 @@ RSpec.describe Rigor::Analysis::CheckRules::RuleWalk do
       totals = Array.new(RuleWalkEquivalenceCases::HOSTED_COLLECTOR_CLASSES.size, 0)
       RuleWalkEquivalenceCases::CURATED.each_value do |source|
         root, scope_index = parse_and_index(source)
-        # Array collectors (flow) count entries; the IvarWrite Hash counts
-        # the classes that carry recorded writes — both are positive only
-        # when the collector actually fired.
+        # Array collectors (flow) count entries; the IvarWrite Hash counts the classes that carry recorded writes — both
+        # are positive only when the collector actually fired.
         legacy_results(root, scope_index).each_with_index { |results, i| totals[i] += results.size }
       end
       expect(totals).to all(be_positive)
@@ -295,12 +288,10 @@ RSpec.describe Rigor::Analysis::CheckRules::RuleWalk do
     end
   end
 
-  # ADR-53 B3c — the stateless main pass rides the same {RuleWalk}; its
-  # `#results` are the per-node diagnostics, so its oracle is the former
-  # inline `Source::NodeWalker.each` `case` (`CheckRules.main_pass_oracle`).
-  # Equivalence is order-sensitive byte equality (the text formatter emits
-  # `result.diagnostics` in array order, unsorted), so we compare the full
-  # serialised diagnostic list.
+  # ADR-53 B3c — the stateless main pass rides the same {RuleWalk}; its `#results` are the per-node diagnostics, so its
+  # oracle is the former inline `Source::NodeWalker.each` `case` (`CheckRules.main_pass_oracle`). Equivalence is
+  # order-sensitive byte equality (the text formatter emits `result.diagnostics` in array order, unsorted), so we
+  # compare the full serialised diagnostic list.
   describe "main pass on the shared walk vs the inline oracle" do
     def main_pass_walk(path, root, scope_index)
       node_diagnostics = ->(node) { Rigor::Analysis::CheckRules.main_pass_node_diagnostics(path, node, scope_index) }
@@ -309,12 +300,10 @@ RSpec.describe Rigor::Analysis::CheckRules::RuleWalk do
       collector.results.map(&:to_h)
     end
 
-    # ADR-53 B4 — drive the main pass through the converged
-    # {Plugin::NodeRuleWalk} traversal (no plugins, so only the built-in
-    # {CollectorDriver} runs). The main pass is a {RuleWalk}-hosted
-    # collector like the others, so the converged walk must reproduce the
-    # inline oracle byte-for-byte too — this is the converged-walk
-    # coverage for the fifth (main-pass) collector.
+    # ADR-53 B4 — drive the main pass through the converged {Plugin::NodeRuleWalk} traversal (no plugins, so only the
+    # built-in {CollectorDriver} runs). The main pass is a {RuleWalk}-hosted collector like the others, so the converged
+    # walk must reproduce the inline oracle byte-for-byte too — this is the converged-walk coverage for the fifth
+    # (main-pass) collector.
     def main_pass_converged_walk(path, root, scope_index)
       node_diagnostics = ->(node) { Rigor::Analysis::CheckRules.main_pass_node_diagnostics(path, node, scope_index) }
       collector = Rigor::Analysis::CheckRules::MainPassCollector.new(node_diagnostics)

--- a/spec/rigor/analysis/check_rules/safe_navigation_undefined_method_spec.rb
+++ b/spec/rigor/analysis/check_rules/safe_navigation_undefined_method_spec.rb
@@ -2,12 +2,10 @@
 
 require "spec_helper"
 
-# N3 (docs/notes/20260613-app-network-corpora-survey.md) — a
-# safe-navigation call (`recv&.m`) never dispatches on the nil edge of
-# its receiver: at runtime it short-circuits to nil. The
-# `call.undefined-method` existence check must therefore apply only to
-# the NON-nil constituents of the receiver. A pure-nil receiver is
-# silent; a `T | nil` receiver is checked against `T` alone.
+# N3 (docs/notes/20260613-app-network-corpora-survey.md) — a safe-navigation call (`recv&.m`) never dispatches on the
+# nil edge of its receiver: at runtime it short-circuits to nil. The `call.undefined-method` existence check must
+# therefore apply only to the NON-nil constituents of the receiver. A pure-nil receiver is silent; a `T | nil` receiver
+# is checked against `T` alone.
 RSpec.describe "safe-navigation undefined-method suppression" do
   def diagnostics_for(source)
     Rigor::Analysis::Runner.new(configuration: Rigor::Configuration.new("paths" => []), cache_store: nil)
@@ -63,11 +61,9 @@ RSpec.describe "safe-navigation undefined-method suppression" do
   end
 
   it "stays silent for a `&.` call on a nil-bearing union receiver" do
-    # A `T | nil` union has no single concrete class, so the
-    # `call.undefined-method` rule already bails — and a `&.` must not
-    # newly fire on the non-nil constituent (for a cross-file project def
-    # that would be a working-code false positive). Only the pure-nil case
-    # is the bug N3 fixes.
+    # A `T | nil` union has no single concrete class, so the `call.undefined-method` rule already bails — and a `&.`
+    # must not newly fire on the non-nil constituent (for a cross-file project def that would be a working-code false
+    # positive). Only the pure-nil case is the bug N3 fixes.
     source = <<~RUBY
       def g(x)
         y = x ? 5 : nil
@@ -79,8 +75,8 @@ RSpec.describe "safe-navigation undefined-method suppression" do
   end
 
   it "leaves a plain (non-safe-nav) nil-union receiver's diagnostics unchanged" do
-    # Regression guard: the safe-nav narrowing must not touch the plain
-    # call path. A plain union receiver behaves exactly as before.
+    # Regression guard: the safe-nav narrowing must not touch the plain call path. A plain union receiver behaves
+    # exactly as before.
     source = <<~RUBY
       def g(x)
         y = x ? 5 : nil
@@ -88,8 +84,8 @@ RSpec.describe "safe-navigation undefined-method suppression" do
       end
     RUBY
 
-    # No undefined-method firing on the union (the `possible-nil-receiver`
-    # rule owns this site); the point is the safe-nav path did not perturb it.
+    # No undefined-method firing on the union (the `possible-nil-receiver` rule owns this site); the point is the
+    # safe-nav path did not perturb it.
     expect(undefined_method_messages(source)).to be_empty
   end
 end

--- a/spec/rigor/analysis/check_rules/union_undefined_method_spec.rb
+++ b/spec/rigor/analysis/check_rules/union_undefined_method_spec.rb
@@ -2,13 +2,11 @@
 
 require "spec_helper"
 
-# `call.undefined-method` on a *union* receiver. The scalar existence check
-# bails when the receiver has no single concrete class; this slice fires when
-# every non-nil arm is a fully-known, bounded, instance class on which the
-# method is absent — `A | B` responds to `m` only if both `A` and `B` do, so a
-# method absent on every arm is undefined regardless of which arm the value
-# takes. FP-safe: any Dynamic / unknown / source-declared / open / nil arm
-# suppresses the diagnostic. Surfaced by the tool/mutation teeth sweep.
+# `call.undefined-method` on a *union* receiver. The scalar existence check bails when the receiver has no single
+# concrete class; this slice fires when every non-nil arm is a fully-known, bounded, instance class on which the method
+# is absent — `A | B` responds to `m` only if both `A` and `B` do, so a method absent on every arm is undefined
+# regardless of which arm the value takes. FP-safe: any Dynamic / unknown / source-declared / open / nil arm suppresses
+# the diagnostic. Surfaced by the tool/mutation teeth sweep.
 RSpec.describe "union-receiver undefined-method" do
   def undefined_method_messages(source)
     Rigor::Analysis::Runner.new(configuration: Rigor::Configuration.new("paths" => []), cache_store: nil)
@@ -43,8 +41,8 @@ RSpec.describe "union-receiver undefined-method" do
   end
 
   it "stays silent when at least one arm supports the method" do
-    # `upcase` exists on String but not Integer — the call is sound on the
-    # String arm, so firing would be a false positive.
+    # `upcase` exists on String but not Integer — the call is sound on the String arm, so firing would be a false
+    # positive.
     source = <<~RUBY
       def f(flag)
         x = flag ? "s" : 1
@@ -56,10 +54,9 @@ RSpec.describe "union-receiver undefined-method" do
   end
 
   it "stays silent on a same-class union (a shape-join artifact, not a multi-class union)" do
-    # `[1] | [1, 2, 3]` is two Array shapes, not "an A or a B". Firing there is
-    # the scalar rule's job, and a same-class union is often a join misinference
-    # (a corpus probe caught `Hash | Hash` for an Array); require ≥2 distinct
-    # arm classes.
+    # `[1] | [1, 2, 3]` is two Array shapes, not "an A or a B". Firing there is the scalar rule's job, and a same-class
+    # union is often a join misinference (a corpus probe caught `Hash | Hash` for an Array); require ≥2 distinct arm
+    # classes.
     source = <<~RUBY
       def f(flag)
         a = flag ? [1] : [1, 2, 3]

--- a/spec/rigor/analysis/dependency_recorder_spec.rb
+++ b/spec/rigor/analysis/dependency_recorder_spec.rb
@@ -3,10 +3,9 @@
 require "spec_helper"
 require "tmpdir"
 
-# ADR-46 slice 1 — the cross-file dependency recorder. Verifies that
-# analysing a file records the OTHER files its inference read from;
-# `Incremental.invert` builds the `dependents` index from these
-# records and the body tier re-analyses only the affected closure.
+# ADR-46 slice 1 — the cross-file dependency recorder. Verifies that analysing a file records the OTHER files its
+# inference read from; `Incremental.invert` builds the `dependents` index from these records and the body tier
+# re-analyses only the affected closure.
 RSpec.describe Rigor::Analysis::DependencyRecorder do
   def run_recording(dir)
     configuration = Rigor::Configuration.new("paths" => [dir])
@@ -32,8 +31,8 @@ RSpec.describe Rigor::Analysis::DependencyRecorder do
       record = runner.file_dependencies[File.join(dir, "caller.rb")]
 
       expect(record).not_to be_nil
-      # caller.rb's inference resolved Widget#price through to its body in
-      # model.rb, so model.rb is a recorded dependency.
+      # caller.rb's inference resolved Widget#price through to its body in model.rb, so model.rb is a recorded
+      # dependency.
       expect(record.sources).to include(File.join(dir, "model.rb"))
       # A file does not depend on itself.
       expect(record.sources).not_to include(File.join(dir, "caller.rb"))
@@ -60,9 +59,8 @@ RSpec.describe Rigor::Analysis::DependencyRecorder do
       runner = run_recording(dir)
       record = runner.file_dependencies[File.join(dir, "child.rb")]
 
-      # Resolving Child's `greet` walks the superclass chain through
-      # `superclass_of(Child)` and reads Base#greet's body — both edges
-      # attribute to base.rb.
+      # Resolving Child's `greet` walks the superclass chain through `superclass_of(Child)` and reads Base#greet's body
+      # — both edges attribute to base.rb.
       expect(record.sources).to include(File.join(dir, "base.rb"))
     end
   end
@@ -88,19 +86,17 @@ RSpec.describe Rigor::Analysis::DependencyRecorder do
       runner = run_recording(dir)
       record = runner.file_dependencies[File.join(dir, "host.rb")]
 
-      # Resolving `greet` against the include chain reads `includes_of(Host)`
-      # and Greeter#greet's body — both attribute to mixin.rb.
+      # Resolving `greet` against the include chain reads `includes_of(Host)` and Greeter#greet's body — both attribute
+      # to mixin.rb.
       expect(record.sources).to include(File.join(dir, "mixin.rb"))
     end
   end
 
   it "records every reopening file of a class whose ancestry is read (ADR-46 slice 1)" do
     Dir.mktmpdir do |dir|
-      # `Account` is declared empty in one file and reopened with its
-      # superclass in another. A consumer that resolves an inherited method
-      # depends on BOTH files — removing the superclass in the reopening
-      # must re-check the consumer, so `superclass_of(Account)` records the
-      # full declaring-file set, not just the first declaration.
+      # `Account` is declared empty in one file and reopened with its superclass in another. A consumer that resolves an
+      # inherited method depends on BOTH files — removing the superclass in the reopening must re-check the consumer, so
+      # `superclass_of(Account)` records the full declaring-file set, not just the first declaration.
       File.write(File.join(dir, "account_decl.rb"), "class Account\nend\n")
       File.write(File.join(dir, "account_super.rb"), <<~RUBY)
         class Base
@@ -143,11 +139,11 @@ RSpec.describe Rigor::Analysis::DependencyRecorder do
       runner = run_recording(dir)
       dependents = runner.file_dependents
 
-      # An edit to model.rb must re-check caller.rb (it read Widget#price's
-      # body from there), so caller.rb is a dependent of model.rb.
+      # An edit to model.rb must re-check caller.rb (it read Widget#price's body from there), so caller.rb is a
+      # dependent of model.rb.
       expect(dependents[File.join(dir, "model.rb")]).to include(File.join(dir, "caller.rb"))
-      # A file no one reads from has no dependents entry (nil, not a
-      # mutable default — the frozen index dropped its default proc).
+      # A file no one reads from has no dependents entry (nil, not a mutable default — the frozen index dropped its
+      # default proc).
       expect(dependents[File.join(dir, "caller.rb")]).to be_nil
     end
   end

--- a/spec/rigor/analysis/dependency_source_inference/builder_spec.rb
+++ b/spec/rigor/analysis/dependency_source_inference/builder_spec.rb
@@ -114,8 +114,8 @@ RSpec.describe Rigor::Analysis::DependencySourceInference::Builder do
       )
       allow(walker).to receive(:walk).and_raise(StandardError, "boom")
 
-      # walker_outcome_for rescues the raise and substitutes an empty,
-      # non-truncated Outcome rather than letting the whole build crash.
+      # walker_outcome_for rescues the raise and substitutes an empty, non-truncated Outcome rather than letting the
+      # whole build crash.
       index = described_class.build(dependencies({ "gem" => "alpha" }))
 
       expect(index.contribution_for(class_name: "Alpha", method_name: :one)).to be_nil
@@ -132,10 +132,8 @@ RSpec.describe Rigor::Analysis::DependencySourceInference::Builder do
           gem_dir: gem_dir, mode: :when_missing, roots: %w[lib]
         )
       )
-      # The Index normalizes legacy bare-Symbol catalog values
-      # (`=> :instance`) into `CatalogEntry(kind:)` at
-      # construction, so spec stubs may pass either shape. We
-      # keep the helper's API on bare Symbols for legibility.
+      # The Index normalizes legacy bare-Symbol catalog values (`=> :instance`) into `CatalogEntry(kind:)` at
+      # construction, so spec stubs may pass either shape. We keep the helper's API on bare Symbols for legibility.
       outcome = walker::Outcome.new(catalog: method_catalog, truncated: truncated)
       allow(walker).to receive(:walk).with(
         gem_dir: gem_dir, roots: %w[lib], budget: anything

--- a/spec/rigor/analysis/dependency_source_inference/index_spec.rb
+++ b/spec/rigor/analysis/dependency_source_inference/index_spec.rb
@@ -92,8 +92,7 @@ RSpec.describe Rigor::Analysis::DependencySourceInference::Index do
       catalog = { ["Foo", :bar] => :instance, ["Foo", :baz] => :singleton }
       index = described_class.new(method_catalog: catalog)
 
-      # Walker::CatalogEntry is the post-normalization shape;
-      # bare-Symbol catalog values are accepted at construction
+      # Walker::CatalogEntry is the post-normalization shape; bare-Symbol catalog values are accepted at construction
       # and normalized into the same shape internally.
       expect(index.contribution_for(class_name: "Foo", method_name: :bar).kind).to eq(:instance)
       expect(index.contribution_for(class_name: "Foo", method_name: :baz).kind).to eq(:singleton)

--- a/spec/rigor/analysis/dependency_source_inference/return_type_heuristic_spec.rb
+++ b/spec/rigor/analysis/dependency_source_inference/return_type_heuristic_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe Rigor::Analysis::DependencySourceInference::ReturnTypeHeuristic d
     end
 
     it "digs past a begin/rescue wrapper to the protected body's tail" do
-      # The body is a BeginNode; tail_expression recurses into its
-      # protected statements rather than stopping at the wrapper.
+      # The body is a BeginNode; tail_expression recurses into its protected statements rather than stopping at the
+      # wrapper.
       type = extract_from(<<~RUBY)
         def m
           begin

--- a/spec/rigor/analysis/dependency_source_inference/walker_spec.rb
+++ b/spec/rigor/analysis/dependency_source_inference/walker_spec.rb
@@ -82,9 +82,8 @@ RSpec.describe Rigor::Analysis::DependencySourceInference::Walker do
     end
 
     it "descends a body-less class via the children fallback without aborting the file" do
-      # `class Empty; end` has a nil body, so descend_class_or_module
-      # takes the walk_children branch; the sibling class in the same
-      # file must still be harvested (the fallback must not crash).
+      # `class Empty; end` has a nil body, so descend_class_or_module takes the walk_children branch; the sibling class
+      # in the same file must still be harvested (the fallback must not crash).
       with_fake_gem do |gem_dir|
         File.write(File.join(gem_dir, "lib", "fake.rb"), <<~RUBY)
           class Empty; end
@@ -102,10 +101,8 @@ RSpec.describe Rigor::Analysis::DependencySourceInference::Walker do
     end
 
     it "treats `class << expr` (non-self) as opaque, recording its defs under the surrounding class" do
-      # The singleton receiver is a constant, not `self`, so
-      # descend_singleton_class takes the walk_children fallback: the
-      # inner def is recorded as an ordinary instance method of Outer,
-      # NOT a per-instance singleton.
+      # The singleton receiver is a constant, not `self`, so descend_singleton_class takes the walk_children fallback:
+      # the inner def is recorded as an ordinary instance method of Outer, NOT a per-instance singleton.
       with_fake_gem do |gem_dir|
         File.write(File.join(gem_dir, "lib", "fake.rb"), <<~RUBY)
           module Outer

--- a/spec/rigor/analysis/diagnostic_spec.rb
+++ b/spec/rigor/analysis/diagnostic_spec.rb
@@ -197,8 +197,8 @@ RSpec.describe Rigor::Analysis::Diagnostic do
   end
 
   describe ".from_message_loc" do
-    # A method call with a receiver: message_loc (the "foo" span) starts
-    # past the receiver, so it differs from the receiver-spanning location.
+    # A method call with a receiver: message_loc (the "foo" span) starts past the receiver, so it differs from the
+    # receiver-spanning location.
     let(:call) { Prism.parse("receiver.foo(:bar)").value.statements.body.first }
 
     it "positions at the call's message_loc (the method-name span)" do

--- a/spec/rigor/analysis/incremental_session_spec.rb
+++ b/spec/rigor/analysis/incremental_session_spec.rb
@@ -3,12 +3,10 @@
 require "spec_helper"
 require "tmpdir"
 
-# ADR-46 slice 2 — the in-memory incremental orchestrator. The acceptance
-# property (the `--verify-incremental` gate, here without disk persistence
-# or CLI wiring): after a real on-disk edit, `#recheck` re-analyzes only
-# the affected closure and serves the rest from cache, yet its merged
-# diagnostics are byte-identical — as a sorted set — to a full re-analysis
-# of the edited tree.
+# ADR-46 slice 2 — the in-memory incremental orchestrator. The acceptance property (the `--verify-incremental` gate,
+# here without disk persistence or CLI wiring): after a real on-disk edit, `#recheck` re-analyzes only the affected
+# closure and serves the rest from cache, yet its merged diagnostics are byte-identical — as a sorted set — to a full
+# re-analysis of the edited tree.
 RSpec.describe Rigor::Analysis::IncrementalSession do
   def configuration(dir)
     Rigor::Configuration.new("paths" => [dir])
@@ -37,8 +35,8 @@ RSpec.describe Rigor::Analysis::IncrementalSession do
     Rigor::Cache::IncrementalSnapshot.fingerprint(configuration: config, roots: [dir])
   end
 
-  # A self-contained `def.override-visibility-reduced` (balanced profile →
-  # :warning) plus a referenceable class. `reduced:` toggles the diagnostic.
+  # A self-contained `def.override-visibility-reduced` (balanced profile → :warning) plus a referenceable class.
+  # `reduced:` toggles the diagnostic.
   def write_unit(path, prefix:, reduced: true)
     File.write(path, <<~RUBY)
       class #{prefix}Base
@@ -111,8 +109,8 @@ RSpec.describe Rigor::Analysis::IncrementalSession do
       r1 = session.recheck
       expect(sorted(r1.diagnostics)).to eq(sorted(full_run(dir)))
 
-      # Round 2: erase b.rb's diagnostic too. The session's cache for a.rb
-      # must already reflect round 1, so the merge stays correct.
+      # Round 2: erase b.rb's diagnostic too. The session's cache for a.rb must already reflect round 1, so the merge
+      # stays correct.
       write_unit(b, prefix: "B", reduced: false)
       r2 = session.recheck
       expect(r2.changed).to eq(Set[b])
@@ -120,10 +118,9 @@ RSpec.describe Rigor::Analysis::IncrementalSession do
     end
   end
 
-  # ADR-46 slice 3 — negative-dependency tracking. A top-level call has no
-  # class ancestry to walk, so a miss records no positive edge; without the
-  # negative edge a caller's `call.unresolved-toplevel` would be served stale
-  # after the method is defined elsewhere.
+  # ADR-46 slice 3 — negative-dependency tracking. A top-level call has no class ancestry to walk, so a miss records no
+  # positive edge; without the negative edge a caller's `call.unresolved-toplevel` would be served stale after the
+  # method is defined elsewhere.
   describe "negative (appeared-symbol) dependencies" do
     it "re-checks a caller whose missed top-level method is defined by an edit" do
       Dir.mktmpdir do |dir|
@@ -141,8 +138,8 @@ RSpec.describe Rigor::Analysis::IncrementalSession do
         File.write(b, "def helper\n  1\nend\n")
         recheck = session.recheck
 
-        # a.rb is pulled into the affected closure by the appeared `helper`,
-        # so the merged result matches a full re-analysis (no stale FP).
+        # a.rb is pulled into the affected closure by the appeared `helper`, so the merged result matches a full
+        # re-analysis (no stale FP).
         expect(recheck.affected).to include(a)
         expect(sorted(recheck.diagnostics)).to eq(sorted(full_run(dir)))
         expect(sorted(recheck.diagnostics).map { |h| h["rule"] }).not_to include("call.unresolved-toplevel")
@@ -153,8 +150,8 @@ RSpec.describe Rigor::Analysis::IncrementalSession do
       Dir.mktmpdir do |dir|
         a = File.join(dir, "a.rb")
         b = File.join(dir, "b.rb")
-        # ASub overrides tag with reduced visibility, but NewBase does not yet
-        # exist, so no def.override-* fires at baseline.
+        # ASub overrides tag with reduced visibility, but NewBase does not yet exist, so no def.override-* fires at
+        # baseline.
         File.write(a, "class ASub < NewBase\n  private\n\n  def tag\n    \"y\"\n  end\nend\n")
         File.write(b, "class Placeholder\nend\n")
 
@@ -162,8 +159,8 @@ RSpec.describe Rigor::Analysis::IncrementalSession do
         baseline = session.baseline
         expect(baseline.map(&:rule)).not_to include("def.override-visibility-reduced")
 
-        # Define NewBase (with a public tag) in b.rb — ASub now reduces its
-        # visibility, so the override diagnostic must appear.
+        # Define NewBase (with a public tag) in b.rb — ASub now reduces its visibility, so the override diagnostic must
+        # appear.
         File.write(b, "class NewBase\n  def tag\n    \"x\"\n  end\nend\n")
         recheck = session.recheck
 
@@ -182,8 +179,8 @@ RSpec.describe Rigor::Analysis::IncrementalSession do
 
         session = session_for(configuration(dir))
         session.baseline
-        # Add an unrelated top-level method — a.rb missed `missing_helper`,
-        # not `other`, so it must stay served from cache.
+        # Add an unrelated top-level method — a.rb missed `missing_helper`, not `other`, so it must stay served from
+        # cache.
         File.write(b, "class Thing\n  def existing\n    1\n  end\nend\n\ndef other\n  2\nend\n")
         recheck = session.recheck
 
@@ -193,10 +190,9 @@ RSpec.describe Rigor::Analysis::IncrementalSession do
     end
   end
 
-  # ADR-46 slice 3 (structural tier) — files added / removed between runs are
-  # reconciled incrementally (the `paths:` set is no longer in the snapshot
-  # fingerprint), leaning on the appeared-symbol/class negative edges for
-  # additions and the positive dependents of removed files for removals.
+  # ADR-46 slice 3 (structural tier) — files added / removed between runs are reconciled incrementally (the `paths:` set
+  # is no longer in the snapshot fingerprint), leaning on the appeared-symbol/class negative edges for additions and the
+  # positive dependents of removed files for removals.
   describe "file addition / removal" do
     it "re-checks a caller when a new file defines its missing top-level method" do
       Dir.mktmpdir do |dir|
@@ -244,8 +240,7 @@ RSpec.describe Rigor::Analysis::IncrementalSession do
         File.delete(b)
         recheck = session.recheck
 
-        # a.rb re-checked (now fires unresolved-toplevel); b.rb gone from the
-        # analyzed set and the merged diagnostics.
+        # a.rb re-checked (now fires unresolved-toplevel); b.rb gone from the analyzed set and the merged diagnostics.
         expect(recheck.affected).to include(a)
         expect(session.analyzed_files).not_to include(b)
         expect(sorted(recheck.diagnostics)).to eq(sorted(full_run(dir)))
@@ -284,8 +279,7 @@ RSpec.describe Rigor::Analysis::IncrementalSession do
                      .run_incremental(snapshot: snapshot, fingerprint: fp)
         expect(warm1).to be(false)
 
-        # A new file appears between processes; the roots-keyed fingerprint is
-        # unchanged, so the snapshot still loads.
+        # A new file appears between processes; the roots-keyed fingerprint is unchanged, so the snapshot still loads.
         File.write(File.join(dir, "b.rb"), "def helper\n  1\nend\n")
         diags2, warm2 = session_for(config, paths: [dir])
                         .run_incremental(snapshot: snapshot, fingerprint: fp)
@@ -312,12 +306,11 @@ RSpec.describe Rigor::Analysis::IncrementalSession do
                         .run_incremental(snapshot: snapshot, fingerprint: fp)
         expect(warm1).to be(false)
 
-        # An edit between "processes" — erase a.rb's diagnostic. Content is
-        # not part of the fingerprint, so the snapshot still loads.
+        # An edit between "processes" — erase a.rb's diagnostic. Content is not part of the fingerprint, so the snapshot
+        # still loads.
         write_unit(a, prefix: "A", reduced: false)
 
-        # Process 2 — warm: a fresh session restores the snapshot and
-        # re-analyzes only the changed closure.
+        # Process 2 — warm: a fresh session restores the snapshot and re-analyzes only the changed closure.
         diags2, warm2 = session_for(config, paths: [dir])
                         .run_incremental(snapshot: snapshot, fingerprint: fp)
         expect(warm2).to be(true)

--- a/spec/rigor/analysis/incremental_spec.rb
+++ b/spec/rigor/analysis/incremental_spec.rb
@@ -3,13 +3,10 @@
 require "spec_helper"
 require "tmpdir"
 
-# ADR-46 slice 2 — the incremental step's pure core plus its soundness
-# property. The body tier re-analyses `{changed} ∪ dependents[changed]`
-# and serves every other file from the per-file cache; the property that
-# makes that sound is that an edit whose declaration-structure fingerprint
-# is unchanged never changes the diagnostics of a file OUTSIDE that
-# closure. These specs assert the set algebra in isolation and then drive
-# real runs to confirm the property end-to-end.
+# ADR-46 slice 2 — the incremental step's pure core plus its soundness property. The body tier re-analyses `{changed} ∪
+# dependents[changed]` and serves every other file from the per-file cache; the property that makes that sound is that
+# an edit whose declaration-structure fingerprint is unchanged never changes the diagnostics of a file OUTSIDE that
+# closure. These specs assert the set algebra in isolation and then drive real runs to confirm the property end-to-end.
 RSpec.describe Rigor::Analysis::Incremental do
   describe ".affected" do
     it "is the changed set plus the dependents of every changed file" do
@@ -164,9 +161,8 @@ RSpec.describe Rigor::Analysis::Incremental do
     end
   end
 
-  # End-to-end soundness: drive real runs, mutate one file, and confirm
-  # the files whose diagnostics actually moved are a subset of the affected
-  # closure the body tier would re-analyse.
+  # End-to-end soundness: drive real runs, mutate one file, and confirm the files whose diagnostics actually moved are a
+  # subset of the affected closure the body tier would re-analyse.
   describe "soundness property (real runs)" do
     def baseline(dir)
       config = Rigor::Configuration.new("paths" => [dir])
@@ -182,10 +178,9 @@ RSpec.describe Rigor::Analysis::Incremental do
       Rigor::Analysis::Runner.new(configuration: config, cache_store: nil).run.diagnostics.group_by(&:path)
     end
 
-    # A self-contained `def.override-visibility-reduced` (balanced profile
-    # → :warning). `reduced:` toggles the `private` modifier that is the
-    # diagnostic's cause; `prefix` keeps each file's class names distinct
-    # so the cross-file index never merges two fixtures.
+    # A self-contained `def.override-visibility-reduced` (balanced profile → :warning). `reduced:` toggles the `private`
+    # modifier that is the diagnostic's cause; `prefix` keeps each file's class names distinct so the cross-file index
+    # never merges two fixtures.
     def write_reduction(path, prefix:, reduced:)
       File.write(path, <<~RUBY)
         class #{prefix}Base
@@ -215,20 +210,18 @@ RSpec.describe Rigor::Analysis::Incremental do
         expect(per_file_before[widget]).not_to be_nil
         expect(per_file_before[gadget]).not_to be_nil
 
-        # Body edit to widget that erases its diagnostic. No symbol
-        # added/removed/moved → declaration fingerprint unchanged.
+        # Body edit to widget that erases its diagnostic. No symbol added/removed/moved → declaration fingerprint
+        # unchanged.
         write_reduction(widget, prefix: "W", reduced: false)
 
         changed = described_class.changed_files(per_file_before, per_file(dir))
         affected = described_class.affected([widget], dependents)
 
-        # The soundness invariant: every file whose diagnostics moved is in
-        # the closure the body tier re-analyses.
+        # The soundness invariant: every file whose diagnostics moved is in the closure the body tier re-analyses.
         expect(changed).to be_subset(affected)
         # The edit toggled widget's own diagnostic …
         expect(changed).to include(widget)
-        # … and left gadget untouched — it is correctly served from cache,
-        # demonstrating the leaf-edit pruning win.
+        # … and left gadget untouched — it is correctly served from cache, demonstrating the leaf-edit pruning win.
         expect(changed).not_to include(gadget)
       end
     end
@@ -255,11 +248,9 @@ RSpec.describe Rigor::Analysis::Incremental do
         _diagnostics, dependents = baseline(dir)
         affected = described_class.affected([model], dependents)
 
-        # caller.rb resolved Model#compute through to its body, so a Model
-        # edit re-analyses caller.rb even though Rigor's conservative
-        # inferred-return handling means its diagnostics rarely actually
-        # change — the body tier re-checks it to stay sound, not because a
-        # ripple is guaranteed.
+        # caller.rb resolved Model#compute through to its body, so a Model edit re-analyses caller.rb even though
+        # Rigor's conservative inferred-return handling means its diagnostics rarely actually change — the body tier
+        # re-checks it to stay sound, not because a ripple is guaranteed.
         expect(affected).to include(caller_file)
       end
     end

--- a/spec/rigor/analysis/run_stats_spec.rb
+++ b/spec/rigor/analysis/run_stats_spec.rb
@@ -52,12 +52,10 @@ RSpec.describe Rigor::Analysis::RunStats do
     end
   end
 
-  # The Linux `/proc/self/status` reader is exercised on Linux CI but never on
-  # the macOS dev box (no `/proc`), and even on Linux the `.peak_rss_bytes`
-  # test above only asserts a non-negative integer — so the parse (the
-  # `VmHWM:` line filter, the digit-token extraction, the kB→byte scale) has
-  # no assertion pinning the actual value. Feed synthetic `/proc/self/status`
-  # content so the parse is verified on every platform.
+  # The Linux `/proc/self/status` reader is exercised on Linux CI but never on the macOS dev box (no `/proc`), and even
+  # on Linux the `.peak_rss_bytes` test above only asserts a non-negative integer — so the parse (the `VmHWM:` line
+  # filter, the digit-token extraction, the kB→byte scale) has no assertion pinning the actual value. Feed synthetic
+  # `/proc/self/status` content so the parse is verified on every platform.
   describe ".read_vmhwm_from_proc" do
     it "returns the VmHWM kilobytes scaled to bytes, ignoring sibling lines" do
       allow(File).to receive(:readable?).with("/proc/self/status").and_return(true)

--- a/spec/rigor/analysis/runner_fork_pool_spec.rb
+++ b/spec/rigor/analysis/runner_fork_pool_spec.rb
@@ -9,20 +9,16 @@ require "rigor/plugin"
 
 # ADR-15 Amendment (2026-05-20) — fork-pool equivalence.
 #
-# `workers: N > 0` dispatches per-file analysis across a fork-based
-# worker pool — the active backend (the Ractor pool is preserved only
-# behind `RIGOR_POOL_BACKEND=ractor`). Unlike the Ractor pool — which
-# crashes (~70 % of runs, Ruby Bug #22075) and otherwise emits 100 %
-# `Ractor::IsolationError` diagnostics — the fork pool runs each worker
-# in a separate process, so it is memory-safe and this spec runs in the
-# DEFAULT suite (no `RIGOR_INCLUDE_RACTOR_POOL` gate).
+# `workers: N > 0` dispatches per-file analysis across a fork-based worker pool — the active backend (the Ractor pool is
+# preserved only behind `RIGOR_POOL_BACKEND=ractor`). Unlike the Ractor pool — which crashes (~70 % of runs, Ruby Bug
+# #22075) and otherwise emits 100 % `Ractor::IsolationError` diagnostics — the fork pool runs each worker in a separate
+# process, so it is memory-safe and this spec runs in the DEFAULT suite (no `RIGOR_INCLUDE_RACTOR_POOL` gate).
 #
-# Contract: the fork pool produces the same diagnostic stream as the
-# sequential path AND does real analysis (never an
+# Contract: the fork pool produces the same diagnostic stream as the sequential path AND does real analysis (never an
 # `internal analyzer error`).
 RSpec.describe "Rigor::Analysis::Runner with fork pool (ADR-15 Amendment)" do
-  # Per-file diagnostic comparison key. Severity is stripped — the
-  # severity-profile re-stamping is identical on both code paths.
+  # Per-file diagnostic comparison key. Severity is stripped — the severity-profile re-stamping is identical on both
+  # code paths.
   def diag_keys(diagnostics)
     diagnostics.map do |d|
       [d.path, d.line, d.column, d.rule, d.source_family, d.message]
@@ -36,10 +32,9 @@ RSpec.describe "Rigor::Analysis::Runner with fork pool (ADR-15 Amendment)" do
     end
   end
 
-  # Two-file fixture for the cross-file seed regression: `Widget` is
-  # RBS-known via `signature_paths:` while `Widget#render` is defined in a
-  # different source file than its caller. Returns the definition path,
-  # the caller path, and the configuration entries.
+  # Two-file fixture for the cross-file seed regression: `Widget` is RBS-known via `signature_paths:` while
+  # `Widget#render` is defined in a different source file than its caller. Returns the definition path, the caller path,
+  # and the configuration entries.
   def write_cross_file_fixture(dir)
     FileUtils.mkdir_p(File.join(dir, "sig"))
     File.write(File.join(dir, "sig", "widget.rbs"), "class Widget\nend\n")
@@ -125,29 +120,22 @@ RSpec.describe "Rigor::Analysis::Runner with fork pool (ADR-15 Amendment)" do
     it "carries the cross-file project pre-pass seed into worker scopes " \
        "(regression: workers emitted call.undefined-method false positives)" do
       Dir.mktmpdir do |dir|
-        # Regression for the fork-pool seeding gap observed on rigor's
-        # own self-check (`--workers 2` emitted 20 cross-file
-        # `call.undefined-method` errors the sequential path did not):
-        # {WorkerSession#analyze} built its per-file scope from
-        # `Scope.empty` without `Runner#seed_project_scope`'s cross-file
-        # discovery tables. This fixture makes the seed observable in
-        # the diagnostic STREAM: the receiver class is RBS-known via
-        # `signature_paths:` while `render` is defined in a different
-        # source file, so the ADR-17 diagnostic both paths emit must
-        # carry the `project defines ... at a_widget.rb:2` site, which
-        # only the seeded `discovered_def_sources` table can supply — an
-        # unseeded worker produces a different message and breaks the
+        # Regression for the fork-pool seeding gap observed on rigor's own self-check (`--workers 2` emitted 20
+        # cross-file `call.undefined-method` errors the sequential path did not): {WorkerSession#analyze} built its
+        # per-file scope from `Scope.empty` without `Runner#seed_project_scope`'s cross-file discovery tables. This
+        # fixture makes the seed observable in the diagnostic STREAM: the receiver class is RBS-known via
+        # `signature_paths:` while `render` is defined in a different source file, so the ADR-17 diagnostic both paths
+        # emit must carry the `project defines ... at a_widget.rb:2` site, which only the seeded
+        # `discovered_def_sources` table can supply — an unseeded worker produces a different message and breaks the
         # byte-identical sequential-equivalence contract.
         defn, caller_path, config = write_cross_file_fixture(dir)
         sequential = run_check(dir, [defn, caller_path], config: config, cache_store: nil)
-        # workers: 2 puts each file in its own slice, so the worker
-        # analysing b_board.rb never parses a_widget.rb itself — it can
-        # only resolve `Widget#render` through the seeded pre-pass tables.
+        # workers: 2 puts each file in its own slice, so the worker analysing b_board.rb never parses a_widget.rb itself
+        # — it can only resolve `Widget#render` through the seeded pre-pass tables.
         pool = run_check(dir, [defn, caller_path], config: config, cache_store: nil, workers: 2)
 
-        # Guard the fixture itself: the sequential diagnostic must carry
-        # the cross-file definition site, or the equivalence assertion
-        # below would pass vacuously on two unseeded streams.
+        # Guard the fixture itself: the sequential diagnostic must carry the cross-file definition site, or the
+        # equivalence assertion below would pass vacuously on two unseeded streams.
         expect(sequential.map(&:message)).to include(a_string_matching(/a_widget\.rb:2/))
         expect(diag_keys(pool)).to eq(diag_keys(sequential))
       end

--- a/spec/rigor/analysis/runner_pool_spec.rb
+++ b/spec/rigor/analysis/runner_pool_spec.rb
@@ -34,11 +34,9 @@ require "rigor/plugin"
 # no-cache_store degradation example pins the Ractor backend,
 # because that precondition is Ractor-specific (Phase 4b.x).
 RSpec.describe "Rigor::Analysis::Runner with Ractor pool (Phase 4b)" do
-  # Per-file diagnostic comparison key. Severity is stripped
-  # because the severity-profile re-stamping is identical on
-  # both code paths (the profile sees the same authored
-  # severity → resolved severity table); the remaining fields
-  # are the per-file invariant the equivalence contract binds.
+  # Per-file diagnostic comparison key. Severity is stripped because the severity-profile re-stamping is identical on
+  # both code paths (the profile sees the same authored severity → resolved severity table); the remaining fields are
+  # the per-file invariant the equivalence contract binds.
   def diag_keys(diagnostics)
     diagnostics.map do |d|
       [d.path, d.line, d.column, d.rule, d.source_family, d.message]
@@ -108,15 +106,10 @@ RSpec.describe "Rigor::Analysis::Runner with Ractor pool (Phase 4b)" do
     end
 
     it "handles non-trivial source that exercises the RBS dispatch chain (Phase 4b.x)" do
-      # Without the Phase 4b.x cache pre-warm, the worker
-      # would call `RBS::EnvironmentLoader.new` on first
-      # class lookup and trip
-      # `Ractor::IsolationError` reading
-      # `RBS::EnvironmentLoader::DEFAULT_CORE_ROOT` etc.
-      # The pre-warm ensures every cached producer is warm
-      # on the main Ractor first, so the worker's
-      # `cached_env` Marshal-load path serves every query
-      # without ever touching `EnvironmentLoader.new`.
+      # Without the Phase 4b.x cache pre-warm, the worker would call `RBS::EnvironmentLoader.new` on first class lookup
+      # and trip `Ractor::IsolationError` reading `RBS::EnvironmentLoader::DEFAULT_CORE_ROOT` etc. The pre-warm ensures
+      # every cached producer is warm on the main Ractor first, so the worker's `cached_env` Marshal-load path serves
+      # every query without ever touching `EnvironmentLoader.new`.
       Dir.mktmpdir do |dir|
         path = File.join(dir, "code.rb")
         File.write(path, <<~RUBY)
@@ -138,25 +131,19 @@ RSpec.describe "Rigor::Analysis::Runner with Ractor pool (Phase 4b)" do
           ).run.diagnostics
         end
 
-        # Both runs MUST flag the same `call.undefined-method`
-        # / `call.wrong-arity` diagnostics — proves the
-        # worker dispatched through RBS without crashing.
+        # Both runs MUST flag the same `call.undefined-method` / `call.wrong-arity` diagnostics — proves the worker
+        # dispatched through RBS without crashing.
         expect(diag_keys(pool).select { |k| %w[call.undefined-method call.wrong-arity].include?(k[3]) }).to eq(
           diag_keys(sequential).select { |k| %w[call.undefined-method call.wrong-arity].include?(k[3]) }
         )
       end
     end
 
-    # ADR-15 Phase 4b.x — the no-cache_store degradation is a
-    # RACTOR-backend precondition: without the cache pre-warm a
-    # worker's first reflection query would fall through to
-    # `RBS::EnvironmentLoader.new` and trip
-    # `Ractor::IsolationError`. The fork backend copy-on-write
-    # inherits the parent's warm Environment and needs no
-    # cache_store — its counterpart contract (no degradation)
-    # lives in `runner_fork_pool_spec.rb`. The guard fires
-    # BEFORE any Ractor spawns, so pinning the backend here is
-    # deterministic and carries none of the pool's Bus-Error
+    # ADR-15 Phase 4b.x — the no-cache_store degradation is a RACTOR-backend precondition: without the cache pre-warm a
+    # worker's first reflection query would fall through to `RBS::EnvironmentLoader.new` and trip
+    # `Ractor::IsolationError`. The fork backend copy-on-write inherits the parent's warm Environment and needs no
+    # cache_store — its counterpart contract (no degradation) lives in `runner_fork_pool_spec.rb`. The guard fires
+    # BEFORE any Ractor spawns, so pinning the backend here is deterministic and carries none of the pool's Bus-Error
     # exposure.
     it "degrades gracefully to sequential when the Ractor backend is configured without a cache_store" do
       original = ENV.fetch("RIGOR_POOL_BACKEND", nil)
@@ -182,10 +169,8 @@ RSpec.describe "Rigor::Analysis::Runner with Ractor pool (Phase 4b)" do
 
     it "preserves original path order even when workers complete out of order" do
       Dir.mktmpdir do |dir|
-        # Each file emits a parse-error diagnostic so the
-        # per-file output is deterministic; the resulting
-        # diagnostic stream's `path` sequence MUST match the
-        # input path order.
+        # Each file emits a parse-error diagnostic so the per-file output is deterministic; the resulting diagnostic
+        # stream's `path` sequence MUST match the input path order.
         paths = Array.new(5) do |i|
           path = File.join(dir, "broken_#{i}.rb")
           File.write(path, "def broken_#{i}\n")
@@ -296,8 +281,7 @@ RSpec.describe "Rigor::Analysis::Runner with Ractor pool (Phase 4b)" do
             d.source_family == :plugin_loader &&
             d.message.include?("pool-prepare-raises")
         end
-        # 3 workers, each runs `prepare` and raises; the
-        # coordinator keeps only the first worker's snapshot.
+        # 3 workers, each runs `prepare` and raises; the coordinator keeps only the first worker's snapshot.
         expect(prepare_errors.size).to eq(1)
       end
     end

--- a/spec/rigor/analysis/runner_run_source_spec.rb
+++ b/spec/rigor/analysis/runner_run_source_spec.rb
@@ -3,9 +3,8 @@
 require "spec_helper"
 require "tempfile"
 
-# `Runner#run_source` — in-memory single-source analysis (a clean public
-# entry point for embedders + a faster spec path). It must be diagnostic-
-# equivalent to running the same source from a real file on disk.
+# `Runner#run_source` — in-memory single-source analysis (a clean public entry point for embedders + a faster spec
+# path). It must be diagnostic- equivalent to running the same source from a real file on disk.
 RSpec.describe "Rigor::Analysis::Runner#run_source" do
   def configuration
     Rigor::Configuration.new("paths" => [])
@@ -30,8 +29,8 @@ RSpec.describe "Rigor::Analysis::Runner#run_source" do
     diagnostics.map { |d| [d.rule, d.line, d.column] }.sort
   end
 
-  # Each source exercises a different analysis path; the in-memory and
-  # on-disk runs must agree on every diagnostic's rule + location.
+  # Each source exercises a different analysis path; the in-memory and on-disk runs must agree on every diagnostic's
+  # rule + location.
   {
     "same-file self-call resolution" => "class C\n  def run\n    helper\n  end\n  def helper\n    1\n  end\nend\n",
     "explicit-receiver undefined-method" => "x = 1\nx.no_such_method\n",
@@ -49,8 +48,8 @@ RSpec.describe "Rigor::Analysis::Runner#run_source" do
                                          .run_source(source: "x = 1\nx.nope\n", path: "buffer.rb")
                                          .diagnostics
     expect(diagnostics).not_to be_empty
-    # Per-file diagnostics carry the logical path; the only other path is
-    # the run-level config-info stream (`.rigor.yml`). No tmp/disk path.
+    # Per-file diagnostics carry the logical path; the only other path is the run-level config-info stream
+    # (`.rigor.yml`). No tmp/disk path.
     file_paths = diagnostics.map(&:path).reject { |p| p == ".rigor.yml" }.uniq
     expect(file_paths).to eq(["buffer.rb"])
   end

--- a/spec/rigor/analysis/runner_spec.rb
+++ b/spec/rigor/analysis/runner_spec.rb
@@ -2,15 +2,12 @@
 
 require "rigor/analysis/runner"
 
-# Path-error / parse-error specs intentionally bypass `analyze`
-# because they exercise paths that do not exist or contain
-# non-Ruby content; the helper assumes a writable tmpdir of
-# `.rb` files. Everything else uses `analyze`.
+# Path-error / parse-error specs intentionally bypass `analyze` because they exercise paths that do not exist or contain
+# non-Ruby content; the helper assumes a writable tmpdir of `.rb` files. Everything else uses `analyze`.
 RSpec.describe Rigor::Analysis::Runner do
-  # T1 — a `rescue SyntaxError => e` in one file resolves to the
-  # project's `M::SyntaxError = Class.new(Error)` defined in a sibling
-  # file (not core `::SyntaxError`), so a call on the rescued exception
-  # that the project class supports does not fire undefined-method.
+  # T1 — a `rescue SyntaxError => e` in one file resolves to the project's `M::SyntaxError = Class.new(Error)` defined
+  # in a sibling file (not core `::SyntaxError`), so a call on the rescued exception that the project class supports
+  # does not fire undefined-method.
   it "resolves a cross-file rescue Const to the same-namespace Class.new class" do
     Dir.mktmpdir do |dir|
       File.write(File.join(dir, "a.rb"), <<~RUBY)
@@ -43,10 +40,8 @@ RSpec.describe Rigor::Analysis::Runner do
     Dir.mktmpdir do |dir|
       missing = File.join(dir, "ghost.rb")
       configuration = Rigor::Configuration.new("paths" => [missing])
-      # chdir into a clean tmpdir so the runner does not pick up
-      # rigor's own `Gemfile.lock` (which would fire the
-      # O4-slice-3 missing-RBS diagnostic ahead of the
-      # file-not-found one).
+      # chdir into a clean tmpdir so the runner does not pick up rigor's own `Gemfile.lock` (which would fire the
+      # O4-slice-3 missing-RBS diagnostic ahead of the file-not-found one).
       Dir.chdir(dir) do
         result = described_class.new(configuration: configuration).run
 
@@ -79,8 +74,7 @@ RSpec.describe Rigor::Analysis::Runner do
       txt = File.join(dir, "notes.txt")
       File.write(txt, "hello")
       configuration = Rigor::Configuration.new("paths" => [txt])
-      # See above: chdir away from rigor's repo root so the
-      # missing-RBS diagnostic doesn't surface ahead of the
+      # See above: chdir away from rigor's repo root so the missing-RBS diagnostic doesn't surface ahead of the
       # path-error diagnostic.
       Dir.chdir(dir) do
         result = described_class.new(configuration: configuration).run
@@ -98,14 +92,11 @@ RSpec.describe Rigor::Analysis::Runner do
     expect(result.diagnostics.first.message).not_to be_empty
   end
 
-  # Regression: Rails generator templates ship as `.rb` files but contain
-  # ERB interpolation (`<%= ... %>`), which Prism cannot parse and the
-  # analyzer used to surface as up to ~20 noisy parse-error diagnostics
-  # per file. Redmine's `lib/generators/redmine_plugin_model/templates/
-  # migration.rb` is the canonical example. The closing `%>` marker
-  # cannot appear in valid Ruby (`%` is a binary operator that requires
-  # an operand on its right), so its presence is sufficient evidence
-  # that the file is an ERB template; analysis silently skips it.
+  # Regression: Rails generator templates ship as `.rb` files but contain ERB interpolation (`<%= ... %>`), which Prism
+  # cannot parse and the analyzer used to surface as up to ~20 noisy parse-error diagnostics per file. Redmine's
+  # `lib/generators/redmine_plugin_model/templates/migration.rb` is the canonical example. The closing `%>` marker
+  # cannot appear in valid Ruby (`%` is a binary operator that requires an operand on its right), so its presence is
+  # sufficient evidence that the file is an ERB template; analysis silently skips it.
   context "with an ERB-templated `.rb` file (Rails generator shape)" do
     it "silently skips a file whose source uses `<%= ... %>` interpolation" do
       result = analyze(<<~ERB)
@@ -128,9 +119,8 @@ RSpec.describe Rigor::Analysis::Runner do
   end
 
   describe "exclude: patterns filter directory globs" do
-    # Each test plants a parse-error-shaped file (unclosed `def`)
-    # so analysis attempts surface as diagnostics; the test then
-    # checks whether those diagnostics include the planted path.
+    # Each test plants a parse-error-shaped file (unclosed `def`) so analysis attempts surface as diagnostics; the test
+    # then checks whether those diagnostics include the planted path.
     let(:bad_source) { "def broken\n" }
 
     it "skips the built-in vendor/bundle pattern when a directory expansion contains it" do
@@ -183,12 +173,10 @@ RSpec.describe Rigor::Analysis::Runner do
   end
 
   describe "configuration wiring at runtime (audit guard)" do
-    # Adjacent to the `target_ruby` block below, these specs guard
-    # against any of the documented `.rigor.yml` settings going
-    # phantom — i.e., loaded into `Configuration` but never read
-    # at runtime. The `cache.path` regression that prompted this
-    # block (the CLI hardcoded `".rigor/cache"` and ignored the
-    # config) is covered separately in `cli_spec.rb`.
+    # Adjacent to the `target_ruby` block below, these specs guard against any of the documented `.rigor.yml` settings
+    # going phantom — i.e., loaded into `Configuration` but never read at runtime. The `cache.path` regression that
+    # prompted this block (the CLI hardcoded `".rigor/cache"` and ignored the config) is covered separately in
+    # `cli_spec.rb`.
 
     it "loads `libraries:` stdlib RBS into Environment.for_project" do
       libraries_args = nil
@@ -244,8 +232,7 @@ RSpec.describe Rigor::Analysis::Runner do
               })
 
       expect(captured_kwargs).not_to be_nil
-      # The `analyze` helper chdirs into a tmpdir; on macOS the
-      # tmpdir resolves under `/private/tmp/...`, so match by
+      # The `analyze` helper chdirs into a tmpdir; on macOS the tmpdir resolves under `/private/tmp/...`, so match by
       # suffix rather than full prefix to stay portable.
       expect(captured_kwargs[:allowed_read_roots]).to include(end_with("/vendor/generated"))
       expect(captured_kwargs[:network_policy]).to eq(:disabled)
@@ -301,10 +288,8 @@ RSpec.describe Rigor::Analysis::Runner do
     end
 
     it "respects the per-receiver plugin veto (ADR-10 5a)" do
-      # When a plugin declares manifest(owns_receivers: [...])
-      # and the dispatcher's receiver IS owned by the plugin,
-      # try_dependency_source must decline so the plugin
-      # contribution stays authoritative.
+      # When a plugin declares manifest(owns_receivers: [...]) and the dispatcher's receiver IS owned by the plugin,
+      # try_dependency_source must decline so the plugin contribution stays authoritative.
       Rigor::Plugin.unregister!
       owner = Class.new(Rigor::Plugin::Base) do
         manifest(id: "owns-fake-node", version: "0.1.0", owns_receivers: ["Prism::FakeOwnedNode"])
@@ -381,9 +366,8 @@ RSpec.describe Rigor::Analysis::Runner do
     end
 
     it "surfaces `rbs.coverage.missing-gem` :info exactly once when locked gems have no RBS (O4 slice 3)" do # rubocop:disable RSpec/ExampleLength
-      # Build a tmpdir with Gemfile.lock listing two gems
-      # whose RBS is not covered by ANY of the four resolution
-      # paths (DEFAULT_LIBRARIES / vendored / bundle / collection).
+      # Build a tmpdir with Gemfile.lock listing two gems whose RBS is not covered by ANY of the four resolution paths
+      # (DEFAULT_LIBRARIES / vendored / bundle / collection).
       Dir.mktmpdir("rigor-rbs-coverage-spec-") do |tmpdir|
         File.write(File.join(tmpdir, "Gemfile.lock"), <<~LOCK)
           GEM
@@ -552,15 +536,15 @@ RSpec.describe Rigor::Analysis::Runner do
     it "does not emit `call.undefined-method` on a value of a synthesized stub type" do
       Dir.mktmpdir("rigor-stub-no-fp-") do |tmpdir|
         FileUtils.mkdir_p(File.join(tmpdir, "sig"))
-        # `Acme::Widget#remote` references `Net::FakeService`, which no
-        # loaded signature declares — Rigor stubs it so Widget builds.
+        # `Acme::Widget#remote` references `Net::FakeService`, which no loaded signature declares — Rigor stubs it so
+        # Widget builds.
         File.write(File.join(tmpdir, "sig", "widget.rbs"), <<~RBS)
           class Acme::Widget
             def remote: () -> Net::FakeService
           end
         RBS
-        # The call against the stub-typed value must NOT mis-fire
-        # undefined-method (the real Net::FakeService might define it).
+        # The call against the stub-typed value must NOT mis-fire undefined-method (the real Net::FakeService might
+        # define it).
         File.write(File.join(tmpdir, "code.rb"), <<~RUBY)
           w = Acme::Widget.new
           r = w.remote
@@ -581,11 +565,9 @@ RSpec.describe Rigor::Analysis::Runner do
     end
 
     describe "attr_* accessors suppress cross-file undefined-method" do
-      # A class that defines `attr_reader :x` AND ships RBS that omits
-      # `x` (an incomplete `sig/`) must not fire a false
-      # `undefined-method` on `obj.x` from another file. attr-declared
-      # accessors are recorded as discovered methods and propagated
-      # project-wide.
+      # A class that defines `attr_reader :x` AND ships RBS that omits `x` (an incomplete `sig/`) must not fire a false
+      # `undefined-method` on `obj.x` from another file. attr-declared accessors are recorded as discovered methods and
+      # propagated project-wide.
       it "does not flag an attr_reader method called from another file" do
         Dir.mktmpdir("rigor-attr-xfile-") do |tmpdir|
           FileUtils.mkdir_p(File.join(tmpdir, "sig"))
@@ -596,8 +578,8 @@ RSpec.describe Rigor::Analysis::Runner do
               attr_reader :size
             end
           RUBY
-          # `Widget.new` types the receiver as Widget (RBS-known), so
-          # the undefined-method rule actually evaluates `size`.
+          # `Widget.new` types the receiver as Widget (RBS-known), so the undefined-method rule actually evaluates
+          # `size`.
           File.write(File.join(tmpdir, "user.rb"), <<~RUBY)
             w = Widget.new
             w.size
@@ -705,15 +687,11 @@ RSpec.describe Rigor::Analysis::Runner do
         end
       end
 
-      # Regression: the dispatcher's `try_project_patched_method`
-      # tier resolved the call's TYPE through the registry, but
-      # `CheckRules#undefined_method_diagnostic` ran an independent
-      # "does this method exist?" probe that ignored the registry —
-      # so a patched method on a concretely-typed receiver
-      # (`Nominal[String]` / `Constant["hello"]`) would type
-      # correctly yet still fire `call.undefined-method`. The fix
-      # consults the registry in CheckRules at the same precedence
-      # the dispatcher does.
+      # Regression: the dispatcher's `try_project_patched_method` tier resolved the call's TYPE through the registry,
+      # but `CheckRules#undefined_method_diagnostic` ran an independent "does this method exist?" probe that ignored the
+      # registry — so a patched method on a concretely-typed receiver (`Nominal[String]` / `Constant["hello"]`) would
+      # type correctly yet still fire `call.undefined-method`. The fix consults the registry in CheckRules at the same
+      # precedence the dispatcher does.
       it "suppresses `call.undefined-method` on a patched method called on a concrete receiver" do # rubocop:disable RSpec/ExampleLength
         Dir.mktmpdir("rigor-pre-eval-concrete-") do |tmpdir|
           ext_path = File.join(tmpdir, "string_ext.rb")
@@ -764,10 +742,9 @@ RSpec.describe Rigor::Analysis::Runner do
       end
     end
 
-    # ADR-17 — when a project patch is NOT registered via `pre_eval:`,
-    # the call still fires `call.undefined-method`, but the diagnostic
-    # names the proven definition site and carries it as the structured
-    # `project_definition_site` field for `rigor triage` to key on.
+    # ADR-17 — when a project patch is NOT registered via `pre_eval:`, the call still fires `call.undefined-method`, but
+    # the diagnostic names the proven definition site and carries it as the structured `project_definition_site` field
+    # for `rigor triage` to key on.
     describe "ADR-17 — enriched undefined-method for un-registered project patches" do
       it "names the cross-file def site and sets project_definition_site" do
         Dir.mktmpdir("rigor-mp-enrich-") do |tmpdir|
@@ -989,17 +966,16 @@ RSpec.describe Rigor::Analysis::Runner do
     end
 
     it "surfaces a configuration-error diagnostic when target_ruby is not Prism-accepted" do
-      # `3.0` matches the format regex but Prism rejects it. The
-      # one-time smoke parse in `Runner#run` converts the
-      # `ArgumentError` into a single `:builtin configuration-error`
-      # diagnostic so the run fails fast rather than crashing.
+      # `3.0` matches the format regex but Prism rejects it. The one-time smoke parse in `Runner#run` converts the
+      # `ArgumentError` into a single `:builtin configuration-error` diagnostic so the run fails fast rather than
+      # crashing.
       result = analyze("x = 1\n", config: { "target_ruby" => "3.0" })
       diag = result.diagnostics.find { |d| d.rule == "configuration-error" }
       expect(diag).not_to be_nil
       expect(diag.path).to eq(".rigor.yml")
       expect(diag.message).to include('"3.0"')
-      # The message must name the supported floor and where to read the
-      # right value, so the fix is obvious without a guess-and-retry loop.
+      # The message must name the supported floor and where to read the right value, so the fix is obvious without a
+      # guess-and-retry loop.
       expect(diag.message).to include(described_class.prism_supported_floor)
       expect(diag.message).to match(/Gemfile\.lock|\.ruby-version/)
     end
@@ -1045,8 +1021,8 @@ RSpec.describe Rigor::Analysis::Runner do
     it "carries structured receiver_type / method_name on the undefined-method diagnostic (ADR-23 slice 4)" do
       result = analyze("\"hello\".no_such_method\n")
 
-      # `receiver_type` stores the rendered receiver type — the same
-      # token the message uses; the triage catalogue normalises it.
+      # `receiver_type` stores the rendered receiver type — the same token the message uses; the triage catalogue
+      # normalises it.
       diag = result.diagnostics.find { |d| d.rule == "call.undefined-method" }
       expect([diag&.receiver_type, diag&.method_name]).to eq(['"hello"', "no_such_method"])
     end
@@ -1191,8 +1167,7 @@ RSpec.describe Rigor::Analysis::Runner do
         end
 
         it "respects file-suppression placed at the bottom of the file" do
-          # The convention is to put the comment near the top,
-          # but Rigor scans every comment in the file so any
+          # The convention is to put the comment near the top, but Rigor scans every comment in the file so any
           # placement works.
           result = analyze(<<~RUBY)
             "x".no_method
@@ -1203,8 +1178,7 @@ RSpec.describe Rigor::Analysis::Runner do
         end
 
         it "does not confuse `disable-file` with the line-only `disable`" do
-          # Per-line suppression on line 1 only; line 2's
-          # diagnostic still fires.
+          # Per-line suppression on line 1 only; line 2's diagnostic still fires.
           result = analyze(<<~RUBY)
             "x".no_method # rigor:disable undefined-method
             "y".also_missing
@@ -1415,10 +1389,8 @@ RSpec.describe Rigor::Analysis::Runner do
       end
 
       describe "argument-type-mismatch rule (v0.0.2 #4)" do
-        # `Demo#take_string: (String) -> String` fixture, paired
-        # with the matching `def`. `analyze` writes the sig under
-        # `sig/` and chdirs so `Environment.for_project` discovers
-        # it.
+        # `Demo#take_string: (String) -> String` fixture, paired with the matching `def`. `analyze` writes the sig under
+        # `sig/` and chdirs so `Environment.for_project` discovers it.
         let(:demo_sig) do
           { "demo.rbs" => <<~RBS }
             class Demo
@@ -1448,25 +1420,20 @@ RSpec.describe Rigor::Analysis::Runner do
           expect(arg_errors).to be_empty
         end
 
-        # ADR-58 (N2 extension, 2026-06-13 app/network survey) — the
-        # declaration-sourced-nil-is-not-diagnostic-fuel criterion that
-        # governs `possible-nil-receiver` extends to `argument-type-mismatch`.
-        # A declaration-sourced ivar (the class-ivar index seed of a ctor
-        # `@x = 0` / `@x = nil`, read in a sibling method) types `T | nil`; the
-        # rejecting constituent is the seed nil, and the program's invariant is
-        # that the ivar is set by then. Stripping the nil yields an accepted
-        # type, so the rule withholds. Flow-live nil and genuinely-wrong types
-        # keep firing.
+        # ADR-58 (N2 extension, 2026-06-13 app/network survey) — the declaration-sourced-nil-is-not-diagnostic-fuel
+        # criterion that governs `possible-nil-receiver` extends to `argument-type-mismatch`. A declaration-sourced ivar
+        # (the class-ivar index seed of a ctor `@x = 0` / `@x = nil`, read in a sibling method) types `T | nil`; the
+        # rejecting constituent is the seed nil, and the program's invariant is that the ivar is set by then. Stripping
+        # the nil yields an accepted type, so the rule withholds. Flow-live nil and genuinely-wrong types keep firing.
         context "when the rejecting argument is a declaration-sourced ivar nil (ADR-58 N2)" do
           def arg_mismatch_diags(result)
             result.diagnostics.select { |d| d.message.start_with?("argument type mismatch") }
           end
 
           it "does not fire on `@length` (ctor-seeded Integer ivar) used in `k <= @length`" do
-            # `@length = 0` in the ctor seeds the class-ivar index, so a read in
-            # a sibling method types `0 | nil`. `Integer#<=` expects Numeric;
-            # `0` is gradual-consistent, the seed `nil` is what rejects.
-            # (concurrent-ruby ruby_non_concurrent_priority_queue shape.)
+            # `@length = 0` in the ctor seeds the class-ivar index, so a read in a sibling method types `0 | nil`.
+            # `Integer#<=` expects Numeric; `0` is gradual-consistent, the seed `nil` is what rejects. (concurrent-ruby
+            # ruby_non_concurrent_priority_queue shape.)
             result = analyze(<<~RUBY)
               class PQ
                 def initialize; @length = 0; end
@@ -1495,9 +1462,8 @@ RSpec.describe Rigor::Analysis::Runner do
           end
 
           it "STILL fires on a genuinely-wrong argument type regardless of provenance" do
-            # `@name` is a ctor-seeded String ivar — declaration-sourced — but
-            # passing a String where Numeric is required is a real mismatch with
-            # no nil constituent to strip, so it must still fire.
+            # `@name` is a ctor-seeded String ivar — declaration-sourced — but passing a String where Numeric is
+            # required is a real mismatch with no nil constituent to strip, so it must still fire.
             result = analyze(<<~RUBY)
               class PQ
                 def initialize; @name = "q"; end
@@ -1597,9 +1563,8 @@ RSpec.describe Rigor::Analysis::Runner do
         end
 
         it "is suppressed when an ivar nil-guard fires on an ivar seeded as Constant[nil]" do
-          # Regression: when @ivar is seeded Constant[nil] by the class-ivar
-          # accumulator, @ivar.nil? folds to Constant[true] (always-live branch
-          # optimisation). The fix ensures the early-return narrowing path still
+          # Regression: when @ivar is seeded Constant[nil] by the class-ivar accumulator, @ivar.nil? folds to
+          # Constant[true] (always-live branch optimisation). The fix ensures the early-return narrowing path still
           # applies so downstream code doesn't see the stale nil type.
           result = analyze(<<~RUBY)
             class GuardedService
@@ -1618,18 +1583,13 @@ RSpec.describe Rigor::Analysis::Runner do
         end
       end
 
-      # Regression — liquid v5.x sweep, Event 3
-      # (docs/notes/20260616-liquid-v5.x-regression-sweep.md). A local
-      # conditionally assigned across an `if/elsif/else: raise` chain is
-      # bound on every reachable path (the else raises), so reading it
-      # afterwards must NOT fire `possible-nil-receiver`. The bug only
-      # surfaced when one assigning arm was `Dynamic`-typed and another
-      # concrete: the inner `elsif … else raise` dropped its body's
-      # assignment, leaving the local unbound for the outer if's join to
-      # nil-inject. The `Dynamic | concrete` union then leaked the
-      # injected nil past the FP-discipline gate that silences a *bare*
-      # `Dynamic` receiver. The fix carries the surviving then-body's
-      # scope forward; the whole bisection table must stay clean.
+      # Regression — liquid v5.x sweep, Event 3 (docs/notes/20260616-liquid-v5.x-regression-sweep.md). A local
+      # conditionally assigned across an `if/elsif/else: raise` chain is bound on every reachable path (the else
+      # raises), so reading it afterwards must NOT fire `possible-nil-receiver`. The bug only surfaced when one
+      # assigning arm was `Dynamic`-typed and another concrete: the inner `elsif … else raise` dropped its body's
+      # assignment, leaving the local unbound for the outer if's join to nil-inject. The `Dynamic | concrete` union then
+      # leaked the injected nil past the FP-discipline gate that silences a *bare* `Dynamic` receiver. The fix carries
+      # the surviving then-body's scope forward; the whole bisection table must stay clean.
       describe "if/elsif/else-raise conditional-local definite assignment" do
         def nil_receiver_diags(result)
           result.diagnostics.select { |d| d.rule == "call.possible-nil-receiver" }
@@ -1774,11 +1734,9 @@ RSpec.describe Rigor::Analysis::Runner do
       end
 
       it "does not flag inferred-constant predicates (envelope is literal-only)" do
-        # `class_object.name.nil?` folds to `Constant<false>`
-        # because RBS declares `Module#name -> String`, but
-        # anonymous classes really do return nil at runtime.
-        # The literal-only envelope avoids flagging the
-        # defensive `raise ... if x.name.nil?` shape.
+        # `class_object.name.nil?` folds to `Constant<false>` because RBS declares `Module#name -> String`, but
+        # anonymous classes really do return nil at runtime. The literal-only envelope avoids flagging the defensive
+        # `raise ... if x.name.nil?` shape.
         result = analyze(<<~RUBY)
           def register(class_object)
             raise ArgumentError unless class_object.is_a?(Module)
@@ -1815,8 +1773,7 @@ RSpec.describe Rigor::Analysis::Runner do
       end
 
       it "is suppressible via `# rigor:disable unreachable-branch` on the dead-branch line" do
-        # The diagnostic points at the dead branch's location,
-        # so the suppression comment lives on the dead-branch
+        # The diagnostic points at the dead branch's location, so the suppression comment lives on the dead-branch
         # statement (not the `if` line).
         result = analyze(<<~RUBY)
           if false
@@ -1901,10 +1858,8 @@ RSpec.describe Rigor::Analysis::Runner do
             break
           end
         RUBY
-        # `while x` itself isn't an IfNode so it's outside the
-        # rule's scope; if Rigor ever folds the body's `if`
-        # against a loop-mutated local, the loop ancestor
-        # check keeps the rule from firing.
+        # `while x` itself isn't an IfNode so it's outside the rule's scope; if Rigor ever folds the body's `if` against
+        # a loop-mutated local, the loop ancestor check keeps the rule from firing.
         expect(truthy_diags(result)).to be_empty
       end
 
@@ -1932,16 +1887,13 @@ RSpec.describe Rigor::Analysis::Runner do
         expect(truthy_diags(result)).to be_empty
       end
 
-      # Regression: the class-ivar pre-pass seeds every InstanceVariableWriteNode
-      # rvalue into a per-class accumulator. Defensive-init idioms
-      # (`@x = v unless @x` / `@x = v if @x.nil?` / `unless defined?(@x); @x = v; end`)
-      # used to seed `@x` as `Constant[v]`, then the predicate `@x` folded
-      # to that same constant and fired this rule against working programs —
-      # most visibly in tdiary-core's `TDiary::Configuration#configure_attrs`
-      # (≈ 20 false positives across a single block of consecutive defaults).
-      # The pre-pass now unions `Constant[nil]` into the seeded type for
-      # writes that sit in the THEN body of a conditional whose predicate
-      # tests the same ivar's truthiness / nil-ness / definedness.
+      # Regression: the class-ivar pre-pass seeds every InstanceVariableWriteNode rvalue into a per-class accumulator.
+      # Defensive-init idioms (`@x = v unless @x` / `@x = v if @x.nil?` / `unless defined?(@x); @x = v; end`) used to
+      # seed `@x` as `Constant[v]`, then the predicate `@x` folded to that same constant and fired this rule against
+      # working programs — most visibly in tdiary-core's `TDiary::Configuration#configure_attrs` (≈ 20 false positives
+      # across a single block of consecutive defaults). The pre-pass now unions `Constant[nil]` into the seeded type for
+      # writes that sit in the THEN body of a conditional whose predicate tests the same ivar's truthiness / nil-ness /
+      # definedness.
       context "with defensive ivar-init idioms (tdiary-core configuration.rb cluster)" do
         it "does not fire on `@x = v unless @x`" do
           result = analyze(<<~RUBY)
@@ -1990,14 +1942,11 @@ RSpec.describe Rigor::Analysis::Runner do
           expect(truthy_diags(result)).to be_empty
         end
 
-        # Polarity check: the ELSE branch of `if @x; ...; else; @x = init; end`
-        # is also a defensive-init shape, but treating its write as "guarded
-        # by nil" forces the read of `@x` elsewhere in the class to fold to
-        # `union(init_type, nil)` and surfaces a possible-nil-receiver FP on
-        # any later call against `@x` that relies on a method-call invariant
-        # (the tdiary `TDiary::TDiaryBase#do_eval_rhtml` shape). The fix
-        # leaves the ELSE branch unguarded so those reads continue to type
-        # as they did before.
+        # Polarity check: the ELSE branch of `if @x; ...; else; @x = init; end` is also a defensive-init shape, but
+        # treating its write as "guarded by nil" forces the read of `@x` elsewhere in the class to fold to
+        # `union(init_type, nil)` and surfaces a possible-nil-receiver FP on any later call against `@x` that relies on
+        # a method-call invariant (the tdiary `TDiary::TDiaryBase#do_eval_rhtml` shape). The fix leaves the ELSE branch
+        # unguarded so those reads continue to type as they did before.
         it "does not over-mark the else branch of `if @x; ...; else; @x = init; end`" do
           result = analyze(<<~RUBY)
             class Foo
@@ -2020,13 +1969,10 @@ RSpec.describe Rigor::Analysis::Runner do
         end
       end
 
-      # ADR-58 WD1 — declaration-sourced ivar optionality (the ctor
-      # `@x = nil` seed unioned in via the class-ivar index) is not
-      # diagnostic fuel for `possible-nil-receiver`. The 109-FP class on
-      # idiomatic data-structure Ruby: a node field read whose nil arrives
-      # only from a sibling-method ctor seed, guarded by an unprovable
-      # cross-method invariant. Flow-live nil (a method-local write or a
-      # failed-guard narrowing) keeps firing exactly as before.
+      # ADR-58 WD1 — declaration-sourced ivar optionality (the ctor `@x = nil` seed unioned in via the class-ivar index)
+      # is not diagnostic fuel for `possible-nil-receiver`. The 109-FP class on idiomatic data-structure Ruby: a node
+      # field read whose nil arrives only from a sibling-method ctor seed, guarded by an unprovable cross-method
+      # invariant. Flow-live nil (a method-local write or a failed-guard narrowing) keeps firing exactly as before.
       context "when the ivar nil is declaration-sourced (ADR-58 WD1)" do
         def nil_receiver_diags(result)
           result.diagnostics.select { |d| d.rule == "call.possible-nil-receiver" }
@@ -2104,13 +2050,10 @@ RSpec.describe Rigor::Analysis::Runner do
         end
       end
 
-      # Flow-folding gap G1 — closed via the
-      # `Rigor::Inference::MutationWidening` hook in `eval_call`.
-      # The pre-fix shape used to fold `arms.size == 1` to
-      # `Constant[true]` because the body's `arms << x` mutation
-      # was not reflected in the post-loop binding. Mirrors the
-      # parse_union FP at lib/rigor/inference/hkt_body_parser.rb:140
-      # documented in CURRENT_WORK.md § Flow-folding.
+      # Flow-folding gap G1 — closed via the `Rigor::Inference::MutationWidening` hook in `eval_call`. The pre-fix shape
+      # used to fold `arms.size == 1` to `Constant[true]` because the body's `arms << x` mutation was not reflected in
+      # the post-loop binding. Mirrors the parse_union FP at lib/rigor/inference/hkt_body_parser.rb:140 documented in
+      # CURRENT_WORK.md § Flow-folding.
       context "when a loop body mutates the seeded collection (G1, Mastodon cluster 4)" do
         it "does NOT fire on a tuple seeded then mutated inside a `while`" do
           result = analyze(<<~RUBY)
@@ -2164,12 +2107,9 @@ RSpec.describe Rigor::Analysis::Runner do
         end
 
         it "does NOT fire on an outer-scope tuple mutated INSIDE an `each {}` block" do
-          # This is the hkt_registry.rb:212 shape: a local seeded
-          # as a tuple literal, mutated only inside an iterator
-          # block, then probed with `.empty?` after the block. The
-          # block lives in a child scope; the propagation in
-          # `MutationWidening.widen_after_block` carries the
-          # widening back to the outer scope.
+          # This is the hkt_registry.rb:212 shape: a local seeded as a tuple literal, mutated only inside an iterator
+          # block, then probed with `.empty?` after the block. The block lives in a child scope; the propagation in
+          # `MutationWidening.widen_after_block` carries the widening back to the outer scope.
           result = analyze(<<~RUBY)
             def collect_things(items)
               registrations = []
@@ -2185,8 +2125,7 @@ RSpec.describe Rigor::Analysis::Runner do
         end
 
         it "still fires on a tuple that is genuinely never mutated" do
-          # The widening only triggers on an in-place mutator call;
-          # a tuple whose size is a fact at the predicate site
+          # The widening only triggers on an in-place mutator call; a tuple whose size is a fact at the predicate site
           # MUST still fold. This pins the precision floor.
           result = analyze(<<~RUBY)
             arr = [1]
@@ -2498,8 +2437,8 @@ RSpec.describe Rigor::Analysis::Runner do
         result.diagnostics.select { |d| d.rule == "dump.type" }.map(&:message)
       end
 
-      # `h[:foo]` on an optional key reads `Integer?`; inside a
-      # `h.key?(:foo)` guard the optionality nil is gone → `Integer`.
+      # `h[:foo]` on an optional key reads `Integer?`; inside a `h.key?(:foo)` guard the optionality nil is gone →
+      # `Integer`.
       it "narrows h[:foo] from Integer? to Integer after a `h.key?(:foo)` guard" do
         result = analyze(<<~RUBY, sig: { "demo.rbs" => <<~RBS })
           class Config
@@ -2522,8 +2461,8 @@ RSpec.describe Rigor::Analysis::Runner do
         expect(dumps.last).to eq("dump_type: Integer")      # guarded: nil removed
       end
 
-      # §4-3 false edge: `unless h.key?(:foo)` proves `:foo` absent, so
-      # `h[:foo]` reads `nil` (the key is dropped from the shape).
+      # §4-3 false edge: `unless h.key?(:foo)` proves `:foo` absent, so `h[:foo]` reads `nil` (the key is dropped from
+      # the shape).
       it "narrows h[:foo] to nil in the falsey edge (key proven absent)" do
         result = analyze(<<~RUBY, sig: { "demo.rbs" => <<~RBS })
           class Config
@@ -2548,9 +2487,8 @@ RSpec.describe Rigor::Analysis::Runner do
         result.diagnostics.select { |d| d.rule == "dump.type" }.map(&:message)
       end
 
-      # Inside an `unless arr.empty?` / `if arr.any?` guard the array is
-      # `non-empty-array[T]`, so `size`/`length`/`count` refine from
-      # `non-negative-int` to `positive-int` (Elixir `tuple_size`-style).
+      # Inside an `unless arr.empty?` / `if arr.any?` guard the array is `non-empty-array[T]`, so
+      # `size`/`length`/`count` refine from `non-negative-int` to `positive-int` (Elixir `tuple_size`-style).
       it "refines arr.size to positive-int inside a non-empty guard" do
         result = analyze(<<~RUBY, sig: { "demo.rbs" => <<~RBS })
           class Box
@@ -3082,9 +3020,8 @@ RSpec.describe Rigor::Analysis::Runner do
       end
     end
 
-    # ADR-35 slice 3 — Liskov signature rule for parameters (contravariance).
-    # Uses real (loadable) classes Numeric/Integer so the nominal subtype
-    # check resolves to :no rather than the FP-safe :maybe it returns for
+    # ADR-35 slice 3 — Liskov signature rule for parameters (contravariance). Uses real (loadable) classes
+    # Numeric/Integer so the nominal subtype check resolves to :no rather than the FP-safe :maybe it returns for
     # unloadable user-only class hierarchies.
     describe "override-param-narrowed rule (ADR-35 slice 3)" do
       def override_param_diags(result)
@@ -3362,8 +3299,7 @@ RSpec.describe Rigor::Analysis::Runner do
       end
 
       it "does not flag class-body ivars outside any def" do
-        # Class-level ivars (`Module#@var`) are a separate
-        # surface the engine doesn't yet model.
+        # Class-level ivars (`Module#@var`) are a separate surface the engine doesn't yet model.
         result = analyze(<<~RUBY)
           class Foo
             @config = "default"
@@ -3390,10 +3326,8 @@ RSpec.describe Rigor::Analysis::Runner do
       end
 
       it "does not flag the bool flag idiom (false in initialize, true elsewhere)" do
-        # Common idiom: a memoization flag starts at `false` and
-        # transitions to `true` once the underlying value has been
-        # computed. Both writes are conceptually `bool` — the rule
-        # MUST NOT fire on this shape.
+        # Common idiom: a memoization flag starts at `false` and transitions to `true` once the underlying value has
+        # been computed. Both writes are conceptually `bool` — the rule MUST NOT fire on this shape.
         result = analyze(<<~RUBY)
           class Holder
             def initialize
@@ -3418,14 +3352,10 @@ RSpec.describe Rigor::Analysis::Runner do
       end
 
       it "does not flag a nil-placeholder followed by concrete writes (nullable-slot idiom)" do
-        # The `@parse_method = nil` placeholder followed by
-        # per-state `@parse_method = :foo` / `:bar` assignments
-        # is the common nullable-slot idiom. Pre-fix the
-        # `NilClass` placeholder anchored as `first_class` and
-        # every concrete write tripped the rule; the canonical
-        # type is now the first non-nil write so neither
-        # `Symbol → Symbol` (same class) nor `nil → Symbol`
-        # widening fires.
+        # The `@parse_method = nil` placeholder followed by per-state `@parse_method = :foo` / `:bar` assignments is the
+        # common nullable-slot idiom. Pre-fix the `NilClass` placeholder anchored as `first_class` and every concrete
+        # write tripped the rule; the canonical type is now the first non-nil write so neither `Symbol → Symbol` (same
+        # class) nor `nil → Symbol` widening fires.
         result = analyze(<<~RUBY)
           class Foo
             def initialize
@@ -3447,8 +3377,7 @@ RSpec.describe Rigor::Analysis::Runner do
       end
 
       it "still flags Symbol → String drift even with a leading nil placeholder" do
-        # The leading `nil` shouldn't mask a genuine drift between
-        # two distinct concrete classes.
+        # The leading `nil` shouldn't mask a genuine drift between two distinct concrete classes.
         result = analyze(<<~RUBY)
           class Foo
             def initialize
@@ -3521,12 +3450,9 @@ RSpec.describe Rigor::Analysis::Runner do
     end
 
     it "returns Dynamic[Top] when the top-level def has a complex param shape" do
-      # `def helper(x, kind: :default)` has a kwarg — the
-      # first-iteration binder rejects it. The engine still
-      # prefers the local def over RBS dispatch and returns
-      # `Dynamic[Top]`, suppressing the spurious
-      # `Array#select`-style mis-routing that previously
-      # caused `select(...)` to type as `Array[Elem]`.
+      # `def helper(x, kind: :default)` has a kwarg — the first-iteration binder rejects it. The engine still prefers
+      # the local def over RBS dispatch and returns `Dynamic[Top]`, suppressing the spurious `Array#select`-style
+      # mis-routing that previously caused `select(...)` to type as `Array[Elem]`.
       result = analyze(<<~RUBY)
         def select(class_name, method_name, kind: :instance)
           class_name
@@ -3535,8 +3461,7 @@ RSpec.describe Rigor::Analysis::Runner do
         mt.no_such_method_on_array
       RUBY
 
-      # `mt` is `Dynamic[Top]`; the undefined-method rule
-      # skips Dynamic receivers so no diagnostic surfaces.
+      # `mt` is `Dynamic[Top]`; the undefined-method rule skips Dynamic receivers so no diagnostic surfaces.
       expect(result.diagnostics.select { |d| d.rule == "call.undefined-method" }).to be_empty
     end
   end
@@ -3584,18 +3509,15 @@ RSpec.describe Rigor::Analysis::Runner do
         assert_type("42", x)
       RUBY
 
-      # `String | 42` narrowed to `Integer` keeps only the
-      # integer-side carrier (Constant[42] survives because
-      # it is a subtype of Integer); the String carrier is
-      # dropped.
+      # `String | 42` narrowed to `Integer` keeps only the integer-side carrier (Constant[42] survives because it is a
+      # subtype of Integer); the String carrier is dropped.
       mismatch = result.diagnostics.find { |d| d.rule == "assert.type-mismatch" }
       expect(mismatch).to be_nil
     end
 
     it "leaves the scope unchanged when the matcher shape is unrecognised" do
-      # `to be_truthy` is intentionally NOT modelled; the
-      # post-call type of `x` should remain `String | nil`
-      # and `x.upcase` should still flag.
+      # `to be_truthy` is intentionally NOT modelled; the post-call type of `x` should remain `String | nil` and
+      # `x.upcase` should still flag.
       result = analyze(<<~RUBY)
         x = if rand < 0.5
           "hello"
@@ -3619,8 +3541,7 @@ RSpec.describe Rigor::Analysis::Runner do
     end
 
     it "emits :info fallback diagnostics when explain is on" do
-      # `BEGIN { ... }` is a Prism::PreExecutionNode the engine
-      # does not recognise — a stable explain-mode trigger.
+      # `BEGIN { ... }` is a Prism::PreExecutionNode the engine does not recognise — a stable explain-mode trigger.
       result = analyze("BEGIN { 1 }\n", explain: true)
 
       fallback = result.diagnostics.find { |d| d.rule == "fallback" }
@@ -3679,8 +3600,7 @@ RSpec.describe Rigor::Analysis::Runner do
     end
 
     it "does not fire when the divisor cannot be proved zero" do
-      # `rand(100)` could be zero but the analyzer cannot
-      # prove it, so the rule stays silent.
+      # `rand(100)` could be zero but the analyzer cannot prove it, so the rule stays silent.
       expect(
         analyze("rand(100) / rand(100)\n").diagnostics.find { |d| d.rule == "flow.always-raises" }
       ).to be_nil
@@ -3838,9 +3758,8 @@ RSpec.describe Rigor::Analysis::Runner do
       runtime_errors = result.diagnostics.select do |d|
         d.source_family == :plugin_loader && d.rule == "runtime-error"
       end
-      # The contribution is silently dropped — no diagnostic. The
-      # rest of the run continues. (Plugins that need to surface
-      # their own errors should emit through diagnostics_for_file.)
+      # The contribution is silently dropped — no diagnostic. The rest of the run continues. (Plugins that need to
+      # surface their own errors should emit through diagnostics_for_file.)
       expect(runtime_errors).to be_empty
       expect(result).to be_a(Rigor::Analysis::Result)
     end
@@ -3850,9 +3769,8 @@ RSpec.describe Rigor::Analysis::Runner do
     before { Rigor::Plugin.unregister! }
     after { Rigor::Plugin.unregister! }
 
-    # Synthetic plugin: recognises any call named `narrow_self_to_string!`
-    # and contributes a post_return_fact narrowing self to
-    # `Nominal[String]` from that call onwards.
+    # Synthetic plugin: recognises any call named `narrow_self_to_string!` and contributes a post_return_fact narrowing
+    # self to `Nominal[String]` from that call onwards.
     let(:self_narrowing_plugin) do
       klass = Class.new(Rigor::Plugin::Base) do
         manifest(id: "self-narrower", version: "0.1.0")
@@ -3891,10 +3809,8 @@ RSpec.describe Rigor::Analysis::Runner do
     end
 
     it "applies a plugin-contributed post_return_fact(target_kind: :self) to the surrounding scope" do
-      # Without the narrowing, `self.upcase` would emit
-      # `call.undefined-method` because the implicit-self type
-      # at top level isn't `String`. The plugin narrows self to
-      # `Nominal[String]` after `narrow_self_to_string!`, so
+      # Without the narrowing, `self.upcase` would emit `call.undefined-method` because the implicit-self type at top
+      # level isn't `String`. The plugin narrows self to `Nominal[String]` after `narrow_self_to_string!`, so
       # `self.upcase` resolves cleanly.
       result = run_with_plugin(self_narrowing_plugin, source: <<~RUBY)
         def narrow_self_to_string!; nil; end
@@ -4255,9 +4171,8 @@ RSpec.describe Rigor::Analysis::Runner do
       RBS
       result = analyze("x = 1\n", sig: sig)
 
-      # `_Stream` is namespace-relative (only `Buffers::_Stream` exists), so
-      # resolution must find it under the class's namespace — and then flag
-      # the missing `read`, rather than reporting the interface unresolved.
+      # `_Stream` is namespace-relative (only `Buffers::_Stream` exists), so resolution must find it under the class's
+      # namespace — and then flag the missing `read`, rather than reporting the interface unresolved.
       conformance = result.diagnostics.find { |d| d.rule == "rbs_extended.unsatisfied-conformance" }
       expect(conformance).not_to be_nil
       expect(conformance.message).to include("`#read`")
@@ -4283,8 +4198,7 @@ RSpec.describe Rigor::Analysis::Runner do
             cache_store: nil, workers: 4, buffer: binding
           )
 
-          # `pool_mode?` is private; assert via `send` since the
-          # contract change IS about that predicate.
+          # `pool_mode?` is private; assert via `send` since the contract change IS about that predicate.
           expect(runner.send(:pool_mode?)).to be(false)
         end
       end
@@ -4359,10 +4273,8 @@ RSpec.describe Rigor::Analysis::Runner do
   end
 
   describe "editor mode (BufferBinding)" do
-    # Slice 2: when the runner is wired with `buffer:`, the
-    # logical path in `paths:` is parsed from the physical
-    # buffer's bytes but every diagnostic reports the LOGICAL
-    # path. The on-disk version of the logical file is silently
+    # Slice 2: when the runner is wired with `buffer:`, the logical path in `paths:` is parsed from the physical
+    # buffer's bytes but every diagnostic reports the LOGICAL path. The on-disk version of the logical file is silently
     # replaced by the buffer for parse purposes.
     it "parses bytes from the buffer's physical path but emits diagnostics under the logical path" do
       Dir.mktmpdir("rigor-buffer-binding-") do |tmpdir|
@@ -4383,8 +4295,7 @@ RSpec.describe Rigor::Analysis::Runner do
             configuration: configuration, cache_store: nil, buffer: binding
           ).run
 
-          # The parse error from the buffer surfaces under the
-          # LOGICAL path — that's what the editor highlights.
+          # The parse error from the buffer surfaces under the LOGICAL path — that's what the editor highlights.
           paths = result.diagnostics.map(&:path)
           expect(paths).to include(logical)
           expect(paths).not_to include(physical)
@@ -4399,8 +4310,7 @@ RSpec.describe Rigor::Analysis::Runner do
           other = File.join("lib", "bar.rb")
           FileUtils.mkdir_p("lib")
           File.write(logical, "x = 1\n")
-          # `other` would normally surface a parse error — but under
-          # editor mode it MUST NOT be analyzed.
+          # `other` would normally surface a parse error — but under editor mode it MUST NOT be analyzed.
           File.write(other, "def also_broken\n")
           physical = File.join(tmpdir, "buffer.rb")
           File.write(physical, "x = 1\n")
@@ -4425,8 +4335,7 @@ RSpec.describe Rigor::Analysis::Runner do
     it "analyzes the buffer when its logical path doesn't exist on disk (LSP new-file case)" do
       Dir.mktmpdir("rigor-buffer-binding-phantom-") do |tmpdir|
         Dir.chdir(tmpdir) do
-          # Logical path doesn't exist on disk — user is editing a
-          # brand-new file via LSP.
+          # Logical path doesn't exist on disk — user is editing a brand-new file via LSP.
           logical = File.join(tmpdir, "lib", "fresh.rb")
           physical = File.join(tmpdir, "buffer.rb")
           File.write(physical, "def broken\n")
@@ -4440,8 +4349,7 @@ RSpec.describe Rigor::Analysis::Runner do
           ).run([logical])
 
           paths = result.diagnostics.map(&:path).uniq
-          # The buffer's parse error surfaces under the logical
-          # path — NOT as a "no such file" diagnostic.
+          # The buffer's parse error surfaces under the logical path — NOT as a "no such file" diagnostic.
           expect(paths).to include(logical)
           expect(result.diagnostics.map(&:message)).not_to include(/no such file/)
         end
@@ -4470,8 +4378,7 @@ RSpec.describe Rigor::Analysis::Runner do
 
           paths = result.diagnostics.map(&:path).uniq
           expect(paths).to include(logical)
-          # `app/real.rb` is not analyzed under editor mode even though
-          # it's in `paths:` — single-file scope wins.
+          # `app/real.rb` is not analyzed under editor mode even though it's in `paths:` — single-file scope wins.
           expect(paths).not_to include(File.join("app", "real.rb"))
         end
       end
@@ -4530,10 +4437,8 @@ RSpec.describe Rigor::Analysis::Runner do
                          .prepare_project_scan
         end
 
-        # When prebuilt: is supplied, Plugin::Loader.load MUST NOT
-        # run — the cached registry is the one the runner uses. We
-        # verify by stubbing `Plugin::Loader.load` to raise and
-        # confirming the run still succeeds.
+        # When prebuilt: is supplied, Plugin::Loader.load MUST NOT run — the cached registry is the one the runner uses.
+        # We verify by stubbing `Plugin::Loader.load` to raise and confirming the run still succeeds.
         allow(Rigor::Plugin::Loader).to receive(:load).and_raise("loader.load called unexpectedly")
 
         runner = described_class.new(
@@ -4554,8 +4459,7 @@ RSpec.describe Rigor::Analysis::Runner do
         runner = described_class.new(configuration: configuration, cache_store: nil, collect_stats: false)
         Dir.chdir(tmpdir) { runner.run }
 
-        # Pre-passes ran inline — registry / dep_index built fresh
-        # this call, not adopted from a prior snapshot.
+        # Pre-passes ran inline — registry / dep_index built fresh this call, not adopted from a prior snapshot.
         expect(runner.plugin_registry).not_to be_nil
         expect(runner.dependency_source_index).not_to be_nil
       end
@@ -4572,19 +4476,14 @@ RSpec.describe Rigor::Analysis::Runner do
           signature_paths: configuration.signature_paths
         )
 
-        # Once the override is supplied, Environment.for_project
-        # must NOT be invoked from within analyze_files for the
-        # sequential path. Stubbing to raise lets a single
-        # unexpected call abort the run.
+        # Once the override is supplied, Environment.for_project must NOT be invoked from within analyze_files for the
+        # sequential path. Stubbing to raise lets a single unexpected call abort the run.
         runner = described_class.new(
           configuration: configuration, cache_store: nil, collect_stats: false, environment: env
         )
-        # The runner's pre-pass scaffold still calls
-        # `Environment.for_project` outside `analyze_files`
-        # (synthetic-method scanner uses `environment: nil`,
-        # but the `prewarm_rbs_cache_for_pool` would on pool
-        # mode — sequential path here doesn't). Allow it, but
-        # assert it isn't called by the override path itself.
+        # The runner's pre-pass scaffold still calls `Environment.for_project` outside `analyze_files` (synthetic-method
+        # scanner uses `environment: nil`, but the `prewarm_rbs_cache_for_pool` would on pool mode — sequential path
+        # here doesn't). Allow it, but assert it isn't called by the override path itself.
         expect do
           Dir.chdir(tmpdir) { runner.run }
         end.not_to raise_error
@@ -4609,8 +4508,8 @@ RSpec.describe Rigor::Analysis::Runner do
         )
         Dir.chdir(tmpdir) { runner.run }
 
-        # After the run, the env's reporter slot should reference
-        # the runner's per-run reporter, not the pre-attached one.
+        # After the run, the env's reporter slot should reference the runner's per-run reporter, not the pre-attached
+        # one.
         expect(env.rbs_extended_reporter).not_to equal(original_rbs_reporter)
         expect(env.rbs_extended_reporter).to equal(runner.rbs_extended_reporter)
       end

--- a/spec/rigor/analysis/runner_subset_analysis_spec.rb
+++ b/spec/rigor/analysis/runner_subset_analysis_spec.rb
@@ -3,15 +3,12 @@
 require "spec_helper"
 require "tmpdir"
 
-# ADR-46 slice 2 — the subset-analysis hook (`Runner.new(analyze_only:)`).
-# The body tier re-analyses only the affected closure, so the runner must
-# analyze a subset of files while still running the whole-project pre-pass
-# (the cross-file index must stay complete or a subset analysis would lose
-# resolutions and drift from a full run).
+# ADR-46 slice 2 — the subset-analysis hook (`Runner.new(analyze_only:)`). The body tier re-analyses only the affected
+# closure, so the runner must analyze a subset of files while still running the whole-project pre-pass (the cross-file
+# index must stay complete or a subset analysis would lose resolutions and drift from a full run).
 RSpec.describe "Rigor::Analysis::Runner analyze_only" do
-  # A file carrying its own self-contained `def.override-visibility-reduced`
-  # (balanced profile → :warning) plus a class other files can reference,
-  # so each file has a diagnostic of its own and a cross-file symbol.
+  # A file carrying its own self-contained `def.override-visibility-reduced` (balanced profile → :warning) plus a class
+  # other files can reference, so each file has a diagnostic of its own and a cross-file symbol.
   def write_unit(path, prefix:)
     File.write(path, <<~RUBY)
       class #{prefix}Base
@@ -60,9 +57,8 @@ RSpec.describe "Rigor::Analysis::Runner analyze_only" do
       expect(subset.map(&:path)).to include(a)
       expect(subset.map(&:path)).not_to include(b)
 
-      # a.rb's diagnostics are byte-identical to the full run's — the
-      # pre-pass context is intact, so a subset analysis matches a full one
-      # for the files it does analyze.
+      # a.rb's diagnostics are byte-identical to the full run's — the pre-pass context is intact, so a subset analysis
+      # matches a full one for the files it does analyze.
       expect(subset.select { |d| d.path == a }.map(&:to_h))
         .to eq(full.select { |d| d.path == a }.map(&:to_h))
     end

--- a/spec/rigor/analysis/self_call_resolution_recorder_spec.rb
+++ b/spec/rigor/analysis/self_call_resolution_recorder_spec.rb
@@ -3,19 +3,14 @@
 require "spec_helper"
 require "tmpdir"
 
-# ADR-24 slice 4a — the evaluation-time recorder for unresolved
-# implicit-self calls. The central hypothesis these specs validate: by
-# recording at the engine's OWN resolution miss point (rather than
-# reimplementing resolution in CheckRules, the reverted attempt-1 route),
-# the method classes that produced 135 false positives in attempt 1 —
-# `module_function` siblings, `Data.define` accessors, inherited /
-# included methods — resolve in the engine BEFORE the miss and so never
-# reach the recorder. A genuine typo, with no resolution anywhere, is the
-# only thing that lands.
+# ADR-24 slice 4a — the evaluation-time recorder for unresolved implicit-self calls. The central hypothesis these specs
+# validate: by recording at the engine's OWN resolution miss point (rather than reimplementing resolution in CheckRules,
+# the reverted attempt-1 route), the method classes that produced 135 false positives in attempt 1 — `module_function`
+# siblings, `Data.define` accessors, inherited / included methods — resolve in the engine BEFORE the miss and so never
+# reach the recorder. A genuine typo, with no resolution anywhere, is the only thing that lands.
 RSpec.describe Rigor::Analysis::SelfCallResolutionRecorder do
-  # Runs a recording analysis over `files` (`{ "name.rb" => source }`) and
-  # returns the set of every recorded unresolved implicit-self call as
-  # `[class_name, method_name]` pairs.
+  # Runs a recording analysis over `files` (`{ "name.rb" => source }`) and returns the set of every recorded unresolved
+  # implicit-self call as `[class_name, method_name]` pairs.
   def recorded_calls(files)
     Dir.mktmpdir do |dir|
       files.each { |name, source| File.write(File.join(dir, name), source) }
@@ -70,14 +65,11 @@ RSpec.describe Rigor::Analysis::SelfCallResolutionRecorder do
     expect(calls.map(&:last)).not_to include(:inner)
   end
 
-  # The engine does not model a `Data.define` / `Struct.new` block method's
-  # `self` as the named constant — it types it `Object` — so a synthesized
-  # member accessor (`x`) reaches the type-miss choke-point and IS recorded,
-  # but under `Object`, never under the `Point` constant. `Object` is never
-  # "confidently closed", so the later closed-class gate filters this
-  # over-capture naturally; the recorder never attributes it to a project
-  # class. (Recorded under `Object`, this is the attempt-1 FP class #2 — and
-  # the gate, not the recorder, is what keeps it from re-surfacing.)
+  # The engine does not model a `Data.define` / `Struct.new` block method's `self` as the named constant — it types it
+  # `Object` — so a synthesized member accessor (`x`) reaches the type-miss choke-point and IS recorded, but under
+  # `Object`, never under the `Point` constant. `Object` is never "confidently closed", so the later closed-class gate
+  # filters this over-capture naturally; the recorder never attributes it to a project class. (Recorded under `Object`,
+  # this is the attempt-1 FP class #2 — and the gate, not the recorder, is what keeps it from re-surfacing.)
   it "attributes a `Data.define` block-form accessor over-capture to Object, never the constant" do
     calls = recorded_calls(
       "point.rb" => <<~RUBY

--- a/spec/rigor/analysis/self_undefined_method_rule_spec.rb
+++ b/spec/rigor/analysis/self_undefined_method_rule_spec.rb
@@ -3,10 +3,9 @@
 require "spec_helper"
 require "tmpdir"
 
-# ADR-24 slice 4 — `call.self-undefined-method`. The rule consumes the
-# engine's recorded unresolved implicit-self calls and fires only on a
-# confidently-closed standalone project class. It ships `:off` in every
-# profile, so the specs opt in via `severity_overrides:`.
+# ADR-24 slice 4 — `call.self-undefined-method`. The rule consumes the engine's recorded unresolved implicit-self calls
+# and fires only on a confidently-closed standalone project class. It ships `:off` in every profile, so the specs opt in
+# via `severity_overrides:`.
 RSpec.describe "call.self-undefined-method rule" do
   def firings(source, enable: true)
     Dir.mktmpdir do |dir|
@@ -124,10 +123,9 @@ RSpec.describe "call.self-undefined-method rule" do
   end
 
   it "does not fire on a method an abstract base's subclass implements (template-method hook)" do
-    # Mail::CommonField#decoded calls `do_decode`, defined by every
-    # `< CommonField` subclass; Mail::Retriever#find by POP3 / IMAP. A base
-    # that calls a method its subclasses supply is a template-method hook, not
-    # a typo. (WD4 corpus eval, Bucket 2 — the abstract-base pattern.)
+    # Mail::CommonField#decoded calls `do_decode`, defined by every `< CommonField` subclass; Mail::Retriever#find by
+    # POP3 / IMAP. A base that calls a method its subclasses supply is a template-method hook, not a typo. (WD4 corpus
+    # eval, Bucket 2 — the abstract-base pattern.)
     expect(firings(<<~RUBY)).to be_empty
       class CommonField
         def decoded
@@ -144,8 +142,8 @@ RSpec.describe "call.self-undefined-method rule" do
   end
 
   it "still fires on a genuine typo even when a subclass exists" do
-    # The subclass gate must suppress only the exact missed name — a real typo
-    # (`do_decodee`) that no subclass defines still fires.
+    # The subclass gate must suppress only the exact missed name — a real typo (`do_decodee`) that no subclass defines
+    # still fires.
     expect(firings(<<~RUBY)).to include(:do_decodee)
       class CommonField
         def decoded
@@ -162,9 +160,8 @@ RSpec.describe "call.self-undefined-method rule" do
   end
 
   it "does not fire on a class with a dynamic (non-constant) superclass" do
-    # `class X < DelegateClass(Array)` / `< Struct.new(...)` inherits a
-    # dynamically produced surface the engine cannot enumerate from a constant
-    # name, so a missed self-call is not provably a typo.
+    # `class X < DelegateClass(Array)` / `< Struct.new(...)` inherits a dynamically produced surface the engine cannot
+    # enumerate from a constant name, so a missed self-call is not provably a typo.
     expect(firings(<<~RUBY)).to be_empty
       class PartsList < DelegateClass(Array)
         def collect_each
@@ -175,11 +172,10 @@ RSpec.describe "call.self-undefined-method rule" do
   end
 
   it "does not fire on a universal base (Object / BasicObject) — a self-type fallback, not a typo" do
-    # An implicit-self miss tagged `Object` / `BasicObject` means the engine
-    # fell back to the root self-type because it could not resolve the real
-    # class (a `class << self` / metaprogramming surface). Their method set is
-    # never project-complete, so a miss there is a resolution gap. (WD4 corpus
-    # eval: the dominant false-positive class — protobuf / tdiary, ~357 firings.)
+    # An implicit-self miss tagged `Object` / `BasicObject` means the engine fell back to the root self-type because it
+    # could not resolve the real class (a `class << self` / metaprogramming surface). Their method set is never
+    # project-complete, so a miss there is a resolution gap. (WD4 corpus eval: the dominant false-positive class —
+    # protobuf / tdiary, ~357 firings.)
     expect(firings(<<~RUBY)).to be_empty
       class Object
         def my_helper

--- a/spec/rigor/analysis/worker_session_spec.rb
+++ b/spec/rigor/analysis/worker_session_spec.rb
@@ -86,8 +86,7 @@ RSpec.describe Rigor::Analysis::WorkerSession do
         end
         session_diags = Dir.chdir(dir) { session.analyze(path) }
 
-        # The CoverageScanner stream is identical regardless of
-        # whether the chosen source happens to trigger any
+        # The CoverageScanner stream is identical regardless of whether the chosen source happens to trigger any
         # fallback events — equivalence is the contract proof.
         expect(diag_keys(session_diags)).to eq(diag_keys(runner_diags))
       end
@@ -256,8 +255,8 @@ RSpec.describe Rigor::Analysis::WorkerSession do
     end
 
     it "appends a successful node_result's diagnostics (no error), stamped with plugin source_family" do
-      # Base#diagnostics_for_file already returns [], so no override is
-      # needed — the node_result diagnostics are the only input here.
+      # Base#diagnostics_for_file already returns [], so no override is needed — the node_result diagnostics are the
+      # only input here.
       stub_const("WorkerSessionNodeResultSuccess", Class.new(Rigor::Plugin::Base) do
         manifest(id: "session-noderesult-success", version: "0.1.0")
       end)
@@ -274,8 +273,8 @@ RSpec.describe Rigor::Analysis::WorkerSession do
         path: "x.rb", line: 3, column: 2,
         message: "from node rule", severity: :info, rule: "node-rule"
       )
-      # A Result with no error but carrying diagnostics exercises the
-      # SUCCESS branch `raw += node_result.diagnostics if node_result`.
+      # A Result with no error but carrying diagnostics exercises the SUCCESS branch `raw += node_result.diagnostics if
+      # node_result`.
       node_result = Rigor::Plugin::NodeRuleWalk::Result.new(plugin, [node_diagnostic], nil)
 
       diags = session.send(
@@ -300,8 +299,8 @@ RSpec.describe Rigor::Analysis::WorkerSession do
       session = described_class.new(
         configuration: Rigor::Configuration.new("paths" => []), cache_store: nil
       )
-      # `allocate` avoids invoking a normal `#initialize` path; only the
-      # overridden `#manifest` (which raises) matters for the fallback.
+      # `allocate` avoids invoking a normal `#initialize` path; only the overridden `#manifest` (which raises) matters
+      # for the fallback.
       plugin = raising_manifest_class.allocate
 
       diag = session.send(
@@ -386,11 +385,9 @@ RSpec.describe Rigor::Analysis::WorkerSession do
           binding = Rigor::Analysis::BufferBinding.new(
             logical_path: logical, physical_path: physical
           )
-          # "3.0" is version-shaped (passes Configuration's own
-          # validation) but is older than Prism's supported set, so
-          # Prism.parse itself raises ArgumentError — a discriminating
-          # probe that the buffer-path resolve() AND target_ruby both
-          # actually reach Prism.parse's `version:` keyword.
+          # "3.0" is version-shaped (passes Configuration's own validation) but is older than Prism's supported set, so
+          # Prism.parse itself raises ArgumentError — a discriminating probe that the buffer-path resolve() AND
+          # target_ruby both actually reach Prism.parse's `version:` keyword.
           configuration = Rigor::Configuration.new("paths" => ["lib"], "target_ruby" => "3.0")
           session = described_class.new(
             configuration: configuration, cache_store: nil, buffer: binding
@@ -410,9 +407,8 @@ RSpec.describe Rigor::Analysis::WorkerSession do
        "with column = location.start_column + 1" do
       Dir.mktmpdir do |dir|
         path = File.join(dir, "code.rb")
-        # A flip-flop condition is a directly-unrecognised node, so the
-        # CoverageScanner records a real fail-soft fallback event — driving
-        # `explain_diagnostics` through the non-empty `result.events` map.
+        # A flip-flop condition is a directly-unrecognised node, so the CoverageScanner records a real fail-soft
+        # fallback event — driving `explain_diagnostics` through the non-empty `result.events` map.
         File.write(path, "if (a..b)\nend\n")
         configuration = Rigor::Configuration.new("paths" => [path])
 
@@ -495,8 +491,8 @@ RSpec.describe Rigor::Analysis::WorkerSession do
       Dir.mktmpdir do |dir|
         path = File.join(dir, "code.rb")
         File.write(path, "x = 1\n")
-        # Same "version-shaped but Prism-unsupported" probe as above,
-        # exercised on the non-buffer `Prism.parse_file` path this time.
+        # Same "version-shaped but Prism-unsupported" probe as above, exercised on the non-buffer `Prism.parse_file`
+        # path this time.
         configuration = Rigor::Configuration.new("paths" => [path], "target_ruby" => "3.0")
 
         session = Dir.chdir(dir) do
@@ -605,13 +601,10 @@ RSpec.describe Rigor::Analysis::WorkerSession do
     end
   end
 
-  # Per-file diagnostic comparison key. Severity is intentionally
-  # excluded from the key because the Runner re-stamps severity
-  # via `apply_severity_profile` AFTER the per-file pass, whereas
-  # the WorkerSession returns raw (un-stamped) per-file output —
-  # severity-profile application is the caller's responsibility.
-  # The remaining fields capture every per-file invariant the
-  # equivalence contract is built on.
+  # Per-file diagnostic comparison key. Severity is intentionally excluded from the key because the Runner re-stamps
+  # severity via `apply_severity_profile` AFTER the per-file pass, whereas the WorkerSession returns raw (un-stamped)
+  # per-file output — severity-profile application is the caller's responsibility. The remaining fields capture every
+  # per-file invariant the equivalence contract is built on.
   def diag_keys(diagnostics)
     diagnostics.map do |d|
       [d.path, d.line, d.column, d.rule, d.source_family, d.message]

--- a/spec/rigor/bleeding_edge_spec.rb
+++ b/spec/rigor/bleeding_edge_spec.rb
@@ -2,10 +2,8 @@
 
 require "rigor/bleeding_edge"
 
-# ADR-50 § WD2 — the bleeding-edge overlay. The shipped overlay is
-# empty (the foundation slice); the non-empty behaviour is exercised by
-# stubbing FEATURES so the resolution logic the first real feature will
-# rely on is covered now.
+# ADR-50 § WD2 — the bleeding-edge overlay. The shipped overlay is empty (the foundation slice); the non-empty behaviour
+# is exercised by stubbing FEATURES so the resolution logic the first real feature will rely on is covered now.
 RSpec.describe Rigor::BleedingEdge do
   describe "the shipped (empty) overlay" do
     it "carries no features yet" do

--- a/spec/rigor/builtins/imported_refinements_spec.rb
+++ b/spec/rigor/builtins/imported_refinements_spec.rb
@@ -191,9 +191,8 @@ RSpec.describe Rigor::Builtins::ImportedRefinements do
         end
 
         it "parses key_of[Hash[Symbol, Integer]][Symbol] (chained)" do
-          # key_of[Hash[Symbol, Integer]] = Symbol; Symbol[…] is Top
-          # because Symbol is not an indexable shape. The chain still
-          # parses without error.
+          # key_of[Hash[Symbol, Integer]] = Symbol; Symbol[…] is Top because Symbol is not an indexable shape. The chain
+          # still parses without error.
           result = described_class.parse("key_of[Hash[Symbol, Integer]][Symbol]")
           expect(result).to be_a(Rigor::Type::Top)
         end
@@ -230,11 +229,8 @@ RSpec.describe Rigor::Builtins::ImportedRefinements do
         end
 
         it "parses int_mask_of[Constant union]" do
-          # int_mask_of expects a single type arg; the parser
-          # accepts the resolved type. We use raw Combinator
-          # construction here because the parser grammar does
-          # not have a direct surface for ad-hoc Constant
-          # unions yet.
+          # int_mask_of expects a single type arg; the parser accepts the resolved type. We use raw Combinator
+          # construction here because the parser grammar does not have a direct surface for ad-hoc Constant unions yet.
           flags = Rigor::Type::Combinator.union(
             Rigor::Type::Combinator.constant_of(1),
             Rigor::Type::Combinator.constant_of(2)
@@ -247,8 +243,7 @@ RSpec.describe Rigor::Builtins::ImportedRefinements do
 
     describe "shape projection (ADR-13 slice 4)" do
       it "resolves pick_of[Foo, ...] when Foo names a Nominal carrier" do
-        # `Foo` resolves to Nominal[Foo]; pick_of on a non-HashShape
-        # returns the input unchanged (lossy degradation).
+        # `Foo` resolves to Nominal[Foo]; pick_of on a non-HashShape returns the input unchanged (lossy degradation).
         result = described_class.parse("pick_of[Foo, NameKey]")
         expect(result).to eq(Rigor::Type::Combinator.nominal_of("Foo"))
       end
@@ -278,11 +273,9 @@ RSpec.describe Rigor::Builtins::ImportedRefinements do
 
     describe "shape projection — Tuple (ADR-13 slice 5)" do
       it "evaluates pick_of of a built-up Tuple via Tuple-shaped K argument" do
-        # Construct Tuple[String, Integer] inline through an
-        # auxiliary plugin path is heavy; instead, walk through
-        # Combinator directly to confirm the parser-builder
-        # pipeline isn't a bottleneck. The tuple_of binding is
-        # tested at the Combinator layer.
+        # Construct Tuple[String, Integer] inline through an auxiliary plugin path is heavy; instead, walk through
+        # Combinator directly to confirm the parser-builder pipeline isn't a bottleneck. The tuple_of binding is tested
+        # at the Combinator layer.
         tuple = Rigor::Type::Combinator.tuple_of(
           Rigor::Type::Combinator.nominal_of("String"),
           Rigor::Type::Combinator.nominal_of("Integer")
@@ -333,8 +326,7 @@ RSpec.describe Rigor::Builtins::ImportedRefinements do
         seen = nil
         resolver = make_resolver do |node, _scope|
           seen = node if node.is_a?(Rigor::TypeNode::Generic) && node.head == "Pick"
-          # Resolver still declines so the Nominal fallback runs and the
-          # parse remains valid.
+          # Resolver still declines so the Nominal fallback runs and the parse remains valid.
           nil
         end
         scope = make_scope(resolver)
@@ -383,15 +375,14 @@ RSpec.describe Rigor::Builtins::ImportedRefinements do
         end
         scope = make_scope(resolver)
         described_class.parse("Pick[Address, non-empty-string]", name_scope: scope)
-        # Address — class-shaped → Nominal[Address] (RBS fallback)
-        # non-empty-string — built-in registry
+        # Address — class-shaped → Nominal[Address] (RBS fallback) non-empty-string — built-in registry
         expect(seen_t_type).to eq(Rigor::Type::Combinator.nominal_of("Address"))
         expect(seen_k_type).to eq(Rigor::Type::Combinator.non_empty_string)
       end
 
       it "preserves slice-1 / slice-2 behaviour when no NameScope is supplied" do
-        # Bare names that miss the built-in registry return nil (parser
-        # fail-soft); class-shaped names fall back to Nominal.
+        # Bare names that miss the built-in registry return nil (parser fail-soft); class-shaped names fall back to
+        # Nominal.
         expect(described_class.parse("my-custom-name")).to be_nil
         expected = Rigor::Type::Combinator.nominal_of(
           "Pick",
@@ -438,14 +429,10 @@ RSpec.describe Rigor::Builtins::ImportedRefinements do
       end
 
       it "resolves a `pick_of[Foo, :a | :b]` payload end-to-end (Nominal source degrades to input)" do
-        # The TypeScript-utility-types plugin is the canonical
-        # consumer; a direct synthetic payload exercises the
-        # parser → resolver path without a plugin chain. Before
-        # the literal-token addition this payload would not
-        # tokenise; with it, the resolver returns a non-nil
-        # carrier (Nominal sources degrade to the input itself
-        # — Phase B / `shape_projection_lossy?` covers the
-        # diagnostic emission separately).
+        # The TypeScript-utility-types plugin is the canonical consumer; a direct synthetic payload exercises the parser
+        # → resolver path without a plugin chain. Before the literal-token addition this payload would not tokenise;
+        # with it, the resolver returns a non-nil carrier (Nominal sources degrade to the input itself — Phase B /
+        # `shape_projection_lossy?` covers the diagnostic emission separately).
         result = described_class.parse("pick_of[Foo, :a | :b]")
         expect(result).not_to be_nil
       end

--- a/spec/rigor/builtins/predefined_constant_refinements_spec.rb
+++ b/spec/rigor/builtins/predefined_constant_refinements_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe Rigor::Builtins::PredefinedConstantRefinements do
     end
 
     it "does NOT fold Float::NAN (non-reflexive == would break the Constant equality contract)" do
-      # Float::NAN is a non-empty... it's not a String, so tier 2 also
-      # declines — the lookup falls through to the RBS Nominal[Float].
+      # Float::NAN is a non-empty... it's not a String, so tier 2 also declines — the lookup falls through to the RBS
+      # Nominal[Float].
       expect(described_class.lookup("Float::NAN")).to be_nil
     end
   end
@@ -70,18 +70,15 @@ RSpec.describe Rigor::Builtins::PredefinedConstantRefinements do
     end
 
     it "returns nil for a project-defined constant absent from the analyzer process" do
-      # MyProject::FOO is not loaded into the analyzer — const_get raises
-      # NameError and we fall through to the RBS tier.
+      # MyProject::FOO is not loaded into the analyzer — const_get raises NameError and we fall through to the RBS tier.
       expect(described_class.lookup("MyProject::UNDEFINED_FOO")).to be_nil
     end
 
     it "does not invoke const_missing for a const_missing-resolved path (e.g. Digest::UUID)" do
-      # Analysing a reference must never drive the analyzer's own runtime
-      # through a const_missing hook: `Digest::UUID` makes Digest.const_missing
-      # run `require "digest/uuid"`, and a missing optional library raises
-      # LoadError (a ScriptError, not NameError) — which used to abort the
-      # whole run. The const_defined?(false) guard answers "resolvable here?"
-      # without the side effect.
+      # Analysing a reference must never drive the analyzer's own runtime through a const_missing hook: `Digest::UUID`
+      # makes Digest.const_missing run `require "digest/uuid"`, and a missing optional library raises LoadError (a
+      # ScriptError, not NameError) — which used to abort the whole run. The const_defined?(false) guard answers
+      # "resolvable here?" without the side effect.
       called = false
       probe = Module.new do
         define_singleton_method(:const_missing) do |_name|
@@ -97,9 +94,8 @@ RSpec.describe Rigor::Builtins::PredefinedConstantRefinements do
     end
 
     it "returns nil (rescuing LoadError) when an autoload target library is missing" do
-      # An autoload-registered constant passes the const_defined? guard, so
-      # const_get fires the autoload; a missing target raises LoadError, which
-      # the rescue must absorb into a fall-through rather than crash the run.
+      # An autoload-registered constant passes the const_defined? guard, so const_get fires the autoload; a missing
+      # target raises LoadError, which the rescue must absorb into a fall-through rather than crash the run.
       probe = Module.new
       probe.autoload(:Missing, "rigor/spec/definitely/missing/file")
       stub_const("RigorSpecAutoloadProbe", probe)

--- a/spec/rigor/builtins/static_return_refinements_spec.rb
+++ b/spec/rigor/builtins/static_return_refinements_spec.rb
@@ -97,9 +97,8 @@ RSpec.describe Rigor::Builtins::StaticReturnRefinements do
     end
 
     it "does NOT fire on the (non-existent) instance shape" do
-      # File has no instance-side `expand_path` / `dirname`; the
-      # row is keyed `:singleton`, so an `:instance` lookup must
-      # return nil rather than the singleton handler.
+      # File has no instance-side `expand_path` / `dirname`; the row is keyed `:singleton`, so an `:instance` lookup
+      # must return nil rather than the singleton handler.
       expect(
         described_class.lookup(
           owner_class_name: "File", method_name: :expand_path, kind: :instance

--- a/spec/rigor/cache/descriptor_spec.rb
+++ b/spec/rigor/cache/descriptor_spec.rb
@@ -229,11 +229,9 @@ RSpec.describe Rigor::Cache::Descriptor do
     it "leaves other gems' slices stable when one gem bumps" do
       before = described_class.new(dependencies: [rack_old, faraday])
       after = described_class.new(dependencies: [rack_new, faraday])
-      # The invariant that matters: the descriptor for a producer
-      # keyed only on `faraday` does not change when `rack`
-      # bumps. Slice 3 lands the *primitive* — composing a
-      # producer's per-gem descriptor with the index's
-      # contribution is the consumer's job (slice 4+).
+      # The invariant that matters: the descriptor for a producer keyed only on `faraday` does not change when `rack`
+      # bumps. Slice 3 lands the *primitive* — composing a producer's per-gem descriptor with the index's contribution
+      # is the consumer's job (slice 4+).
       faraday_only_before = described_class.new(dependencies: [faraday])
       faraday_only_after = described_class.new(dependencies: [faraday])
       expect(faraday_only_before.cache_key_for(producer_id: "p", params: {}))

--- a/spec/rigor/cache/rbs_constant_table_spec.rb
+++ b/spec/rigor/cache/rbs_constant_table_spec.rb
@@ -61,18 +61,15 @@ RSpec.describe Rigor::Cache::RbsConstantTable do
     end
 
     it "files slot for a loader with no signature_paths still digests the bundled vendored gem stubs" do
-      # Vendored gem RBS stubs ship with rigor and are loaded by
-      # default (`Environment::RbsLoader.vendored_gem_sig_paths`),
-      # so the descriptor's files slot is never empty even without
-      # any user-supplied `signature_paths:`. The vendored set is
-      # part of the cache invalidation contract: bumping a stub
-      # bumps the cache.
+      # Vendored gem RBS stubs ship with rigor and are loaded by default
+      # (`Environment::RbsLoader.vendored_gem_sig_paths`), so the descriptor's files slot is never empty even without
+      # any user-supplied `signature_paths:`. The vendored set is part of the cache invalidation contract: bumping a
+      # stub bumps the cache.
       descriptor = Rigor::Cache::RbsDescriptor.build(loader)
       expect(descriptor.files).not_to be_empty
       expect(descriptor.files.map(&:comparator).uniq).to eq([:digest])
-      # Bundled signature roots: the vendored gem stubs plus the core
-      # overlay (data/core_overlay, e.g. numeric.rbs) — both ship with
-      # rigor and participate in the same digest-based invalidation.
+      # Bundled signature roots: the vendored gem stubs plus the core overlay (data/core_overlay, e.g. numeric.rbs) —
+      # both ship with rigor and participate in the same digest-based invalidation.
       vendored_root = Rigor::Environment::RbsLoader.vendored_gem_sig_paths.first.to_s
       data_root = vendored_root.split("/")[0..-3].join("/")
       expect(descriptor.files.map(&:path)).to all(start_with(data_root))
@@ -92,13 +89,11 @@ RSpec.describe Rigor::Cache::RbsConstantTable do
 
         custom_loader = Rigor::Environment::RbsLoader.new(signature_paths: [sig_dir])
         descriptor = Rigor::Cache::RbsDescriptor.build(custom_loader)
-        # The two user files MUST be present; vendored stubs add
-        # their own entries on top.
+        # The two user files MUST be present; vendored stubs add their own entries on top.
         custom_paths = descriptor.files.map(&:path).select { |p| p.start_with?(sig_dir) }
         expect(custom_paths.size).to eq(2)
         expect(descriptor.files.map(&:comparator).uniq).to eq([:digest])
-        # Sanity: the descriptor SHOULD also include the bundled
-        # vendored stubs so a stub edit invalidates the cache.
+        # Sanity: the descriptor SHOULD also include the bundled vendored stubs so a stub edit invalidates the cache.
         vendored_root = Rigor::Environment::RbsLoader.vendored_gem_sig_paths.first.to_s
         expect(descriptor.files.size).to be > custom_paths.size
         expect(descriptor.files.map(&:path).any? { |p| p.start_with?(File.dirname(vendored_root)) }).to be(true)

--- a/spec/rigor/cache/store_spec.rb
+++ b/spec/rigor/cache/store_spec.rb
@@ -104,11 +104,9 @@ RSpec.describe Rigor::Cache::Store do
       store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :first }
       File.write(File.join(cache_root, "schema_version.txt"), "999")
 
-      # The disk-level schema-mismatch recovery applies on
-      # the disk-read path. A fresh `Store` (process restart
-      # / new CLI invocation) is the scenario that triggers
-      # it; the same-instance in-memory memo would skip the
-      # disk read entirely.
+      # The disk-level schema-mismatch recovery applies on the disk-read path. A fresh `Store` (process restart / new
+      # CLI invocation) is the scenario that triggers it; the same-instance in-memory memo would skip the disk read
+      # entirely.
       fresh_store = described_class.new(root: cache_root)
       called = 0
       result = fresh_store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) do
@@ -124,9 +122,8 @@ RSpec.describe Rigor::Cache::Store do
 
   describe "format-version marker (ADR-54)" do
     it "clears the root left by a pre-compression Rigor (old marker without the format suffix)" do
-      # A pre-WD2 cache: marker carries only the descriptor schema
-      # ("3"), and its entries are unreadable v1 bytes that no run
-      # would otherwise ever reclaim (they sit below the eviction cap).
+      # A pre-WD2 cache: marker carries only the descriptor schema ("3"), and its entries are unreadable v1 bytes that
+      # no run would otherwise ever reclaim (they sit below the eviction cap).
       FileUtils.mkdir_p(File.join(cache_root, "p", "ab"))
       stale_entry = File.join(cache_root, "p", "ab", "cdef.entry")
       File.binwrite(stale_entry, "RIGOR\x00\x01stale-v1-bytes#{"\x00" * 32}")
@@ -176,13 +173,12 @@ RSpec.describe Rigor::Cache::Store do
       key = descriptor.cache_key_for(producer_id: "demo", params: {})
       entry_path = File.join(cache_root, "demo", key[0, 2], "#{key[2..]}.entry")
       bytes = File.binread(entry_path)
-      # ADR-54 WD2 — the value payload is zlib-deflated on disk, so
-      # the serialiser output no longer appears verbatim in the file...
+      # ADR-54 WD2 — the value payload is zlib-deflated on disk, so the serialiser output no longer appears verbatim in
+      # the file...
       expect(bytes).not_to include('{"name":"Alice","age":30}')
 
-      # ...but the deserialiser receives EXACTLY the serialiser's
-      # bytes back (no Marshal wrapping; compression is transparent
-      # at the contract layer). A fresh Store forces the disk read.
+      # ...but the deserialiser receives EXACTLY the serialiser's bytes back (no Marshal wrapping; compression is
+      # transparent at the contract layer). A fresh Store forces the disk read.
       fresh = described_class.new(root: cache_root)
       result = fresh.fetch_or_compute(
         producer_id: "demo", params: {}, descriptor: descriptor,
@@ -226,9 +222,8 @@ RSpec.describe Rigor::Cache::Store do
         producer_id: "demo", params: {}, descriptor: descriptor,
         serialize: identity, deserialize: identity
       ) { "first" }
-      # `Store#fetch_or_compute` memoises the produced value
-      # in-process; the disk-read deserialise path is exercised
-      # by a fresh `Store` ("process restart" scenario).
+      # `Store#fetch_or_compute` memoises the produced value in-process; the disk-read deserialise path is exercised by
+      # a fresh `Store` ("process restart" scenario).
       fresh_store = described_class.new(root: cache_root)
       result = fresh_store.fetch_or_compute(
         producer_id: "demo", params: {}, descriptor: descriptor,
@@ -429,14 +424,10 @@ RSpec.describe Rigor::Cache::Store do
       store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :first }
     end
 
-    # The corruption-tolerance cases simulate the disk being
-    # mutated externally (e.g. by a buggy editor or a crash
-    # mid-write). The fault-tolerance guarantee is "a fresh
-    # process reading the corrupt entry treats it as a miss";
-    # an in-process `Store` that already produced the value
-    # legitimately keeps it in memory and never touches disk.
-    # Each test re-creates the `Store` post-corruption to
-    # exercise the fault-tolerance path.
+    # The corruption-tolerance cases simulate the disk being mutated externally (e.g. by a buggy editor or a crash
+    # mid-write). The fault-tolerance guarantee is "a fresh process reading the corrupt entry treats it as a miss"; an
+    # in-process `Store` that already produced the value legitimately keeps it in memory and never touches disk. Each
+    # test re-creates the `Store` post-corruption to exercise the fault-tolerance path.
     def fresh_store_after_corruption
       described_class.new(root: cache_root)
     end
@@ -520,10 +511,9 @@ RSpec.describe Rigor::Cache::Store do
       end
       threads.each(&:join)
 
-      # Every writer raced for the SAME entry; the last rename wins but the
-      # entry must be intact (one of the written values) and no temp file
-      # from any writer is left behind — collisions there would clobber a
-      # sibling writer's in-flight temp file.
+      # Every writer raced for the SAME entry; the last rename wins but the entry must be intact (one of the written
+      # values) and no temp file from any writer is left behind — collisions there would clobber a sibling writer's
+      # in-flight temp file.
       expect(Dir.glob("#{entry_path}.tmp.*")).to be_empty
       final = described_class.new(root: cache_root).fetch_or_compute(
         producer_id: "p", params: {}, descriptor: descriptor
@@ -597,8 +587,7 @@ RSpec.describe Rigor::Cache::Store do
       path = Dir.glob(File.join(cache_root, "**", "*.entry")).first
       old_mtime = File.mtime(path)
 
-      # Wait a small amount so mtime can differ, then read via a fresh store
-      # (no in-process memo).
+      # Wait a small amount so mtime can differ, then read via a fresh store (no in-process memo).
       sleep(0.05)
       fresh = described_class.new(root: cache_root, max_bytes: 10 * 1024 * 1024)
       fresh.fetch_or_compute(

--- a/spec/rigor/cli/baseline_command_spec.rb
+++ b/spec/rigor/cli/baseline_command_spec.rb
@@ -95,10 +95,8 @@ RSpec.describe Rigor::CLI::BaselineCommand do
 
   describe "rigor check --baseline" do
     let(:diagnostic_source) do
-      # Deliberate undefined-method on a well-typed receiver
-      # (Integer) so rigor fires `call.undefined-method`
-      # reliably. Two sites so the baseline gets a non-empty
-      # bucket.
+      # Deliberate undefined-method on a well-typed receiver (Integer) so rigor fires `call.undefined-method` reliably.
+      # Two sites so the baseline gets a non-empty bucket.
       <<~RUBY
         1.this_method_does_not_exist
         2.also_not_a_method

--- a/spec/rigor/cli/check_command_spec.rb
+++ b/spec/rigor/cli/check_command_spec.rb
@@ -6,12 +6,10 @@ require "tmpdir"
 
 require "rigor/cli/check_command"
 
-# Focused unit coverage for the extracted `rigor check` command object.
-# The full behavioural surface (CI formats, baselines, incremental modes,
-# editor mode, cache stats) is exercised end-to-end through the dispatcher
-# in `spec/rigor/cli_spec.rb`; this spec is the safety net for the move
-# itself — that `CheckCommand` parses options, runs the analysis, and
-# returns the right exit code when driven directly as a command object.
+# Focused unit coverage for the extracted `rigor check` command object. The full behavioural surface (CI formats,
+# baselines, incremental modes, editor mode, cache stats) is exercised end-to-end through the dispatcher in
+# `spec/rigor/cli_spec.rb`; this spec is the safety net for the move itself — that `CheckCommand` parses options, runs
+# the analysis, and returns the right exit code when driven directly as a command object.
 RSpec.describe Rigor::CLI::CheckCommand do
   def run(argv)
     out = StringIO.new
@@ -162,9 +160,8 @@ RSpec.describe Rigor::CLI::CheckCommand do
   end
 
   it "seeds parallel-assignment ivar writes so a cross-method read is not always-falsey (N1)" do
-    # `old, @cb = @cb, block` records the `@cb` target into the
-    # class-ivar union; before N1 the collector dropped it and `@cb`
-    # seeded pure `Constant[nil]`, folding `if @cb` always-falsey.
+    # `old, @cb = @cb, block` records the `@cb` target into the class-ivar union; before N1 the collector dropped it and
+    # `@cb` seeded pure `Constant[nil]`, folding `if @cb` always-falsey.
     File.write("channel.rb", <<~RUBY)
       class Channel
         def initialize
@@ -251,8 +248,7 @@ RSpec.describe Rigor::CLI::CheckCommand do
     end
   end
 
-  # ADR-50 § WD2 — the `--bleeding-edge[=ids]` / `--no-bleeding-edge` CLI
-  # mirror of the `bleeding_edge:` config key.
+  # ADR-50 § WD2 — the `--bleeding-edge[=ids]` / `--no-bleeding-edge` CLI mirror of the `bleeding_edge:` config key.
   describe "the --bleeding-edge flag" do
     def options_for(argv)
       command = described_class.new(argv: argv, out: StringIO.new, err: StringIO.new)

--- a/spec/rigor/cli/coverage_command_spec.rb
+++ b/spec/rigor/cli/coverage_command_spec.rb
@@ -6,11 +6,10 @@ require "tmpdir"
 
 require "rigor/cli/coverage_command"
 
-# Focused coverage for the `rigor coverage` command object: the ADR-63 Tier 2
-# mutation-effectiveness mode (`--protection --mutation`) and its git-changed-
-# files default, plus unit safety nets for the default type-precision mode and
-# the static Tier 1 protection mode (`--protection`), which are otherwise only
-# exercised through the dispatcher / `make coverage`.
+# Focused coverage for the `rigor coverage` command object: the ADR-63 Tier 2 mutation-effectiveness mode (`--protection
+# --mutation`) and its git-changed- files default, plus unit safety nets for the default type-precision mode and the
+# static Tier 1 protection mode (`--protection`), which are otherwise only exercised through the dispatcher / `make
+# coverage`.
 RSpec.describe Rigor::CLI::CoverageCommand do
   def run(argv)
     out = StringIO.new
@@ -81,8 +80,7 @@ RSpec.describe Rigor::CLI::CoverageCommand do
     end
 
     it "exits 1 when the precision ratio is below --threshold, 0 when it meets it" do
-      # An untyped-parameter receiver dispatch is imprecise (Dynamic),
-      # so the ratio is below 1.0 and above 0.0.
+      # An untyped-parameter receiver dispatch is imprecise (Dynamic), so the ratio is below 1.0 and above 0.0.
       File.write("dyn.rb", "def f(x)\n  x.whatever\nend\n")
 
       below, = run(["--threshold", "1.0", "dyn.rb"])
@@ -127,8 +125,8 @@ RSpec.describe Rigor::CLI::CoverageCommand do
     end
   end
 
-  # ADR-70 — the fused static∪dynamic overlay. The TestSuiteOracle is stubbed so
-  # the orchestration / report / exit logic is exercised without shelling out.
+  # ADR-70 — the fused static∪dynamic overlay. The TestSuiteOracle is stubbed so the orchestration / report / exit logic
+  # is exercised without shelling out.
   describe "--with-tests (fused protection)" do
     def fake_oracle(green:, kills:)
       oracle = Object.new
@@ -192,8 +190,8 @@ RSpec.describe Rigor::CLI::CoverageCommand do
     end
 
     it "mutates Dynamic-receiver sites under --include-dynamic, crediting the test axis (Seam 2)" do
-      # `x.save` on an untyped param has no biteable site; --include-dynamic
-      # mutates it anyway so the test axis can score it.
+      # `x.save` on an untyped param has no biteable site; --include-dynamic mutates it anyway so the test axis can
+      # score it.
       File.write("dyn.rb", %(def f(x)\n  x.save\nend\n))
       stub_oracle(green: true, kills: true)
 

--- a/spec/rigor/cli/docs_command_spec.rb
+++ b/spec/rigor/cli/docs_command_spec.rb
@@ -5,11 +5,9 @@ require "stringio"
 require "rigor/cli"
 require "rigor/cli/docs_command"
 
-# `rigor docs` serves the docs bundled with the gem OFFLINE (ADR-74).
-# These examples exercise the real on-disk `docs/` tree so the contract
-# an installed Rigor + the SKILL-driven UX depend on is verified
-# end-to-end. The grammar mirrors `rigor skill`: the positional slot is
-# a doc name; alternative outputs are flags (`--list` / `--path`).
+# `rigor docs` serves the docs bundled with the gem OFFLINE (ADR-74). These examples exercise the real on-disk `docs/`
+# tree so the contract an installed Rigor + the SKILL-driven UX depend on is verified end-to-end. The grammar mirrors
+# `rigor skill`: the positional slot is a doc name; alternative outputs are flags (`--list` / `--path`).
 RSpec.describe Rigor::CLI::DocsCommand do
   def run(argv)
     out = StringIO.new
@@ -22,8 +20,8 @@ RSpec.describe Rigor::CLI::DocsCommand do
     it "prints the bundled llms.txt doc index" do
       status, out, = run([])
       expect(status).to eq(0)
-      # ASCII-only assertions: the index is read with the external
-      # encoding, so a non-ASCII substring (an em-dash) would clash.
+      # ASCII-only assertions: the index is read with the external encoding, so a non-ASCII substring (an em-dash) would
+      # clash.
       expect(out).to include("offline doc index")
       expect(out).to include("rigor docs <name>")
     end

--- a/spec/rigor/cli/doctor_command_spec.rb
+++ b/spec/rigor/cli/doctor_command_spec.rb
@@ -25,9 +25,8 @@ RSpec.describe Rigor::CLI::DoctorCommand do
 
   describe "with no configuration" do
     it "reports a config issue because no config file exists" do
-      # When no config exists, Configuration.load(nil) uses defaults.
-      # The default paths may not exist, but the runner handles that.
-      # We just assert the command completes without crashing.
+      # When no config exists, Configuration.load(nil) uses defaults. The default paths may not exist, but the runner
+      # handles that. We just assert the command completes without crashing.
       status, out, = run([])
       expect(status).to be_a(Integer)
       expect(out).to include("rigor doctor:")
@@ -103,8 +102,8 @@ RSpec.describe Rigor::CLI::DoctorCommand do
     it "fails with a drift summary when a recorded bucket no longer fires" do
       File.write("clean.rb", "x = 1\n")
       File.write(".rigor.yml", "paths:\n  - .\nbaseline: .rigor-baseline.yml\n")
-      # The bucket records one expected call.undefined-method on clean.rb, but
-      # the file is clean now → actual 0 → a :cleared drift row.
+      # The bucket records one expected call.undefined-method on clean.rb, but the file is clean now → actual 0 → a
+      # :cleared drift row.
       File.write(".rigor-baseline.yml", <<~YAML)
         version: 1
         ignored:
@@ -173,10 +172,9 @@ RSpec.describe Rigor::CLI::DoctorCommand do
     end
   end
 
-  # The private summary formatter behind the "Baseline drift detected (...)"
-  # message. Exercised directly with fabricated audit rows (each answers
-  # #status) so the by-status counting, per-status labels, and joining are
-  # pinned without staging a real drifting baseline.
+  # The private summary formatter behind the "Baseline drift detected (...)" message. Exercised directly with fabricated
+  # audit rows (each answers #status) so the by-status counting, per-status labels, and joining are pinned without
+  # staging a real drifting baseline.
   describe "#baseline_drift_summary (private)" do
     let(:command) { described_class.new(argv: [], out: StringIO.new, err: StringIO.new) }
 

--- a/spec/rigor/cli/mcp_command_spec.rb
+++ b/spec/rigor/cli/mcp_command_spec.rb
@@ -7,9 +7,8 @@ require "rigor/cli"
 require "rigor/cli/mcp_command"
 
 RSpec.describe Rigor::CLI::McpCommand do
-  # Build the command with captured streams. The happy `#run` path boots a
-  # long-running stdio server loop (ADR-33), so these examples exercise only
-  # the option parsing and the early-return branches — the unit-testable logic.
+  # Build the command with captured streams. The happy `#run` path boots a long-running stdio server loop (ADR-33), so
+  # these examples exercise only the option parsing and the early-return branches — the unit-testable logic.
   let(:out) { StringIO.new }
   let(:err) { StringIO.new }
 

--- a/spec/rigor/cli/mutation_protection_report_spec.rb
+++ b/spec/rigor/cli/mutation_protection_report_spec.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 require "rigor/cli/mutation_protection_report"
 require "rigor/protection/mutation_scanner"
 
-# ADR-63 Tier 2 — aggregation of per-file effectiveness results into a project
-# report: the kill ratio, per-file rows, and a ranked "missed breakage" list.
+# ADR-63 Tier 2 — aggregation of per-file effectiveness results into a project report: the kill ratio, per-file rows,
+# and a ranked "missed breakage" list.
 RSpec.describe Rigor::CLI::MutationProtectionReport do
   def file_result(path, killed:, survived:, sites: [])
     Rigor::Protection::MutationScanner::FileResult.new(

--- a/spec/rigor/cli/plugin_command_spec.rb
+++ b/spec/rigor/cli/plugin_command_spec.rb
@@ -5,11 +5,9 @@ require "stringio"
 require "rigor/cli"
 require "rigor/cli/plugin_command"
 
-# `rigor plugin` (singular) exposes the plugin source Rigor bundles
-# under `plugins/` and `examples/` so authors (and the
-# `rigor-plugin-author` skill) can read a real, working plugin as a
-# worked example. The examples here exercise the real on-disk tree so
-# the contract the skill + AI agents depend on is verified end-to-end.
+# `rigor plugin` (singular) exposes the plugin source Rigor bundles under `plugins/` and `examples/` so authors (and the
+# `rigor-plugin-author` skill) can read a real, working plugin as a worked example. The examples here exercise the real
+# on-disk tree so the contract the skill + AI agents depend on is verified end-to-end.
 RSpec.describe Rigor::CLI::PluginCommand do
   def run(argv)
     out = StringIO.new

--- a/spec/rigor/cli/plugins_command_spec.rb
+++ b/spec/rigor/cli/plugins_command_spec.rb
@@ -6,15 +6,11 @@ require "tmpdir"
 
 require "rigor/cli/plugins_command"
 
-# `rigor plugins` is a read-only inspection command that loads
-# the project's `.rigor.yml`, attempts plugin activation, and
-# reports per-plugin status (loaded / load-error) plus every
-# manifest-declared extension surface.
+# `rigor plugins` is a read-only inspection command that loads the project's `.rigor.yml`, attempts plugin activation,
+# and reports per-plugin status (loaded / load-error) plus every manifest-declared extension surface.
 #
-# The integration-style examples here exercise the real
-# `Plugin::Loader` rather than mocking the registry — that is
-# the contract the SKILL / `rigor init` / CI consumers actually
-# depend on.
+# The integration-style examples here exercise the real `Plugin::Loader` rather than mocking the registry — that is the
+# contract the SKILL / `rigor init` / CI consumers actually depend on.
 RSpec.describe Rigor::CLI::PluginsCommand do
   def run(argv)
     out = StringIO.new
@@ -29,14 +25,10 @@ RSpec.describe Rigor::CLI::PluginsCommand do
     end
   end
 
-  # Other plugin integration specs in the suite call
-  # `Rigor::Plugin.unregister!` in their before/after hooks,
-  # which can leave the global registry empty when our spec runs
-  # after them. Since `require` is a no-op for an already-loaded
-  # plugin file, the file's top-level `Rigor::Plugin.register(...)`
-  # call does NOT re-run; the loader then can't match the gem
-  # name to a registered class. Re-register the plugins our
-  # examples reference so the spec is order-independent.
+  # Other plugin integration specs in the suite call `Rigor::Plugin.unregister!` in their before/after hooks, which can
+  # leave the global registry empty when our spec runs after them. Since `require` is a no-op for an already-loaded
+  # plugin file, the file's top-level `Rigor::Plugin.register(...)` call does NOT re-run; the loader then can't match
+  # the gem name to a registered class. Re-register the plugins our examples reference so the spec is order-independent.
   before do
     require "rigor-activesupport-core-ext"
     require "rigor-activerecord"
@@ -68,12 +60,9 @@ RSpec.describe Rigor::CLI::PluginsCommand do
 
   context "with a valid bundled plugin" do
     before do
-      # Use the explicit gem/id form so the loader's id-based
-      # lookup matches the already-registered plugin class even
-      # when the require is a no-op (the plugin gets eager-loaded
-      # by other specs in the suite; `require` is idempotent
-      # which makes the loader's bare-string newly_registered
-      # detector miss).
+      # Use the explicit gem/id form so the loader's id-based lookup matches the already-registered plugin class even
+      # when the require is a no-op (the plugin gets eager-loaded by other specs in the suite; `require` is idempotent
+      # which makes the loader's bare-string newly_registered detector miss).
       File.write(".rigor.yml", <<~YAML)
         paths: [.]
         plugins:
@@ -157,11 +146,9 @@ RSpec.describe Rigor::CLI::PluginsCommand do
 
   context "with an open_receiver-bearing plugin" do
     before do
-      # Activate rigor-activerecord, which declares
-      # open_receivers: ["ActiveRecord::Relation"]. We don't need
-      # a real db/schema.rb because plugin LOADING (manifest
-      # resolution + init) does not require the schema — only the
-      # later analysis pipeline does, and we never run that here.
+      # Activate rigor-activerecord, which declares open_receivers: ["ActiveRecord::Relation"]. We don't need a real
+      # db/schema.rb because plugin LOADING (manifest resolution + init) does not require the schema — only the later
+      # analysis pipeline does, and we never run that here.
       File.write(".rigor.yml", <<~YAML)
         paths: [.]
         plugins:

--- a/spec/rigor/cli/prism_colorizer_spec.rb
+++ b/spec/rigor/cli/prism_colorizer_spec.rb
@@ -32,8 +32,7 @@ RSpec.describe Rigor::CLI::PrismColorizer do
   end
 
   it "paints the whole symbol — including a keyword-shaped name — in one colour" do
-    # `:then` lexes as SYMBOL_BEGIN + KEYWORD_THEN; both halves
-    # must carry the symbol colour, never the keyword colour.
+    # `:then` lexes as SYMBOL_BEGIN + KEYWORD_THEN; both halves must carry the symbol colour, never the keyword colour.
     colored = colorize(":then\n")
 
     expect(colored).to include("\e[36m:\e[0m\e[36mthen\e[0m")
@@ -41,8 +40,8 @@ RSpec.describe Rigor::CLI::PrismColorizer do
   end
 
   it "keeps a trailing newline outside the colour span" do
-    # The comment token includes its newline; the reset must sit
-    # before it so the escape does not bleed onto the next line.
+    # The comment token includes its newline; the reset must sit before it so the escape does not bleed onto the next
+    # line.
     expect(colorize("# c\n")).to end_with("\e[0m\n")
   end
 
@@ -53,9 +52,8 @@ RSpec.describe Rigor::CLI::PrismColorizer do
   end
 
   it "retags a US-ASCII-labelled source carrying UTF-8 bytes before lexing" do
-    # Sources read under a POSIX locale arrive tagged US-ASCII; the
-    # colorizer dups and retags to UTF-8 so the token regexes do not
-    # raise on the multibyte comment.
+    # Sources read under a POSIX locale arrive tagged US-ASCII; the colorizer dups and retags to UTF-8 so the token
+    # regexes do not raise on the multibyte comment.
     source = "x = 1  # コメント\n".dup.force_encoding(Encoding::US_ASCII)
     stripped = colorize(source).gsub(/\e\[[0-9;]*m/, "")
 

--- a/spec/rigor/cli/show_bleedingedge_command_spec.rb
+++ b/spec/rigor/cli/show_bleedingedge_command_spec.rb
@@ -7,10 +7,9 @@ require "tmpdir"
 require "rigor/cli"
 require "rigor/cli/show_bleedingedge_command"
 
-# ADR-50 § WD2 — `rigor show-bleedingedge` prints the bleeding-edge
-# overlay and what the project's `bleeding_edge:` config adopts. The
-# overlay is empty in this release, so the default run reports an empty
-# set; a stubbed feature exercises the populated rendering.
+# ADR-50 § WD2 — `rigor show-bleedingedge` prints the bleeding-edge overlay and what the project's `bleeding_edge:`
+# config adopts. The overlay is empty in this release, so the default run reports an empty set; a stubbed feature
+# exercises the populated rendering.
 RSpec.describe Rigor::CLI::ShowBleedingedgeCommand do
   def run(argv)
     out = StringIO.new

--- a/spec/rigor/cli/skill_command_spec.rb
+++ b/spec/rigor/cli/skill_command_spec.rb
@@ -7,11 +7,9 @@ require "tmpdir"
 require "rigor/cli"
 require "rigor/cli/skill_command"
 
-# `rigor skill` exposes the SKILL.md files Rigor bundles under
-# `skills/` (`rigor-project-init`, `rigor-baseline-reduce`,
-# `rigor-plugin-author`). The integration-style examples here
-# exercise the real on-disk skill directory so the contract the
-# bundled skills + AI agents depend on is verified end-to-end.
+# `rigor skill` exposes the SKILL.md files Rigor bundles under `skills/` (`rigor-project-init`, `rigor-baseline-reduce`,
+# `rigor-plugin-author`). The integration-style examples here exercise the real on-disk skill directory so the contract
+# the bundled skills + AI agents depend on is verified end-to-end.
 RSpec.describe Rigor::CLI::SkillCommand do
   def run(argv)
     out = StringIO.new
@@ -43,8 +41,8 @@ RSpec.describe Rigor::CLI::SkillCommand do
   end
 
   describe "describe" do
-    # `describe` probes the *current working directory*, so each
-    # example sets up a throwaway project root and runs from inside it.
+    # `describe` probes the *current working directory*, so each example sets up a throwaway project root and runs from
+    # inside it.
     def describe_in(files, argv = ["describe"])
       Dir.mktmpdir do |dir|
         files.each do |relative, contents|
@@ -65,8 +63,8 @@ RSpec.describe Rigor::CLI::SkillCommand do
       expect(out).to include("## Recommended next step")
       expect(out).to include("## All skills you can run next")
       expect(out).to include("## For the agent")
-      # P1-C: the agent prompt teaches check-aware routing (describe itself
-      # stays presence-only — it never runs `rigor check`).
+      # P1-C: the agent prompt teaches check-aware routing (describe itself stays presence-only — it never runs `rigor
+      # check`).
       expect(out).to include("refine the choice")
       expect(out).to include("→ rigor-monkeypatch-resolve")
     end
@@ -94,10 +92,8 @@ RSpec.describe Rigor::CLI::SkillCommand do
     end
 
     it "does not push rigor-baseline-reduce as the headline when a baseline exists" do
-      # A present baseline is a healthy onboarding-complete state, not a chore
-      # to grind down \u2014 the headline routes to an additive step instead, while
-      # baseline-reduce stays available in the catalogue for the user who
-      # chooses it.
+      # A present baseline is a healthy onboarding-complete state, not a chore to grind down \u2014 the headline routes
+      # to an additive step instead, while baseline-reduce stays available in the catalogue for the user who chooses it.
       _status, out, = describe_in(
         {
           ".rigor.dist.yml" => "target_ruby: '3.3'\n",
@@ -145,9 +141,8 @@ RSpec.describe Rigor::CLI::SkillCommand do
       expect(out).to include("Community RBS:  collection installed")
     end
 
-    # NB: assert on the recommendation *reason* (unique to the headline),
-    # not the bare skill name — the "For the agent" routing block also
-    # mentions `→ rigor-plugin-tune` as a conditional hint.
+    # NB: assert on the recommendation *reason* (unique to the headline), not the bare skill name — the "For the agent"
+    # routing block also mentions `→ rigor-plugin-tune` as a conditional hint.
     it "recommends rigor-plugin-tune for a configured Rails app with no Rails plugins enabled" do
       _status, out, = describe_in(
         {
@@ -292,9 +287,8 @@ RSpec.describe Rigor::CLI::SkillCommand do
 
   describe "--full <name>" do
     it "prints the SKILL.md body followed by each references/*.md inline" do
-      # rigor-doctor is a thin shell whose step detail lives in
-      # references/01-checks.md; --full re-assembles the complete,
-      # version-current procedure so a frozen copy can re-fetch it.
+      # rigor-doctor is a thin shell whose step detail lives in references/01-checks.md; --full re-assembles the
+      # complete, version-current procedure so a frozen copy can re-fetch it.
       status, out, = run(%w[--full rigor-doctor])
       expect(status).to eq(0)
       expect(out).to start_with("# Rigor skill: rigor-doctor\n")
@@ -302,8 +296,7 @@ RSpec.describe Rigor::CLI::SkillCommand do
       # The references are appended, each behind a labelled separator.
       expect(out).to include("references/01-checks.md")
       expect(out).to include("# 01 — The four checks")
-      # The separator names the shipping version so the reader can tell
-      # a stale vendored copy from the installed one.
+      # The separator names the shipping version so the reader can tell a stale vendored copy from the installed one.
       expect(out).to include("bundled with rigortype #{Rigor::VERSION}")
     end
 

--- a/spec/rigor/cli/trace_command_spec.rb
+++ b/spec/rigor/cli/trace_command_spec.rb
@@ -73,9 +73,8 @@ RSpec.describe Rigor::CLI::TraceCommand do
   it "replays a file containing multibyte characters (Prism offsets are bytes)" do
     Dir.mktmpdir do |dir|
       path = File.join(dir, "multibyte.rb")
-      # An em dash before the code shifts every later byte offset off
-      # its character index; a multibyte literal exercises the
-      # highlight slicing itself.
+      # An em dash before the code shifts every later byte offset off its character index; a multibyte literal exercises
+      # the highlight slicing itself.
       File.write(path, "# コメント — note\na = \"あ\"\nb = a + \"い\"\n")
 
       status, out, err = run_cli("trace", path)

--- a/spec/rigor/cli/triage_command_spec.rb
+++ b/spec/rigor/cli/triage_command_spec.rb
@@ -6,8 +6,8 @@ require "tmpdir"
 
 require "rigor/cli/triage_command"
 
-# ADR-23 — end-to-end wiring of `rigor triage`: the command runs
-# the real analysis pipeline, then renders the triage report.
+# ADR-23 — end-to-end wiring of `rigor triage`: the command runs the real analysis pipeline, then renders the triage
+# report.
 RSpec.describe Rigor::CLI::TriageCommand do
   def run(argv)
     out = StringIO.new

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe Rigor::CLI do
     it "reports OK and exits 0 when incremental matches a full run" do
       Dir.mktmpdir do |dir|
         File.write(File.join(dir, ".rigor.yml"), "severity_profile: balanced\n")
-        # One file carries a diagnostic so the merge moves real data; the
-        # other is plain, so the cache-serving path is exercised too.
+        # One file carries a diagnostic so the merge moves real data; the other is plain, so the cache-serving path is
+        # exercised too.
         File.write(File.join(dir, "a.rb"), <<~RUBY)
           class Base
             def greet
@@ -214,8 +214,7 @@ RSpec.describe Rigor::CLI do
       end
 
       it "reads bytes from --tmp-file when probing the logical path" do
-        # Logical path has a different value at (1,1) than the buffer.
-        # On disk: ":on_disk_sym"; in buffer: "42".
+        # Logical path has a different value at (1,1) than the buffer. On disk: ":on_disk_sym"; in buffer: "42".
         logical = write_fixture("a.rb", ":on_disk_sym\n")
         buffer = write_fixture("buf.rb", "42\n")
 
@@ -227,8 +226,7 @@ RSpec.describe Rigor::CLI do
         )
 
         expect(status).to eq(0)
-        # The probe must reflect the BUFFER's bytes (42), not the
-        # on-disk symbol literal.
+        # The probe must reflect the BUFFER's bytes (42), not the on-disk symbol literal.
         expect(out).to include("Prism::IntegerNode")
         expect(out).to include("type:    42")
       end
@@ -284,10 +282,8 @@ RSpec.describe Rigor::CLI do
 
         expect(err).to eq("")
         expect(status).to eq(0)
-        # The constant reference evaluates to the class object itself,
-        # i.e. singleton(CliRbsDemoFixture). Phase 2b enforces this
-        # distinction so subsequent class-method dispatch can hit
-        # singleton-side definitions.
+        # The constant reference evaluates to the class object itself, i.e. singleton(CliRbsDemoFixture). Phase 2b
+        # enforces this distinction so subsequent class-method dispatch can hit singleton-side definitions.
         expect(out).to include("type:    singleton(CliRbsDemoFixture)")
       end
     end
@@ -368,11 +364,9 @@ RSpec.describe Rigor::CLI do
     it "prints '(empty)' under --cache-stats when no cache directory exists" do
       write_check_fixture("a.rb", "1\n")
       Dir.chdir(tmpdir) do
-        # `--no-cache` keeps the run from writing anything: both the
-        # default stats summary (which forces `class_decl_paths` to build
-        # the RBS env) and the ADR-45 whole-run result cache would warm
-        # `.rigor/cache` and defeat the "no cache directory exists"
-        # assertion.
+        # `--no-cache` keeps the run from writing anything: both the default stats summary (which forces
+        # `class_decl_paths` to build the RBS env) and the ADR-45 whole-run result cache would warm `.rigor/cache` and
+        # defeat the "no cache directory exists" assertion.
         status, out, _err = run_cli("check", "--cache-stats", "--no-cache", "a.rb")
         expect(status).to eq(0)
         expect(out).to include("Cache (root: .rigor/cache)")
@@ -423,10 +417,9 @@ RSpec.describe Rigor::CLI do
         FileUtils.mkdir_p(cache_root)
         File.write(File.join(cache_root, "schema_version.txt"), "1\n")
 
-        # `--no-cache` (see the sibling spec): otherwise the run re-warms
-        # the cache after the clear — both the stats summary and the
-        # ADR-45 whole-run result cache write — re-creating the directory
-        # we're asserting got deleted. `--clear-cache` still runs first.
+        # `--no-cache` (see the sibling spec): otherwise the run re-warms the cache after the clear — both the stats
+        # summary and the ADR-45 whole-run result cache write — re-creating the directory we're asserting got deleted.
+        # `--clear-cache` still runs first.
         status, out, _err = run_cli("check", "--clear-cache", "--no-cache", "a.rb")
         expect(status).to eq(0)
         expect(out).to include("Cleared cache: .rigor/cache")
@@ -515,16 +508,13 @@ RSpec.describe Rigor::CLI do
     end
 
     before do
-      # Load the plugin gem into $LOAD_PATH and register it so
-      # the flag's injected entry can resolve through
+      # Load the plugin gem into $LOAD_PATH and register it so the flag's injected entry can resolve through
       # `Plugin::Loader.require_gem!`.
       plugin_lib = File.expand_path("../../plugins/rigor-rbs-inline/lib", __dir__)
       $LOAD_PATH.unshift(plugin_lib) unless $LOAD_PATH.include?(plugin_lib)
       require "rigor-rbs-inline"
-      # Explicitly re-register in case another spec in the same
-      # parallel-worker process already loaded the gem and then
-      # called `Rigor::Plugin.unregister!` — `require` would be
-      # a no-op and the class would stay unregistered.
+      # Explicitly re-register in case another spec in the same parallel-worker process already loaded the gem and then
+      # called `Rigor::Plugin.unregister!` — `require` would be a no-op and the class would stay unregistered.
       Rigor::Plugin.register(Rigor::Plugin::RbsInline) unless Rigor::Plugin.registered_for("rbs-inline")
     end
 
@@ -551,12 +541,10 @@ RSpec.describe Rigor::CLI do
     end
 
     it "loads the include-aware config and still injects rigor-rbs-inline when a .rigor.yml exists" do
-      # Regression: `load_check_configuration` reached for
-      # `Configuration.load_with_includes`, which was
-      # `private_class_method` — so the moment a config file was
-      # present (the ternary's truthy branch) the flag crashed
-      # with `NoMethodError: private method 'load_with_includes'`.
-      # The no-config example above never exercises that branch.
+      # Regression: `load_check_configuration` reached for `Configuration.load_with_includes`, which was
+      # `private_class_method` — so the moment a config file was present (the ternary's truthy branch) the flag crashed
+      # with `NoMethodError: private method 'load_with_includes'`. The no-config example above never exercises that
+      # branch.
       write_check_fixture(".rigor.yml", <<~YAML)
         paths:
           - .
@@ -862,8 +850,8 @@ RSpec.describe Rigor::CLI do
         status, out, _err = run_cli("type-scan", "source.rb")
 
         expect(status).to eq(0)
-        # ScanRbsDemoFixture would be unrecognized without the project
-        # signature loader; with sig/ in scope it resolves cleanly.
+        # ScanRbsDemoFixture would be unrecognized without the project signature loader; with sig/ in scope it resolves
+        # cleanly.
         expect(out).not_to match(%r{Prism::ConstantReadNode\s+\d+/\d+})
       end
     end
@@ -1239,9 +1227,8 @@ RSpec.describe Rigor::CLI do
         status, _out, err = run_cli("sig-gen", "--write", "--print")
 
         expect(status).to eq(0).or eq(Rigor::CLI::EXIT_USAGE)
-        # --print after --write just overrides the mode; OptionParser does not
-        # treat them as exclusive at parse time. The validation_error path catches
-        # invalid mode values; ensure no crash.
+        # --print after --write just overrides the mode; OptionParser does not treat them as exclusive at parse time.
+        # The validation_error path catches invalid mode values; ensure no crash.
         expect(err).not_to include("Traceback")
       end
     end
@@ -1256,10 +1243,9 @@ RSpec.describe Rigor::CLI do
     end
 
     it "returns 0 when stdin closes cleanly with no LSP messages" do
-      # `rigor lsp` blocks reading LSP frames from $stdin via the
-      # gem's Io::Reader. Under RSpec stdin is non-TTY and hits EOF
-      # immediately, so the loop exits with exit_code=0 (no
-      # shutdown → server.exit_code stays nil → CLI returns 0).
+      # `rigor lsp` blocks reading LSP frames from $stdin via the gem's Io::Reader. Under RSpec stdin is non-TTY and
+      # hits EOF immediately, so the loop exits with exit_code=0 (no shutdown → server.exit_code stays nil → CLI returns
+      # 0).
       status, _out, _err = run_cli("lsp")
 
       expect(status).to eq(0)
@@ -1334,8 +1320,7 @@ RSpec.describe Rigor::CLI do
 
     after { FileUtils.remove_entry(tmpdir) }
 
-    # A single reliable `call.undefined-method` (rule-bearing) diagnostic
-    # at line 2, column 3.
+    # A single reliable `call.undefined-method` (rule-bearing) diagnostic at line 2, column 3.
     def run_format(format)
       Dir.chdir(tmpdir) do
         File.write("demo.rb", "x = \"hello\"\nx.no_such_method_here\n")
@@ -1459,13 +1444,11 @@ RSpec.describe Rigor::CLI do
 
     after { FileUtils.remove_entry(tmpdir) }
 
-    # The suite forces RIGOR_CI_DETECT=0 (spec_helper) for determinism; each
-    # example opts back in and simulates one platform, restoring all touched
-    # keys afterwards.
+    # The suite forces RIGOR_CI_DETECT=0 (spec_helper) for determinism; each example opts back in and simulates one
+    # platform, restoring all touched keys afterwards.
     #
-    # All known CI provider variables are also saved and cleared so that running
-    # the suite under a real CI (e.g. GitHub Actions) does not bleed its own
-    # GITHUB_ACTIONS=true into tests that simulate a different platform.
+    # All known CI provider variables are also saved and cleared so that running the suite under a real CI (e.g. GitHub
+    # Actions) does not bleed its own GITHUB_ACTIONS=true into tests that simulate a different platform.
     def with_ci_env(vars)
       all_provider_vars = Rigor::CLI::CiDetector::PROVIDERS.map { |p| p[:var] }
       keys = (vars.keys + ["RIGOR_CI_DETECT"] + all_provider_vars).uniq
@@ -1614,9 +1597,8 @@ RSpec.describe Rigor::CLI do
       _status, out, _err = run_cli("annotate", "--no-color", path)
 
       lines = out.lines
-      # The loop body must reflect the converged (widened) bindings —
-      # never the cap-N intermediate constants of the ADR-56 fixpoint
-      # (`1 | 2`), nor the RHS literal of the operator-write (`1`).
+      # The loop body must reflect the converged (widened) bindings — never the cap-N intermediate constants of the
+      # ADR-56 fixpoint (`1 | 2`), nor the RHS literal of the operator-write (`1`).
       expect(lines[4]).to include("result *= i").and include("#=> Integer")
       expect(lines[5]).to include("i += 1").and include("#=> Integer")
       expect(lines[0]).to include("#=> Integer")
@@ -1638,9 +1620,8 @@ RSpec.describe Rigor::CLI do
       _status, out, _err = run_cli("annotate", "--no-color", path)
 
       lines = out.lines
-      # The header line's widest node is the BlockParametersNode — a
-      # non-expression whose evaluation falls back to `Dynamic[top]`.
-      # The annotation must instead show the bound parameter type(s).
+      # The header line's widest node is the BlockParametersNode — a non-expression whose evaluation falls back to
+      # `Dynamic[top]`. The annotation must instead show the bound parameter type(s).
       expect(lines[1]).to include("1.upto(5) do |i|").and include("#=> int<1, 5>")
       expect(lines[5]).to include("each do |k, v|").and include("#=> [:x, 1]")
       expect(out).not_to include("Dynamic")
@@ -1663,8 +1644,8 @@ RSpec.describe Rigor::CLI do
 
       lines = out.lines
       expect(lines[0]).to include("def greet(name)").and include("#=> String")
-      # The default annotation for the parameter (`Dynamic[top]`)
-      # is replaced by the return-type override on the header line.
+      # The default annotation for the parameter (`Dynamic[top]`) is replaced by the return-type override on the header
+      # line.
       expect(lines[0]).not_to include("Dynamic")
     end
 
@@ -1686,10 +1667,9 @@ RSpec.describe Rigor::CLI do
     end
 
     it "reads UTF-8 source even when `Encoding.default_external` is US-ASCII" do
-      # Em-dash + Japanese — the multi-byte content that triggers
-      # `invalid byte sequence in US-ASCII` from `String#sub`
-      # downstream when the file is read under a US-ASCII default
-      # external encoding (the Nix sandbox / minimal locale shape).
+      # Em-dash + Japanese — the multi-byte content that triggers `invalid byte sequence in US-ASCII` from `String#sub`
+      # downstream when the file is read under a US-ASCII default external encoding (the Nix sandbox / minimal locale
+      # shape).
       path = write_fixture("a.rb", "# Hello — こんにちは\n1\n")
 
       original = Encoding.default_external
@@ -1743,8 +1723,7 @@ RSpec.describe Rigor::CLI do
     end
 
     describe "bat integration (https://github.com/sharkdp/bat)" do
-      # Runs annotate with PATH pointing at `dir` (optionally
-      # holding a fake `bat`), with colour forced on.
+      # Runs annotate with PATH pointing at `dir` (optionally holding a fake `bat`), with colour forced on.
       def run_annotate_with_path(dir, *argv)
         original = ENV.fetch("PATH", "")
         ENV["PATH"] = dir
@@ -1758,8 +1737,7 @@ RSpec.describe Rigor::CLI do
 
       def write_fake_bat(dir)
         path = File.join(dir, "bat")
-        # `/bin/cat` because the test replaces PATH wholesale, so a
-        # bare `cat` would not resolve inside the fake script.
+        # `/bin/cat` because the test replaces PATH wholesale, so a bare `cat` would not resolve inside the fake script.
         File.write(path, "#!/bin/sh\necho BATMARK\n/bin/cat\n")
         File.chmod(0o755, path)
         path
@@ -1835,9 +1813,8 @@ RSpec.describe Rigor::CLI do
     end
 
     describe "NO_COLOR support (https://no-color.org)" do
-      # Runs `rigor annotate` against an out stream that reports
-      # itself as a tty, with `NO_COLOR` set to `value` (or unset
-      # when `value` is `:unset`).
+      # Runs `rigor annotate` against an out stream that reports itself as a tty, with `NO_COLOR` set to `value` (or
+      # unset when `value` is `:unset`).
       def run_annotate_tty(*argv, no_color: :unset)
         out = StringIO.new
         out.define_singleton_method(:tty?) { true }

--- a/spec/rigor/config_audit_spec.rb
+++ b/spec/rigor/config_audit_spec.rb
@@ -92,8 +92,7 @@ RSpec.describe Rigor::ConfigAudit do
 
       bp = warnings.find { |w| w.kind == :bundler_bundle_path }
       expect(bp).not_to be_nil
-      # Pin the config-key label, not just the descriptor, so the message
-      # names which setting to fix.
+      # Pin the config-key label, not just the descriptor, so the message names which setting to fix.
       expect(bp.message).to include("bundler.bundle_path").and include("is not a directory")
     end
 

--- a/spec/rigor/config_schema_spec.rb
+++ b/spec/rigor/config_schema_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe "Rigor configuration JSON Schema" do
     missing = default_keys - schema_keys
     expect(missing).to(be_empty, "schema is missing keys present in Configuration::DEFAULTS: #{missing.inspect}")
 
-    # `includes` is a load-time directive, not part of DEFAULTS, but
-    # it MUST be in the schema so editors stop flagging it.
+    # `includes` is a load-time directive, not part of DEFAULTS, but it MUST be in the schema so editors stop flagging
+    # it.
     expect(schema_keys).to include("includes")
   end
 

--- a/spec/rigor/configuration/dependencies_spec.rb
+++ b/spec/rigor/configuration/dependencies_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Rigor::Configuration::Dependencies do
     end
 
     it "treats source_inference: false as disabled (empty), not a crash" do
-      # `Array(false) == [false]` in Ruby, so a plain "off" config must be
-      # handled explicitly rather than fed into the per-entry coercer.
+      # `Array(false) == [false]` in Ruby, so a plain "off" config must be handled explicitly rather than fed into the
+      # per-entry coercer.
       deps = described_class.from_h("source_inference" => false)
 
       expect(deps.source_inference).to eq([])

--- a/spec/rigor/configuration/severity_profile_spec.rb
+++ b/spec/rigor/configuration/severity_profile_spec.rb
@@ -77,9 +77,8 @@ RSpec.describe Rigor::Configuration::SeverityProfile do
       ).to eq(:info)
     end
 
-    # ADR-50 § WD2 — the bleeding-edge overlay composes below the user's
-    # own overrides and above the profile table. Defaults to {} so the
-    # shipped (empty) overlay leaves resolution bit-for-bit unchanged.
+    # ADR-50 § WD2 — the bleeding-edge overlay composes below the user's own overrides and above the profile table.
+    # Defaults to {} so the shipped (empty) overlay leaves resolution bit-for-bit unchanged.
     describe "bleeding_edge_overrides:" do
       it "defaults to an empty map, leaving resolution unchanged" do
         expect(

--- a/spec/rigor/configuration_spec.rb
+++ b/spec/rigor/configuration_spec.rb
@@ -204,9 +204,8 @@ RSpec.describe Rigor::Configuration do
     it "reads severity_profile + severity_overrides from the YAML file" do
       Dir.mktmpdir do |dir|
         path = File.join(dir, ".rigor.yml")
-        # NOTE: `off` is reserved in YAML 1.1 (parses to `false`),
-        # so users quote `"off"` when they want the severity. The
-        # config loader does NOT auto-coerce booleans.
+        # NOTE: `off` is reserved in YAML 1.1 (parses to `false`), so users quote `"off"` when they want the severity.
+        # The config loader does NOT auto-coerce booleans.
         File.write(path, <<~YAML)
           severity_profile: strict
           severity_overrides:
@@ -242,8 +241,7 @@ RSpec.describe Rigor::Configuration do
     end
 
     it "gives a friendly error when a severity is an unquoted YAML boolean" do
-      # `off` is YAML 1.1-reserved and parses to `false`; the user
-      # almost certainly meant the severity string "off".
+      # `off` is YAML 1.1-reserved and parses to `false`; the user almost certainly meant the severity string "off".
       expect do
         described_class.new(
           Rigor::Configuration::DEFAULTS.merge(
@@ -314,8 +312,8 @@ RSpec.describe Rigor::Configuration do
         expect(Ractor.shareable?(config_with("all" => true, "except" => ["x"]))).to be(true)
       end
 
-      # ADR-50 § WD2 — the CLI mirror (`--bleeding-edge[=ids]`) overrides the
-      # configured selection for a single run via this method.
+      # ADR-50 § WD2 — the CLI mirror (`--bleeding-edge[=ids]`) overrides the configured selection for a single run via
+      # this method.
       describe "#with_bleeding_edge" do
         let(:base) { config_with(false) }
 
@@ -326,9 +324,8 @@ RSpec.describe Rigor::Configuration do
         end
 
         it "recomputes bleeding_edge_severity_overrides from the new selector" do
-          # The overlay is empty in this release, so every selection still maps
-          # to an empty severity overlay — the wiring, not a populated result,
-          # is what this pins.
+          # The overlay is empty in this release, so every selection still maps to an empty severity overlay — the
+          # wiring, not a populated result, is what this pins.
           expect(base.with_bleeding_edge(true).bleeding_edge_severity_overrides).to eq({})
         end
 

--- a/spec/rigor/environment/bundle_sig_discovery_spec.rb
+++ b/spec/rigor/environment/bundle_sig_discovery_spec.rb
@@ -12,9 +12,8 @@ RSpec.describe Rigor::Environment::BundleSigDiscovery do
   after { FileUtils.rm_rf(tmpdir) }
 
   def make_bundle_layout(root, *gem_entries)
-    # gem_entries: [name, version, ruby_version] tuples; creates
-    # <root>/ruby/<ruby_version>/gems/<name>-<version>/sig/ + a
-    # stub .rbs file inside so the dir exists.
+    # gem_entries: [name, version, ruby_version] tuples; creates <root>/ruby/<ruby_version>/gems/<name>-<version>/sig/ +
+    # a stub .rbs file inside so the dir exists.
     gem_entries.each do |name, version, ruby_version|
       sig_dir = File.join(root, "ruby", ruby_version, "gems", "#{name}-#{version}", "sig")
       FileUtils.mkdir_p(sig_dir)
@@ -89,8 +88,7 @@ RSpec.describe Rigor::Environment::BundleSigDiscovery do
     end
 
     it "returns [] when neither .bundle/config nor vendor/bundle resolves" do
-      # `home:` points at an empty dir so the real user `~/.bundle/config`
-      # is not consulted — the test stays hermetic.
+      # `home:` points at an empty dir so the real user `~/.bundle/config` is not consulted — the test stays hermetic.
       result = described_class.discover(bundle_path: nil, project_root: tmpdir, auto_detect: true, home: tmpdir)
       expect(result).to eq([])
     end
@@ -151,8 +149,7 @@ RSpec.describe Rigor::Environment::BundleSigDiscovery do
   end
 
   describe ".discover with a lockfile filter (O4 Layer 3)" do
-    # The lockfile filter accepts a `{name => LockedGem}` map.
-    # Only sig dirs whose `(name, version, platform)` matches a
+    # The lockfile filter accepts a `{name => LockedGem}` map. Only sig dirs whose `(name, version, platform)` matches a
     # lockfile entry survive.
     let(:locked_gem_klass) { Rigor::Environment::LockfileResolver::LockedGem }
 
@@ -177,8 +174,7 @@ RSpec.describe Rigor::Environment::BundleSigDiscovery do
 
     it "drops sig dirs whose version does not match the lockfile (bundle drift)" do
       bundle = File.join(tmpdir, "bundle")
-      # Bundle dir has acme_sdk-2.0.0 left over from before a
-      # `bundle update`; lockfile now pins 1.2.3.
+      # Bundle dir has acme_sdk-2.0.0 left over from before a `bundle update`; lockfile now pins 1.2.3.
       make_bundle_layout(bundle, ["acme_sdk", "2.0.0", "4.0.0"])
       locked = {
         "acme_sdk" => locked_gem_klass.new(name: "acme_sdk", version: "1.2.3", platform: "ruby")

--- a/spec/rigor/environment/class_registry_spec.rb
+++ b/spec/rigor/environment/class_registry_spec.rb
@@ -82,8 +82,8 @@ RSpec.describe Rigor::Environment::ClassRegistry do
     end
 
     it "normalizes a leading :: and accepts Symbol names" do
-      # normalize_name strips the top-level "::" and coerces to String,
-      # so "::Integer" and :Integer resolve to the same registered class.
+      # normalize_name strips the top-level "::" and coerces to String, so "::Integer" and :Integer resolve to the same
+      # registered class.
       expect(registry.class_ordering("::Integer", "Integer")).to eq(:equal)
       expect(registry.class_ordering(:Integer, :Numeric)).to eq(:subclass)
     end

--- a/spec/rigor/environment/lockfile_resolver_spec.rb
+++ b/spec/rigor/environment/lockfile_resolver_spec.rb
@@ -8,8 +8,7 @@ require "rigor/environment/lockfile_resolver"
 RSpec.describe Rigor::Environment::LockfileResolver do
   let(:tmpdir) { Dir.mktmpdir("rigor-lockfile-resolver-spec-") }
 
-  # A minimal valid Gemfile.lock body. Two pure-Ruby gems + one
-  # platform-tagged gem. Matches what `bundle lock` emits.
+  # A minimal valid Gemfile.lock body. Two pure-Ruby gems + one platform-tagged gem. Matches what `bundle lock` emits.
   let(:simple_lockfile_body) do
     <<~LOCKFILE
       GEM
@@ -100,20 +99,17 @@ RSpec.describe Rigor::Environment::LockfileResolver do
     end
 
     it "returns empty and warns when Bundler raises on truly corrupt lockfile" do
-      # Truncating mid-section forces Bundler's state machine into
-      # an unparseable transition (the exact form varies by
-      # Bundler version, so the test just asserts the contract:
-      # never crash, never return junk).
+      # Truncating mid-section forces Bundler's state machine into an unparseable transition (the exact form varies by
+      # Bundler version, so the test just asserts the contract: never crash, never return junk).
       path = write_lockfile("GEM\n  remote:")
       result = described_class.locked_gems(lockfile_path: path, project_root: tmpdir, auto_detect: false)
       expect(result).to eq({})
     end
 
     it "warns to stderr (naming the path and error) when the parser raises" do
-      # Deterministically drive the malformed-lockfile rescue: a real
-      # corrupt body's failure mode is Bundler-version-dependent, so
-      # force the raise and assert the warning the user relies on to
-      # learn why their lockfile was ignored.
+      # Deterministically drive the malformed-lockfile rescue: a real corrupt body's failure mode is
+      # Bundler-version-dependent, so force the raise and assert the warning the user relies on to learn why their
+      # lockfile was ignored.
       require "bundler"
       path = write_lockfile(simple_lockfile_body)
       allow(Bundler::LockfileParser).to receive(:new).and_raise(RuntimeError.new("boom"))
@@ -126,9 +122,8 @@ RSpec.describe Rigor::Environment::LockfileResolver do
     end
 
     it "warns to stderr and returns empty when bundler cannot be required" do
-      # The LoadError rescue: bundler is always present in the test
-      # env, so stub the require to drive the branch that tells the
-      # user their lockfile could not be read.
+      # The LoadError rescue: bundler is always present in the test env, so stub the require to drive the branch that
+      # tells the user their lockfile could not be read.
       path = write_lockfile(simple_lockfile_body)
       allow(described_class).to receive(:require).with("bundler").and_raise(LoadError.new("no bundler"))
 
@@ -166,10 +161,8 @@ RSpec.describe Rigor::Environment::LockfileResolver do
       result = described_class.locked_gems(lockfile_path: path, project_root: tmpdir, auto_detect: false)
       ffi = result.fetch("ffi")
       expect(ffi.version).to eq("1.17.4")
-      # The active spec depends on which platform Bundler selected
-      # at parse time; either "ruby" or the platform-tagged form
-      # is acceptable. The point is the resolver returns *some*
-      # consistent platform string.
+      # The active spec depends on which platform Bundler selected at parse time; either "ruby" or the platform-tagged
+      # form is acceptable. The point is the resolver returns *some* consistent platform string.
       expect(ffi.platform).to be_a(String)
       expect(ffi.platform).not_to be_empty
     end

--- a/spec/rigor/environment/rbs_collection_discovery_spec.rb
+++ b/spec/rigor/environment/rbs_collection_discovery_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe Rigor::Environment::RbsCollectionDiscovery do
 
   after { FileUtils.rm_rf(tmpdir) }
 
-  # Builds a `.gem_rbs_collection/<gem>/<version>/<gem>.rbs`
-  # layout matching what `rbs collection install` produces.
+  # Builds a `.gem_rbs_collection/<gem>/<version>/<gem>.rbs` layout matching what `rbs collection install` produces.
   def make_collection(root, *entries)
     entries.each do |name, version|
       gem_dir = File.join(root, name, version)
@@ -82,10 +81,8 @@ RSpec.describe Rigor::Environment::RbsCollectionDiscovery do
     end
 
     it "skips gems named in skip_gem_names regardless of source type" do # rubocop:disable RSpec/ExampleLength
-      # `cgi` / `logger` are stdlib-extracted default gems that
-      # ruby/gem_rbs_collection ships under a `git` source, yet
-      # rigor loads them from its bundled stdlib — admitting the
-      # collection copy double-declares and raises
+      # `cgi` / `logger` are stdlib-extracted default gems that ruby/gem_rbs_collection ships under a `git` source, yet
+      # rigor loads them from its bundled stdlib — admitting the collection copy double-declares and raises
       # RBS::DuplicatedDeclarationError.
       make_collection(
         File.join(tmpdir, ".gem_rbs_collection"),
@@ -202,9 +199,8 @@ RSpec.describe Rigor::Environment::RbsCollectionDiscovery do
     end
 
     it "returns [] when the collection root referenced by the lockfile doesn't exist" do
-      # Lockfile says `path: .gem_rbs_collection` but the dir
-      # has never been created (e.g., committed lockfile, no
-      # `rbs collection install` run yet).
+      # Lockfile says `path: .gem_rbs_collection` but the dir has never been created (e.g., committed lockfile, no `rbs
+      # collection install` run yet).
       body = <<~YAML
         ---
         path: ".gem_rbs_collection"
@@ -267,8 +263,7 @@ RSpec.describe Rigor::Environment::RbsCollectionDiscovery do
 
   describe ".discover with non-default collection path" do
     it "resolves a custom `path:` field against the lockfile's directory" do
-      # Lockfile lives in `<tmpdir>/config/` and points at
-      # `<tmpdir>/config/../rbs/`.
+      # Lockfile lives in `<tmpdir>/config/` and points at `<tmpdir>/config/../rbs/`.
       config_dir = File.join(tmpdir, "config")
       FileUtils.mkdir_p(config_dir)
       make_collection(File.join(tmpdir, "rbs"), ["rack", "3.0"])

--- a/spec/rigor/environment/rbs_coverage_report_spec.rb
+++ b/spec/rigor/environment/rbs_coverage_report_spec.rb
@@ -87,10 +87,8 @@ RSpec.describe Rigor::Environment::RbsCoverageReport do
     end
 
     it "respects DEFAULT_LIBRARIES precedence over VENDORED_GEM_NAMES (DEFAULT wins)" do
-      # If a gem is in both lists, the order in `classify` puts
-      # default_library first. In practice this is a theoretical
-      # case — DEFAULT_LIBRARIES and vendored_gem_sigs are
-      # curated to not overlap — but the contract is stable.
+      # If a gem is in both lists, the order in `classify` puts default_library first. In practice this is a theoretical
+      # case — DEFAULT_LIBRARIES and vendored_gem_sigs are curated to not overlap — but the contract is stable.
       locked_gems = { "json" => locked("json", "2.0") }
       rows = described_class.classify(
         locked_gems: locked_gems,

--- a/spec/rigor/environment/rbs_loader_spec.rb
+++ b/spec/rigor/environment/rbs_loader_spec.rb
@@ -25,9 +25,8 @@ RSpec.describe Rigor::Environment::RbsLoader do
   describe ".vendored_gem_names" do
     it "returns the gem subdirectory names under data/vendored_gem_sigs/" do
       names = described_class.vendored_gem_names
-      # The set is the source of truth for RbsCollectionDiscovery's
-      # skip list; assert the known native-ext / Rails-ubiquitous
-      # gems that drove the collision fix are present.
+      # The set is the source of truth for RbsCollectionDiscovery's skip list; assert the known native-ext /
+      # Rails-ubiquitous gems that drove the collision fix are present.
       expect(names).to include("redis", "nokogiri", "pg", "bcrypt", "cgi")
     end
 
@@ -88,11 +87,10 @@ RSpec.describe Rigor::Environment::RbsLoader do
   end
 
   describe "class-alias resolution (`class Mutex = Thread::Mutex`)" do
-    # An RBS class alias lives only in `class_alias_decls`, so `class_known?`
-    # reports it but the definition builder (which only knows `class_decls`)
-    # could not enumerate its methods. The loader now normalises the alias to
-    # its canonical target before building, so dispatch and the
-    # `call.undefined-method` existence check both work on `Mutex`.
+    # An RBS class alias lives only in `class_alias_decls`, so `class_known?` reports it but the definition builder
+    # (which only knows `class_decls`) could not enumerate its methods. The loader now normalises the alias to its
+    # canonical target before building, so dispatch and the `call.undefined-method` existence check both work on
+    # `Mutex`.
     it "reports the alias as known" do
       expect(loader.class_known?("Mutex")).to be(true)
     end
@@ -198,10 +196,9 @@ RSpec.describe Rigor::Environment::RbsLoader do
   end
 
   describe "core overlay (data/core_overlay/)" do
-    # `Numeric#to_f`/`to_i`/`to_r` are not declared on the abstract
-    # `Numeric` by upstream `ruby/rbs` (only on the concrete subclasses),
-    # but Rigor widens arithmetic chains to `Numeric`, so the overlay
-    # reopens the class to supply them. See data/core_overlay/numeric.rbs.
+    # `Numeric#to_f`/`to_i`/`to_r` are not declared on the abstract `Numeric` by upstream `ruby/rbs` (only on the
+    # concrete subclasses), but Rigor widens arithmetic chains to `Numeric`, so the overlay reopens the class to supply
+    # them. See data/core_overlay/numeric.rbs.
     it "exposes a non-empty overlay sig path set" do
       expect(described_class.core_overlay_sig_paths).not_to be_empty
       expect(described_class.core_overlay_sig_paths).to all(be_a(Pathname))
@@ -221,21 +218,19 @@ RSpec.describe Rigor::Environment::RbsLoader do
       end
     end
 
-    # `Pathname#expand_path` delegates to `File.expand_path` at runtime, which
-    # accepts any `to_path`-bearing object as its `dir` base.  The upstream RBS
-    # sig only allows `String`, causing false positives when a `Pathname` is
-    # passed as the base (the Bundler pattern).  See data/core_overlay/pathname.rbs.
+    # `Pathname#expand_path` delegates to `File.expand_path` at runtime, which accepts any `to_path`-bearing object as
+    # its `dir` base. The upstream RBS sig only allows `String`, causing false positives when a `Pathname` is passed as
+    # the base (the Bundler pattern). See data/core_overlay/pathname.rbs.
     context "with the pathname stdlib library loaded" do
-      # Pathname is a stdlib library (not core), so we need a loader that
-      # opts in to it.
+      # Pathname is a stdlib library (not core), so we need a loader that opts in to it.
       let(:pathname_loader) { described_class.new(libraries: ["pathname"]) }
 
       it "resolves Pathname#expand_path with the widened overlay signature" do
         method = pathname_loader.instance_method(class_name: "Pathname", method_name: :expand_path)
         expect(method).not_to be_nil, "expected overlay to declare Pathname#expand_path"
         expect(method.method_types).not_to be_empty
-        # The overlay widens the optional `dir` parameter to accept Pathname
-        # in addition to String; verify at least one overload carries a parameter.
+        # The overlay widens the optional `dir` parameter to accept Pathname in addition to String; verify at least one
+        # overload carries a parameter.
         param_types = method.method_types.flat_map { |mt| mt.type.required_positionals + mt.type.optional_positionals }
         expect(param_types).not_to be_empty
       end
@@ -278,8 +273,8 @@ RSpec.describe Rigor::Environment::RbsLoader do
     end
 
     it "is namespace-disjoint from #instance_method" do
-      # Module#instance_methods is a singleton-side method on every
-      # class type; it MUST NOT be exposed on the instance side.
+      # Module#instance_methods is a singleton-side method on every class type; it MUST NOT be exposed on the instance
+      # side.
       expect(loader.instance_method(class_name: "Integer", method_name: :instance_methods)).to be_nil
       expect(loader.singleton_method(class_name: "Integer", method_name: :instance_methods)).not_to be_nil
     end
@@ -343,13 +338,10 @@ RSpec.describe Rigor::Environment::RbsLoader do
   end
 
   describe "#class_decl_paths" do
-    # Regression: `class_decl_paths` called `entry.primary_decl`
-    # unguarded, which only exists on RBS 4.x. Under RBS 3.x (allowed
-    # by the gemspec `rbs >= 3.0, < 5.0`, which exposes `entry.primary`
-    # instead) `rigor check` crashed with
-    # `undefined method 'primary_decl'`. The shared `primary_decl_for`
-    # helper normalises both shapes, so this maps every loaded class to
-    # the file its first declaration came from across the whole range.
+    # Regression: `class_decl_paths` called `entry.primary_decl` unguarded, which only exists on RBS 4.x. Under RBS 3.x
+    # (allowed by the gemspec `rbs >= 3.0, < 5.0`, which exposes `entry.primary` instead) `rigor check` crashed with
+    # `undefined method 'primary_decl'`. The shared `primary_decl_for` helper normalises both shapes, so this maps every
+    # loaded class to the file its first declaration came from across the whole range.
     it "maps core classes to the RBS source file of their first declaration" do
       paths = loader.class_decl_paths
       expect(paths).not_to be_empty
@@ -397,8 +389,7 @@ RSpec.describe Rigor::Environment::RbsLoader do
       loader = described_class.new(libraries: ["prism"], signature_paths: [tmpdir])
       allow(loader).to receive(:warn) # silence the once-per-loader env-build-failure warning
       allow(described_class).to receive(:build_env_for).and_call_original
-      # Touch env many times; the broken state should be memoised
-      # so build_env_for runs at most once.
+      # Touch env many times; the broken state should be memoised so build_env_for runs at most once.
       10.times { loader.send(:env) }
       expect(described_class).to have_received(:build_env_for).at_most(:once)
       expect(loader.send(:env)).to be_nil
@@ -434,12 +425,10 @@ RSpec.describe Rigor::Environment::RbsLoader do
   end
 
   describe "missing-namespace synthesis (ADR-5 robustness)" do
-    # A project sig set that declares qualified names without ever
-    # declaring the enclosing namespace is invalid upstream (`rbs
-    # validate` rejects it); pre-fix every method on every such class
-    # degraded to Dynamic[Top] because `build_instance` raised
-    # `NoTypeFoundError`. The loader now synthesizes the missing
-    # `module` so the otherwise-inert signatures resolve.
+    # A project sig set that declares qualified names without ever declaring the enclosing namespace is invalid upstream
+    # (`rbs validate` rejects it); pre-fix every method on every such class degraded to Dynamic[Top] because
+    # `build_instance` raised `NoTypeFoundError`. The loader now synthesizes the missing `module` so the otherwise-inert
+    # signatures resolve.
     let(:tmpdir) { Dir.mktmpdir("rigor-rbs-loader-namespace-spec-") }
 
     after { FileUtils.rm_rf(tmpdir) }
@@ -487,10 +476,9 @@ RSpec.describe Rigor::Environment::RbsLoader do
   end
 
   describe "referenced-type stub synthesis (ADR-5 robustness)" do
-    # A single reference to a type no loaded signature declares makes
-    # RBS's per-class build fail wholesale, so EVERY method on the
-    # referencing class degrades to Dynamic[Top]. Stubbing the missing
-    # type lets the rest of the class build.
+    # A single reference to a type no loaded signature declares makes RBS's per-class build fail wholesale, so EVERY
+    # method on the referencing class degrades to Dynamic[Top]. Stubbing the missing type lets the rest of the class
+    # build.
     let(:tmpdir) { Dir.mktmpdir("rigor-rbs-loader-stub-spec-") }
 
     after { FileUtils.rm_rf(tmpdir) }
@@ -535,13 +523,10 @@ RSpec.describe Rigor::Environment::RbsLoader do
     end
 
     it "does not collapse the env when a class references its own nested type (2026-07-04 redmine)" do
-      # The stub sweep must stub only the missing leaf
-      # (`GitAdapter::Revision`), never re-declare the already-declared
-      # `GitAdapter` as a `module` — that class-vs-module kind mismatch
-      # made `resolve_type_names` raise DuplicatedDeclarationError and
-      # nulled the WHOLE env (every type-of query → Dynamic[Top]). The
-      # exact shape `rigor sig-gen` emitted for a subclass whose sig
-      # dropped the superclass.
+      # The stub sweep must stub only the missing leaf (`GitAdapter::Revision`), never re-declare the already-declared
+      # `GitAdapter` as a `module` — that class-vs-module kind mismatch made `resolve_type_names` raise
+      # DuplicatedDeclarationError and nulled the WHOLE env (every type-of query → Dynamic[Top]). The exact shape `rigor
+      # sig-gen` emitted for a subclass whose sig dropped the superclass.
       File.write(
         File.join(tmpdir, "adapter.rbs"),
         <<~RBS
@@ -562,9 +547,8 @@ RSpec.describe Rigor::Environment::RbsLoader do
     end
 
     it "does not re-stub a leaf whose namespace prefix is already a declared class" do
-      # `append_stub_declarations` mirrors `collect_missing_namespaces`'s
-      # `declared.include?` guard: an enclosing prefix already present in
-      # the env is never re-emitted.
+      # `append_stub_declarations` mirrors `collect_missing_namespaces`'s `declared.include?` guard: an enclosing prefix
+      # already present in the env is never re-emitted.
       File.write(
         File.join(tmpdir, "adapter.rbs"),
         <<~RBS

--- a/spec/rigor/environment/reflection_spec.rb
+++ b/spec/rigor/environment/reflection_spec.rb
@@ -3,8 +3,8 @@
 require "spec_helper"
 
 RSpec.describe Rigor::Environment::Reflection do
-  # Reflection is immutable and the examples below only query it, so build the
-  # expensive RBS-backed surface once for the file instead of once per example.
+  # Reflection is immutable and the examples below only query it, so build the expensive RBS-backed surface once for the
+  # file instead of once per example.
   before(:all) do # rubocop:disable RSpec/BeforeAfterAll
     @reflection = Rigor::Environment.for_project.reflection
   end

--- a/spec/rigor/environment_spec.rb
+++ b/spec/rigor/environment_spec.rb
@@ -284,18 +284,15 @@ RSpec.describe Rigor::Environment do
         expect(env.singleton_for_name("JSON")).not_to be_nil
         expect(env.singleton_for_name("YAML")).not_to be_nil
         expect(env.singleton_for_name("Pathname")).not_to be_nil
-        # `tmpdir` extends Dir with `Dir.mktmpdir`; verify the
-        # singleton method is now reachable.
+        # `tmpdir` extends Dir with `Dir.mktmpdir`; verify the singleton method is now reachable.
         loader = env.rbs_loader
         expect(loader.singleton_method(class_name: "Dir", method_name: :mktmpdir)).not_to be_nil
         expect(env.singleton_for_name("StringIO")).not_to be_nil
       end
 
       it "merges caller-supplied libraries on top of the defaults, preserving order and de-duplicating" do
-        # `coverage` is not in DEFAULT_LIBRARIES (it's a
-        # test-time-only stdlib library, intentionally kept out
-        # of the default-load set). The user opts in explicitly
-        # here.
+        # `coverage` is not in DEFAULT_LIBRARIES (it's a test-time-only stdlib library, intentionally kept out of the
+        # default-load set). The user opts in explicitly here.
         env = described_class.for_project(libraries: %w[coverage json], signature_paths: [])
         loader = env.rbs_loader
         expect(loader.libraries).to start_with(*Rigor::Environment::DEFAULT_LIBRARIES)

--- a/spec/rigor/flow_contribution/merger_spec.rb
+++ b/spec/rigor/flow_contribution/merger_spec.rb
@@ -92,10 +92,8 @@ RSpec.describe Rigor::FlowContribution::Merger do
       expect(conflict.kind).to eq(:return_type)
       expect(conflict.reason).to eq(:return_type_collapse)
       expect(conflict.provenances).to include(plugin_alpha, plugin_beta)
-      # The conflict message uses type#describe(:short); asserting the
-      # exact message kills the undefined_method mutant that renames the
-      # describe call to a fallback type.inspect (which would wrap names
-      # in a #<...> carrier prefix).
+      # The conflict message uses type#describe(:short); asserting the exact message kills the undefined_method mutant
+      # that renames the describe call to a fallback type.inspect (which would wrap names in a #<...> carrier prefix).
       expect(conflict.message).to match(/\Areturn-type intersection collapses to bot: String vs Integer\z/)
     end
 
@@ -193,8 +191,7 @@ RSpec.describe Rigor::FlowContribution::Merger do
       end
 
       it "falls back to inspect for a type without describe" do
-        # The else branch: when `respond_to?(:describe)` is false,
-        # `type.inspect` is returned directly.
+        # The else branch: when `respond_to?(:describe)` is false, `type.inspect` is returned directly.
         plain = "untyped"
         result = described_class.send(:describe, plain)
         expect(result).to eq(plain.inspect)

--- a/spec/rigor/inference/acceptance_spec.rb
+++ b/spec/rigor/inference/acceptance_spec.rb
@@ -3,11 +3,9 @@
 require "spec_helper"
 
 RSpec.describe Rigor::Inference::Acceptance do
-  # The acceptance dispatch matrix needs many short-lived type carriers,
-  # but they are all immutable flyweights or simple structural objects.
-  # Using `let` for each would trip RSpec/MultipleMemoizedHelpers, so we
-  # expose them as plain helper methods on the example group. The thin
-  # value objects make any per-call construction cost negligible.
+  # The acceptance dispatch matrix needs many short-lived type carriers, but they are all immutable flyweights or simple
+  # structural objects. Using `let` for each would trip RSpec/MultipleMemoizedHelpers, so we expose them as plain helper
+  # methods on the example group. The thin value objects make any per-call construction cost negligible.
   def top = Rigor::Type::Combinator.top
   def bot = Rigor::Type::Combinator.bot
   def dyn_top = Rigor::Type::Combinator.untyped
@@ -78,25 +76,18 @@ RSpec.describe Rigor::Inference::Acceptance do
     end
 
     it "is no when target is unresolvable but actual's ancestor chain excludes it" do
-      # When the target's Ruby class is not loaded (e.g. a stdlib
-      # gem like `bigdecimal` that rigor's own process never
-      # `require`s) but the actual side IS loaded, the actual's
-      # ancestor chain is authoritative. `Integer.ancestors`
-      # does not contain "Definitely::Not::A::Real::Class", so
-      # the subtype relation is definitively `:no` — not the
-      # conservative `:maybe` it used to be. Required to keep
-      # the `OverloadSelector` from picking
-      # `Integer#+(BigDecimal) -> BigDecimal` over
-      # `Integer#+(Integer) -> Integer` when the bigdecimal RBS
-      # reopen puts the BigDecimal arm first in the overload
-      # list.
+      # When the target's Ruby class is not loaded (e.g. a stdlib gem like `bigdecimal` that rigor's own process never
+      # `require`s) but the actual side IS loaded, the actual's ancestor chain is authoritative. `Integer.ancestors`
+      # does not contain "Definitely::Not::A::Real::Class", so the subtype relation is definitively `:no` — not the
+      # conservative `:maybe` it used to be. Required to keep the `OverloadSelector` from picking `Integer#+(BigDecimal)
+      # -> BigDecimal` over `Integer#+(Integer) -> Integer` when the bigdecimal RBS reopen puts the BigDecimal arm first
+      # in the overload list.
       unresolved = Rigor::Type::Combinator.nominal_of("Definitely::Not::A::Real::Class")
       expect(accepts(unresolved, int_nominal)).to be_no
     end
 
     it "is maybe when neither side resolves to a Ruby class" do
-      # Two user-defined classes neither side can load. Without
-      # an ancestor chain to fall back on we keep the
+      # Two user-defined classes neither side can load. Without an ancestor chain to fall back on we keep the
       # conservative `:maybe` answer.
       left = Rigor::Type::Combinator.nominal_of("Definitely::Not::A::Real::Class")
       right = Rigor::Type::Combinator.nominal_of("Also::Not::Real")
@@ -128,26 +119,19 @@ RSpec.describe Rigor::Inference::Acceptance do
   end
 
   describe "Nominal acceptance of Constant with an unloadable target" do
-    # Regression: when `Nominal[BigDecimal]` (target unloadable
-    # because rigor's process never requires `bigdecimal`)
-    # checks acceptance of `Constant<1>` (value class Integer),
-    # the answer MUST be `:no` so the `OverloadSelector` cannot
-    # pick `Integer#+(BigDecimal) -> BigDecimal` over
-    # `Integer#+(Integer) -> Integer`. Previously this answered
-    # `:maybe` (resolve_class fallback) and the BigDecimal arm
-    # — which the bigdecimal stdlib RBS reopens at the FRONT
-    # of `Integer#+` — won by overload-list position, polluting
-    # the inferred type of plain Integer arithmetic.
+    # Regression: when `Nominal[BigDecimal]` (target unloadable because rigor's process never requires `bigdecimal`)
+    # checks acceptance of `Constant<1>` (value class Integer), the answer MUST be `:no` so the `OverloadSelector`
+    # cannot pick `Integer#+(BigDecimal) -> BigDecimal` over `Integer#+(Integer) -> Integer`. Previously this answered
+    # `:maybe` (resolve_class fallback) and the BigDecimal arm — which the bigdecimal stdlib RBS reopens at the FRONT of
+    # `Integer#+` — won by overload-list position, polluting the inferred type of plain Integer arithmetic.
     it "answers :no when the target is unloadable but the constant's value class excludes it" do
       bd_nominal = Rigor::Type::Combinator.nominal_of("BigDecimal")
       expect(accepts(bd_nominal, int_constant)).to be_no
     end
 
     it "answers :yes when the target is unloadable but the constant's value class ancestors include it" do
-      # `Numeric` IS loadable so this routes through `is_a?` —
-      # asserted here to make the assignment of behavior clear:
-      # the ancestor fallback only kicks in when the target
-      # Ruby class can't be resolved.
+      # `Numeric` IS loadable so this routes through `is_a?` — asserted here to make the assignment of behavior clear:
+      # the ancestor fallback only kicks in when the target Ruby class can't be resolved.
       expect(accepts(numeric_nominal, int_constant)).to be_yes
     end
   end
@@ -182,12 +166,9 @@ RSpec.describe Rigor::Inference::Acceptance do
     end
 
     it "is maybe when no member proves yes but some member is maybe" do
-      # Both sides unresolvable so the Nominal acceptance can
-      # only answer `:maybe` — the ancestor-chain fallback that
-      # collapsed the single-unresolved case to `:no` (see the
-      # Nominal spec immediately above) needs an authoritative
-      # actual side, and a Nominal-vs-Nominal pair where the
-      # actual is also user-defined leaves us with no chain to
+      # Both sides unresolvable so the Nominal acceptance can only answer `:maybe` — the ancestor-chain fallback that
+      # collapsed the single-unresolved case to `:no` (see the Nominal spec immediately above) needs an authoritative
+      # actual side, and a Nominal-vs-Nominal pair where the actual is also user-defined leaves us with no chain to
       # consult. The Union-merge then surfaces that `:maybe`.
       left = Rigor::Type::Combinator.nominal_of("Definitely::Not::A::Real::Class")
       right = Rigor::Type::Combinator.nominal_of("Also::Not::Real")
@@ -270,15 +251,11 @@ RSpec.describe Rigor::Inference::Acceptance do
       expect(accepts(a, b)).to be_no
     end
 
-    # Parametrized-ancestor projection: `Hash[K, V]` is
-    # `Enumerable[[K, V]]` per RBS (`include Enumerable[[K, V]]` in
-    # Hash's class body). Without projection the arity check would
-    # reject because Hash carries two type_args and Enumerable only
-    # one; with projection the actual is rewritten to `Enumerable
-    # [Tuple[K, V]]` and the element-wise covariance succeeds.
-    # Surfaced on Discourse via `URI.encode_www_form(hash)` calls
-    # that the parameter binder previously flagged as type
-    # mismatches.
+    # Parametrized-ancestor projection: `Hash[K, V]` is `Enumerable[[K, V]]` per RBS (`include Enumerable[[K, V]]` in
+    # Hash's class body). Without projection the arity check would reject because Hash carries two type_args and
+    # Enumerable only one; with projection the actual is rewritten to `Enumerable [Tuple[K, V]]` and the element-wise
+    # covariance succeeds. Surfaced on Discourse via `URI.encode_www_form(hash)` calls that the parameter binder
+    # previously flagged as type mismatches.
     it "accepts Hash[K, V] against Enumerable[Tuple[K, V]] via ancestor projection" do
       tuple = Rigor::Type::Combinator.tuple_of(
         Rigor::Type::Combinator.nominal_of(Symbol),

--- a/spec/rigor/inference/block_inject_fold_spec.rb
+++ b/spec/rigor/inference/block_inject_fold_spec.rb
@@ -4,15 +4,12 @@ require "spec_helper"
 
 # Block-form `inject` / `reduce` return-type fold.
 #
-# Part 1 (soundness): the RBS generic `(S) { (S, E) -> S } -> S` binds
-# `S` from a SINGLE block pass (acc=seed, elem=element-join), so a
-# multiplying accumulator over `(1..5)` typed `int<1, 5>` against a
-# runtime of 120 — an interval the runtime escapes. The accumulator now
-# reaches a capped fixpoint, converging to the nominal carrier.
+# Part 1 (soundness): the RBS generic `(S) { (S, E) -> S } -> S` binds `S` from a SINGLE block pass (acc=seed,
+# elem=element-join), so a multiplying accumulator over `(1..5)` typed `int<1, 5>` against a runtime of 120 — an
+# interval the runtime escapes. The accumulator now reaches a capped fixpoint, converging to the nominal carrier.
 #
-# Part 2 (precision): a fully-constant finite receiver threads the
-# running constant through per-element block evaluation to the exact
-# folded value.
+# Part 2 (precision): a fully-constant finite receiver threads the running constant through per-element block evaluation
+# to the exact folded value.
 RSpec.describe "block-form inject/reduce fold", type: :runner do
   def dumped_type(source)
     result = analyze(<<~RUBY)
@@ -25,9 +22,8 @@ RSpec.describe "block-form inject/reduce fold", type: :runner do
 
   describe "Part 1 — soundness (no value-bounded interval the runtime escapes)" do
     it "the multiplying accumulator over a constant range never types a value interval" do
-      # Regression: this exact shape typed `int<1, 5>` (runtime 120) — the
-      # single-pass accumulator bug. The folded answer (Part 2) is the
-      # exact value; what MUST never reappear is the unsound interval.
+      # Regression: this exact shape typed `int<1, 5>` (runtime 120) — the single-pass accumulator bug. The folded
+      # answer (Part 2) is the exact value; what MUST never reappear is the unsound interval.
       message = dumped_type("dump_type((1..5).inject(1) { |acc, i| acc * i })")
       expect(message).not_to include("int<1, 5>")
       expect(message).to include("120")
@@ -103,9 +99,8 @@ RSpec.describe "block-form inject/reduce fold", type: :runner do
       RUBY
       messages = result.diagnostics.select { |d| d.message.start_with?("dump_type") }.map(&:message)
       expect(messages[0]).to include("6")
-      # Write-back: `sink` carries the appended element types, proving the
-      # ADR-56 statement-level write-back ran despite this fold answering
-      # the call's return type.
+      # Write-back: `sink` carries the appended element types, proving the ADR-56 statement-level write-back ran despite
+      # this fold answering the call's return type.
       expect(messages[1]).to include("Array")
       expect(messages[1]).to match(/1.*2.*3/)
     end

--- a/spec/rigor/inference/block_parameter_binder_spec.rb
+++ b/spec/rigor/inference/block_parameter_binder_spec.rb
@@ -64,9 +64,8 @@ RSpec.describe Rigor::Inference::BlockParameterBinder do
     end
 
     it "binds a trailing required positional after a rest (the `|a, *b, c|` shape)" do
-      # Regression: `bind_trailing_positionals` previously called an
-      # undefined `required_name` helper, so a `post` parameter raised
-      # NoMethodError. It now routes through `bind_required_param`.
+      # Regression: `bind_trailing_positionals` previously called an undefined `required_name` helper, so a `post`
+      # parameter raised NoMethodError. It now routes through `bind_required_param`.
       block = parse_block("foo { |a, *b, c| c }")
       bindings = described_class.new(expected_param_types: [integer_nominal]).bind(block)
       expect(bindings[:a]).to eq(integer_nominal)
@@ -109,9 +108,8 @@ RSpec.describe Rigor::Inference::BlockParameterBinder do
     end
 
     it "binds MultiTargetNode block parameters with a non-Tuple slot to Dynamic[Top]" do
-      # When the slot expected type is not a Tuple, MultiTargetBinder
-      # falls back to Dynamic[Top] for every inner local. The outer
-      # `c` still binds to its slot type.
+      # When the slot expected type is not a Tuple, MultiTargetBinder falls back to Dynamic[Top] for every inner local.
+      # The outer `c` still binds to its slot type.
       block = parse_block("foo { |(a, b), c| c }")
       bindings = described_class.new(
         expected_param_types: [integer_nominal, string_nominal]

--- a/spec/rigor/inference/body_fixpoint_spec.rb
+++ b/spec/rigor/inference/body_fixpoint_spec.rb
@@ -2,13 +2,10 @@
 
 require "spec_helper"
 
-# Unit-level coverage for {Rigor::Inference::BodyFixpoint} (ADR-56 WD3) —
-# the capped-fixpoint mechanism shared by the non-escaping block
-# captured-local write-back (slice A) and the loop-body fixpoint (slice
-# B). `evaluate_body` and `widen` are plain callables, so the contract
-# pins directly against hand-built `evaluate_body` lambdas rather than
-# going through the flow engine (that integration is exercised by the
-# loop / block specs under `spec/integration/`).
+# Unit-level coverage for {Rigor::Inference::BodyFixpoint} (ADR-56 WD3) — the capped-fixpoint mechanism shared by the
+# non-escaping block captured-local write-back (slice A) and the loop-body fixpoint (slice B). `evaluate_body` and
+# `widen` are plain callables, so the contract pins directly against hand-built `evaluate_body` lambdas rather than
+# going through the flow engine (that integration is exercised by the loop / block specs under `spec/integration/`).
 RSpec.describe Rigor::Inference::BodyFixpoint do
   let(:widen) { Rigor::Type::Combinator.method(:widen_value_pinned) }
 
@@ -68,8 +65,8 @@ RSpec.describe Rigor::Inference::BodyFixpoint do
       )
 
       expect(result).to eq(seed)
-      # Joining the exit type back into an equal assumption is stable on
-      # the very first pass, so the loop breaks instead of running to CAP.
+      # Joining the exit type back into an equal assumption is stable on the very first pass, so the loop breaks instead
+      # of running to CAP.
       expect(calls).to eq(1)
     end
 
@@ -119,8 +116,7 @@ RSpec.describe Rigor::Inference::BodyFixpoint do
         names: [:a], seed_bindings: seed, widen: widen,
         evaluate_body: lambda { |_bindings|
           calls += 1
-          # A fresh Constant every pass (`+= 1`-style accumulator):
-          # never join-stable under plain `union`.
+          # A fresh Constant every pass (`+= 1`-style accumulator): never join-stable under plain `union`.
           { a: constant(calls + 1) }
         }
       )
@@ -138,9 +134,8 @@ RSpec.describe Rigor::Inference::BodyFixpoint do
         names: [:a], seed_bindings: seed, widen: widen,
         evaluate_body: lambda { |bindings|
           calls += 1
-          # `a = [a]` — grows structurally each pass, so even widening
-          # both sides on the final iteration cannot make the join
-          # collapse back to the widened assumption.
+          # `a = [a]` — grows structurally each pass, so even widening both sides on the final iteration cannot make the
+          # join collapse back to the widened assumption.
           { a: Rigor::Type::Combinator.tuple_of(bindings[:a]) }
         }
       )
@@ -171,8 +166,7 @@ RSpec.describe Rigor::Inference::BodyFixpoint do
         evaluate_body: lambda { |bindings|
           calls += 1
           if calls == 1
-            # Only `a` is written this pass; `b` is absent from the
-            # returned hash and must keep its current assumption.
+            # Only `a` is written this pass; `b` is absent from the returned hash and must keep its current assumption.
             { a: Rigor::Type::Combinator.union(bindings[:a], constant(2)) }
           else
             {}

--- a/spec/rigor/inference/budget_trace_spec.rb
+++ b/spec/rigor/inference/budget_trace_spec.rb
@@ -37,10 +37,8 @@ RSpec.describe Rigor::Inference::BudgetTrace do
       expect(snap[described_class::BLOCK_WRITEBACK_CAP]).to eq(0)
     end
 
-    # ADR-56 slice A — a compounding captured-local write
-    # (`a = [a]` grows structurally each pass) never converges, so the
-    # block-write-back fixpoint runs to its cap and collapses that local
-    # to `Dynamic[top]`, recording a hit.
+    # ADR-56 slice A — a compounding captured-local write (`a = [a]` grows structurally each pass) never converges, so
+    # the block-write-back fixpoint runs to its cap and collapses that local to `Dynamic[top]`, recording a hit.
     it "records a block-write-back-cap hit when a compounding captured local floors" do
       source = <<~RUBY
         a = 1
@@ -51,8 +49,7 @@ RSpec.describe Rigor::Inference::BudgetTrace do
       expect(described_class.snapshot[described_class::BLOCK_WRITEBACK_CAP]).to be >= 1
     end
 
-    # An accumulator that converges (or widens cleanly on the final
-    # iteration) must NOT record a cap hit.
+    # An accumulator that converges (or widens cleanly on the final iteration) must NOT record a cap hit.
     it "records no hit when the captured local converges or widens cleanly" do
       source = <<~RUBY
         c = 0
@@ -157,10 +154,9 @@ RSpec.describe Rigor::Inference::BudgetTrace do
     end
 
     it "records a recursion-unroll fuel-exhaustion firing (ADR-55 slice 1)" do
-      # factorial(100) unrolls past the 32-frame fuel budget, so the
-      # extended value-key path falls back to the plain guard and the
-      # `RECURSION_UNROLL_FUEL` counter ticks. The run also must not
-      # raise (graceful degradation to today's widened result).
+      # factorial(100) unrolls past the 32-frame fuel budget, so the extended value-key path falls back to the plain
+      # guard and the `RECURSION_UNROLL_FUEL` counter ticks. The run also must not raise (graceful degradation to
+      # today's widened result).
       source = <<~RUBY
         class Factorial
           def of(n)
@@ -173,8 +169,8 @@ RSpec.describe Rigor::Inference::BudgetTrace do
       tree = result.value
       scope = Rigor::Scope.empty(environment: Rigor::Environment.default)
       index = Rigor::Inference::ScopeIndexer.index(tree, default_scope: scope)
-      # `CheckRules.diagnose` drives a full per-node walk, exercising the
-      # recursive inference at the call site (and must not raise).
+      # `CheckRules.diagnose` drives a full per-node walk, exercising the recursive inference at the call site (and must
+      # not raise).
       expect do
         Rigor::Analysis::CheckRules.diagnose(
           path: "fuel", root: tree, scope_index: index, comments: result.comments || []

--- a/spec/rigor/inference/builtins/method_catalog_spec.rb
+++ b/spec/rigor/inference/builtins/method_catalog_spec.rb
@@ -35,16 +35,15 @@ RSpec.describe Rigor::Inference::Builtins::MethodCatalog do
 
     it "STRING_CATALOG blocks `crypt` (platform `crypt(3)` — not reproducible across OS / libc)" do
       catalog = Rigor::Inference::Builtins::STRING_CATALOG
-      # `crypt` is classified `:leaf` in string.yml, but its output is
-      # platform-dependent, so it must not fold to a Constant.
+      # `crypt` is classified `:leaf` in string.yml, but its output is platform-dependent, so it must not fold to a
+      # Constant.
       expect(catalog.safe_for_folding?("String", :crypt)).to be(false)
     end
 
     it "universally blocks per-process-non-reproducible selectors (hash / object_id)" do
-      # `#hash` is SipHash-salted per process and `#object_id` is
-      # per-process identity — folding either bakes one process's value
-      # into the type + cache. The block is universal (catalog-wide), not
-      # per-class, because these are Object-level methods on every receiver.
+      # `#hash` is SipHash-salted per process and `#object_id` is per-process identity — folding either bakes one
+      # process's value into the type + cache. The block is universal (catalog-wide), not per-class, because these are
+      # Object-level methods on every receiver.
       %w[String Symbol].each do |klass|
         expect(Rigor::Inference::Builtins::STRING_CATALOG.safe_for_folding?(klass, :hash)).to be(false)
       end
@@ -70,10 +69,9 @@ RSpec.describe Rigor::Inference::Builtins::MethodCatalog do
 
     it "HASH_CATALOG blocks block-yielding leaves classified as :leaf by the C-body heuristic" do
       catalog = Rigor::Inference::Builtins::HASH_CATALOG
-      # `each*` / `select` / `filter` / `reject` / `transform_values` /
-      # `merge` all dispatch through `rb_hash_foreach` (or yield via a
-      # static callback) — the regex-based classifier marks them as
-      # `:leaf` despite being block-dependent.
+      # `each*` / `select` / `filter` / `reject` / `transform_values` / `merge` all dispatch through `rb_hash_foreach`
+      # (or yield via a static callback) — the regex-based classifier marks them as `:leaf` despite being
+      # block-dependent.
       %i[each each_pair each_key each_value select filter reject transform_values merge].each do |sel|
         expect(catalog.safe_for_folding?("Hash", sel)).to be(false)
       end
@@ -109,10 +107,9 @@ RSpec.describe Rigor::Inference::Builtins::MethodCatalog do
   end
 
   describe "alias resolution and reset!" do
-    # A real catalog ships an `aliases` section mapping an alias
-    # selector to its canonical target; `method_entry` resolves the
-    # alias to the target's entry. Exercise it from a temp YAML so the
-    # whole resolve_alias_entry path (and `reset!`) is covered.
+    # A real catalog ships an `aliases` section mapping an alias selector to its canonical target; `method_entry`
+    # resolves the alias to the target's entry. Exercise it from a temp YAML so the whole resolve_alias_entry path (and
+    # `reset!`) is covered.
     let(:catalog_yaml) do
       <<~YAML
         classes:
@@ -134,8 +131,8 @@ RSpec.describe Rigor::Inference::Builtins::MethodCatalog do
       YAML
     end
 
-    # Writes `catalog_yaml` to a temp file and yields a catalog built
-    # from it; the file is removed when the block returns.
+    # Writes `catalog_yaml` to a temp file and yields a catalog built from it; the file is removed when the block
+    # returns.
     def with_catalog
       Tempfile.create(["method-catalog", ".yml"]) do |f|
         f.write(catalog_yaml)
@@ -159,8 +156,7 @@ RSpec.describe Rigor::Inference::Builtins::MethodCatalog do
     end
 
     it "folds exactly the leaf / trivial / leaf_when_numeric purities" do
-      # Pins the FOLDABLE_PURITIES membership: each foldable purity folds,
-      # and a non-foldable one (`dispatch`) does not.
+      # Pins the FOLDABLE_PURITIES membership: each foldable purity folds, and a non-foldable one (`dispatch`) does not.
       with_catalog do |catalog|
         expect(catalog.safe_for_folding?("Foo", :real_method)).to be(true)     # leaf
         expect(catalog.safe_for_folding?("Foo", :trivial_method)).to be(true)  # trivial

--- a/spec/rigor/inference/builtins/numeric_catalog_spec.rb
+++ b/spec/rigor/inference/builtins/numeric_catalog_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe "Rigor::Inference::Builtins::NUMERIC_CATALOG" do
 
   describe "#safe_for_folding?" do
     it "approves prelude :leaf-marked methods" do
-      # Integer#abs, #even?, #odd? are prelude `Primitive.attr! :leaf`
-      # (numeric.rb) and surface as `leaf` in the catalog.
+      # Integer#abs, #even?, #odd? are prelude `Primitive.attr! :leaf` (numeric.rb) and surface as `leaf` in the
+      # catalog.
       expect(catalog.safe_for_folding?("Integer", :abs)).to be(true)
       expect(catalog.safe_for_folding?("Integer", :even?)).to be(true)
       expect(catalog.safe_for_folding?("Integer", :odd?)).to be(true)

--- a/spec/rigor/inference/case_equality_chain_narrowing_spec.rb
+++ b/spec/rigor/inference/case_equality_chain_narrowing_spec.rb
@@ -2,9 +2,8 @@
 
 require "spec_helper"
 
-# `Class === <local/ivar>.<method>` case-equality narrowing for a stable
-# single-hop method chain — the `open3` `if Hash === cmd.last` idiom. The
-# branch narrows `cmd.last` to the class, mirroring `cmd.last.is_a?(Hash)`.
+# `Class === <local/ivar>.<method>` case-equality narrowing for a stable single-hop method chain — the `open3` `if Hash
+# === cmd.last` idiom. The branch narrows `cmd.last` to the class, mirroring `cmd.last.is_a?(Hash)`.
 RSpec.describe "case-equality chain narrowing", type: :runner do
   def dumped_type(source)
     result = analyze(source)
@@ -42,10 +41,9 @@ RSpec.describe "case-equality chain narrowing", type: :runner do
   end
 
   it "narrows the falsey edge to `not Hash` via `unless`" do
-    # The `unless` falsey-edge keeps the chain narrowed to "not Hash" in
-    # the guarded body; with the chain un-narrowed the dump would show the
-    # entry (Dynamic) type, so a Hash-free dump confirms the falsey edge is
-    # recorded too. Here we just confirm the truthy `if` records cleanly.
+    # The `unless` falsey-edge keeps the chain narrowed to "not Hash" in the guarded body; with the chain un-narrowed
+    # the dump would show the entry (Dynamic) type, so a Hash-free dump confirms the falsey edge is recorded too. Here
+    # we just confirm the truthy `if` records cleanly.
     message = dumped_type(<<~RUBY)
       require "rigor/testing"
       include Rigor::Testing
@@ -59,8 +57,8 @@ RSpec.describe "case-equality chain narrowing", type: :runner do
   end
 
   it "leaves a non-stable chain (call with arguments) un-narrowed" do
-    # `cmd.fetch(0)` has an argument, so it is not a stable single-hop
-    # chain; the narrowing must NOT fire (re-evaluation soundness).
+    # `cmd.fetch(0)` has an argument, so it is not a stable single-hop chain; the narrowing must NOT fire (re-evaluation
+    # soundness).
     message = dumped_type(<<~RUBY)
       require "rigor/testing"
       include Rigor::Testing

--- a/spec/rigor/inference/def_return_typer_spec.rb
+++ b/spec/rigor/inference/def_return_typer_spec.rb
@@ -131,10 +131,9 @@ RSpec.describe Rigor::Inference::DefReturnTyper do
       end
 
       it "recurses through a BeginNode body to its inner last statement" do
-        # The inline def-rescue form parses with a BeginNode *body* directly
-        # (an explicit `begin…end` nests under a StatementsNode instead), so
-        # this is what exercises the recursive `Prism::BeginNode` arm — and the
-        # exact-value assertion pins the unwrap rather than merely non-nil.
+        # The inline def-rescue form parses with a BeginNode *body* directly (an explicit `begin…end` nests under a
+        # StatementsNode instead), so this is what exercises the recursive `Prism::BeginNode` arm — and the exact-value
+        # assertion pins the unwrap rather than merely non-nil.
         body = parse_def("def foo; 1; rescue; 2; end").body
         expect(body).to be_a(Prism::BeginNode)
         result = described_class.body_last_expression(body)

--- a/spec/rigor/inference/expression_typer_spec.rb
+++ b/spec/rigor/inference/expression_typer_spec.rb
@@ -194,13 +194,10 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
   end
 
   describe "LHS-only target nodes (non-value positions)" do
-    # `*TargetNode` kinds appear only on the left of destructuring
-    # assignments, in pattern bodies, or as inner slots of block
-    # parameters. They have no value to extract; the typer recognises
-    # them so the coverage scanner / `--explain` stream stops counting
-    # them as fail-soft fallbacks. Binding the inner names back into
-    # the scope is `StatementEvaluator` / `MultiTargetBinder` /
-    # `BlockParameterBinder`'s concern, never `type_of`'s.
+    # `*TargetNode` kinds appear only on the left of destructuring assignments, in pattern bodies, or as inner slots of
+    # block parameters. They have no value to extract; the typer recognises them so the coverage scanner / `--explain`
+    # stream stops counting them as fail-soft fallbacks. Binding the inner names back into the scope is
+    # `StatementEvaluator` / `MultiTargetBinder` / `BlockParameterBinder`'s concern, never `type_of`'s.
     def find_first(node, klass)
       return node if node.is_a?(klass)
       return nil unless node.respond_to?(:compact_child_nodes)
@@ -423,9 +420,8 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
 
   describe "method dispatch (Slice 4: RBS-backed)" do
     it "resolves Integer#succ on a Constant receiver via unary fold (v0.0.3 C)" do
-      # `1.succ` folds to `Constant[2]`; the RBS-widened
-      # `Nominal[Integer]` answer is exercised via
-      # non-constant receivers in dispatch_spec.
+      # `1.succ` folds to `Constant[2]`; the RBS-widened `Nominal[Integer]` answer is exercised via non-constant
+      # receivers in dispatch_spec.
       type = scope.type_of(parse_expression("1.succ"))
 
       expect(type).to be_a(Rigor::Type::Constant)
@@ -440,9 +436,8 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
     end
 
     it "resolves Array#length on a Nominal[Array] receiver" do
-      # Returns the precise Tuple length as a Constant rather than
-      # the projected Nominal[Integer]; the carrier still erases
-      # to Integer.
+      # Returns the precise Tuple length as a Constant rather than the projected Nominal[Integer]; the carrier still
+      # erases to Integer.
       type = scope.type_of(parse_expression("[1, 2, 3].length"))
 
       expect(type).to eq(Rigor::Type::Combinator.constant_of(3))
@@ -456,20 +451,16 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
     end
 
     it "resolves bool predicates more precisely than RBS when the receiver is a constant (v0.0.3 C)" do
-      # `1.zero?` folds to `Constant[false]` — the unary
-      # constant-folding catalogue wins over the RBS-widened
-      # `Union[Constant[true], Constant[false]]`.
-      # When the receiver is *not* a constant, the union
-      # representation is still the answer; the broader
-      # widening behaviour is exercised below.
+      # `1.zero?` folds to `Constant[false]` — the unary constant-folding catalogue wins over the RBS-widened
+      # `Union[Constant[true], Constant[false]]`. When the receiver is *not* a constant, the union representation is
+      # still the answer; the broader widening behaviour is exercised below.
       type = scope.type_of(parse_expression("1.zero?"))
       expect(type).to be_a(Rigor::Type::Constant)
       expect(type.value).to be(false)
 
       union_type = scope.type_of(parse_expression("def f(n); n.zero?; end"))
-      # The DefNode's type isn't the body's bool, but the
-      # widened-union proof lives in the dedicated unary
-      # tests in `constant_folding_spec.rb`.
+      # The DefNode's type isn't the body's bool, but the widened-union proof lives in the dedicated unary tests in
+      # `constant_folding_spec.rb`.
       expect(union_type).not_to be_nil
     end
 
@@ -576,8 +567,7 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
 
     describe "lexical constant lookup (Slice A constant-walk)" do
       it "resolves a ConstantReadNode using the surrounding class path" do
-        # Inside `Rigor::CLI::Foo`, a bare `Integer` reference still
-        # resolves through the top-level fallback.
+        # Inside `Rigor::CLI::Foo`, a bare `Integer` reference still resolves through the top-level fallback.
         cli_self = Rigor::Type::Combinator.singleton_of("Rigor::CLI::Foo")
         bound = scope.with_self_type(cli_self)
         type = bound.type_of(parse_expression("Integer"))
@@ -586,10 +576,9 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       end
 
       it "resolves a ConstantPathNode by stripping the lexical prefix one segment at a time" do
-        # Inside a hypothetical `IO::SomeNested`, the bare reference
-        # `Comparable` (a top-level RBS-core module) still resolves.
-        # The walk tries `IO::SomeNested::Comparable` and `IO::Comparable`
-        # first (both miss) before falling through to bare `Comparable`.
+        # Inside a hypothetical `IO::SomeNested`, the bare reference `Comparable` (a top-level RBS-core module) still
+        # resolves. The walk tries `IO::SomeNested::Comparable` and `IO::Comparable` first (both miss) before falling
+        # through to bare `Comparable`.
         nested_self = Rigor::Type::Combinator.singleton_of("IO::SomeNested")
         bound = scope.with_self_type(nested_self)
         type = bound.type_of(parse_expression("Comparable"))
@@ -598,9 +587,8 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       end
 
       it "prefers the lexically-qualified candidate when one matches the surrounding path" do
-        # `Errno::ENOENT` is RBS-core. Inside `Errno::SomeFakeNested`,
-        # a bare `ENOENT` reference walks via `Errno::SomeFakeNested::ENOENT`
-        # (miss) → `Errno::ENOENT` (hit).
+        # `Errno::ENOENT` is RBS-core. Inside `Errno::SomeFakeNested`, a bare `ENOENT` reference walks via
+        # `Errno::SomeFakeNested::ENOENT` (miss) → `Errno::ENOENT` (hit).
         nested_self = Rigor::Type::Combinator.singleton_of("Errno::SomeFakeNested")
         bound = scope.with_self_type(nested_self)
         type = bound.type_of(parse_expression("ENOENT"))
@@ -609,12 +597,9 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       end
 
       it "prefers the most-specific candidate over the bare name when both exist" do
-        # `Integer` exists at top level. From inside a class whose
-        # path joined to `Integer` would coincidentally match an
-        # already-known nominal, the most-specific candidate wins.
-        # Here we use a synthetic case that forces the bare match
-        # because no Rigor::CLI::Integer is known: Integer still
-        # resolves (the bare candidate is reached after the
+        # `Integer` exists at top level. From inside a class whose path joined to `Integer` would coincidentally match
+        # an already-known nominal, the most-specific candidate wins. Here we use a synthetic case that forces the bare
+        # match because no Rigor::CLI::Integer is known: Integer still resolves (the bare candidate is reached after the
         # qualified ones miss).
         cli_self = Rigor::Type::Combinator.singleton_of("Rigor::CLI::Foo")
         bound = scope.with_self_type(cli_self)
@@ -656,10 +641,8 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       end
 
       it "in-source value overrides an RBS constant decl of the same name" do
-        # Sanity: the RBS constant lookup would normally win; the
-        # in-source map takes precedence per Ruby's runtime
-        # semantics (user code is the authoritative source for
-        # its own constants).
+        # Sanity: the RBS constant lookup would normally win; the in-source map takes precedence per Ruby's runtime
+        # semantics (user code is the authoritative source for its own constants).
         constants = { "Float::INFINITY" => Rigor::Type::Combinator.constant_of(:overridden) }.freeze
         bound = scope.with_discovery(scope.discovery.with(in_source_constants: constants))
         type = bound.type_of(parse_expression("Float::INFINITY"))
@@ -684,10 +667,8 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       end
 
       it "resolves a non-class constant declared in RBS through Environment#constant_for_name" do
-        # `Rigor::Analysis::FactStore::BUCKETS` is declared in
-        # sig/rigor/analysis/fact_store.rbs as Array[bucket].
-        # singleton_for_name MUST miss (BUCKETS is not a class)
-        # and constant_for_name MUST take over.
+        # `Rigor::Analysis::FactStore::BUCKETS` is declared in sig/rigor/analysis/fact_store.rbs as Array[bucket].
+        # singleton_for_name MUST miss (BUCKETS is not a class) and constant_for_name MUST take over.
         project_env = Rigor::Environment.for_project
         project_scope = Rigor::Scope.empty(environment: project_env)
         type = project_scope.type_of(parse_expression("Rigor::Analysis::FactStore::BUCKETS"))
@@ -696,8 +677,7 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       end
 
       it "resolves the same constant through the lexical walk from inside FactStore" do
-        # Inside Rigor::Analysis::FactStore the bare `BUCKETS`
-        # reference walks the candidate list and lands on the
+        # Inside Rigor::Analysis::FactStore the bare `BUCKETS` reference walks the candidate list and lands on the
         # qualified `Rigor::Analysis::FactStore::BUCKETS` decl.
         project_env = Rigor::Environment.for_project
         inner_self = Rigor::Type::Combinator.singleton_of("Rigor::Analysis::FactStore")
@@ -725,10 +705,8 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
     end
 
     it "resolves Array.new(3) as Tuple[nil, nil, nil] via singleton dispatch (v0.0.7)" do
-      # `Array.new(n)` lifts to a per-position
-      # `Tuple[Constant[nil] * n]` carrier when `n` is a small
-      # `Constant<Integer>`. Oversize `n` falls back to
-      # `Nominal[Array]`.
+      # `Array.new(n)` lifts to a per-position `Tuple[Constant[nil] * n]` carrier when `n` is a small
+      # `Constant<Integer>`. Oversize `n` falls back to `Nominal[Array]`.
       type = scope.type_of(parse_expression("Array.new(3)"))
 
       expect(type).to be_a(Rigor::Type::Tuple)
@@ -836,9 +814,8 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
     end
 
     it "still resolves the 0-arg overload of Array#first" do
-      # `() -> Elem` — narrows to the precise first member
-      # of the Tuple shape rather than returning the projected
-      # `Elem` union from the underlying `Array#first`.
+      # `() -> Elem` — narrows to the precise first member of the Tuple shape rather than returning the projected `Elem`
+      # union from the underlying `Array#first`.
       type = scope.type_of(parse_expression("[1, 2, 3].first"))
 
       expect(type).to eq(Rigor::Type::Combinator.constant_of(1))
@@ -875,9 +852,8 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
     end
 
     it "falls back to the first overload when no overload accepts the args" do
-      # Integer#+ has overloads for Integer/Float/Rational/Complex.
-      # Symbol matches none, so the selector falls back to the first
-      # overload (Integer) and returns Nominal[Integer].
+      # Integer#+ has overloads for Integer/Float/Rational/Complex. Symbol matches none, so the selector falls back to
+      # the first overload (Integer) and returns Nominal[Integer].
       union_recv = Rigor::Type::Combinator.nominal_of(Integer)
       sym_arg = Rigor::Type::Combinator.constant_of(:foo)
 
@@ -902,10 +878,8 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
     end
 
     it "types empty HashNode as the empty HashShape{} carrier (v0.0.7)" do
-      # `{}` resolves to `HashShape{}` (closed, no pairs) so
-      # HashShape projections (`empty?`, `count`, `first`, `keys`,
-      # `values`) fold against it. Both carriers erase to plain
-      # `Hash` for RBS interop.
+      # `{}` resolves to `HashShape{}` (closed, no pairs) so HashShape projections (`empty?`, `count`, `first`, `keys`,
+      # `values`) fold against it. Both carriers erase to plain `Hash` for RBS interop.
       type = scope.type_of(parse_expression("{}"))
 
       expect(type).to be_a(Rigor::Type::HashShape)
@@ -1064,12 +1038,9 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
     it "selects the block-bearing overload of Hash#transform_values for &:freeze" do
       type = project_scope.type_of(parse_expression('{ a: "x" }.transform_values(&:freeze)'))
 
-      # Without the gap-(d) fix, this resolves to
-      # `Enumerator[...]` via the no-block overload. With the
-      # per-pair HashShape fold (added alongside ADR-14 gap-(d)),
-      # the result is a precise `HashShape` rather than the
-      # widened `Hash` — both confirm the block-bearing overload
-      # was selected.
+      # Without the gap-(d) fix, this resolves to `Enumerator[...]` via the no-block overload. With the per-pair
+      # HashShape fold (added alongside ADR-14 gap-(d)), the result is a precise `HashShape` rather than the widened
+      # `Hash` — both confirm the block-bearing overload was selected.
       expect(type).to be_a(Rigor::Type::HashShape)
       expect(type.pairs.keys).to eq([:a])
     end
@@ -1077,11 +1048,9 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
     it "per-element folds Array#map for &:to_s into a Tuple" do
       type = project_scope.type_of(parse_expression("[1, 2, 3].map(&:to_s)"))
 
-      # The per-element block fold now recognises the `&:symbol`
-      # shorthand: the symbol is dispatched as a zero-arg method
-      # on each Tuple element, so `[1, 2, 3].map(&:to_s)` folds
-      # to `Tuple[Constant["1"], Constant["2"], Constant["3"]]` —
-      # strictly tighter than the RBS-projected `Array[String]`.
+      # The per-element block fold now recognises the `&:symbol` shorthand: the symbol is dispatched as a zero-arg
+      # method on each Tuple element, so `[1, 2, 3].map(&:to_s)` folds to `Tuple[Constant["1"], Constant["2"],
+      # Constant["3"]]` — strictly tighter than the RBS-projected `Array[String]`.
       expect(type).to be_a(Rigor::Type::Tuple)
       expect(type.elements.map(&:value)).to eq(%w[1 2 3])
     end
@@ -1171,8 +1140,8 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
     end
 
     it "strips the left operand's truthy constituents on the AndNode short-circuit edge" do
-      # `s && 7` yields `s` only when `s` is falsey, so a `String?` left
-      # contributes only its `nil` (the `String` part hands off to `7`).
+      # `s && 7` yields `s` only when `s` is falsey, so a `String?` left contributes only its `nil` (the `String` part
+      # hands off to `7`).
       nullable_string = Rigor::Type::Combinator.union(
         Rigor::Type::Combinator.nominal_of("String"),
         Rigor::Type::Combinator.constant_of(nil)
@@ -1207,9 +1176,8 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
     end
 
     it "unions prior `:maybe` branches with the first definitely-matching `when`" do
-      # rand(10) -> Integer (always-yes against `Integer`). Prior `when 0`
-      # is `:maybe` (Integer might be 0), so the result includes both
-      # bodies but stops before reaching the else.
+      # rand(10) -> Integer (always-yes against `Integer`). Prior `when 0` is `:maybe` (Integer might be 0), so the
+      # result includes both bodies but stops before reaching the else.
       type = scope.type_of(parse_expression("case rand(10); when 0; :zero; when Integer; :int; else; :other; end"))
 
       expected = Rigor::Type::Combinator.union(
@@ -1333,9 +1301,8 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
     end
 
     it "folds a RangeNode whose bounds TYPE as Constant into Constant<Range>" do
-      # `n` is pinned to a constant by an enclosing binding; the bound is
-      # a LocalVariableReadNode, not a literal IntegerNode, so the fold
-      # has to consult the evaluated bound type (fact2 chain).
+      # `n` is pinned to a constant by an enclosing binding; the bound is a LocalVariableReadNode, not a literal
+      # IntegerNode, so the fold has to consult the evaluated bound type (fact2 chain).
       type = scope.with_local(:n, Rigor::Type::Combinator.constant_of(5))
                   .type_of(parse_expression("(1..n)", scopes: [[:n]]))
 
@@ -1385,8 +1352,7 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
     end
 
     it "still unions both branches when the predicate is non-Constant" do
-      # `x` is unbound so its type is `Dynamic[Top]`; both branches
-      # remain live and the result is the union.
+      # `x` is unbound so its type is `Dynamic[Top]`; both branches remain live and the result is the union.
       type = scope.type_of(parse_expression('x ? "yes" : "no"'))
       members = type.members.map(&:value)
       expect(members).to contain_exactly("yes", "no")

--- a/spec/rigor/inference/hkt_reducer_spec.rb
+++ b/spec/rigor/inference/hkt_reducer_spec.rb
@@ -200,10 +200,8 @@ RSpec.describe Rigor::Inference::HktReducer do
         app = make_app(:"json::value", [str_nominal])
         result = described_class.new(registry).reduce(app)
         expect(result).to be_a(Rigor::Type::Union)
-        # leaf atoms — nil / true / false / Integer / Float / String
-        # (Constant<nil> / Constant<true> / Constant<false> render as the
-        # bare scalar form in the Union's display per the Constant carrier's
-        # describe rule)
+        # leaf atoms — nil / true / false / Integer / Float / String (Constant<nil> / Constant<true> / Constant<false>
+        # render as the bare scalar form in the Union's display per the Constant carrier's describe rule)
         expect(result.members.map(&:describe)).to include(
           "nil", "true", "false", "Integer", "Float", "String"
         )
@@ -385,8 +383,7 @@ RSpec.describe Rigor::Inference::HktReducer do
     end
 
     context "with cross-URI references" do
-      # outer::it[K] = Array[App[inner::it, K]]
-      # inner::it[K] = K
+      # outer::it[K] = Array[App[inner::it, K]] inner::it[K] = K
       let(:registry) do
         registry_class.new(
           registrations: [

--- a/spec/rigor/inference/indexed_narrowing_spec.rb
+++ b/spec/rigor/inference/indexed_narrowing_spec.rb
@@ -7,14 +7,11 @@ require "rigor/inference/indexed_narrowing"
 require "rigor/scope"
 require "rigor/type"
 
-# Unit-level coverage for {Rigor::Inference::IndexedNarrowing}.
-# The recorder side (`Inference::StatementEvaluator#eval_index_or_write`)
-# and the consumer side (`Inference::ExpressionTyper#call_type_for`)
-# are exercised end-to-end by the
-# `fixtures/indexed_or_narrowing.rb` integration fixture; this
-# file pins the address-recognition + invalidation primitives
-# in isolation so the narrowing's soundness story has a stable
-# regression surface.
+# Unit-level coverage for {Rigor::Inference::IndexedNarrowing}. The recorder side
+# (`Inference::StatementEvaluator#eval_index_or_write`) and the consumer side
+# (`Inference::ExpressionTyper#call_type_for`) are exercised end-to-end by the `fixtures/indexed_or_narrowing.rb`
+# integration fixture; this file pins the address-recognition + invalidation primitives in isolation so the narrowing's
+# soundness story has a stable regression surface.
 RSpec.describe Rigor::Inference::IndexedNarrowing do
   let(:scope) { Rigor::Scope.empty }
   let(:tuple_empty) { Rigor::Type::Combinator.tuple_of }

--- a/spec/rigor/inference/method_chain_narrowing_spec.rb
+++ b/spec/rigor/inference/method_chain_narrowing_spec.rb
@@ -8,19 +8,13 @@ require "rigor/type"
 require "rigor/inference/narrowing"
 require "rigor/inference/scope_indexer"
 
-# Unit-level coverage for stable single-hop method-chain
-# narrowing. The recorder lives in `Narrowing` (extension to
-# `analyse_class_predicate`); the lookup lives in
-# `ExpressionTyper#call_type_for` via
-# `method_chain_narrowing_for`; the invalidator lives in
-# `IndexedNarrowing.invalidate_chain_after_call` and is wired
-# into `StatementEvaluator#eval_call`.
+# Unit-level coverage for stable single-hop method-chain narrowing. The recorder lives in `Narrowing` (extension to
+# `analyse_class_predicate`); the lookup lives in `ExpressionTyper#call_type_for` via `method_chain_narrowing_for`; the
+# invalidator lives in `IndexedNarrowing.invalidate_chain_after_call` and is wired into `StatementEvaluator#eval_call`.
 #
-# Integration coverage of the truthy/falsey edge + Array
-# dispatch lives in `spec/integration/fixtures/method_chain_narrowing.rb`.
-# This file pins the address-keying + invalidation contract in
-# isolation so the slice's soundness story has a stable
-# regression surface.
+# Integration coverage of the truthy/falsey edge + Array dispatch lives in
+# `spec/integration/fixtures/method_chain_narrowing.rb`. This file pins the address-keying + invalidation contract in
+# isolation so the slice's soundness story has a stable regression surface.
 RSpec.describe "Stable single-hop method-chain narrowing" do
   let(:default_scope) { Rigor::Scope.empty }
 
@@ -33,12 +27,9 @@ RSpec.describe "Stable single-hop method-chain narrowing" do
 
   describe "recorder" do
     it "records `(local, :xs, :last) → Array` on the truthy edge of `if xs.last.is_a?(::Array)`" do
-      # `xs` is a method parameter (Dynamic[top]) — the narrowing
-      # path widens Dynamic to the asked class, so the recorded
-      # carrier is `Nominal[Array]`. A locally-bound `xs` whose
-      # `.last` already carries a Tuple subtype would narrow to
-      # the more-precise Tuple, not Array, because narrowing
-      # never coarsens.
+      # `xs` is a method parameter (Dynamic[top]) — the narrowing path widens Dynamic to the asked class, so the
+      # recorded carrier is `Nominal[Array]`. A locally-bound `xs` whose `.last` already carries a Tuple subtype would
+      # narrow to the more-precise Tuple, not Array, because narrowing never coarsens.
       program, _scope, index = post_scope_for(<<~RUBY)
         def f(xs)
           if xs.last.is_a?(::Array)
@@ -66,8 +57,7 @@ RSpec.describe "Stable single-hop method-chain narrowing" do
           end
         end
       RUBY
-      # Walk to the assignment inside the method body. With no
-      # `@list` seed in the class-ivar accumulator, the ivar
+      # Walk to the assignment inside the method body. With no `@list` seed in the class-ivar accumulator, the ivar
       # reads as `Dynamic[top]` and narrowing produces `Nominal[Array]`.
       class_node = program.statements.body.first
       def_f = class_node.body.body.first
@@ -117,8 +107,7 @@ RSpec.describe "Stable single-hop method-chain narrowing" do
       if_node = program.statements.body[1]
       probe_assign = if_node.statements.body.first
       entry_scope = index[probe_assign]
-      # The inner `xs.first` is not the predicate's outermost
-      # receiver, so the recorder does not register it.
+      # The inner `xs.first` is not the predicate's outermost receiver, so the recorder does not register it.
       expect(entry_scope.method_chain_narrowing(:local, :xs, :first)).to be_nil
     end
   end

--- a/spec/rigor/inference/method_dispatcher/block_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/block_folding_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::BlockFolding do
     end
 
     it "filter { false } on Array[Integer] folds to the empty tuple" do
-      # `filter` is an alias of `select` in Ruby; we cover it explicitly
-      # because the dispatcher receives the raw method name.
+      # `filter` is an alias of `select` in Ruby; we cover it explicitly because the dispatcher receives the raw method
+      # name.
       result = fold(receiver: array_of(integer_nominal), method: :filter, block: false_const)
       expect(result).to eq(tuple_of)
     end
@@ -181,8 +181,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher::BlockFolding do
     end
 
     it "folds count { true } over a finite-bound Range constant" do
-      # `(1..5).count { true }` — the inclusive integer range
-      # has 5 elements, so the truthy block sees all of them.
+      # `(1..5).count { true }` — the inclusive integer range has 5 elements, so the truthy block sees all of them.
       const_range = constant_of(1..5)
       expect(fold(receiver: const_range, method: :count, block: true_const)).to eq(constant_of(5))
     end
@@ -218,9 +217,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::BlockFolding do
     end
 
     it "treats Constant[1] as truthy and Constant[nil] as falsey for predicate folds" do
-      # Block bodies often produce `Constant[1]` (e.g. `x.tap { 1 }`) or
-      # `Constant[nil]`; predicate folds should follow Ruby's
-      # truthiness semantics, not require literal true/false.
+      # Block bodies often produce `Constant[1]` (e.g. `x.tap { 1 }`) or `Constant[nil]`; predicate folds should follow
+      # Ruby's truthiness semantics, not require literal true/false.
       expect(fold(receiver: array_of(integer_nominal), method: :all?, block: constant_of(1)))
         .to eq(true_const)
       expect(fold(receiver: array_of(integer_nominal), method: :any?, block: constant_of(nil)))

--- a/spec/rigor/inference/method_dispatcher/constant_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/constant_folding_spec.rb
@@ -19,18 +19,16 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
 
     it "returns nil when the method is not in the binary catalogue" do
-      # `:foo_no_such_op` is purely synthetic — the existing surface
-      # gates folds via the `NUMERIC_BINARY` set, and `divmod` now
-      # has its own Tuple-shaped fold path (covered separately below).
+      # `:foo_no_such_op` is purely synthetic — the existing surface gates folds via the `NUMERIC_BINARY` set, and
+      # `divmod` now has its own Tuple-shaped fold path (covered separately below).
       expect(fold(1, :foo_no_such_op, [2])).to be_nil
     end
   end
 
   describe "per-process-non-reproducible selectors never fold" do
-    # `#hash` is SipHash-salted per process; folding `"abc".hash` would
-    # bake one process's random value into a Constant (and the on-disk
-    # cache), wrong in every other process. The fold must decline so the
-    # RBS tier answers with the widened `Integer`.
+    # `#hash` is SipHash-salted per process; folding `"abc".hash` would bake one process's random value into a Constant
+    # (and the on-disk cache), wrong in every other process. The fold must decline so the RBS tier answers with the
+    # widened `Integer`.
     it "declines #hash on Integer / Float / String / Symbol / nil / true" do
       expect(fold(5, :hash)).to be_nil
       expect(fold(1.5, :hash)).to be_nil
@@ -118,11 +116,9 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
 
       it "folds nil.nil? to true and 1.nil? on Integer is unsupported (no `nil?` in INTEGER_UNARY)" do
         expect(fold(nil, :nil?).value).to be(true)
-        # Integer's nil? is not in the catalogue — folding
-        # is conservative, returning nil so the RBS tier
-        # answers via `Method | Bool`. The integration
-        # test below proves the engine still returns the
-        # correct precise value through dispatch.
+        # Integer's nil? is not in the catalogue — folding is conservative, returning nil so the RBS tier answers via
+        # `Method | Bool`. The integration test below proves the engine still returns the correct precise value through
+        # dispatch.
         expect(fold(1, :nil?)).to be_nil
       end
 
@@ -139,9 +135,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
 
     it "returns nil when the method's result is not a foldable scalar" do
-      # `Integer#coerce` returns an Array — not in the
-      # `foldable_constant_value?` envelope, and `:coerce` is not
-      # in any binary allow list, so the fold declines.
+      # `Integer#coerce` returns an Array — not in the `foldable_constant_value?` envelope, and `:coerce` is not in any
+      # binary allow list, so the fold declines.
       expect(fold(123, :coerce, [1])).to be_nil
     end
   end
@@ -284,8 +279,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
 
     it "does not fold a NaN-producing result into a Constant" do
-      # 0.0 / 0.0 == NaN, which is non-reflexive under ==; the fold
-      # must decline so it never produces a Constant[NaN].
+      # 0.0 / 0.0 == NaN, which is non-reflexive under ==; the fold must decline so it never produces a Constant[NaN].
       expect(fold(0.0, :/, [0.0])).to be_nil
     end
   end
@@ -317,8 +311,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
 
     it "declines the bit-test predicates on a Float receiver (no such method)" do
-      # Listing them in the shared NUMERIC_BINARY set is Float-safe: the
-      # method does not exist on Float, so invoke_binary rescues to nil.
+      # Listing them in the shared NUMERIC_BINARY set is Float-safe: the method does not exist on Float, so
+      # invoke_binary rescues to nil.
       expect(fold(3.5, :allbits?, [2])).to be_nil
       expect(fold(3.5, :anybits?, [2])).to be_nil
       expect(fold(3.5, :nobits?, [2])).to be_nil
@@ -344,9 +338,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
 
     it "lifts String#grapheme_clusters to a per-grapheme Tuple (distinct from #chars)" do
-      # "e" + a combining acute accent (U+0301): one extended grapheme
-      # cluster, but two #chars. Built from codepoints so the source stays
-      # ASCII and the decomposed (not precomposed) form is unambiguous.
+      # "e" + a combining acute accent (U+0301): one extended grapheme cluster, but two #chars. Built from codepoints so
+      # the source stays ASCII and the decomposed (not precomposed) form is unambiguous.
       e_acute = [0x65, 0x301].pack("U*") # "e" + combining acute accent
       g = fold(e_acute, :grapheme_clusters)
       expect(g).to be_a(Rigor::Type::Tuple)
@@ -355,8 +348,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
 
     it "folds the Float rational accessors numerator / denominator" do
-      # The exact rational decomposition of the float — the Float
-      # siblings of the already-folded Rational accessors.
+      # The exact rational decomposition of the float — the Float siblings of the already-folded Rational accessors.
       expect(fold(2.5, :numerator).value).to eq(5)
       expect(fold(2.5, :denominator).value).to eq(2)
       expect(fold(3.0, :numerator).value).to eq(3)
@@ -364,8 +356,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
 
     it "keeps the non-finite Float numerator / denominator folds sound" do
-      # Infinity folds to the same value Ruby returns at runtime;
-      # a NaN numerator is non-reflexive under == so the fold declines.
+      # Infinity folds to the same value Ruby returns at runtime; a NaN numerator is non-reflexive under == so the fold
+      # declines.
       expect(fold(Float::INFINITY, :numerator).value).to eq(Float::INFINITY)
       expect(fold(Float::INFINITY, :denominator).value).to eq(1)
       expect(fold(Float::NAN, :numerator)).to be_nil
@@ -396,12 +388,10 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
   end
 
-  # Methods unlocked by the offline numeric.yml catalog: methods
-  # whose CRuby implementation the catalog classifies as `leaf`
-  # (no Ruby-level callout) or `leaf_when_numeric` (callout only on
-  # non-Numeric arg, gated upstream by the literal-only fold).
-  # The hand-rolled `NUMERIC_BINARY` / `INTEGER_UNARY` sets do not
-  # cover these, so before the wiring landed the fold returned nil.
+  # Methods unlocked by the offline numeric.yml catalog: methods whose CRuby implementation the catalog classifies as
+  # `leaf` (no Ruby-level callout) or `leaf_when_numeric` (callout only on non-Numeric arg, gated upstream by the
+  # literal-only fold). The hand-rolled `NUMERIC_BINARY` / `INTEGER_UNARY` sets do not cover these, so before the wiring
+  # landed the fold returned nil.
   describe "catalog-driven binary fold" do
     it "folds Integer#** (power)" do
       expect(fold(2, :**, [10]).value).to eq(1024)
@@ -508,13 +498,10 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
   end
 
-  # STRING_FOLD_BYTE_LIMIT (4096) keeps a literal-string fold from
-  # materialising an unbounded result in the analyzer. The three guarded
-  # paths are `*` by a count (count > limit), `*` by bytesize
-  # (receiver.bytesize * count > limit), and `+` concat
-  # (left.bytesize + right.bytesize > limit). A declined fold returns
-  # nil so dispatch falls through to the RBS `String` envelope — the
-  # value is still typed, just not as a literal.
+  # STRING_FOLD_BYTE_LIMIT (4096) keeps a literal-string fold from materialising an unbounded result in the analyzer.
+  # The three guarded paths are `*` by a count (count > limit), `*` by bytesize (receiver.bytesize * count > limit), and
+  # `+` concat (left.bytesize + right.bytesize > limit). A declined fold returns nil so dispatch falls through to the
+  # RBS `String` envelope — the value is still typed, just not as a literal.
   describe "STRING_FOLD_BYTE_LIMIT enforcement" do
     it "folds a small String#* within the byte budget" do
       type = fold("x", :*, [10])
@@ -527,8 +514,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
 
     it "declines String#* when bytesize * count exceeds the limit" do
-      # 100-byte receiver * 50 = 5000 bytes > 4096, even though the
-      # count (50) is itself under the limit.
+      # 100-byte receiver * 50 = 5000 bytes > 4096, even though the count (50) is itself under the limit.
       expect(fold("y" * 100, :*, [50])).to be_nil
     end
 
@@ -544,10 +530,9 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
   end
 
-  # Union[Constant…] folding. Each Constant in a union represents a
-  # possible runtime value; a binary op over two unions is the
-  # cartesian fold, deduplicated. Bounded by the input/output
-  # cardinality caps so an analyzer-side blowup is not possible.
+  # Union[Constant…] folding. Each Constant in a union represents a possible runtime value; a binary op over two unions
+  # is the cartesian fold, deduplicated. Bounded by the input/output cardinality caps so an analyzer-side blowup is not
+  # possible.
   describe "union fold" do
     def constant_union(*values)
       Rigor::Type::Combinator.union(
@@ -605,9 +590,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
 
     it "drops always-raising pairs and keeps the safe ones" do
-      # `Union[5, 7] / Union[0, 2]` — the (·, 0) pairs are
-      # division-by-zero (caught by safe?), so only 5/2=2 and
-      # 7/2=3 reach the result. The fold returns the survivors.
+      # `Union[5, 7] / Union[0, 2]` — the (·, 0) pairs are division-by-zero (caught by safe?), so only 5/2=2 and 7/2=3
+      # reach the result. The fold returns the survivors.
       type = fold_types(
         constant_union(5, 7),
         :/,
@@ -634,9 +618,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
 
     it "widens to IntegerRange when output cardinality exceeds UNION_FOLD_OUTPUT_LIMIT" do
-      # 5 × 5 = 25 inputs (under input cap), `:+` over disjoint ranges
-      # produces 25 distinct sums (>8). The graceful escape valve is to
-      # return the bounding `IntegerRange[min..max]` rather than `nil`.
+      # 5 × 5 = 25 inputs (under input cap), `:+` over disjoint ranges produces 25 distinct sums (>8). The graceful
+      # escape valve is to return the bounding `IntegerRange[min..max]` rather than `nil`.
       receiver = constant_union(1, 2, 3, 4, 5)
       arg = constant_union(10, 20, 30, 40, 50)
       type = fold_types(receiver, :+, [arg])
@@ -646,8 +629,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
 
     it "narrows to Union[true, false] via comparisons regardless of input width" do
-      # `Union[1, 2, 3] < 2` — outputs only true/false; the
-      # output cap is 8 so this comfortably folds.
+      # `Union[1, 2, 3] < 2` — outputs only true/false; the output cap is 8 so this comfortably folds.
       type = fold_types(
         constant_union(1, 2, 3),
         :<,
@@ -684,10 +666,9 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
   end
 
-  # IntegerRange (positive-int, non-negative-int, int<a, b>, …) folding.
-  # Compare to PHPStan's `int<min, max>` family. The carrier never widens
-  # beyond what the inputs imply, so `int<5, 10> + int<1, 2>` is exactly
-  # `int<6, 12>` rather than the looser `Nominal[Integer]`.
+  # IntegerRange (positive-int, non-negative-int, int<a, b>, …) folding. Compare to PHPStan's `int<min, max>` family.
+  # The carrier never widens beyond what the inputs imply, so `int<5, 10> + int<1, 2>` is exactly `int<6, 12>` rather
+  # than the looser `Nominal[Integer]`.
   describe "integer range fold" do
     def positive_int = Rigor::Type::Combinator.positive_int
     def non_negative_int = Rigor::Type::Combinator.non_negative_int
@@ -837,8 +818,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
       end
 
       it "treats 0 × +∞ as 0 (algebraic, not Float arithmetic)" do
-        # non_negative_int × Constant[0] = exactly Constant[0]
-        # because 0 × anything is 0 even at the +∞ endpoint.
+        # non_negative_int × Constant[0] = exactly Constant[0] because 0 × anything is 0 even at the +∞ endpoint.
         type = fold_types(non_negative_int, :*, [constant_of(0)])
         expect(type).to eq(constant_of(0))
       end
@@ -889,10 +869,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
       end
     end
 
-    # Signed-infinity edges: arithmetic where one or both endpoints are
-    # ±∞. The corner computations (with safe_mul's `0 × ∞ = 0`) must
-    # produce algebraically correct bounded/half-bounded results rather
-    # than NaN-corrupted ranges.
+    # Signed-infinity edges: arithmetic where one or both endpoints are ±∞. The corner computations (with safe_mul's `0
+    # × ∞ = 0`) must produce algebraically correct bounded/half-bounded results rather than NaN-corrupted ranges.
     describe "signed-infinity arithmetic edges" do
       it "negative-int * positive-int is negative-int" do
         # (-∞, -1] × [1, +∞): max corner is (-1)(1) = -1, min is -∞.
@@ -1003,8 +981,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
       end
 
       it "projects union receivers per tuple position" do
-        # Union[5, 7].divmod(3) → 5.divmod(3) = [1, 2]; 7.divmod(3) = [2, 1]
-        # → Tuple[Union[Constant[1], Constant[2]], Union[Constant[1], Constant[2]]]
+        # Union[5, 7].divmod(3) → 5.divmod(3) = [1, 2]; 7.divmod(3) = [2, 1] → Tuple[Union[Constant[1], Constant[2]],
+        # Union[Constant[1], Constant[2]]]
         type = fold_types(constant_union(5, 7), :divmod, [constant_of(3)])
         expect(type).to be_a(Rigor::Type::Tuple)
         expect(type.elements.size).to eq(2)
@@ -1042,8 +1020,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
       end
 
       it "does not yet fold IntegerRange divmod (returns nil)" do
-        # Range divmod is a follow-up; for now the fold bails so the
-        # caller can fall back to the RBS-widened result.
+        # Range divmod is a follow-up; for now the fold bails so the caller can fall back to the RBS-widened result.
         expect(fold_types(positive_int, :divmod, [constant_of(3)])).to be_nil
       end
     end
@@ -1063,16 +1040,15 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
       end
 
       it "does not widen when the result set has non-Integer members" do
-        # Each Float arg keeps the result a Float, so widening is
-        # not an option. The cap becomes a hard nil.
+        # Each Float arg keeps the result a Float, so widening is not an option. The cap becomes a hard nil.
         receiver = Rigor::Type::Combinator.union(
           *(1..5).map { |v| constant_of(v) }
         )
         arg = Rigor::Type::Combinator.union(
           *(1..5).map { |v| constant_of(v.to_f) }
         )
-        # 5×5 = 25 inputs (under input cap); 25 distinct Float sums (over output cap).
-        # Inputs include Float, so widening to IntegerRange is rejected.
+        # 5×5 = 25 inputs (under input cap); 25 distinct Float sums (over output cap). Inputs include Float, so widening
+        # to IntegerRange is rejected.
         expect(fold_types(receiver, :+, [arg])).to be_nil
       end
     end
@@ -1090,13 +1066,10 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
 
     it "folds Integer#clamp through Comparable's catalog when Numeric has no entry" do
-      # `Integer#clamp(0..10)` is provided by the included
-      # Comparable module — it is NOT registered directly on
-      # Integer in `Init_Numeric`, so numeric.yml has no entry.
-      # The include-aware fallthrough consults
-      # `COMPARABLE_CATALOG`, which classifies `clamp` as
-      # `:leaf`, and the fold materialises through the Ruby
-      # invocation `5.clamp(0..10) #=> 5`.
+      # `Integer#clamp(0..10)` is provided by the included Comparable module — it is NOT registered directly on Integer
+      # in `Init_Numeric`, so numeric.yml has no entry. The include-aware fallthrough consults `COMPARABLE_CATALOG`,
+      # which classifies `clamp` as `:leaf`, and the fold materialises through the Ruby invocation `5.clamp(0..10) #=>
+      # 5`.
       result = fold_types(constant_of(5), :clamp, [constant_of(0..10)])
       expect(result).to eq(constant_of(5))
     end
@@ -1154,10 +1127,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
 
     it "bails when an IntegerRange argument reaches the 2-arg path" do
-      # IntegerRange args (vs IntegerRange receivers) still
-      # decline; the v0.0.6 IntegerRange-aware ternary fold
-      # only triggers for IntegerRange receivers paired with
-      # scalar Constant args.
+      # IntegerRange args (vs IntegerRange receivers) still decline; the v0.0.6 IntegerRange-aware ternary fold only
+      # triggers for IntegerRange receivers paired with scalar Constant args.
       receiver = constant_of(5)
       range_arg = Rigor::Type::Combinator.integer_range(0, 10)
       expect(fold_types(receiver, :between?, [range_arg, constant_of(20)])).to be_nil
@@ -1199,10 +1170,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
       end
 
       it "declines clamp when bracket excludes the range entirely" do
-        # int<10, 20>.clamp(0, 5) — the bracket is fully below
-        # the range, so every receiver value snaps to 5; the
-        # fold declines so the RBS tier widens rather than the
-        # dispatcher inventing the snap point.
+        # int<10, 20>.clamp(0, 5) — the bracket is fully below the range, so every receiver value snaps to 5; the fold
+        # declines so the RBS tier widens rather than the dispatcher inventing the snap point.
         result = fold_types(integer_range(10, 20), :clamp, [constant_of(0), constant_of(5)])
         expect(result).to be_nil
       end
@@ -1230,10 +1199,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
 
       it "folds Constant<String> % HashShape of Constants for hash format specs" do
         shape = hash_shape_of(name: constant_of("Alice"), age: constant_of(30))
-        # The format template uses Ruby's `%{key}` hash-format
-        # spec. Build it from String#new to keep the rubocop
-        # FormatStringToken cop quiet (the cop only inspects
-        # interpolated string literals).
+        # The format template uses Ruby's `%{key}` hash-format spec. Build it from String#new to keep the rubocop
+        # FormatStringToken cop quiet (the cop only inspects interpolated string literals).
         template = String.new("%") << "{name} is " << "%" << "{age}"
         result = fold_types(constant_of(template), :%, [shape])
         expect(result).to eq(constant_of("Alice is 30"))
@@ -1250,15 +1217,13 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
       end
 
       it "declines on a malformed format spec (no crash)" do
-        # `%q` is not a recognised String#% conversion; Ruby raises
-        # `ArgumentError`. The fold catches the exception and falls
-        # through.
+        # `%q` is not a recognised String#% conversion; Ruby raises `ArgumentError`. The fold catches the exception and
+        # falls through.
         expect(fold_types(constant_of("%q"), :%, [tuple_of(constant_of(1))])).to be_nil
       end
 
       it "declines for non-String receivers" do
-        # Sanity: `Constant<Integer> % Constant<Integer>` still flows
-        # through the standard numeric binary path (modulo).
+        # Sanity: `Constant<Integer> % Constant<Integer>` still flows through the standard numeric binary path (modulo).
         expect(fold_types(constant_of(7), :%, [constant_of(3)])).to eq(constant_of(1))
       end
     end
@@ -1313,9 +1278,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
       end
 
       it "lifts #split to a Tuple[dirname, basename] of Pathname constants" do
-        # `Pathname#split` is the Array-returning sibling of the scalar
-        # `dirname` / `basename` folds — pure `@path` string manipulation,
-        # no filesystem read.
+        # `Pathname#split` is the Array-returning sibling of the scalar `dirname` / `basename` folds — pure `@path`
+        # string manipulation, no filesystem read.
         result = fold_types(constant_of(Pathname.new("/a/b/c.rb")), :split)
         expect(result).to be_a(Rigor::Type::Tuple)
         expect(result.elements).to eq([
@@ -1331,9 +1295,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
       end
 
       it "declines on filesystem-touching methods (e.g. exist?)" do
-        # `exist?` reads the host filesystem. Even on a Constant<Pathname>
-        # receiver the answer depends on the analysis machine, so the
-        # fold tier MUST decline so the RBS tier widens to bool.
+        # `exist?` reads the host filesystem. Even on a Constant<Pathname> receiver the answer depends on the analysis
+        # machine, so the fold tier MUST decline so the RBS tier widens to bool.
         expect(fold_types(p, :exist?)).to be_nil
       end
     end
@@ -1379,8 +1342,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
       end
 
       it "declines on a malformed split argument (no crash)" do
-        # `split(nil)` raises TypeError on most String forms; the
-        # rescue catches it and the fold falls through.
+        # `split(nil)` raises TypeError on most String forms; the rescue catches it and the fold falls through.
         expect(fold_types(constant_of("a,b"), :split, [constant_of(nil)])).to be_nil
       end
     end
@@ -1436,8 +1398,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
       end
 
       it "still declines for non-integer-bounded ranges" do
-        # Float ranges decline because the elements would not be a
-        # finite enumerable; RBS tier widens.
+        # Float ranges decline because the elements would not be a finite enumerable; RBS tier widens.
         expect(fold_types(constant_of(1.0..2.0), :to_a)).to be_nil
       end
     end

--- a/spec/rigor/inference/method_dispatcher/data_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/data_folding_spec.rb
@@ -2,13 +2,10 @@
 
 require "spec_helper"
 
-# ADR-48 — `Data.define` value folding, exercised end-to-end through the
-# full Runner pipeline (the project pre-pass that builds the class-name ->
-# member-layout side-table only runs there, not under the reduced
-# precision-snapshot harness).
+# ADR-48 — `Data.define` value folding, exercised end-to-end through the full Runner pipeline (the project pre-pass that
+# builds the class-name -> member-layout side-table only runs there, not under the reduced precision-snapshot harness).
 RSpec.describe "Data.define value folding", type: :runner do
-  # Returns the `describe(:short)` strings recorded by each `dump_type(...)`
-  # call in source order.
+  # Returns the `describe(:short)` strings recorded by each `dump_type(...)` call in source order.
   def dumped_types(source)
     result = analyze("require \"rigor/testing\"\ninclude Rigor::Testing\n#{source}")
     result.diagnostics
@@ -83,10 +80,9 @@ RSpec.describe "Data.define value folding", type: :runner do
       RUBY
     end
 
-    # Regression: `build_fresh_body_scope` (the ADR-44 single-allocation
-    # body-scope constructor) must carry `data_member_layouts` like every
-    # other discovery table — it was omitted when ADR-48 added the table,
-    # so member folding silently degraded inside method bodies.
+    # Regression: `build_fresh_body_scope` (the ADR-44 single-allocation body-scope constructor) must carry
+    # `data_member_layouts` like every other discovery table — it was omitted when ADR-48 added the table, so member
+    # folding silently degraded inside method bodies.
     it "keeps the member layout visible inside a method body" do
       expect(dumped_types(<<~RUBY)).to eq(["3"])
         Point = Data.define(:x, :y)
@@ -126,10 +122,8 @@ RSpec.describe "Data.define value folding", type: :runner do
     end
 
     it "does not fold a bare-local Data.define carrying a block" do
-      # The local block form has no resolvable class name, so its block
-      # method definitions cannot be consulted to guard a redefined reader;
-      # it stays conservatively unfolded (the named forms below do fold,
-      # guarded).
+      # The local block form has no resolvable class name, so its block method definitions cannot be consulted to guard
+      # a redefined reader; it stays conservatively unfolded (the named forms below do fold, guarded).
       types = dumped_types(<<~RUBY)
         c = Data.define(:x) do
           def double = x * 2
@@ -162,8 +156,8 @@ RSpec.describe "Data.define value folding", type: :runner do
     end
 
     it "does not fold a member read whose reader the subclass body redefines" do
-      # `def x` shadows the synthesised reader, so `p.x` runs that method, not
-      # the member — folding it to the member value would be unsound.
+      # `def x` shadows the synthesised reader, so `p.x` runs that method, not the member — folding it to the member
+      # value would be unsound.
       types = dumped_types(<<~RUBY)
         class Point < Data.define(:x, :y)
           def x = "overridden"

--- a/spec/rigor/inference/method_dispatcher/file_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/file_folding_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::FileFolding do
                                  ))
   end
 
-  # Toggle the module-global flag for the duration of a single
-  # test; restore it afterwards so other specs see the default.
+  # Toggle the module-global flag for the duration of a single test; restore it afterwards so other specs see the
+  # default.
   around do |example|
     original = described_class.fold_platform_specific_paths
     example.run

--- a/spec/rigor/inference/method_dispatcher/hkt_builtin_return_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/hkt_builtin_return_spec.rb
@@ -2,10 +2,8 @@
 
 require "spec_helper"
 
-# ADR-20 slice 3 end-to-end check: `JSON.parse(...)` dispatched
-# through the top-level `MethodDispatcher.dispatch` returns the
-# reduced HKT type instead of the upstream rbs gem's `untyped`
-# slot.
+# ADR-20 slice 3 end-to-end check: `JSON.parse(...)` dispatched through the top-level `MethodDispatcher.dispatch`
+# returns the reduced HKT type instead of the upstream rbs gem's `untyped` slot.
 RSpec.describe Rigor::Inference::MethodDispatcher do # rubocop:disable RSpec/SpecFilePathFormat
   let(:environment) { Rigor::Environment.default }
   let(:json_singleton) { Rigor::Type::Combinator.singleton_of(JSON) }
@@ -132,9 +130,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher do # rubocop:disable RSpec/Spe
         arg_types: [Rigor::Type::Combinator.nominal_of(String)],
         environment: environment
       )
-      # The instance-side path falls through to standard dispatch (RBS or
-      # user-class fallback). Whatever it returns, it MUST NOT be the
-      # singleton-side reduced Union.
+      # The instance-side path falls through to standard dispatch (RBS or user-class fallback). Whatever it returns, it
+      # MUST NOT be the singleton-side reduced Union.
       expect(type).not_to be_a(Rigor::Type::Union)
     end
 
@@ -232,8 +229,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher do # rubocop:disable RSpec/Spe
       end
 
       it "does NOT augment JSON.parse (no post_reduce on JSON_VALUE_SPEC)" do
-        # JSON.parse with a similarly-shaped opts hash should NOT pick up Date —
-        # only YAML/Psych entries have the post_reduce hook.
+        # JSON.parse with a similarly-shaped opts hash should NOT pick up Date — only YAML/Psych entries have the
+        # post_reduce hook.
         require "date"
         opts_shape = Rigor::Type::HashShape.new(
           permitted_classes: Rigor::Type::Tuple.new([singleton_of_class("Date")])
@@ -249,10 +246,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher do # rubocop:disable RSpec/Spe
     end
 
     context "with CSV.parse / CSV.read overrides (no-headers shape)" do
-      # CSV is stdlib loaded by Rigor's bundled RBS but not
-      # `require`d in the test process; construct the
-      # Singleton from the class name string directly so the
-      # spec works regardless of `require "csv"` availability.
+      # CSV is stdlib loaded by Rigor's bundled RBS but not `require`d in the test process; construct the Singleton from
+      # the class name string directly so the spec works regardless of `require "csv"` availability.
       let(:csv_singleton) { Rigor::Type::Singleton.new("CSV") }
 
       it "CSV.parse(str) returns Array[Array[String | nil]]" do
@@ -308,9 +303,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher do # rubocop:disable RSpec/Spe
         arg_types: [Rigor::Type::Combinator.nominal_of(String)],
         environment: environment
       )
-      # YAML.parse is NOT in METHOD_RETURN_OVERRIDES; the dispatcher
-      # falls through to RBS / whatever else and the result MUST NOT be
-      # the json::value Union shape.
+      # YAML.parse is NOT in METHOD_RETURN_OVERRIDES; the dispatcher falls through to RBS / whatever else and the result
+      # MUST NOT be the json::value Union shape.
       next if type.nil?
 
       if type.is_a?(Rigor::Type::Union)

--- a/spec/rigor/inference/method_dispatcher/iterator_dispatch_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/iterator_dispatch_spec.rb
@@ -37,8 +37,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher::IteratorDispatch do
     end
 
     it "is vacuous on 0.times — falls back to non_negative_int" do
-      # `0.times` does not iterate; the body still type-checks
-      # against a sensible binding.
+      # `0.times` does not iterate; the body still type-checks against a sensible binding.
       expect(block_params(constant_of(0), :times)).to eq([non_negative_int])
     end
 

--- a/spec/rigor/inference/method_dispatcher/kernel_dispatch_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/kernel_dispatch_spec.rb
@@ -67,17 +67,15 @@ RSpec.describe Rigor::Inference::MethodDispatcher::KernelDispatch do
     end
 
     it "narrows Integer(decimal-int-string) to universal-int (signed: `\"-7\"` parses to -7)" do
-      # The decimal-int-string predicate `/\A-?\d+\z/` admits a leading
-      # sign, so `Integer("-7") == -7 < 0` — the result is a plain
-      # Integer, NOT non-negative-int. `Integer()` is total over the
-      # carrier, so the (signed) IntegerRange is sound.
+      # The decimal-int-string predicate `/\A-?\d+\z/` admits a leading sign, so `Integer("-7") == -7 < 0` — the result
+      # is a plain Integer, NOT non-negative-int. `Integer()` is total over the carrier, so the (signed) IntegerRange is
+      # sound.
       expect(integer_dispatch(Rigor::Type::Combinator.decimal_int_string)).to eq(universal_int)
     end
 
     it "declines Integer(numeric-string) — the widened grammar is not Integer-total nor non-negative" do
-      # numeric-string now covers the full Ruby numeric-literal grammar
-      # (`1.5`, `2i`, `-3`, …), so Integer(numeric_string) may raise or
-      # be negative — narrowing it to non-negative-int would be unsound.
+      # numeric-string now covers the full Ruby numeric-literal grammar (`1.5`, `2i`, `-3`, …), so
+      # Integer(numeric_string) may raise or be negative — narrowing it to non-negative-int would be unsound.
       expect(integer_dispatch(Rigor::Type::Combinator.numeric_string)).to be_nil
     end
 

--- a/spec/rigor/inference/method_dispatcher/method_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/method_folding_spec.rb
@@ -27,10 +27,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::MethodFolding do
     end
 
     it "declines on a non-literal symbol argument" do
-      # The receiver `"1"` is precise, but the argument is an
-      # unknown identifier the engine cannot fold to a
-      # `Constant<Symbol>`; the forward fold declines and the
-      # RBS tier answers `Nominal[Method]` instead.
+      # The receiver `"1"` is precise, but the argument is an unknown identifier the engine cannot fold to a
+      # `Constant<Symbol>`; the forward fold declines and the RBS tier answers `Nominal[Method]` instead.
       type = scope.type_of(parse_expression('"1".method(unknown_name)'))
 
       expect(type).not_to be_a(Rigor::Type::BoundMethod)
@@ -86,14 +84,10 @@ RSpec.describe Rigor::Inference::MethodDispatcher::MethodFolding do
     end
 
     it "preserves Tuple per-element precision through `.curry.call` over a Symbol Array" do
-      # The pre-Option-A behaviour for this expression was
-      # `Tuple[Dynamic[Top]×3]` because `Method#curry`
-      # collapsed to `Nominal[Proc]` and `Proc#call` then
-      # fell through to `Dynamic[Top]`. Option A keeps the
-      # `BoundMethod` carrier through `.curry`, so the
-      # backward fold's recursive dispatch on the bound
-      # `(receiver_type, method_name)` pair runs as if the
-      # `.curry` were never written.
+      # The pre-Option-A behaviour for this expression was `Tuple[Dynamic[Top]×3]` because `Method#curry` collapsed to
+      # `Nominal[Proc]` and `Proc#call` then fell through to `Dynamic[Top]`. Option A keeps the `BoundMethod` carrier
+      # through `.curry`, so the backward fold's recursive dispatch on the bound `(receiver_type, method_name)` pair
+      # runs as if the `.curry` were never written.
       type = scope.type_of(parse_expression(
                              '[:to_i, :to_f, :to_sym].map { |m| "1".method(m).curry.call }'
                            ))

--- a/spec/rigor/inference/method_dispatcher/overload_selector_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/overload_selector_spec.rb
@@ -78,21 +78,17 @@ RSpec.describe Rigor::Inference::MethodDispatcher::OverloadSelector do
     end
 
     it "skips overloads with required keyword arguments" do
-      # We construct a synthetic method with one keyword-required and
-      # one positional-only overload to ensure the selector skips the
-      # keyword-required one. We use Object#tap which has no kwargs as
-      # baseline; the synthetic part is a stub that simulates a kwargs
-      # overload via a dummy MethodType. Easier: just verify behaviour
-      # via Hash#fetch which has keyword-free overloads in core RBS.
+      # We construct a synthetic method with one keyword-required and one positional-only overload to ensure the
+      # selector skips the keyword-required one. We use Object#tap which has no kwargs as baseline; the synthetic part
+      # is a stub that simulates a kwargs overload via a dummy MethodType. Easier: just verify behaviour via Hash#fetch
+      # which has keyword-free overloads in core RBS.
       mt = select("Hash", :fetch, [Rigor::Type::Combinator.constant_of(:k)])
       expect(mt).not_to be_nil
     end
 
     describe "block-less call-site overload selection" do
-      # `Array#filter` declares the block-bearing overload first
-      # (`() { (Elem) -> boolish } -> Array[Elem]`) and the
-      # bare-call overload second (`() -> Enumerator[...]`). A
-      # call with no block must pick the second: `[1, 2].filter`
+      # `Array#filter` declares the block-bearing overload first (`() { (Elem) -> boolish } -> Array[Elem]`) and the
+      # bare-call overload second (`() -> Enumerator[...]`). A call with no block must pick the second: `[1, 2].filter`
       # yields an `Enumerator`, not an `Array`.
       it "skips a required-block overload when the call has no block" do
         mt = select("Array", :filter, [], block_required: false)
@@ -107,9 +103,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::OverloadSelector do
       end
 
       it "keeps the only overload when every candidate requires a block" do
-        # `Array#each_with_object` has a single required-block
-        # overload; a block-less call still resolves to it via
-        # the `overloads.first` fall-back.
+        # `Array#each_with_object` has a single required-block overload; a block-less call still resolves to it via the
+        # `overloads.first` fall-back.
         mt = select("Array", :each_with_object, [Rigor::Type::Combinator.constant_of(0)], block_required: false)
         expect(mt).not_to be_nil
       end
@@ -153,16 +148,14 @@ RSpec.describe Rigor::Inference::MethodDispatcher::OverloadSelector do
 
       it "still picks the alias-typed overload when only it is arity-compatible (Array#[](Integer))" do
         mt = select("Array", :[], [Rigor::Type::Combinator.nominal_of("Integer")])
-        # Pass 1 (strict) finds nothing — Range param doesn't
-        # accept Integer. Pass 2 falls back to the gradual
-        # behaviour and the alias-typed overload wins.
+        # Pass 1 (strict) finds nothing — Range param doesn't accept Integer. Pass 2 falls back to the gradual behaviour
+        # and the alias-typed overload wins.
         expect(mt.type.required_positionals.size).to eq(1)
         expect(mt.type.required_positionals.first.type).to be_a(RBS::Types::Alias)
       end
 
       it "still picks the alias-typed overload for two-Integer slicing (Array#[](Integer, Integer))" do
-        # The two-int overload is arity-2 and the only option;
-        # neither pass changes the outcome here.
+        # The two-int overload is arity-2 and the only option; neither pass changes the outcome here.
         mt = select(
           "Array", :[],
           [Rigor::Type::Combinator.nominal_of("Integer"), Rigor::Type::Combinator.nominal_of("Integer")]
@@ -198,16 +191,11 @@ RSpec.describe Rigor::Inference::MethodDispatcher::OverloadSelector do
     end
 
     describe "receiver-affinity pre-sort (BigDecimal-coerce regression)" do
-      # When the `bigdecimal` stdlib RBS is loaded, its reopen
-      # of `Integer#+` adds `(BigDecimal) -> BigDecimal` at the
-      # FRONT of the overload list. Without the pre-sort the
-      # selector picks that arm for unknown / Integer args and
-      # produces a spurious BigDecimal return — surfacing as
-      # `undefined method 'upto' for BigDecimal` on plain
-      # `(i + 1).upto(n)` code. The pre-sort demotes the
-      # disjoint-sibling arm so the receiver-preserving
-      # `(Integer) -> Integer` wins for both Integer and
-      # untyped args.
+      # When the `bigdecimal` stdlib RBS is loaded, its reopen of `Integer#+` adds `(BigDecimal) -> BigDecimal` at the
+      # FRONT of the overload list. Without the pre-sort the selector picks that arm for unknown / Integer args and
+      # produces a spurious BigDecimal return — surfacing as `undefined method 'upto' for BigDecimal` on plain `(i +
+      # 1).upto(n)` code. The pre-sort demotes the disjoint-sibling arm so the receiver-preserving `(Integer) ->
+      # Integer` wins for both Integer and untyped args.
       let(:env) { Rigor::Environment.for_project(root: Dir.pwd) }
 
       def select_with_env(class_name, method_name, arg_types)
@@ -249,11 +237,9 @@ RSpec.describe Rigor::Inference::MethodDispatcher::OverloadSelector do
       end
 
       it "still routes Integer#*(Float) -> Float when the arg actually is a Float" do
-        # The pre-sort is stable: when a non-affinity arm
-        # accepts the actual arg and the affinity arm does not,
-        # the non-affinity arm still wins via Pass 1. Asserted
-        # so the pre-sort isn't misread as "always prefer the
-        # receiver class."
+        # The pre-sort is stable: when a non-affinity arm accepts the actual arg and the affinity arm does not, the
+        # non-affinity arm still wins via Pass 1. Asserted so the pre-sort isn't misread as "always prefer the receiver
+        # class."
         mt = select_with_env("Integer", :*, [Rigor::Type::Combinator.nominal_of("Float")])
         param_class = mt.type.required_positionals.first.type
         expect(param_class).to be_a(RBS::Types::ClassInstance)
@@ -262,15 +248,11 @@ RSpec.describe Rigor::Inference::MethodDispatcher::OverloadSelector do
     end
 
     describe "value-pinning params vs untyped args (hash_shape.rb:182 regression)" do
-      # `Kernel#Array` declares `(nil) -> []` FIRST. An `untyped`
-      # arg gradually accepts against every param, so pass 2 used
-      # to lock in that overload purely by list position — typing
-      # `Array(dynamic_keys)` as the empty tuple `[]` and folding
-      # every downstream `keys.uniq.size == keys.size` guard to a
-      # false `always-truthy-condition` (surfaced by the self-check
-      # on `Type::HashShape#canonical_key_list`). A value-pinning
-      # param (nil / literal carriers) must not be matched by an
-      # arg that carries zero evidence for the pinned value.
+      # `Kernel#Array` declares `(nil) -> []` FIRST. An `untyped` arg gradually accepts against every param, so pass 2
+      # used to lock in that overload purely by list position — typing `Array(dynamic_keys)` as the empty tuple `[]` and
+      # folding every downstream `keys.uniq.size == keys.size` guard to a false `always-truthy-condition` (surfaced by
+      # the self-check on `Type::HashShape#canonical_key_list`). A value-pinning param (nil / literal carriers) must not
+      # be matched by an arg that carries zero evidence for the pinned value.
       it "does not let an untyped arg select `Kernel#Array: (nil) -> []`" do
         mt = select("Kernel", :Array, [Rigor::Type::Combinator.untyped])
         expect(mt.type.return_type).to be_a(RBS::Types::ClassInstance)
@@ -284,20 +266,17 @@ RSpec.describe Rigor::Inference::MethodDispatcher::OverloadSelector do
       end
 
       it "keeps a value-pinning overload reachable via the fallback when nothing else matches" do
-        # `NilClass#&` has a single `(untyped) -> false` overload —
-        # the literal return must still resolve for an untyped arg
-        # (the first-overload fallback, unchanged behaviour).
+        # `NilClass#&` has a single `(untyped) -> false` overload — the literal return must still resolve for an untyped
+        # arg (the first-overload fallback, unchanged behaviour).
         mt = select("NilClass", :&, [Rigor::Type::Combinator.untyped])
         expect(mt).not_to be_nil
       end
     end
 
     describe "block passed to a method whose overloads declare none" do
-      # In Ruby a block handed to a method that never yields it is
-      # simply ignored. `Integer#succ` (`() -> Integer`, no block
-      # clause) must therefore still resolve when the call site carries
-      # a block — otherwise the call degrades to Dynamic[Top] (and on a
-      # self-send suppresses the method's whole return type).
+      # In Ruby a block handed to a method that never yields it is simply ignored. `Integer#succ` (`() -> Integer`, no
+      # block clause) must therefore still resolve when the call site carries a block — otherwise the call degrades to
+      # Dynamic[Top] (and on a self-send suppresses the method's whole return type).
       it "falls back to the block-less overload instead of returning nil" do
         without_block = select("Integer", :succ, [], block_required: false)
         with_block = select("Integer", :succ, [], block_required: true)
@@ -332,8 +311,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::OverloadSelector do
 
   describe "positional param binding" do
     it "absorbs surplus actual args into a rest positional" do
-      # `Array#push: (*Elem) -> self` has a rest positional and no fixed
-      # params, so binding 3 actual args fills three rest slots.
+      # `Array#push: (*Elem) -> self` has a rest positional and no fixed params, so binding 3 actual args fills three
+      # rest slots.
       fun = loader.instance_definition("Array").methods[:push].method_types.first.type
 
       expect(described_class.send(:positional_params_for, fun, 3).size).to eq(3)

--- a/spec/rigor/inference/method_dispatcher/rbs_complete_ancestor_resolution_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/rbs_complete_ancestor_resolution_spec.rb
@@ -2,17 +2,15 @@
 
 require "spec_helper"
 
-# ADR-43 — RBS-complete ancestor resolution. A Ruby-source subclass of
-# an allow-listed RBS-complete ancestor (seed `Rigor::Plugin::Base`)
-# resolves its *inherited* method calls against that ancestor's RBS, so
-# the normal call rules (here `call.undefined-method`) apply to misuse
-# of the inherited contract surface. Every other RBS ancestor keeps the
+# ADR-43 — RBS-complete ancestor resolution. A Ruby-source subclass of an allow-listed RBS-complete ancestor (seed
+# `Rigor::Plugin::Base`) resolves its *inherited* method calls against that ancestor's RBS, so the normal call rules
+# (here `call.undefined-method`) apply to misuse of the inherited contract surface. Every other RBS ancestor keeps the
 # false-positive-safe `Dynamic[Top]` fallback.
 RSpec.describe "ADR-43 RBS-complete ancestor resolution" do
   include RunnerHelpers
 
-  # An RBS where the allow-listed `Rigor::Plugin::Base` declares an
-  # inherited method returning a closed core type (`Integer`).
+  # An RBS where the allow-listed `Rigor::Plugin::Base` declares an inherited method returning a closed core type
+  # (`Integer`).
   let(:plugin_base_sig) do
     {
       "plugin_base.rbs" => <<~RBS
@@ -58,8 +56,7 @@ RSpec.describe "ADR-43 RBS-complete ancestor resolution" do
       end
     RUBY
 
-    # `Integer#succ` exists — resolving `contract_value` to Integer must
-    # NOT manufacture a diagnostic on a real method.
+    # `Integer#succ` exists — resolving `contract_value` to Integer must NOT manufacture a diagnostic on a real method.
     expect(result.diagnostics.select { |d| d.rule == "call.undefined-method" }).to be_empty
   end
 
@@ -80,9 +77,8 @@ RSpec.describe "ADR-43 RBS-complete ancestor resolution" do
       end
     RUBY
 
-    # `OpenBase` is not allow-listed, so the inherited call stays
-    # `Dynamic[Top]` and `call.undefined-method` must not fire — the
-    # false-positive-safe behaviour that protects `< ActionController::Base`.
+    # `OpenBase` is not allow-listed, so the inherited call stays `Dynamic[Top]` and `call.undefined-method` must not
+    # fire — the false-positive-safe behaviour that protects `< ActionController::Base`.
     expect(result.diagnostics.select { |d| d.rule == "call.undefined-method" }).to be_empty
   end
 end

--- a/spec/rigor/inference/method_dispatcher/rbs_dispatch_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/rbs_dispatch_spec.rb
@@ -92,10 +92,9 @@ RSpec.describe Rigor::Inference::MethodDispatcher::RbsDispatch do
       end
 
       it "does NOT confuse instance and singleton namespaces" do
-        # Module#instance_methods is a singleton-side method on every class
-        # type (Foo.instance_methods works), but is NOT itself an instance
-        # method of Integer. Phase 2b must keep these distinct: dispatching
-        # :instance_methods on Nominal[Integer] returns nil.
+        # Module#instance_methods is a singleton-side method on every class type (Foo.instance_methods works), but is
+        # NOT itself an instance method of Integer. Phase 2b must keep these distinct: dispatching :instance_methods on
+        # Nominal[Integer] returns nil.
         instance_recv = Rigor::Type::Combinator.nominal_of(Integer)
         expect(dispatch(instance_recv, :instance_methods)).to be_nil
 
@@ -137,8 +136,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::RbsDispatch do
       end
 
       it "leaves unbound variables as Dynamic[Top] for raw receivers" do
-        # Raw `Nominal[Array]` carries no type_args, so Array#first on
-        # the raw form falls back to the original phase-2c behavior.
+        # Raw `Nominal[Array]` carries no type_args, so Array#first on the raw form falls back to the original phase-2c
+        # behavior.
         type = dispatch(Rigor::Type::Combinator.nominal_of(Array), :first)
         expect(type).to equal(Rigor::Type::Combinator.untyped)
       end

--- a/spec/rigor/inference/method_dispatcher/reduce_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/reduce_folding_spec.rb
@@ -82,9 +82,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ReduceFolding do
       end
 
       it "declines an endless range `(1..)` (constant path declines; nominal path too)" do
-        # The constant path declines (no finite size); `element_type_of`
-        # on an endless `Constant[Range]` also declines, so the whole
-        # tier returns nil — byte-identical to pre-fold behaviour.
+        # The constant path declines (no finite size); `element_type_of` on an endless `Constant[Range]` also declines,
+        # so the whole tier returns nil — byte-identical to pre-fold behaviour.
         expect(fold(constant_of(1..), :reduce, [constant_of(:+)])).to be_nil
       end
 
@@ -98,8 +97,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ReduceFolding do
       end
 
       it "declines an operator outside the constant allow-list (`:max`)" do
-        # `Integer#max` does not exist; the nominal fold also cannot
-        # dispatch it, so the whole call declines (nil).
+        # `Integer#max` does not exist; the nominal fold also cannot dispatch it, so the whole call declines (nil).
         expect(fold(tuple(1, 2, 3), :reduce, [constant_of(:max)])).to be_nil
       end
 
@@ -112,8 +110,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ReduceFolding do
       end
 
       it "declines a non-Constant seed (range members constant, seed nominal)" do
-        # A nominal seed makes the fold non-constant, so the value path
-        # declines but the carrier path still answers `Integer`.
+        # A nominal seed makes the fold non-constant, so the value path declines but the carrier path still answers
+        # `Integer`.
         expect(fold(int_range, :reduce, [integer, constant_of(:*)])).to eq(integer)
       end
 

--- a/spec/rigor/inference/method_dispatcher/regexp_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/regexp_folding_spec.rb
@@ -122,10 +122,9 @@ RSpec.describe Rigor::Inference::MethodDispatcher::RegexpFolding do
     def string_t     = Rigor::Type::Combinator.nominal_of("String")
     def nil_t        = Rigor::Type::Combinator.constant_of(nil)
 
-    # A scope on the truthy match edge: `$~` narrowed to MatchData and
-    # the numbered globals narrowed as
-    # `Narrowing#regex_match_predicate_scopes` leaves them. `$1` present
-    # (String) means capture group 1 is unconditional.
+    # A scope on the truthy match edge: `$~` narrowed to MatchData and the numbered globals narrowed as
+    # `Narrowing#regex_match_predicate_scopes` leaves them. `$1` present (String) means capture group 1 is
+    # unconditional.
     def proven_scope(extra = {})
       defaults = { :$~ => match_data_t, :$1 => string_t }
       defaults.merge(extra).reduce(Rigor::Scope.empty) do |s, (name, type)|

--- a/spec/rigor/inference/method_dispatcher/shape_dispatch_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/shape_dispatch_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ShapeDispatch do
       expect(dispatch(receiver: t, method_name: :fetch, args: [constant(99)])).to be_nil
     end
 
-    # `Array#slice` is an exact alias of `Array#[]`, so it folds identically
-    # across the integer / Range / start-length forms.
+    # `Array#slice` is an exact alias of `Array#[]`, so it folds identically across the integer / Range / start-length
+    # forms.
     it "folds `tuple.slice(i)` like `tuple[i]`, including negative indices" do
       expect(dispatch(receiver: t, method_name: :slice, args: [constant(0)])).to eq(constant(1))
       expect(dispatch(receiver: t, method_name: :slice, args: [constant(-1)])).to eq(constant(3))
@@ -116,19 +116,16 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ShapeDispatch do
     end
 
     it "falls through for methods outside the catalogue" do
-      # `:map` is not handled by ShapeDispatch — element-wise
-      # block re-evaluation lives in `ExpressionTyper` (v0.0.6
-      # phase 2). `:reverse` IS handled by ShapeDispatch as of
-      # v0.0.7, so the existing assertion shifts to a method that
+      # `:map` is not handled by ShapeDispatch — element-wise block re-evaluation lives in `ExpressionTyper` (v0.0.6
+      # phase 2). `:reverse` IS handled by ShapeDispatch as of v0.0.7, so the existing assertion shifts to a method that
       # has not been catalogued.
       expect(dispatch(receiver: t, method_name: :map)).to be_nil
       expect(dispatch(receiver: t, method_name: :weird_method)).to be_nil
     end
 
     it "ignores arity mismatches by returning nil" do
-      # `tuple.first(2)` is the Slice-4 RBS overload; we let RbsDispatch
-      # handle it through the projection so the precise tier doesn't
-      # accidentally claim ownership.
+      # `tuple.first(2)` is the Slice-4 RBS overload; we let RbsDispatch handle it through the projection so the precise
+      # tier doesn't accidentally claim ownership.
       expect(dispatch(receiver: t, method_name: :first, args: [constant(2)])).to be_nil
     end
 
@@ -499,8 +496,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ShapeDispatch do
     end
 
     it "falls through (nil) for `fetch(missing)` so RbsDispatch handles the projection" do
-      # `fetch` raises at runtime; the precise tier defers rather than
-      # manufacturing a Constant[nil] the runtime would never produce.
+      # `fetch` raises at runtime; the precise tier defers rather than manufacturing a Constant[nil] the runtime would
+      # never produce.
       expect(dispatch(receiver: shape, method_name: :fetch, args: [constant(:missing)])).to be_nil
     end
 
@@ -541,8 +538,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ShapeDispatch do
     end
 
     it "falls through for multi-arg dig when the intermediate is a non-shape Constant" do
-      # shape.dig(:a, :b) — :a resolves to Constant[1], which is
-      # neither nil nor a shape, so the chain cannot continue.
+      # shape.dig(:a, :b) — :a resolves to Constant[1], which is neither nil nor a shape, so the chain cannot continue.
       expect(dispatch(receiver: shape, method_name: :dig, args: [constant(:a), constant(:b)])).to be_nil
     end
 
@@ -809,8 +805,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ShapeDispatch do
     end
 
     it "returns keys in argument order, matching Ruby's Hash#slice semantics" do
-      # Ruby's Hash#slice follows argument order, not receiver insertion order:
-      # { a:, b:, c: }.slice(:c, :a) => { c:, a: }
+      # Ruby's Hash#slice follows argument order, not receiver insertion order: { a:, b:, c: }.slice(:c, :a) => { c:, a:
+      # }
       result = dispatch(receiver: shape, method_name: :slice, args: [constant(:c), constant(:a)])
       expect(result.pairs.keys).to eq(%i[c a])
     end
@@ -952,11 +948,9 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ShapeDispatch do
       let(:receiver) { Rigor::Type::Combinator.decimal_int_string }
 
       it "narrows `to_i` to universal-int (signed: `\"-7\".to_i == -7`)" do
-        # The decimal-int-string predicate `/\A-?\d+\z/` admits a
-        # leading sign, so a `"-7"` inhabitant parses to a negative
-        # Integer — the result is a plain (signed) Integer, NOT
-        # non-negative-int. `String#to_i` is total, so the projection
-        # stays sound.
+        # The decimal-int-string predicate `/\A-?\d+\z/` admits a leading sign, so a `"-7"` inhabitant parses to a
+        # negative Integer — the result is a plain (signed) Integer, NOT non-negative-int. `String#to_i` is total, so
+        # the projection stays sound.
         expect(dispatch(receiver: receiver, method_name: :to_i)).to eq(universal_int)
       end
 
@@ -974,18 +968,16 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ShapeDispatch do
       let(:receiver) { Rigor::Type::Combinator.numeric_string }
 
       it "declines `to_i` / `to_int` — the full numeric-literal grammar is not non-negative-int" do
-        # `"1.5".to_i` truncates, `"-3".to_i` is negative, `"2i"` is
-        # not an Integer at all, so projecting to non-negative-int
-        # would be unsound; the projection falls through to RBS Integer.
+        # `"1.5".to_i` truncates, `"-3".to_i` is negative, `"2i"` is not an Integer at all, so projecting to
+        # non-negative-int would be unsound; the projection falls through to RBS Integer.
         expect(dispatch(receiver: receiver, method_name: :to_i)).to be_nil
         expect(dispatch(receiver: receiver, method_name: :to_int)).to be_nil
       end
 
       it "preserves the refinement across `#downcase` but drops to base String on `#upcase`" do
-        # downcasing a numeric literal stays a valid literal (hex
-        # digits / `0X` / `E` lowercase fine); upcasing breaks the
-        # lowercase-only rational / imaginary suffixes (`"1r"` →
-        # `"1R"`), so the refinement soundly drops to plain String.
+        # downcasing a numeric literal stays a valid literal (hex digits / `0X` / `E` lowercase fine); upcasing breaks
+        # the lowercase-only rational / imaginary suffixes (`"1r"` → `"1R"`), so the refinement soundly drops to plain
+        # String.
         expect(dispatch(receiver: receiver, method_name: :downcase)).to eq(receiver)
         expect(dispatch(receiver: receiver, method_name: :upcase)).to eq(Rigor::Type::Combinator.nominal_of("String"))
       end

--- a/spec/rigor/inference/method_dispatcher/shellwords_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/shellwords_folding_spec.rb
@@ -99,8 +99,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ShellwordsFolding do
     end
 
     it "escapes tokens with spaces" do
-      # Shellwords.join uses Shellwords.escape per token, which
-      # backslash-escapes rather than quoting: "initial commit" → "initial\ commit"
+      # Shellwords.join uses Shellwords.escape per token, which backslash-escapes rather than quoting: "initial commit"
+      # → "initial\ commit"
       arg = tuple(c("git"), c("commit"), c("-m"), c("initial commit"))
       expect(fold(:join, arg)).to eq(c("git commit -m initial\\ commit"))
     end

--- a/spec/rigor/inference/method_dispatcher/struct_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/struct_folding_spec.rb
@@ -2,15 +2,12 @@
 
 require "spec_helper"
 
-# ADR-48 Struct follow-up — `Struct.new` value folding, exercised end-to-end
-# through the full Runner pipeline (the project pre-pass that builds the
-# class-name -> member-layout side-table only runs there). The distinguishing
-# property versus the immutable `Data` sibling: a `Struct` is mutable, so a
-# member read folds only off a FRESH (chained) instance; a read off a STORED
-# binding soundly degrades to `Dynamic[top]`.
+# ADR-48 Struct follow-up — `Struct.new` value folding, exercised end-to-end through the full Runner pipeline (the
+# project pre-pass that builds the class-name -> member-layout side-table only runs there). The distinguishing property
+# versus the immutable `Data` sibling: a `Struct` is mutable, so a member read folds only off a FRESH (chained)
+# instance; a read off a STORED binding soundly degrades to `Dynamic[top]`.
 RSpec.describe "Struct.new value folding", type: :runner do
-  # Returns the `describe(:short)` strings recorded by each `dump_type(...)`
-  # call in source order.
+  # Returns the `describe(:short)` strings recorded by each `dump_type(...)` call in source order.
   def dumped_types(source)
     result = analyze("require \"rigor/testing\"\ninclude Rigor::Testing\n#{source}")
     result.diagnostics
@@ -71,10 +68,9 @@ RSpec.describe "Struct.new value folding", type: :runner do
     end
 
     it "does NOT fold a member read off an unrecognised local-class binding" do
-      # `p = c.new(1)` where `c` is a local StructClass is conservatively not
-      # treated as a fold-safe materialisation (the scan resolves the constant
-      # and inline forms, not a local-class intermediate) — degrades, never
-      # a stale value.
+      # `p = c.new(1)` where `c` is a local StructClass is conservatively not treated as a fold-safe materialisation
+      # (the scan resolves the constant and inline forms, not a local-class intermediate) — degrades, never a stale
+      # value.
       expect(dumped_types(<<~RUBY)).to eq(["Dynamic[top]"])
         c = Struct.new(:x)
         p = c.new(1)

--- a/spec/rigor/inference/method_dispatcher/synthetic_method_promotion_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/synthetic_method_promotion_spec.rb
@@ -55,9 +55,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher, ".dispatch" do
         environment: env
       )
 
-      # Comparable#between? is declared as `() -> bool` in core RBS;
-      # the precision-promoted dispatcher returns the module's
-      # actual return type, NOT the slice-2b/3b floor's untyped.
+      # Comparable#between? is declared as `() -> bool` in core RBS; the precision-promoted dispatcher returns the
+      # module's actual return type, NOT the slice-2b/3b floor's untyped.
       expect(result).not_to be_nil
       expect(result).not_to eq(Rigor::Type::Combinator.untyped)
     end
@@ -98,8 +97,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher, ".dispatch" do
         ],
         environment: env
       )
-      # The first entry's origin_module doesn't resolve; the
-      # promotion walk falls through to the second entry which DOES
+      # The first entry's origin_module doesn't resolve; the promotion walk falls through to the second entry which DOES
       # resolve. End result is the resolved type — NOT untyped.
       expect(result).not_to be_nil
       expect(result).not_to eq(Rigor::Type::Combinator.untyped)
@@ -126,8 +124,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher, ".dispatch" do
         method_name: :city,
         arg_types: [], environment: env
       )
-      # "String" is in core RBS — nominal_for_name resolves to
-      # Nominal[String], NOT the untyped floor.
+      # "String" is in core RBS — nominal_for_name resolves to Nominal[String], NOT the untyped floor.
       expect(result).to eq(Rigor::Type::Combinator.nominal_of("String"))
     end
 
@@ -164,8 +161,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher, ".dispatch" do
         method_name: :city,
         arg_types: [], environment: env
       )
-      # "Array[String]" is not a bare class name — nominal_for_name
-      # returns nil; substrate falls back to the WD13 floor.
+      # "Array[String]" is not a bare class name — nominal_for_name returns nil; substrate falls back to the WD13 floor.
       expect(result).to eq(Rigor::Type::Combinator.untyped)
     end
   end

--- a/spec/rigor/inference/method_dispatcher_spec.rb
+++ b/spec/rigor/inference/method_dispatcher_spec.rb
@@ -266,9 +266,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher do
           arg_types: [],
           environment: env
         )
-        # No plugin tier consulted; falls through to RBS / fallback,
-        # which doesn't know `Object#foo`. Expect nil rather than
-        # the plugin's "admin" string.
+        # No plugin tier consulted; falls through to RBS / fallback, which doesn't know `Object#foo`. Expect nil rather
+        # than the plugin's "admin" string.
         expect(result).to be_nil
       end
 
@@ -356,12 +355,9 @@ RSpec.describe Rigor::Inference::MethodDispatcher do
       end
 
       describe "ADR-10 return-type heuristic (post-floor enhancement)" do
-        # The Walker's ReturnTypeHeuristic populates the
-        # CatalogEntry's `return_type:` with a static facet for
-        # literal-tail method bodies; the dispatcher wraps that
-        # facet in `Dynamic[T]` per the gem-boundary contract
-        # instead of falling back to the pre-heuristic
-        # `Dynamic[top]`.
+        # The Walker's ReturnTypeHeuristic populates the CatalogEntry's `return_type:` with a static facet for
+        # literal-tail method bodies; the dispatcher wraps that facet in `Dynamic[T]` per the gem-boundary contract
+        # instead of falling back to the pre-heuristic `Dynamic[top]`.
         let(:catalog_entry_klass) { Rigor::Analysis::DependencySourceInference::Walker::CatalogEntry }
 
         it "wraps a heuristic-supplied Constant<Integer> return into Dynamic[Constant<value>]" do
@@ -496,10 +492,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher do
       end
 
       it "records a boundary-cross entry when RBS resolves an Integer call on a `mode: :full` gem class" do
-        # Integer is in core RBS so `RbsDispatch.try_dispatch`
-        # resolves `1.bit_length` to `Integer`. The pretend-
-        # to-own-Integer gem-source catalog turns the call site
-        # into a `mode: :full` boundary crossing.
+        # Integer is in core RBS so `RbsDispatch.try_dispatch` resolves `1.bit_length` to `Integer`. The pretend-
+        # to-own-Integer gem-source catalog turns the call site into a `mode: :full` boundary crossing.
         env = env_with_full_mode_index(
           class_to_gem: { "Integer" => "core_shim" },
           gem_modes: { "core_shim" => :full },
@@ -585,8 +579,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher do
       end
 
       it "does NOT fire for a BasicObject receiver (Kernel not mixed in)" do
-        # BasicObject is the one class that explicitly excludes
-        # Kernel, so the tightened return would be wrong.
+        # BasicObject is the one class that explicitly excludes Kernel, so the tightened return would be wrong.
         result = described_class.dispatch(
           receiver_type: Rigor::Type::Combinator.nominal_of("BasicObject"),
           method_name: :__dir__, arg_types: [], environment: env
@@ -599,10 +592,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher do
       let(:env) { Rigor::Environment.default }
 
       it "routes Nominal[<core module>].inspect through Nominal[Object]" do
-        # Comparable is a real RBS module that does not declare
-        # `inspect` itself. With the module-mixin fallback in
-        # `user_class_fallback_receiver`, the dispatcher retries
-        # against Nominal[Object] and resolves Kernel#inspect.
+        # Comparable is a real RBS module that does not declare `inspect` itself. With the module-mixin fallback in
+        # `user_class_fallback_receiver`, the dispatcher retries against Nominal[Object] and resolves Kernel#inspect.
         result = described_class.dispatch(
           receiver_type: Rigor::Type::Combinator.nominal_of("Comparable"),
           method_name: :inspect, arg_types: [], environment: env
@@ -616,31 +607,23 @@ RSpec.describe Rigor::Inference::MethodDispatcher do
           receiver_type: Rigor::Type::Combinator.nominal_of("Comparable"),
           method_name: :class, arg_types: [], environment: env
         )
-        # `meta_class` for a Nominal returns Singleton[<class_name>]
-        # — the receiver-side `class` always wins at the
-        # meta-introspection tier (above the fallback). The point
-        # of the test is that this doesn't surface as
-        # `undefined-method` because the fallback would have
-        # caught it even if meta-introspection didn't.
+        # `meta_class` for a Nominal returns Singleton[<class_name>] — the receiver-side `class` always wins at the
+        # meta-introspection tier (above the fallback). The point of the test is that this doesn't surface as
+        # `undefined-method` because the fallback would have caught it even if meta-introspection didn't.
         expect(result).to be_a(Rigor::Type::Singleton)
       end
 
       it "does NOT route Nominal[<core class>] through the module fallback" do
-        # Object is a class, not a module. The fallback path is
-        # NOT taken — the dispatcher uses Object's own RBS
+        # Object is a class, not a module. The fallback path is NOT taken — the dispatcher uses Object's own RBS
         # directly, not a fallback against Object's parent.
         expect(env.rbs_module?("Object")).to be(false)
       end
 
       it "preserves the original receiver type as `self` when falling back through Object" do
-        # `Kernel#dup: () -> self` resolved through the Object
-        # fallback (because `MyApp::UriThing` is not in RBS)
-        # MUST return `Nominal[MyApp::UriThing]`, not
-        # `Nominal[Object]`. Without `self_type_override`,
-        # `base = self.dup` inside a `Bundler::URI::Generic`
-        # method body types `base` as `Object` and every
-        # subsequent `base.fragment=` / `base.set_path(...)`
-        # call fires `undefined-method for Object`.
+        # `Kernel#dup: () -> self` resolved through the Object fallback (because `MyApp::UriThing` is not in RBS) MUST
+        # return `Nominal[MyApp::UriThing]`, not `Nominal[Object]`. Without `self_type_override`, `base = self.dup`
+        # inside a `Bundler::URI::Generic` method body types `base` as `Object` and every subsequent `base.fragment=` /
+        # `base.set_path(...)` call fires `undefined-method for Object`.
         unknown_receiver = Rigor::Type::Combinator.nominal_of("MyApp::UriThing")
         result = described_class.dispatch(
           receiver_type: unknown_receiver,
@@ -667,11 +650,9 @@ RSpec.describe Rigor::Inference::MethodDispatcher do
       end
 
       it "does NOT resolve a private Kernel method on an explicit non-self receiver" do
-        # `Favourite.select(:col)` (ActiveRecord) must not adopt the
-        # private `Kernel#select` signature (`-> Array[String]`).
-        # Ruby raises NoMethodError for a private method called with
-        # an explicit receiver, so the fallback returns nil and the
-        # call types `Dynamic[top]` rather than a wrong `Array[String]`.
+        # `Favourite.select(:col)` (ActiveRecord) must not adopt the private `Kernel#select` signature (`->
+        # Array[String]`). Ruby raises NoMethodError for a private method called with an explicit receiver, so the
+        # fallback returns nil and the call types `Dynamic[top]` rather than a wrong `Array[String]`.
         result = described_class.dispatch(
           receiver_type: Rigor::Type::Combinator.singleton_of("Favourite"),
           method_name: :select, arg_types: [Rigor::Type::Combinator.constant_of(:status_id)],
@@ -682,9 +663,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher do
       end
 
       it "still resolves a private Kernel method on an IMPLICIT-self call" do
-        # `puts "x"` inside a method body is an implicit-self call:
-        # `call_node.receiver` is nil, so the fallback keeps resolving
-        # `Kernel#puts` (the fallback's intended target).
+        # `puts "x"` inside a method body is an implicit-self call: `call_node.receiver` is nil, so the fallback keeps
+        # resolving `Kernel#puts` (the fallback's intended target).
         result = described_class.dispatch(
           receiver_type: Rigor::Type::Combinator.nominal_of("MyApp::Greeter"),
           method_name: :puts, arg_types: [Rigor::Type::Combinator.nominal_of("String")],
@@ -695,8 +675,7 @@ RSpec.describe Rigor::Inference::MethodDispatcher do
       end
 
       it "still resolves a public Kernel method on an explicit non-self receiver" do
-        # `.dup` is public — the explicit-receiver suppression must
-        # not touch it.
+        # `.dup` is public — the explicit-receiver suppression must not touch it.
         unknown_receiver = Rigor::Type::Combinator.nominal_of("MyApp::Thing")
         result = described_class.dispatch(
           receiver_type: unknown_receiver,
@@ -765,9 +744,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher do
       def sym(value) = Rigor::Type::Combinator.constant_of(value)
 
       it "folds `Struct.new(:a, :b)` (all symbol members) to a StructClass member layout" do
-        # ADR-48 Struct follow-up — StructFolding supersedes the old
-        # `struct_new_lift` (which produced a bare `Singleton[Struct]`); the
-        # chained `.new` now dispatches against the precise member layout.
+        # ADR-48 Struct follow-up — StructFolding supersedes the old `struct_new_lift` (which produced a bare
+        # `Singleton[Struct]`); the chained `.new` now dispatches against the precise member layout.
         result = dispatch(receiver: singleton("Struct"), method_name: :new, args: [sym(:a), sym(:b)])
         expect(result).to eq(Rigor::Type::Combinator.struct_class_of(members: %i[a b]))
       end

--- a/spec/rigor/inference/method_parameter_binder_spec.rb
+++ b/spec/rigor/inference/method_parameter_binder_spec.rb
@@ -46,17 +46,14 @@ RSpec.describe Rigor::Inference::MethodParameterBinder do
     end
 
     it "skips overloads that omit a parameter slot when unioning across overloads" do
-      # Array#first has both `()` and `(int)` overloads; binding a
-      # `def first(n)` redefinition MUST union from the only overload
-      # that has slot 0.
+      # Array#first has both `()` and `(int)` overloads; binding a `def first(n)` redefinition MUST union from the only
+      # overload that has slot 0.
       binder = described_class.new(environment: env, class_path: "Array", singleton: false)
       result = binder.bind(def_node("def first(n); n; end"))
 
-      # The single relevant overload's type is `int` (an RBS interface),
-      # which the translator currently degrades to `Dynamic[Top]`.
-      # The binder MUST NOT have left it at the default-untyped sentinel
-      # under a different identity — it should match the translator's
-      # canonical Dynamic[Top].
+      # The single relevant overload's type is `int` (an RBS interface), which the translator currently degrades to
+      # `Dynamic[Top]`. The binder MUST NOT have left it at the default-untyped sentinel under a different identity — it
+      # should match the translator's canonical Dynamic[Top].
       expect(result[:n]).to eq(Rigor::Type::Combinator.untyped)
     end
 
@@ -64,8 +61,7 @@ RSpec.describe Rigor::Inference::MethodParameterBinder do
       binder = described_class.new(environment: env, class_path: "Integer", singleton: true)
       result = binder.bind(def_node("def sqrt(n); n; end"))
 
-      # `Integer.sqrt(::int)` again degrades to Dynamic[Top] but the
-      # singleton path MUST be the one consulted.
+      # `Integer.sqrt(::int)` again degrades to Dynamic[Top] but the singleton path MUST be the one consulted.
       expect(result.keys).to eq([:n])
       expect(result[:n]).to eq(Rigor::Type::Combinator.untyped)
     end
@@ -88,8 +84,8 @@ RSpec.describe Rigor::Inference::MethodParameterBinder do
     end
 
     it "binds keyword parameters by name from RBS" do
-      # We pick a method that has at least one keyword parameter in
-      # core RBS. `Numeric#step` has `by:` and `to:` keywords.
+      # We pick a method that has at least one keyword parameter in core RBS. `Numeric#step` has `by:` and `to:`
+      # keywords.
       binder = described_class.new(environment: env, class_path: "Numeric", singleton: false)
       result = binder.bind(def_node("def step(by:, to:); by; end"))
 
@@ -143,13 +139,10 @@ RSpec.describe Rigor::Inference::MethodParameterBinder do
     end
 
     context "with every positional/keyword/rest/block slot kind bound from RBS" do
-      # A single fixture method exercising every ParamSlot kind in one
-      # pass: required/optional/rest/trailing positionals, required/
-      # optional keywords, keyword-rest, and a block. Each slot's RBS
-      # type is a distinct concrete nominal so a wrong RBS_TYPE_PROVIDERS
-      # lookup (wrong lambda, wrong `.index`/`.name` key) or a wrong
-      # `wrap_for_kind` argument surfaces as a mismatched class_name
-      # rather than merely "not Dynamic".
+      # A single fixture method exercising every ParamSlot kind in one pass: required/optional/rest/trailing
+      # positionals, required/optional keywords, keyword-rest, and a block. Each slot's RBS type is a distinct concrete
+      # nominal so a wrong RBS_TYPE_PROVIDERS lookup (wrong lambda, wrong `.index`/`.name` key) or a wrong
+      # `wrap_for_kind` argument surfaces as a mismatched class_name rather than merely "not Dynamic".
       def with_full_slot_demo
         Dir.mktmpdir do |dir|
           FileUtils.mkdir_p(File.join(dir, "sig"))
@@ -183,10 +176,8 @@ RSpec.describe Rigor::Inference::MethodParameterBinder do
               type_args: [Rigor::Type::Combinator.nominal_of("Symbol"), Rigor::Type::Combinator.nominal_of("Numeric")]
             )
           )
-          # The block slot has no RBS counterpart to bind against (the
-          # `{ ... }` in the signature types the *call*, not a `&blk`
-          # parameter) — it MUST still be present in the entry scope,
-          # defaulted to Dynamic[Top].
+          # The block slot has no RBS counterpart to bind against (the `{ ... }` in the signature types the *call*, not
+          # a `&blk` parameter) — it MUST still be present in the entry scope, defaulted to Dynamic[Top].
           expect(result[:blk]).to equal(Rigor::Type::Combinator.untyped)
         end
       end

--- a/spec/rigor/inference/multi_target_binder_spec.rb
+++ b/spec/rigor/inference/multi_target_binder_spec.rb
@@ -87,10 +87,9 @@ RSpec.describe Rigor::Inference::MultiTargetBinder do
       expect(result).to eq(a: constant(1), b: constant(2), c: constant(3))
     end
 
-    # ADR-57 slice 3 — a destructured slot that flow typed as optional
-    # (`X | nil`) is softened to its non-nil constituent, because the nil is
-    # almost always excluded by a correlated invariant the per-slot flow
-    # cannot see (the canonical haml `parse_tag` case).
+    # ADR-57 slice 3 — a destructured slot that flow typed as optional (`X | nil`) is softened to its non-nil
+    # constituent, because the nil is almost always excluded by a correlated invariant the per-slot flow cannot see (the
+    # canonical haml `parse_tag` case).
     it "softens an optional `X | nil` slot to its non-nil constituent" do
       node = parse_multi_write("a, b = pair")
       optional = Rigor::Type::Combinator.union(constant("x"), constant(nil))

--- a/spec/rigor/inference/mutation_widening_spec.rb
+++ b/spec/rigor/inference/mutation_widening_spec.rb
@@ -7,11 +7,9 @@ require "rigor/inference/mutation_widening"
 require "rigor/scope"
 require "rigor/type"
 
-# Unit-level coverage for {Rigor::Inference::MutationWidening}.
-# The integration with `eval_call` (the actual G1 / G2
-# flow-folding gap closure) is exercised by the
-# end-to-end loop-mutation spec under `spec/integration/`;
-# this file pins the widening primitive in isolation.
+# Unit-level coverage for {Rigor::Inference::MutationWidening}. The integration with `eval_call` (the actual G1 / G2
+# flow-folding gap closure) is exercised by the end-to-end loop-mutation spec under `spec/integration/`; this file pins
+# the widening primitive in isolation.
 RSpec.describe Rigor::Inference::MutationWidening do
   describe ".pure_self_returner?" do
     it "recognizes freeze, dup, clone, and itself" do
@@ -91,12 +89,9 @@ RSpec.describe Rigor::Inference::MutationWidening do
   end
 
   describe ".widen_after_call" do
-    # Parses the last statement in `source` as a CallNode. We
-    # parse a multi-statement source so that local-variable reads
-    # in the target expression resolve to `LocalVariableReadNode`
-    # — Prism's parser needs an explicit assignment to a name
-    # before treating later occurrences as locals (otherwise they
-    # parse as zero-arg implicit-self calls).
+    # Parses the last statement in `source` as a CallNode. We parse a multi-statement source so that local-variable
+    # reads in the target expression resolve to `LocalVariableReadNode` — Prism's parser needs an explicit assignment to
+    # a name before treating later occurrences as locals (otherwise they parse as zero-arg implicit-self calls).
     def parse_call(source)
       Prism.parse(source).value.statements.body.last
     end
@@ -171,11 +166,9 @@ RSpec.describe Rigor::Inference::MutationWidening do
   end
 
   describe ".widen_after_block" do
-    # Parses a method body so that locals declared at method scope
-    # and read inside a block resolve as LocalVariableReadNode with
-    # `depth >= 1` (the outer-scope hop count Prism records).
-    # Returns the outer-most call carrying the block (the
-    # `.each do ... end` call site).
+    # Parses a method body so that locals declared at method scope and read inside a block resolve as
+    # LocalVariableReadNode with `depth >= 1` (the outer-scope hop count Prism records). Returns the outer-most call
+    # carrying the block (the `.each do ... end` call site).
     def parse_each_call(body_source)
       source = "def m\n#{body_source}\nend\n"
       def_node = Prism.parse(source).value.statements.body.first
@@ -209,8 +202,8 @@ RSpec.describe Rigor::Inference::MutationWidening do
     end
 
     it "is a no-op when the receiver is a block-local shadow (depth 0)" do
-      # `arr` in the block parameter list shadows the outer name —
-      # mutations on the shadow MUST NOT widen the outer binding.
+      # `arr` in the block parameter list shadows the outer name — mutations on the shadow MUST NOT widen the outer
+      # binding.
       call = parse_each_call(<<~RUBY)
         arr = [1]
         items.each do |arr|
@@ -234,9 +227,8 @@ RSpec.describe Rigor::Inference::MutationWidening do
     end
 
     it "does not descend into a nested call's own block" do
-      # Outer `arr.each` carries the relevant block; the nested
-      # `[1,2].each` block also contains `acc << x` but `acc`
-      # is the nested call's block scope, not ours.
+      # Outer `arr.each` carries the relevant block; the nested `[1,2].each` block also contains `acc << x` but `acc` is
+      # the nested call's block scope, not ours.
       call = parse_each_call(<<~RUBY)
         arr = [1]
         items.each do |x|
@@ -247,10 +239,8 @@ RSpec.describe Rigor::Inference::MutationWidening do
       RUBY
       seeded = Rigor::Scope.empty.with_local(:arr, tuple)
       result = described_class.widen_after_block(call_node: call, outer_scope: seeded)
-      # The recursive walk still finds the mutation; we just want
-      # to verify we don't crash on nesting. The widening MUST
-      # apply because the inner `arr` is still an outer-scope
-      # local (depth >= 1).
+      # The recursive walk still finds the mutation; we just want to verify we don't crash on nesting. The widening MUST
+      # apply because the inner `arr` is still an outer-scope local (depth >= 1).
       expect(result.local(:arr).class_name).to eq("Array")
     end
 
@@ -276,10 +266,9 @@ RSpec.describe Rigor::Inference::MutationWidening do
     end
   end
 
-  # ADR-56 slice C helpers — receiver-content element-type extraction and
-  # JOIN. Unlike the arity-forgetting widening above, these compute the
-  # exact continuation element/key/value types, so exact-`eq` assertions on
-  # the returned carriers are load-bearing.
+  # ADR-56 slice C helpers — receiver-content element-type extraction and JOIN. Unlike the arity-forgetting widening
+  # above, these compute the exact continuation element/key/value types, so exact-`eq` assertions on the returned
+  # carriers are load-bearing.
   describe ".collection_element_types" do
     let(:int_type) { Rigor::Type::Combinator.nominal_of("Integer") }
     let(:str_type) { Rigor::Type::Combinator.nominal_of("String") }
@@ -303,8 +292,7 @@ RSpec.describe Rigor::Inference::MutationWidening do
       tuple = Rigor::Type::Combinator.tuple_of(int_type)
       array = Rigor::Type::Combinator.nominal_of("Array", type_args: [str_type])
       union = Rigor::Type::Combinator.union(tuple, array)
-      # Combinator.union may reorder members, so assert set membership rather
-      # than element order.
+      # Combinator.union may reorder members, so assert set membership rather than element order.
       expect(described_class.send(:collection_element_types, union)).to contain_exactly(int_type, str_type)
     end
 
@@ -363,8 +351,7 @@ RSpec.describe Rigor::Inference::MutationWidening do
       hash = Rigor::Type::Combinator.nominal_of("Hash", type_args: [sym_type, str_type])
       union = Rigor::Type::Combinator.union(shape, hash)
       keys, values = described_class.send(:hash_shape_key_values, union)
-      # Combinator.union may reorder members, so assert set membership rather
-      # than pair order.
+      # Combinator.union may reorder members, so assert set membership rather than pair order.
       expect(keys).to contain_exactly(sym_type, sym_type)
       expect(values).to contain_exactly(int_type, str_type)
     end

--- a/spec/rigor/inference/narrowing_spec.rb
+++ b/spec/rigor/inference/narrowing_spec.rb
@@ -253,8 +253,8 @@ RSpec.describe Rigor::Inference::Narrowing do
       truthy, falsey = described_class.predicate_scopes(pred, bound)
       expect(truthy.local(:x)).to eq(integer_nominal)
       expect(truthy.local(:y)).to eq(string_nominal)
-      # Falsey edge unions the LHS-falsey scope (y untouched) with
-      # the LHS-truthy/RHS-falsey scope (x narrowed, y narrowed).
+      # Falsey edge unions the LHS-falsey scope (y untouched) with the LHS-truthy/RHS-falsey scope (x narrowed, y
+      # narrowed).
       expect(falsey.local(:x)).to eq(union_int_nil)
       expect(falsey.local(:y)).to eq(union_str_nil)
     end
@@ -266,8 +266,7 @@ RSpec.describe Rigor::Inference::Narrowing do
               .with_local(:y, union_str_nil)
       pred = parse_predicate("x || y")
       truthy, falsey = described_class.predicate_scopes(pred, bound)
-      # Truthy edge unions LHS-truthy (x narrowed, y untouched) with
-      # LHS-falsey/RHS-truthy (x = nil, y narrowed).
+      # Truthy edge unions LHS-truthy (x narrowed, y untouched) with LHS-falsey/RHS-truthy (x = nil, y narrowed).
       expect(truthy.local(:x)).to eq(union_int_nil)
       expect(truthy.local(:y)).to eq(union_str_nil)
       # Falsey edge: both are nil.
@@ -302,8 +301,8 @@ RSpec.describe Rigor::Inference::Narrowing do
       truthy, falsey = described_class.predicate_scopes(pred, bound)
       expect(truthy.local(:h).required_key?(:foo)).to be(true)
       expect(truthy.local(:h).optional_key?(:foo)).to be(false)
-      # §4-3 falsey edge: `key?` false proves `:foo` absent, so it is
-      # dropped from the shape (a subsequent `h[:foo]` reads nil).
+      # §4-3 falsey edge: `key?` false proves `:foo` absent, so it is dropped from the shape (a subsequent `h[:foo]`
+      # reads nil).
       expect(falsey.local(:h).pairs).not_to have_key(:foo)
       expect(falsey.local(:h).optional_key?(:foo)).to be(false)
     end
@@ -321,8 +320,8 @@ RSpec.describe Rigor::Inference::Narrowing do
       bound = scope.with_local(:h, required_shape)
       pred = parse_predicate("h.key?(:foo)", locals: %i[h])
       truthy, falsey = described_class.predicate_scopes(pred, bound)
-      # `key?` on a required key is always true → the predicate is opaque,
-      # both edges keep the shape unchanged (no false-edge key removal).
+      # `key?` on a required key is always true → the predicate is opaque, both edges keep the shape unchanged (no
+      # false-edge key removal).
       expect(truthy.local(:h)).to eq(required_shape)
       expect(falsey.local(:h)).to eq(required_shape)
     end
@@ -436,10 +435,8 @@ RSpec.describe Rigor::Inference::Narrowing do
       end
     end
 
-    # `if x = expr` — `StatementEvaluator#eval_local_write`
-    # binds `x` in `post_pred` before narrowing runs, so the
-    # write narrows the bound local on truthy/falsey edges the
-    # same way a bare local read does.
+    # `if x = expr` — `StatementEvaluator#eval_local_write` binds `x` in `post_pred` before narrowing runs, so the write
+    # narrows the bound local on truthy/falsey edges the same way a bare local read does.
     it "narrows the bound local through a bare assignment predicate" do
       bound = scope.with_local(:x, union_int_nil)
       pred = parse_predicate("x = recv()")
@@ -448,10 +445,8 @@ RSpec.describe Rigor::Inference::Narrowing do
       expect(falsey.local(:x)).to eq(constant_nil)
     end
 
-    # `if y && (x = expr)` — the Redmine-style guard. `&&`
-    # threads `truthy_left` into the right side, and the
-    # `LocalVariableWriteNode` (wrapped in ParenthesesNode) now
-    # narrows `x` on both edges so callers inside the truthy
+    # `if y && (x = expr)` — the Redmine-style guard. `&&` threads `truthy_left` into the right side, and the
+    # `LocalVariableWriteNode` (wrapped in ParenthesesNode) now narrows `x` on both edges so callers inside the truthy
     # block see the non-falsey fragment.
     it "narrows the bound local through `cond && (var = expr)`" do
       bound = scope
@@ -460,15 +455,12 @@ RSpec.describe Rigor::Inference::Narrowing do
       pred = parse_predicate("y && (x = recv())")
       truthy, falsey = described_class.predicate_scopes(pred, bound)
       expect(truthy.local(:x)).to eq(integer_nominal)
-      # Falsey edge: LHS falsey OR (LHS truthy AND RHS falsey)
-      # — `x` falls back to its joined post-predicate binding.
+      # Falsey edge: LHS falsey OR (LHS truthy AND RHS falsey) — `x` falls back to its joined post-predicate binding.
       expect(falsey.local(:x)).not_to eq(integer_nominal)
     end
 
-    # `if y && x = expr` (no parens). Ruby parses this as
-    # `y && (x = expr)` (`=` ends a complete expression
-    # inside `&&`'s RHS), so the AST shape is the same as the
-    # parenthesised form modulo the wrapping ParenthesesNode.
+    # `if y && x = expr` (no parens). Ruby parses this as `y && (x = expr)` (`=` ends a complete expression inside
+    # `&&`'s RHS), so the AST shape is the same as the parenthesised form modulo the wrapping ParenthesesNode.
     it "narrows the bound local through `cond && var = expr` (no parens)" do
       bound = scope
               .with_local(:x, union_int_nil)
@@ -539,10 +531,8 @@ RSpec.describe Rigor::Inference::Narrowing do
       expect(falsey.local(:x)).to eq(literal_b)
     end
 
-    # v0.1.1 Track 1 slice 4 — `String#start_with?` /
-    # `#end_with?` / `#include?` against a literal needle
-    # attaches a flow fact on each edge but does not change
-    # the receiver type (no "starts-with-X" carrier today).
+    # v0.1.1 Track 1 slice 4 — `String#start_with?` / `#end_with?` / `#include?` against a literal needle attaches a
+    # flow fact on each edge but does not change the receiver type (no "starts-with-X" carrier today).
     describe "String predicate flow facts (v0.1.1 Track 1 slice 4)" do
       %i[start_with? end_with? include?].each do |sel|
         it "attaches a #{sel} relational fact with the needle on both edges" do
@@ -660,8 +650,7 @@ RSpec.describe Rigor::Inference::Narrowing do
     end
 
     it "uses exact equality under instance_of?" do
-      # `Integer.new(...).instance_of?(Numeric)` is FALSE in Ruby
-      # (instance_of? is exact, not inclusive of subclasses).
+      # `Integer.new(...).instance_of?(Numeric)` is FALSE in Ruby (instance_of? is exact, not inclusive of subclasses).
       expect(described_class.narrow_class(integer_nominal, "Numeric", exact: true)).to eq(Rigor::Type::Combinator.bot)
     end
 
@@ -670,8 +659,8 @@ RSpec.describe Rigor::Inference::Narrowing do
     end
 
     it "leaves the type unchanged when the asked class is unknown to the host Ruby" do
-      # `Foo::Bar` is not defined in the test environment, so the
-      # ordering check returns `:unknown` and we stay conservative.
+      # `Foo::Bar` is not defined in the test environment, so the ordering check returns `:unknown` and we stay
+      # conservative.
       expect(described_class.narrow_class(integer_nominal, "Foo::Bar")).to eq(integer_nominal)
     end
 
@@ -703,8 +692,7 @@ RSpec.describe Rigor::Inference::Narrowing do
     end
 
     it "preserves Nominal[Numeric] under !is_a?(Integer)" do
-      # The narrower cannot prove a Numeric is NOT an Integer, so it
-      # stays conservative and preserves the type.
+      # The narrower cannot prove a Numeric is NOT an Integer, so it stays conservative and preserves the type.
       numeric = Rigor::Type::Combinator.nominal_of("Numeric")
       expect(described_class.narrow_not_class(numeric, "Integer")).to eq(numeric)
     end
@@ -716,9 +704,8 @@ RSpec.describe Rigor::Inference::Narrowing do
     end
 
     it "preserves Constant under instance_of? when v.class is a subclass of the asked class but not equal" do
-      # `1.instance_of?(Numeric)` is FALSE, so the falsey edge KEEPS
-      # Constant[1] (it does not satisfy the predicate, so it
-      # belongs to the not-class fragment).
+      # `1.instance_of?(Numeric)` is FALSE, so the falsey edge KEEPS Constant[1] (it does not satisfy the predicate, so
+      # it belongs to the not-class fragment).
       expect(described_class.narrow_not_class(integer_one, "Numeric", exact: true)).to eq(integer_one)
     end
   end
@@ -745,10 +732,8 @@ RSpec.describe Rigor::Inference::Narrowing do
     it "uses exact matching for instance_of?" do
       numeric = Rigor::Type::Combinator.nominal_of("Numeric")
       bound = scope.with_local(:x, numeric)
-      # `Numeric#instance_of?(Numeric)` could be true (a literal
-      # Numeric instance) but `instance_of?(Integer)` requires the
-      # class to be exactly Integer. Under exact matching the
-      # truthy edge therefore collapses (we cannot prove it is
+      # `Numeric#instance_of?(Numeric)` could be true (a literal Numeric instance) but `instance_of?(Integer)` requires
+      # the class to be exactly Integer. Under exact matching the truthy edge therefore collapses (we cannot prove it is
       # Integer-exact from a Nominal[Numeric] alone).
       pred = parse_predicate("x.instance_of?(Integer)")
       truthy, falsey = described_class.predicate_scopes(pred, bound)
@@ -783,8 +768,8 @@ RSpec.describe Rigor::Inference::Narrowing do
       bound = scope.with_local(:x, union_int_str)
       pred = parse_predicate("!x.is_a?(Integer)")
       truthy, falsey = described_class.predicate_scopes(pred, bound)
-      # `!x.is_a?(Integer)` is true exactly when x is not an Integer,
-      # so the truthy edge is the falsey edge of `x.is_a?(Integer)`.
+      # `!x.is_a?(Integer)` is true exactly when x is not an Integer, so the truthy edge is the falsey edge of
+      # `x.is_a?(Integer)`.
       expect(truthy.local(:x)).to eq(string_nominal)
       expect(falsey.local(:x)).to eq(integer_nominal)
     end
@@ -803,8 +788,7 @@ RSpec.describe Rigor::Inference::Narrowing do
         pred = parse_predicate("/foo/ === x")
         truthy, falsey = described_class.predicate_scopes(pred, bound)
         expect(truthy.local(:x)).to eq(string_nominal)
-        # Falsey edge keeps the entry type — Regexp#=== returns
-        # false for non-Strings AND non-matching Strings.
+        # Falsey edge keeps the entry type — Regexp#=== returns false for non-Strings AND non-matching Strings.
         expect(falsey.local(:x)).to eq(union_int_str)
       end
 
@@ -812,8 +796,7 @@ RSpec.describe Rigor::Inference::Narrowing do
         bound = scope.with_local(:x, union_int_str)
         pred = parse_predicate("(1..10) === x")
         truthy, _falsey = described_class.predicate_scopes(pred, bound)
-        # x must be Numeric on the truthy edge; the Integer member
-        # of the union survives, String is dropped.
+        # x must be Numeric on the truthy edge; the Integer member of the union survives, String is dropped.
         expect(truthy.local(:x)).to eq(integer_nominal)
       end
 
@@ -889,9 +872,8 @@ RSpec.describe Rigor::Inference::Narrowing do
       end
 
       it "leaves non-Integer Constants untouched (Bot rather than widen)" do
-        # `Constant["foo"]` cannot satisfy `> 0`; collapses to Bot
-        # rather than the analyser silently leaving a non-numeric
-        # value on the truthy edge of an integer comparison.
+        # `Constant["foo"]` cannot satisfy `> 0`; collapses to Bot rather than the analyser silently leaving a
+        # non-numeric value on the truthy edge of an integer comparison.
         c = Rigor::Type::Combinator.constant_of("foo")
         expect(described_class.narrow_integer_comparison(c, :>, 0))
           .to be_a(Rigor::Type::Bot)
@@ -992,8 +974,7 @@ RSpec.describe Rigor::Inference::Narrowing do
     end
 
     it "narrows zero? to Constant[0] / Nominal[Integer]" do
-      # truthy: Nominal[Integer] -> Constant[0]
-      # falsey: Nominal[Integer] -> preserved (cannot punch a hole)
+      # truthy: Nominal[Integer] -> Constant[0] falsey: Nominal[Integer] -> preserved (cannot punch a hole)
       expect_truthy_falsey(
         :zero?,
         Rigor::Type::Combinator.constant_of(0),
@@ -1180,9 +1161,8 @@ RSpec.describe Rigor::Inference::Narrowing do
         end
       RUBY
       body = first_when_body_scope(case_node, bound)
-      # `Nominal[String]` is not integer-rooted; the existing
-      # class-narrowing path runs and produces `narrow_class(String, "Numeric")`,
-      # which collapses to Bot since String is disjoint from Numeric.
+      # `Nominal[String]` is not integer-rooted; the existing class-narrowing path runs and produces
+      # `narrow_class(String, "Numeric")`, which collapses to Bot since String is disjoint from Numeric.
       expect(body.local(:n)).to be_a(Rigor::Type::Bot)
     end
   end
@@ -1198,11 +1178,9 @@ RSpec.describe Rigor::Inference::Narrowing do
     let(:integer_nominal) { Rigor::Type::Combinator.nominal_of("Integer") }
     let(:string_nominal) { Rigor::Type::Combinator.nominal_of("String") }
 
-    # Parses a `case` statement with `x` declared as a local
-    # (via the existing `parse_program(locals:)` helper) so
-    # Prism resolves the bare `x` subject as a
-    # `LocalVariableReadNode` rather than the variable-call
-    # `CallNode` that an unbound bare read parses to.
+    # Parses a `case` statement with `x` declared as a local (via the existing `parse_program(locals:)` helper) so Prism
+    # resolves the bare `x` subject as a `LocalVariableReadNode` rather than the variable-call `CallNode` that an
+    # unbound bare read parses to.
     def parse_case_of_x(case_source)
       parse_program(case_source).statements.body.first
     end
@@ -1308,8 +1286,7 @@ RSpec.describe Rigor::Inference::Narrowing do
     end
 
     it "falls back to Difference[String, refined] when no complement pair is registered" do
-      # decimal-int-string has no complement pair registered today, so the
-      # carrier-of-last-resort still applies.
+      # decimal-int-string has no complement pair registered today, so the carrier-of-last-resort still applies.
       di = Rigor::Type::Combinator.decimal_int_string
       result = described_class.narrow_not_refinement(nominal("String"), di)
       expect(result).to eq(Rigor::Type::Combinator.difference(nominal("String"), di))
@@ -1318,9 +1295,8 @@ RSpec.describe Rigor::Inference::Narrowing do
     it "drops the negated refinement itself from a union" do
       lc = Rigor::Type::Combinator.lowercase_string
       union = Rigor::Type::Combinator.union(lc, nominal("Integer"))
-      # ~lowercase-string within (lowercase-string | Integer) = Integer
-      # (Integer is disjoint from String; the lowercase-string member
-      # is the exact negated subset and drops).
+      # ~lowercase-string within (lowercase-string | Integer) = Integer (Integer is disjoint from String; the
+      # lowercase-string member is the exact negated subset and drops).
       expect(described_class.narrow_not_refinement(union, lc)).to eq(nominal("Integer"))
     end
 
@@ -1329,8 +1305,7 @@ RSpec.describe Rigor::Inference::Narrowing do
       union = Rigor::Type::Combinator.union(nominal("String"), nominal("Integer"))
       result = described_class.narrow_not_refinement(union, lc)
       expect(result).to be_a(Rigor::Type::Union)
-      # The Integer member is disjoint from String and survives;
-      # the String member becomes non-lowercase-string via the
+      # The Integer member is disjoint from String and survives; the String member becomes non-lowercase-string via the
       # paired-complement registry.
       expect(result.members).to contain_exactly(
         nominal("Integer"),
@@ -1375,16 +1350,15 @@ RSpec.describe Rigor::Inference::Narrowing do
       end
 
       it "narrows an existing IntegerRange to its meet with the complement halves" do
-        # current = int<0, 20>, refinement = int<5, 10>
-        # ~int<5, 10> ∩ int<0, 20> = int<0, 4> | int<11, 20>
+        # current = int<0, 20>, refinement = int<5, 10> ~int<5, 10> ∩ int<0, 20> = int<0, 4> | int<11, 20>
         result = described_class.narrow_not_refinement(integer_range(0, 20), integer_range(5, 10))
         expect(result).to be_a(Rigor::Type::Union)
         expect(result.members).to contain_exactly(integer_range(0, 4), integer_range(11, 20))
       end
 
       it "drops a Constant[Integer] outside both complement halves" do
-        # current = Constant[7], refinement = int<5, 10>; 7 is in [5,10]
-        # so its complement against [5,10] is empty — return current_type unchanged.
+        # current = Constant[7], refinement = int<5, 10>; 7 is in [5,10] so its complement against [5,10] is empty —
+        # return current_type unchanged.
         result = described_class.narrow_not_refinement(constant_of(7), integer_range(5, 10))
         expect(result).to eq(constant_of(7))
       end

--- a/spec/rigor/inference/parameter_inference_collector_spec.rb
+++ b/spec/rigor/inference/parameter_inference_collector_spec.rb
@@ -5,9 +5,8 @@ require "tmpdir"
 require "rigor/inference/parameter_inference_collector"
 require "rigor/environment"
 
-# ADR-67 WD3 — single-level call-site parameter inference. A parameter's
-# inferred type is the union of resolved call-site argument types; an argument
-# that is itself untyped (the fixpoint case) poisons the parameter.
+# ADR-67 WD3 — single-level call-site parameter inference. A parameter's inferred type is the union of resolved
+# call-site argument types; an argument that is itself untyped (the fixpoint case) poisons the parameter.
 RSpec.describe Rigor::Inference::ParameterInferenceCollector do
   def collect(*sources, max_rounds: described_class::DEFAULT_ROUNDS)
     Dir.mktmpdir do |dir|
@@ -52,9 +51,8 @@ RSpec.describe Rigor::Inference::ParameterInferenceCollector do
         end
       end
     RUBY
-    # `widget.run(Widget.new)` — widget is untyped, so the receiver does not
-    # resolve and this call is skipped; the test asserts only that the
-    # collector does not crash and produces no false entry for `run`.
+    # `widget.run(Widget.new)` — widget is untyped, so the receiver does not resolve and this call is skipped; the test
+    # asserts only that the collector does not crash and produces no false entry for `run`.
     expect(table[["Widget", :run, :instance]]).to be_nil
   end
 
@@ -173,8 +171,8 @@ RSpec.describe Rigor::Inference::ParameterInferenceCollector do
       end
     RUBY
     table = collect(source)
-    # `middle.x` is concrete in round 1 (called with `A.new`); `inner.y` is only
-    # reachable in round 2, once `x` is seeded so `inner(x)` types `x` as `A`.
+    # `middle.x` is concrete in round 1 (called with `A.new`); `inner.y` is only reachable in round 2, once `x` is
+    # seeded so `inner(x)` types `x` as `A`.
     expect(table.fetch(["Hub", :middle, :instance])[:x].describe(:short)).to eq("A")
     expect(table.fetch(["Hub", :inner, :instance])[:y].describe(:short)).to eq("A")
   end

--- a/spec/rigor/inference/parameter_inference_seeding_spec.rb
+++ b/spec/rigor/inference/parameter_inference_seeding_spec.rb
@@ -6,10 +6,9 @@ require "rigor/inference/protection_scanner"
 require "rigor/scope"
 require "rigor/type"
 
-# ADR-67 WD3 consumption side — `build_method_entry_scope` seeds an undeclared
-# parameter from the `param_inferred_types` table. Exercised through the
-# protection scanner (its `Scope#type_of` path runs the method-entry seed), the
-# same surface `coverage --protection` measures.
+# ADR-67 WD3 consumption side — `build_method_entry_scope` seeds an undeclared parameter from the `param_inferred_types`
+# table. Exercised through the protection scanner (its `Scope#type_of` path runs the method-entry seed), the same
+# surface `coverage --protection` measures.
 RSpec.describe "ADR-67 WD3 inferred-parameter seeding" do
   def scan(source, table)
     root = Prism.parse(source).value
@@ -46,11 +45,10 @@ RSpec.describe "ADR-67 WD3 inferred-parameter seeding" do
   end
 
   it "does not override an RBS-declared parameter (RBS wins)" do
-    # `String#upcase` is declared, so even a (wrong) seeded Integer entry must
-    # not replace the declared parameter — the binder produced a concrete
-    # (non-untyped) type, which the seed leaves untouched. Here the parameter
-    # has no RBS sig, so we assert the inverse via a singleton kind mismatch:
-    # an entry keyed :singleton must not seed an :instance method.
+    # `String#upcase` is declared, so even a (wrong) seeded Integer entry must not replace the declared parameter — the
+    # binder produced a concrete (non-untyped) type, which the seed leaves untouched. Here the parameter has no RBS sig,
+    # so we assert the inverse via a singleton kind mismatch: an entry keyed :singleton must not seed an :instance
+    # method.
     table = { ["Processor", :process, :singleton] => { item: string_type } }
     result = scan(<<~RUBY, table)
       class Processor

--- a/spec/rigor/inference/precision_scanner_spec.rb
+++ b/spec/rigor/inference/precision_scanner_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe Rigor::Inference::PrecisionScanner do
 
   describe "non-expression node exclusion" do
     it "counts only the value expression, not its Program/Statements wrappers" do
-      # `1` parses as Program > Statements > IntegerNode; the two
-      # wrappers are non-expressions and must not be counted.
+      # `1` parses as Program > Statements > IntegerNode; the two wrappers are non-expressions and must not be counted.
       result = scan("1\n")
       expect(result.total).to eq(1)
       expect(result.tier_counts.fetch(:constant)).to eq(1)
@@ -21,10 +20,8 @@ RSpec.describe Rigor::Inference::PrecisionScanner do
     end
 
     it "skips the ArgumentsNode container but counts the call and its arguments" do
-      # `foo(1, 2)` => Call + Arguments + two Integers (+ Program /
-      # Statements). Counted: the CallNode (opaque — foo is unknown)
-      # and the two Integer literals (constant). Arguments / Program /
-      # Statements are skipped.
+      # `foo(1, 2)` => Call + Arguments + two Integers (+ Program / Statements). Counted: the CallNode (opaque — foo is
+      # unknown) and the two Integer literals (constant). Arguments / Program / Statements are skipped.
       result = scan("foo(1, 2)\n")
       expect(result.total).to eq(3)
       expect(result.tier_counts.fetch(:constant)).to eq(2)
@@ -32,8 +29,8 @@ RSpec.describe Rigor::Inference::PrecisionScanner do
     end
 
     it "does not count parameter declarations in a method definition" do
-      # The def's parameter list and each RequiredParameterNode are
-      # non-expressions; the parameter *reads* in the body are not.
+      # The def's parameter list and each RequiredParameterNode are non-expressions; the parameter *reads* in the body
+      # are not.
       result = scan("def f(a, b)\n  a\nend\n")
       expect(result.total).to eq(2) # the DefNode + the `a` read
     end
@@ -101,8 +98,8 @@ RSpec.describe Rigor::Inference::PrecisionScanner do
     end
 
     it "precision_ratio and opaque_ratio handle a zero-expression file without error" do
-      # A source containing only comments has no expression nodes —
-      # totals will be 0 and both ratios must not divide by zero.
+      # A source containing only comments has no expression nodes — totals will be 0 and both ratios must not divide by
+      # zero.
       result = scan("# no expressions\n")
       expect(result.total).to eq(0)
       expect(result.precision_ratio).to eq(1.0)
@@ -142,9 +139,8 @@ RSpec.describe Rigor::Inference::PrecisionScanner do
   end
 
   describe "FileResult tier accessors (exact per-tier counts)" do
-    # The existing helper tests assert ratios and self-referential sums,
-    # so the per-tier `tier_counts.fetch` reads survive mutation. Pin the
-    # exact counts to bite a wrong key / default.
+    # The existing helper tests assert ratios and self-referential sums, so the per-tier `tier_counts.fetch` reads
+    # survive mutation. Pin the exact counts to bite a wrong key / default.
     let(:result) do
       described_class::FileResult.new(
         total: 9,
@@ -169,9 +165,8 @@ RSpec.describe Rigor::Inference::PrecisionScanner do
     end
 
     it "defaults absent tiers to zero across every accessor" do
-      # An empty count map exercises each `fetch(tier, 0)` default — the
-      # present-key cases above never reach it, so the default survives
-      # mutation unless a key is genuinely absent.
+      # An empty count map exercises each `fetch(tier, 0)` default — the present-key cases above never reach it, so the
+      # default survives mutation unless a key is genuinely absent.
       empty = described_class::FileResult.new(total: 0, tier_counts: {})
 
       expect(empty.precise_count).to eq(0)

--- a/spec/rigor/inference/project_patched_scanner_spec.rb
+++ b/spec/rigor/inference/project_patched_scanner_spec.rb
@@ -180,9 +180,8 @@ RSpec.describe Rigor::Inference::ProjectPatchedScanner do
         outcome = described_class.scan([path])
         diag = outcome.diagnostics.first
         expect(diag[:rule]).to eq("pre-eval.parse-error")
-        # The parse-error message is distinct from the read-failure one
-        # below — assert the specific text so a bypass to the rescue
-        # (which also names the path) does not satisfy this.
+        # The parse-error message is distinct from the read-failure one below — assert the specific text so a bypass to
+        # the rescue (which also names the path) does not satisfy this.
         expect(diag[:message]).to include("has a parse error").and include("broken.rb")
       end
     end

--- a/spec/rigor/inference/protection_scanner_spec.rb
+++ b/spec/rigor/inference/protection_scanner_spec.rb
@@ -5,9 +5,8 @@ require "prism"
 require "rigor/inference/protection_scanner"
 require "rigor/scope"
 
-# ADR-63 Tier 1 — the static type-protection proxy: a dispatch site is
-# protected when its receiver types concrete (Rigor's call rules can bite),
-# unprotected when the receiver is Dynamic.
+# ADR-63 Tier 1 — the static type-protection proxy: a dispatch site is protected when its receiver types concrete
+# (Rigor's call rules can bite), unprotected when the receiver is Dynamic.
 RSpec.describe Rigor::Inference::ProtectionScanner do
   def scan(source)
     root = Prism.parse(source).value

--- a/spec/rigor/inference/scope_indexer_spec.rb
+++ b/spec/rigor/inference/scope_indexer_spec.rb
@@ -36,8 +36,7 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
 
       expect(idx[program]).to eq(default_scope)
       expect(idx[assignment]).to eq(default_scope)
-      # The local-variable read happens AFTER the assignment, so its
-      # entry scope MUST carry `x` bound to Constant[1].
+      # The local-variable read happens AFTER the assignment, so its entry scope MUST carry `x` bound to Constant[1].
       expect(idx[read].local(:x)).to eq(Rigor::Type::Combinator.constant_of(1))
     end
 
@@ -66,9 +65,8 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
       rhs = assignment_y.value # CallNode for `x + 2`
       receiver = rhs.receiver  # LocalVariableReadNode for `x`
 
-      # The rvalue (and its receiver child) is reached via sub_eval from
-      # eval_local_write under the post-`x = 1` scope, so `x` MUST be
-      # visible at both the call and its receiver.
+      # The rvalue (and its receiver child) is reached via sub_eval from eval_local_write under the post-`x = 1` scope,
+      # so `x` MUST be visible at both the call and its receiver.
       expect(idx[rhs].local(:x)).to eq(Rigor::Type::Combinator.constant_of(1))
       expect(idx[receiver].local(:x)).to eq(Rigor::Type::Combinator.constant_of(1))
     end
@@ -88,18 +86,15 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
       x_inside_branch = then_statements[1] # LocalVariableReadNode for `x`
       expect(idx[x_inside_branch].local(:x)).to eq(Rigor::Type::Combinator.constant_of(1))
 
-      # After the if (with no else), nil-injection on the join-with-nil
-      # path makes `x` visible as `Constant[1] | Constant[nil]`.
+      # After the if (with no else), nil-injection on the join-with-nil path makes `x` visible as `Constant[1] |
+      # Constant[nil]`.
       expect(idx[after_if].local(:x)).to be_a(Rigor::Type::Union)
       expect(idx[after_if].local(:x).members.map(&:value)).to contain_exactly(1, nil)
     end
 
-    # Returns the index built for the canonical "expression-position
-    # conditional with a previously-bound x" shape, plus the
-    # LocalVariableReadNode for `x` extracted by `branch_path`. Pre-binding
-    # `x = nil` makes Prism parse the inner `x` as a local read; the
-    # surrounding `[]=` CallNode hides the conditional from
-    # StatementEvaluator's eval_if path.
+    # Returns the index built for the canonical "expression-position conditional with a previously-bound x" shape, plus
+    # the LocalVariableReadNode for `x` extracted by `branch_path`. Pre-binding `x = nil` makes Prism parse the inner
+    # `x` as a local read; the surrounding `[]=` CallNode hides the conditional from StatementEvaluator's eval_if path.
     def index_and_x_read_for(conditional, branch_path)
       program = parse("x = nil; cache[:k] = #{conditional}")
       assignment = program.statements.body[1]
@@ -159,12 +154,9 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
       )
     end
 
-    # v0.1.2 — Data.define / Struct.new block-body methods are
-    # registered under the constant's qualified name in both
-    # `discovered_methods` and `discovered_def_nodes`. Without
-    # this, the block-body `def initialize(...)` override is
-    # invisible to `Reflection.user_def_for` / `discovered_method?`
-    # and the canonical-sig contract is missing.
+    # v0.1.2 — Data.define / Struct.new block-body methods are registered under the constant's qualified name in both
+    # `discovered_methods` and `discovered_def_nodes`. Without this, the block-body `def initialize(...)` override is
+    # invisible to `Reflection.user_def_for` / `discovered_method?` and the canonical-sig contract is missing.
     it "registers Data.define block-body methods under the constant's name" do
       program = parse(<<~RUBY)
         Point = Data.define(:x, :y) do
@@ -206,9 +198,8 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
       expect(scope.discovered_method?("Row", :to_pair, :instance)).to be(true)
     end
 
-    # Module-singleton call resolution (ADR-57 follow-up) — singleton-side
-    # def-node table that `ExpressionTyper#try_singleton_method_inference`
-    # re-types against a `Singleton[X]` receiver.
+    # Module-singleton call resolution (ADR-57 follow-up) — singleton-side def-node table that
+    # `ExpressionTyper#try_singleton_method_inference` re-types against a `Singleton[X]` receiver.
     it "records `def self.x` / `def Foo.x` / `class << self` singleton def-nodes" do
       program = parse(<<~RUBY)
         module Util
@@ -283,14 +274,10 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
       expect(scope.discovered_method?("Coord", :lng, :instance)).to be(true)
     end
 
-    # Survey item (e) — `Const = Module.new do ... end` and
-    # `Const = Class.new(?super) do ... end` are block-as-method
-    # idioms that mirror the Data.define / Struct.new shape: the
-    # block body holds method overrides whose canonical class is
-    # the named constant. Driven by `references/ruby/lib/resolv.rb`
-    # (~8 sites) where `ClassHash = Module.new do; def []=; ...; end; end`
-    # registers an instance method that `ClassHash[k] = v` then
-    # calls.
+    # Survey item (e) — `Const = Module.new do ... end` and `Const = Class.new(?super) do ... end` are block-as-method
+    # idioms that mirror the Data.define / Struct.new shape: the block body holds method overrides whose canonical class
+    # is the named constant. Driven by `references/ruby/lib/resolv.rb` (~8 sites) where `ClassHash = Module.new do; def
+    # []=; ...; end; end` registers an instance method that `ClassHash[k] = v` then calls.
     it "registers Module.new block-body methods under the constant's name" do
       program = parse(<<~RUBY)
         ClassHash = Module.new do
@@ -425,9 +412,8 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
     end
 
     it "narrows IfNode branches when the conditional sits in expression position" do
-      # `x = nil` makes x's entry type Constant[nil]; narrow_truthy collapses
-      # it to Bot. Without branch-aware propagation x would still read as
-      # Constant[nil] inside the truthy branch.
+      # `x = nil` makes x's entry type Constant[nil]; narrow_truthy collapses it to Bot. Without branch-aware
+      # propagation x would still read as Constant[nil] inside the truthy branch.
       idx, x_read = index_and_x_read_for("if x; x.foo; else; default; end",
                                          ->(n) { n.statements.body.first })
       expect(x_read).to be_a(Prism::LocalVariableReadNode)
@@ -435,8 +421,8 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
     end
 
     it "narrows UnlessNode branches in expression position (mirror of IfNode)" do
-      # `unless x` runs the body when x is falsey; the else branch is the
-      # truthy edge, so x narrows away from Constant[nil] (collapsing to Bot).
+      # `unless x` runs the body when x is falsey; the else branch is the truthy edge, so x narrows away from
+      # Constant[nil] (collapsing to Bot).
       idx, x_read = index_and_x_read_for("unless x; default; else; x.foo; end",
                                          ->(n) { n.else_clause.statements.body.first })
       expect(x_read).to be_a(Prism::LocalVariableReadNode)
@@ -444,10 +430,9 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
     end
 
     it "honors propagation order so visited entries are not overwritten" do
-      # `(x = 1; x)` : the parens visit the inner StatementsNode and the
-      # local-variable read; after StatementEvaluator runs, propagate
-      # MUST NOT overwrite the read's scope (which has `x` bound) with
-      # the parens' entry scope (which does not).
+      # `(x = 1; x)` : the parens visit the inner StatementsNode and the local-variable read; after StatementEvaluator
+      # runs, propagate MUST NOT overwrite the read's scope (which has `x` bound) with the parens' entry scope (which
+      # does not).
       program, idx = index_for("(x = 1; x)")
       parens = program.statements.body.first
       inner_read = parens.body.body[1] # LocalVariableReadNode
@@ -457,10 +442,8 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
     end
 
     it "does not invoke the StatementEvaluator's tracer (it is built tracer-free)" do
-      # If the indexer threaded a tracer, the user's later type_of probe
-      # would see double-counted events. The indexer's StatementEvaluator
-      # MUST run with no tracer so events come only from the post-index
-      # type_of call.
+      # If the indexer threaded a tracer, the user's later type_of probe would see double-counted events. The indexer's
+      # StatementEvaluator MUST run with no tracer so events come only from the post-index type_of call.
       tracer = Rigor::Inference::FallbackTracer.new
       program = parse("foo(1)")
       idx = described_class.index(program, default_scope: default_scope)
@@ -477,14 +460,11 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
       expect(idx[foreign]).to eq(default_scope)
     end
 
-    # Regression: kwarg default value expressions execute when the
-    # method is INVOKED, so their `self` is the instance — not the
-    # surrounding class body's `self`. Previously the scope-index
-    # filled parameter-subtree nodes with the outer class-body
-    # scope (`self_type = singleton(C)`) via `propagate`, causing
-    # `def copy(x: self.foo)`-style idioms to be analysed as
-    # singleton-side calls. Observed surfacing 915 false positives
-    # in `prism-1.9.0`'s auto-generated `copy` methods.
+    # Regression: kwarg default value expressions execute when the method is INVOKED, so their `self` is the instance —
+    # not the surrounding class body's `self`. Previously the scope-index filled parameter-subtree nodes with the outer
+    # class-body scope (`self_type = singleton(C)`) via `propagate`, causing `def copy(x: self.foo)`-style idioms to be
+    # analysed as singleton-side calls. Observed surfacing 915 false positives in `prism-1.9.0`'s auto-generated `copy`
+    # methods.
     it "scopes parameter default values under the method's body scope (instance self)" do
       program = parse(<<~RUBY)
         class Foo
@@ -653,9 +633,8 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
       mid = program.statements.body.first.body.body.first
       def_node = mid.body.body.first
       method_body_scope = idx[def_node.body.body.first]
-      # The fresh method-body scope still sees declared_types so a
-      # later override probe (e.g. SelfNode lookup, or a future
-      # constant-position annotation inside the body) can resolve.
+      # The fresh method-body scope still sees declared_types so a later override probe (e.g. SelfNode lookup, or a
+      # future constant-position annotation inside the body) can resolve.
       expect(method_body_scope.declared_types).not_to be_empty
     end
   end
@@ -721,8 +700,7 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
       RUBY
       idx = described_class.index(program, default_scope: default_scope)
       outer_scope = idx[program]
-      # Not a singleton method of Foo::Bar; the receiver names a different
-      # constant so the slice does not promote.
+      # Not a singleton method of Foo::Bar; the receiver names a different constant so the slice does not promote.
       expect(outer_scope.discovered_method?("Foo::Bar", :unrelated, :singleton)).to be(false)
     end
   end
@@ -835,8 +813,7 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
         idx = described_class.index(program, default_scope: default_scope)
         outer = idx[program]
         type = outer.class_ivars_for("Pure")[:@struct]
-        # `.last` is NOT a mutator, so no widening fires; the
-        # seed precision is preserved.
+        # `.last` is NOT a mutator, so no widening fires; the seed precision is preserved.
         expect(type).to be_a(Rigor::Type::Tuple)
       end
     end
@@ -852,8 +829,7 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
         RUBY
         idx = described_class.index(program, default_scope: default_scope)
         outer = idx[program]
-        # No other writes to @x in the class — the skip means
-        # the accumulator has no entry for @x at all.
+        # No other writes to @x in the class — the skip means the accumulator has no entry for @x at all.
         expect(outer.class_ivars_for("C")).not_to have_key(:@x)
       end
 
@@ -880,8 +856,7 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
         RUBY
         idx = described_class.index(program, default_scope: default_scope)
         outer = idx[program]
-        # The non-falsey rvalue's union with `Constant[nil]`
-        # does NOT collapse, so the seed is preserved.
+        # The non-falsey rvalue's union with `Constant[nil]` does NOT collapse, so the seed is preserved.
         type = outer.class_ivars_for("C")[:@z]
         expect(type).not_to be_nil
       end
@@ -1098,8 +1073,7 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
           expect(values).to include(nil, true)
         end
 
-        # ADR-38 — a plugin-declared additional initializer is
-        # treated like `initialize` at the read-before-write gate.
+        # ADR-38 — a plugin-declared additional initializer is treated like `initialize` at the read-before-write gate.
         context "with a plugin-declared additional initializer (ADR-38)" do
           let(:setup_source) do
             <<~RUBY
@@ -1232,9 +1206,8 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
             members.any? { |m| m.is_a?(Rigor::Type::Constant) && m.value.nil? }
           end
 
-          # Without a declaration the block body is never descended, so the
-          # ivar is simply absent from the accumulator (no type at all — a
-          # different problem than nil-widening, but equally undesirable).
+          # Without a declaration the block body is never descended, so the ivar is simply absent from the accumulator
+          # (no type at all — a different problem than nil-widening, but equally undesirable).
           it "control: without declaration, @user is not collected from a block body" do
             outer = parse(before_block_source).then do |program|
               described_class.index(program, default_scope: default_scope)[program]
@@ -1242,8 +1215,8 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
             expect(user_type(outer)).to be_nil
           end
 
-          # With declaration: block body descended → type collected → init_writes
-          # suppresses the read-before-write nil contribution.
+          # With declaration: block body descended → type collected → init_writes suppresses the read-before-write nil
+          # contribution.
           it "collects @user and suppresses nil widening when `before` is a declared block_method" do
             entry = Rigor::Plugin::AdditionalInitializer.new(
               receiver_constraint: "FooSpec", block_methods: [:before]
@@ -1272,9 +1245,8 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
             expect(user_type(outer)).to be_nil
           end
 
-          # A def-form `before` method is walked by collect_def_ivar_writes as
-          # usual. It is NOT in init_writes (block_methods: [:before] only covers
-          # block-form calls, not defs), so the read-before-write nil contribution
+          # A def-form `before` method is walked by collect_def_ivar_writes as usual. It is NOT in init_writes
+          # (block_methods: [:before] only covers block-form calls, not defs), so the read-before-write nil contribution
           # fires — the nil-widening IS the expected result here.
           it "nil-widens a def-form `before` method even when block_methods: [:before] is declared" do
             entry = Rigor::Plugin::AdditionalInitializer.new(
@@ -1319,10 +1291,8 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
           idx = described_class.index(program, default_scope: default_scope)
           outer = idx[program]
           type = outer.class_ivars_for("StreamingServerManager")[:@running_thread]
-          # Class-body write exempts the read-before-write nil
-          # contribution. Without the exemption, an unjustified
-          # nil widening would propagate into Thread.new's block
-          # body and produce a `.kill for nil` style FP.
+          # Class-body write exempts the read-before-write nil contribution. Without the exemption, an unjustified nil
+          # widening would propagate into Thread.new's block body and produce a `.kill for nil` style FP.
           members = type.is_a?(Rigor::Type::Union) ? type.members : [type]
           expect(members.find { |m| m.is_a?(Rigor::Type::Constant) && m.value.nil? }).to be_nil
         end
@@ -1342,19 +1312,15 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
         RUBY
         idx = described_class.index(program, default_scope: default_scope)
         outer = idx[program]
-        # The falsey-default write itself is skipped — the
-        # `init` write still seeds `@w` to its rvalue type. The
-        # B2.3 read-before-write pre-pass additionally unions
-        # `nil` here because `configure` reads `@w` before any
-        # write IN THAT METHOD BODY and `init` is NOT
-        # `initialize` (so the soundness gate's "constructor
-        # initialised" exemption does not apply).
+        # The falsey-default write itself is skipped — the `init` write still seeds `@w` to its rvalue type. The B2.3
+        # read-before-write pre-pass additionally unions `nil` here because `configure` reads `@w` before any write IN
+        # THAT METHOD BODY and `init` is NOT `initialize` (so the soundness gate's "constructor initialised" exemption
+        # does not apply).
         type = outer.class_ivars_for("C")[:@w]
         expect(type).to be_a(Rigor::Type::Union)
         member_kinds = type.members.map(&:class)
         expect(member_kinds).to include(Rigor::Type::Constant)
-        # And `init`'s rvalue precision survives — the union
-        # carries `Constant["hello"]` (plus the read-before-write
+        # And `init`'s rvalue precision survives — the union carries `Constant["hello"]` (plus the read-before-write
         # `Constant[nil]`).
         constant_member = type.members.find { |m| m.is_a?(Rigor::Type::Constant) && m.value == "hello" }
         expect(constant_member).not_to be_nil
@@ -1391,9 +1357,8 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
         idx = described_class.index(program, default_scope: default_scope)
         outer = idx[program]
         type = outer.class_ivars_for("B")[:@thr]
-        # An unanalyzable parallel assignment means *unknown*, not nil —
-        # the sound floor is Dynamic[top]. A pure-nil seed here is the N1
-        # bug (it false-fires `@thr.alive?` undefined-for-nil).
+        # An unanalyzable parallel assignment means *unknown*, not nil — the sound floor is Dynamic[top]. A pure-nil
+        # seed here is the N1 bug (it false-fires `@thr.alive?` undefined-for-nil).
         expect(type).to be_a(Rigor::Type::Dynamic)
       end
 
@@ -1441,15 +1406,15 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
         idx = described_class.index(program, default_scope: default_scope)
         outer = idx[program]
         type = outer.class_ivars_for("G")[:@x]
-        # `@x` is written by both a single write (Constant[1]) and a
-        # multi-write (Dynamic from `y`) — the union carries both.
+        # `@x` is written by both a single write (Constant[1]) and a multi-write (Dynamic from `y`) — the union carries
+        # both.
         expect(type).to be_a(Rigor::Type::Union)
       end
     end
   end
 
-  # T1 — cross-file `Const = Class.new(Super)` discovery so a rescue /
-  # const reference in a sibling file resolves to the project class.
+  # T1 — cross-file `Const = Class.new(Super)` discovery so a rescue / const reference in a sibling file resolves to the
+  # project class.
   describe ".discovered_classes_for_paths with Class.new constants" do
     def with_files(files)
       Dir.mktmpdir do |dir|

--- a/spec/rigor/inference/statement_evaluator_spec.rb
+++ b/spec/rigor/inference/statement_evaluator_spec.rb
@@ -127,10 +127,9 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       expect(type.members.map(&:value)).to contain_exactly(1, 2, 3)
     end
 
-    # The surviving path of `if P then BODY else raise end` is BODY,
-    # so the post-scope must carry BODY's assignments forward — not the
-    # bare predicate narrowing, which would leave them unbound. Mirrors
-    # the case/when `drops a terminating else` rule.
+    # The surviving path of `if P then BODY else raise end` is BODY, so the post-scope must carry BODY's assignments
+    # forward — not the bare predicate narrowing, which would leave them unbound. Mirrors the case/when `drops a
+    # terminating else` rule.
     it "carries a then-body assignment past a terminating else (no nil-injection)" do
       _, post = evaluate(<<~RUBY)
         if cond
@@ -153,11 +152,9 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       expect(post.local(:x)).to eq(Rigor::Type::Combinator.constant_of(1))
     end
 
-    # Regression — liquid v5.x sweep, Event 3. The inner `elsif … else
-    # raise` previously returned the bare truthy narrowing (with `x`
-    # unbound), so the OUTER if's join nil-injected `x` into a spurious
-    # `… | nil`. Every reachable path assigns `x` (the else raises), so
-    # the post-scope must bind `x` without nil.
+    # Regression — liquid v5.x sweep, Event 3. The inner `elsif … else raise` previously returned the bare truthy
+    # narrowing (with `x` unbound), so the OUTER if's join nil-injected `x` into a spurious `… | nil`. Every reachable
+    # path assigns `x` (the else raises), so the post-scope must bind `x` without nil.
     it "binds a local across an if/elsif/else-raise chain without nil-injection" do
       _, post = evaluate(<<~RUBY)
         if a
@@ -237,11 +234,9 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
           v
         end
       RUBY
-      # The then-branch sees `v` narrowed to non-nil (`"[x]"`); the
-      # if-as-a-whole unions in the falsey `nil`. The discriminator is
-      # that the then-branch value is NOT nilable — without the safe-nav
-      # narrowing `v.end_with?` would have fired possible-nil and `v`
-      # inside would stay `"[x]" | nil`.
+      # The then-branch sees `v` narrowed to non-nil (`"[x]"`); the if-as-a-whole unions in the falsey `nil`. The
+      # discriminator is that the then-branch value is NOT nilable — without the safe-nav narrowing `v.end_with?` would
+      # have fired possible-nil and `v` inside would stay `"[x]" | nil`.
       expect(type.members.map(&:value)).to contain_exactly("[x]", nil)
     end
 
@@ -252,9 +247,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
           v.upcase
         end
       RUBY
-      # `v.upcase` runs on a non-nil receiver and constant-folds to
-      # `"[X]"`; the falsey branch unions `nil`. Without the safe-nav
-      # narrowing `v` would stay nilable and `upcase` could not fold.
+      # `v.upcase` runs on a non-nil receiver and constant-folds to `"[X]"`; the falsey branch unions `nil`. Without the
+      # safe-nav narrowing `v` would stay nilable and `upcase` could not fold.
       expect(type.members.map(&:value)).to contain_exactly("[X]", nil)
     end
   end
@@ -329,12 +323,10 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       expect(type.members.map(&:value)).to contain_exactly(2, 3)
     end
 
-    # When a rescue arm unconditionally exits (`return`, `next`,
-    # `break`, `raise`, `throw`, `exit`, `abort`, `fail`),
-    # control cannot reach the post-begin scope via that arm, so
-    # it contributes neither a value-fragment nor a scope-binding
-    # to the join. The primary body's bindings survive without
-    # nil-injection from the (unreachable) rescue path.
+    # When a rescue arm unconditionally exits (`return`, `next`, `break`, `raise`, `throw`, `exit`, `abort`, `fail`),
+    # control cannot reach the post-begin scope via that arm, so it contributes neither a value-fragment nor a
+    # scope-binding to the join. The primary body's bindings survive without nil-injection from the (unreachable) rescue
+    # path.
     it "drops a rescue arm whose body returns from the post-begin scope" do
       type, post = evaluate(<<~RUBY)
         x = begin
@@ -345,9 +337,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
         end
         x.size
       RUBY
-      # `list` survives without being widened by the
-      # (unreachable) rescue arm; `x` is the primary body's value
-      # type (Array<Integer>-shaped), so `.size` resolves cleanly.
+      # `list` survives without being widened by the (unreachable) rescue arm; `x` is the primary body's value type
+      # (Array<Integer>-shaped), so `.size` resolves cleanly.
       expect(post.local(:list)).to be_a(Rigor::Type::Tuple)
       expect(type).to be_a(Rigor::Type::Constant)
     end
@@ -361,8 +352,7 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
         end
         list
       RUBY
-      # `list` remains the primary-body Tuple — the rescue arm
-      # would have raised, never bound `list`, but its scope is
+      # `list` remains the primary-body Tuple — the rescue arm would have raised, never bound `list`, but its scope is
       # excluded so no nil-injection occurs.
       expect(post.local(:list)).to be_a(Rigor::Type::Tuple)
     end
@@ -388,24 +378,18 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
           return
         end
       RUBY
-      # The StandardError arm exits, so it contributes nothing;
-      # the TypeError arm survives and joins with the primary
-      # body. The post-scope's `x` is exactly { 1, 2 } — NOT
-      # widened by the exiting arm.
+      # The StandardError arm exits, so it contributes nothing; the TypeError arm survives and joins with the primary
+      # body. The post-scope's `x` is exactly { 1, 2 } — NOT widened by the exiting arm.
       expect(post.local(:x).members.map(&:value)).to contain_exactly(1, 2)
     end
   end
 
   describe "begin/rescue/retry (retry-edge widening)" do
-    # B2.1: when a rescue arm contains `retry` AND rebinds a local
-    # across the retry edge, the primary body observes the rebound
-    # local widened to its Nominal envelope (not the pre-retry
-    # Constant) because control can re-enter the primary body via
-    # that rescue arm. Without the widening, `tries += 1` inside
-    # the primary body would keep folding from `Constant[0]` on
-    # every notional retry pass instead of reflecting that `tries`
-    # can already be a live Integer by the time the primary body
-    # re-runs.
+    # B2.1: when a rescue arm contains `retry` AND rebinds a local across the retry edge, the primary body observes the
+    # rebound local widened to its Nominal envelope (not the pre-retry Constant) because control can re-enter the
+    # primary body via that rescue arm. Without the widening, `tries += 1` inside the primary body would keep folding
+    # from `Constant[0]` on every notional retry pass instead of reflecting that `tries` can already be a live Integer
+    # by the time the primary body re-runs.
     it "widens a local rebound across a retry edge to its Nominal envelope" do
       type, post = evaluate(<<~RUBY)
         tries = 0
@@ -435,11 +419,9 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     end
 
     it "widens a local introduced only inside the retrying rescue arm" do
-      # `y` has no pre-existing binding in the entry scope (the
-      # `pre.nil?` branch of `retry_widened_type`): the retry edge
-      # still widens it to its Nominal envelope rather than leaving
-      # it untouched, because the arm's own rebind cycles back
-      # through the primary body on retry.
+      # `y` has no pre-existing binding in the entry scope (the `pre.nil?` branch of `retry_widened_type`): the retry
+      # edge still widens it to its Nominal envelope rather than leaving it untouched, because the arm's own rebind
+      # cycles back through the primary body on retry.
       _type, post = evaluate(<<~RUBY)
         begin
           1
@@ -457,10 +439,9 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     end
 
     it "does NOT widen when the rescue arm does not contain retry" do
-      # Guards `arm_contains_retry?` / `widen_entry_for_retry`'s nil
-      # return: an ordinary (non-retrying) rescue arm rebinding the
-      # same local must keep the precise Constant union produced by
-      # the un-widened join, not a Nominal envelope.
+      # Guards `arm_contains_retry?` / `widen_entry_for_retry`'s nil return: an ordinary (non-retrying) rescue arm
+      # rebinding the same local must keep the precise Constant union produced by the un-widened join, not a Nominal
+      # envelope.
       _type, post = evaluate(<<~RUBY)
         tries = 0
         begin
@@ -473,9 +454,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     end
 
     it "re-evaluates the else-clause under the widened retry entry" do
-      # Exercises eval_begin_primary_under's else-clause branch
-      # (the primary body ran, then else replaces its value) under
-      # a widened entry produced by a sibling retry arm.
+      # Exercises eval_begin_primary_under's else-clause branch (the primary body ran, then else replaces its value)
+      # under a widened entry produced by a sibling retry arm.
       type, post = evaluate(<<~RUBY)
         tries = 0
         begin
@@ -508,11 +488,9 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     end
 
     it "re-evaluates every arm of a multi-rescue chain under the widened entry" do
-      # Only the first arm retries, but widen_entry_for_retry widens
-      # the shared entry scope once, and BOTH collect_rescue_chain_results
-      # calls (pre- and post-widening) walk the full rescue_clause
-      # chain — the second (non-retrying) arm's fresh evaluation
-      # must also be visible in the final union.
+      # Only the first arm retries, but widen_entry_for_retry widens the shared entry scope once, and BOTH
+      # collect_rescue_chain_results calls (pre- and post-widening) walk the full rescue_clause chain — the second
+      # (non-retrying) arm's fresh evaluation must also be visible in the final union.
       type, post = evaluate(<<~RUBY)
         tries = 0
         begin
@@ -560,9 +538,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
         end
       RUBY
       expect(type).to eq(Rigor::Type::Combinator.constant_of(nil))
-      # `i` is bound only inside the body, so the no-iteration join
-      # path nil-injects it into the post-loop scope. The element
-      # type comes from the Tuple[1, 2, 3] carrier.
+      # `i` is bound only inside the body, so the no-iteration join path nil-injects it into the post-loop scope. The
+      # element type comes from the Tuple[1, 2, 3] carrier.
       i_type = post.local(:i)
       members = i_type.members.map { |m| m.is_a?(Rigor::Type::Constant) ? m.value : m }
       expect(members).to include(1, 2, 3, nil)
@@ -573,10 +550,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
         for a, b in [[1, 2]]
         end
       RUBY
-      # `[[1, 2]]` is `Tuple[Tuple[1, 2]]`; the per-iteration element
-      # is `Tuple[1, 2]`, which the multi-target binder splits into
-      # `a: 1` and `b: 2`. The names are nil-injected through the
-      # zero-iteration join.
+      # `[[1, 2]]` is `Tuple[Tuple[1, 2]]`; the per-iteration element is `Tuple[1, 2]`, which the multi-target binder
+      # splits into `a: 1` and `b: 2`. The names are nil-injected through the zero-iteration join.
       expect(post.local(:a).members).to include(Rigor::Type::Combinator.constant_of(1))
       expect(post.local(:b).members).to include(Rigor::Type::Combinator.constant_of(2))
     end
@@ -614,9 +589,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
         for k, v in { a: 1, b: 2 }
         end
       RUBY
-      # `Hash#each` yields `[K, V]`; the multi-target binder splits
-      # that into per-iteration `k` and `v` bindings, nil-injected
-      # through the zero-iteration join.
+      # `Hash#each` yields `[K, V]`; the multi-target binder splits that into per-iteration `k` and `v` bindings,
+      # nil-injected through the zero-iteration join.
       k_members = post.local(:k).members.map { |m| m.is_a?(Rigor::Type::Constant) ? m.value : m }
       v_members = post.local(:v).members.map { |m| m.is_a?(Rigor::Type::Constant) ? m.value : m }
       expect(k_members).to include(:a, :b, nil)
@@ -629,8 +603,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
           y = "hi"
         end
       RUBY
-      # Unlike `each {}`, `for` does not introduce a new variable
-      # scope: writes inside the body are observable after the loop.
+      # Unlike `each {}`, `for` does not introduce a new variable scope: writes inside the body are observable after the
+      # loop.
       expect(post.local(:y).members.map(&:value)).to contain_exactly("hi", nil)
     end
   end
@@ -652,12 +626,10 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       expect(type.members.map(&:value)).to contain_exactly(1, "hi")
     end
 
-    # Early-return narrowing through the OR / AND seam, mirroring
-    # the `eval_if` / `eval_unless` `branch_unconditionally_exits?`
-    # path. When the RHS terminates (raise / return / throw / exit /
-    # abort / fail / next / break), the surviving control flow is
-    # the LHS-skipped edge alone, so the post-scope narrows the
-    # write target accordingly.
+    # Early-return narrowing through the OR / AND seam, mirroring the `eval_if` / `eval_unless`
+    # `branch_unconditionally_exits?` path. When the RHS terminates (raise / return / throw / exit / abort / fail / next
+    # / break), the surviving control flow is the LHS-skipped edge alone, so the post-scope narrows the write target
+    # accordingly.
     context "when the RHS unconditionally exits (early-return narrowing across or / and)" do
       let(:union_local) do
         Rigor::Type::Combinator.union(
@@ -675,8 +647,7 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
         _, post = bound_scope.evaluate(parse(<<~RUBY))
           (m = v) or raise "bad"
         RUBY
-        # The OR survives only when the LHS write is truthy; the
-        # nil fragment is removed from `m`.
+        # The OR survives only when the LHS write is truthy; the nil fragment is removed from `m`.
         expect(post.local(:m)).to be_a(Rigor::Type::Nominal)
         expect(post.local(:m).class_name).to eq("String")
       end
@@ -706,8 +677,7 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
         _, post = bound_scope.evaluate(parse(<<~RUBY))
           (m = v) and raise "got something"
         RUBY
-        # AND survives only when LHS is falsey, so `m` is the nil
-        # fragment.
+        # AND survives only when LHS is falsey, so `m` is the nil fragment.
         expect(post.local(:m)).to eq(Rigor::Type::Combinator.constant_of(nil))
       end
 
@@ -715,8 +685,7 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
         type, _post = bound_scope.evaluate(parse(<<~RUBY))
           (m = v) or raise "bad"
         RUBY
-        # Value of the OR expression is the truthy fragment of the
-        # LHS write — String only, no nil.
+        # Value of the OR expression is the truthy fragment of the LHS write — String only, no nil.
         expect(type).to be_a(Rigor::Type::Nominal)
         expect(type.class_name).to eq("String")
       end
@@ -769,8 +738,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       RUBY
       described_class.new(scope: scope, on_enter: on_enter).evaluate(ast)
 
-      # Sanity: every recursive sub_eval threads the callback so the
-      # rvalue (`x + 2`) is recorded with `x` already bound.
+      # Sanity: every recursive sub_eval threads the callback so the rvalue (`x + 2`) is recorded with `x` already
+      # bound.
       x_plus_2_event = events.find { |klass, _| klass == Prism::CallNode }
       expect(x_plus_2_event).not_to be_nil
       expect(x_plus_2_event[1]).to include(:x)
@@ -782,9 +751,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       ast = parse_program("foo(1)")
       described_class.new(scope: scope, on_enter: on_enter).evaluate(ast)
 
-      # The CallNode has no statement-evaluator handler; the default
-      # branch still fires on_enter so callers (the ScopeIndexer) can
-      # record its entry scope.
+      # The CallNode has no statement-evaluator handler; the default branch still fires on_enter so callers (the
+      # ScopeIndexer) can record its entry scope.
       expect(events).to include(Prism::CallNode)
     end
 
@@ -798,10 +766,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
   describe "DefNode / ClassNode handlers (Slice 3 phase 2 follow-up)" do
     let(:default_env_scope) { Rigor::Scope.empty(environment: Rigor::Environment.default) }
 
-    # Build an `on_enter` callback that records the entry-scope
-    # binding for `name` whenever the evaluator visits a
-    # LocalVariableReadNode for that name. Returns the events array
-    # (mutable) and the callback together.
+    # Build an `on_enter` callback that records the entry-scope binding for `name` whenever the evaluator visits a
+    # LocalVariableReadNode for that name. Returns the events array (mutable) and the callback together.
     def watch_local_reads(name)
       events = []
       on_enter = lambda do |node, s|
@@ -842,10 +808,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
           def self.sqrt(n); n; end
         end
       RUBY
-      # The singleton path was consulted (no exception, the local is
-      # bound to *some* type, possibly Dynamic[Top] when the RBS type
-      # is an interface alias). The structural property under test is
-      # that the local was bound at all.
+      # The singleton path was consulted (no exception, the local is bound to *some* type, possibly Dynamic[Top] when
+      # the RBS type is an interface alias). The structural property under test is that the local was bound at all.
       expect(events).not_to be_empty
       expect(events.first).not_to be_nil
     end
@@ -878,8 +842,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       class_body_scopes = []
       on_enter = ->(_node, s) { class_body_scopes << s.locals.keys.sort }
       described_class.new(scope: scope, on_enter: on_enter).evaluate(ast)
-      # The class body's children enter with the fresh empty scope
-      # (`[]`), even though the outer `x = 1` post-scope contains x.
+      # The class body's children enter with the fresh empty scope (`[]`), even though the outer `x = 1` post-scope
+      # contains x.
       expect(class_body_scopes).to include([])
     end
 
@@ -943,9 +907,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     end
 
     it "qualifies nested class names with :: without raising" do
-      # The binder's class_path is "A::B" here. Neither A nor A::B exist
-      # in core RBS, so x falls back to Dynamic[Top]; the structural
-      # test is just that no exception is raised.
+      # The binder's class_path is "A::B" here. Neither A nor A::B exist in core RBS, so x falls back to Dynamic[Top];
+      # the structural test is just that no exception is raised.
       ast = parse_program("class A; class B; def foo(x); x; end; end; end")
       expect { described_class.new(scope: scope).evaluate(ast) }.not_to raise_error
     end
@@ -960,8 +923,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
           end
         end
       RUBY
-      # The body of `bar` -- inside the ruby2_keywords(<DefNode>) call --
-      # sees self as Nominal[Foo] (instance method), NOT Singleton[Foo].
+      # The body of `bar` -- inside the ruby2_keywords(<DefNode>) call -- sees self as Nominal[Foo] (instance method),
+      # NOT Singleton[Foo].
       expect(observed).to include(Rigor::Type::Combinator.nominal_of("Foo"))
       expect(observed).not_to include(Rigor::Type::Combinator.singleton_of("Foo"))
     end
@@ -991,18 +954,14 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       )
     end
 
-    # Parse `source` with `x` and `y` pre-declared as locals so the
-    # parser produces `LocalVariableReadNode` rather than implicit
-    # `CallNode` references. Tests that need a different local set
-    # MAY pass `locals:`.
+    # Parse `source` with `x` and `y` pre-declared as locals so the parser produces `LocalVariableReadNode` rather than
+    # implicit `CallNode` references. Tests that need a different local set MAY pass `locals:`.
     def parse_with_locals(source, locals: %i[x y])
       Prism.parse(source, scopes: [locals]).value
     end
 
-    # Build an `on_enter` callback that records the entry-scope
-    # binding for `name` whenever the evaluator visits a
-    # LocalVariableReadNode for that name. Returns the events array
-    # (mutable) and the callback together.
+    # Build an `on_enter` callback that records the entry-scope binding for `name` whenever the evaluator visits a
+    # LocalVariableReadNode for that name. Returns the events array (mutable) and the callback together.
     def watch_local_reads(name)
       events = []
       on_enter = lambda do |node, s|
@@ -1025,9 +984,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       RUBY
       described_class.new(scope: bound, on_enter: on_enter).evaluate(ast)
 
-      # Predicate read sees the untouched union; the then-branch
-      # read sees x narrowed to Integer; the else-branch read sees
-      # x narrowed to Constant[nil].
+      # Predicate read sees the untouched union; the then-branch read sees x narrowed to Integer; the else-branch read
+      # sees x narrowed to Constant[nil].
       expect(events[0]).to eq(union_int_nil)
       expect(events[1]).to eq(Rigor::Type::Combinator.nominal_of("Integer"))
       expect(events[2]).to eq(Rigor::Type::Combinator.constant_of(nil))
@@ -1062,8 +1020,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       RUBY
       described_class.new(scope: bound, on_enter: on_enter).evaluate(ast)
 
-      # In `unless x` the body runs when x is falsey, the else-clause
-      # when x is truthy. The narrower swaps the two edges accordingly.
+      # In `unless x` the body runs when x is falsey, the else-clause when x is truthy. The narrower swaps the two edges
+      # accordingly.
       then_read, else_read = events.last(2)
       expect(then_read).to eq(Rigor::Type::Combinator.constant_of(nil))
       expect(else_read).to eq(Rigor::Type::Combinator.nominal_of("Integer"))
@@ -1129,18 +1087,15 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
           x
         end
       RUBY
-      # After the if, x has the union of the two narrowed branches,
-      # which collapses back to the original `Integer | nil` because
-      # the two narrowings partition the union.
+      # After the if, x has the union of the two narrowed branches, which collapses back to the original `Integer | nil`
+      # because the two narrowings partition the union.
       expect(post.local(:x)).to eq(union_int_nil)
     end
 
     it "evaluates the RHS of `&&` under the LHS truthy scope" do
-      # `x.succ` only resolves cleanly when `x` is narrowed to a
-      # non-nil Integer; otherwise dispatch over `Integer | nil`
-      # cannot prove `NilClass` defines `succ`. The RHS therefore
-      # types as `Nominal[Integer]` only when the narrower flowed
-      # `x` into the RHS scope.
+      # `x.succ` only resolves cleanly when `x` is narrowed to a non-nil Integer; otherwise dispatch over `Integer |
+      # nil` cannot prove `NilClass` defines `succ`. The RHS therefore types as `Nominal[Integer]` only when the
+      # narrower flowed `x` into the RHS scope.
       bound = scope.with_local(:x, union_int_nil)
       type, _post = bound.evaluate(parse_with_locals("x && x.succ"))
 
@@ -1169,17 +1124,14 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       ast = parse_with_locals("x || x.nil?")
       described_class.new(scope: bound, on_enter: on_enter).evaluate(ast)
 
-      # The LHS read sees the unnarrowed union; we don't assert on
-      # `events[1]` because the RHS receiver is typed via
-      # ExpressionTyper, which does not fire `on_enter`. The
-      # behavioural proof is in the dispatched return type below.
+      # The LHS read sees the unnarrowed union; we don't assert on `events[1]` because the RHS receiver is typed via
+      # ExpressionTyper, which does not fire `on_enter`. The behavioural proof is in the dispatched return type below.
       expect(events.first).to eq(union_int_nil)
 
       type, _post = bound.evaluate(ast)
       expect(type).to be_a(Rigor::Type::Union)
-      # The RHS `x.nil?` resolves on `Constant[nil]` to
-      # `Constant[true]` because `x` was narrowed to `nil` in the
-      # falsey branch. The full expression unions LHS and RHS.
+      # The RHS `x.nil?` resolves on `Constant[nil]` to `Constant[true]` because `x` was narrowed to `nil` in the falsey
+      # branch. The full expression unions LHS and RHS.
       expect(type.members).to include(Rigor::Type::Combinator.constant_of(true))
     end
 
@@ -1219,8 +1171,7 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
               .with_local(:y, union_str_nil)
       type, _post = bound.evaluate(parse_with_locals("if x && y; x; else; 0; end"))
 
-      # In the truthy branch x is narrowed to its non-falsey
-      # fragment; the read of `x` therefore returns `Integer`.
+      # In the truthy branch x is narrowed to its non-falsey fragment; the read of `x` therefore returns `Integer`.
       expect(type).to be_a(Rigor::Type::Union)
       expect(type.members).to include(
         Rigor::Type::Combinator.nominal_of("Integer"),
@@ -1235,8 +1186,7 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       bound = scope.with_local(:x, union)
       type, _post = bound.evaluate(parse_with_locals('if x == "a" && x == "b"; x; else; 0; end'))
 
-      # The truthy branch is unreachable because the RHS sees x
-      # narrowed to "a", then intersects that with "b".
+      # The truthy branch is unreachable because the RHS sees x narrowed to "a", then intersects that with "b".
       expect(type).to eq(Rigor::Type::Combinator.constant_of(0))
     end
 
@@ -1249,8 +1199,7 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       ast = parse_with_locals("if x.is_a?(Integer); x; else; x; end")
       events, on_enter = watch_local_reads(:x)
       described_class.new(scope: bound, on_enter: on_enter).evaluate(ast)
-      # The predicate receiver is typed by ExpressionTyper directly
-      # and is not surfaced through `on_enter`. Only the two
+      # The predicate receiver is typed by ExpressionTyper directly and is not surfaced through `on_enter`. Only the two
       # body-position reads of `x` are observed here.
       expect(events.size).to eq(2)
       then_read, else_read = events
@@ -1265,8 +1214,7 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       described_class.new(scope: bound, on_enter: on_enter).evaluate(ast)
       then_read, else_read = events
       expect(then_read).to eq(Rigor::Type::Combinator.nominal_of("Integer"))
-      # The else edge cannot prove "Numeric is not an Integer", so it
-      # stays conservative and preserves Nominal[Numeric].
+      # The else edge cannot prove "Numeric is not an Integer", so it stays conservative and preserves Nominal[Numeric].
       expect(else_read).to eq(Rigor::Type::Combinator.nominal_of("Numeric"))
     end
 
@@ -1354,12 +1302,10 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
 
   describe "block return type uplift (Slice 6 phase C sub-phase 2)" do
     it "infers a per-position Tuple from `[1, 2, 3].map { |n| n.to_s }`" do
-      # v0.0.6 phase 2 — per-element block re-evaluation over a
-      # Tuple-shaped receiver. Each position binds its own constant
-      # to the block parameter, the body folds to the corresponding
-      # `Constant[String]`, and the assembled answer is
-      # `Tuple[Constant["1"], Constant["2"], Constant["3"]]` —
-      # strictly tighter than the previous `Array[union]` projection.
+      # v0.0.6 phase 2 — per-element block re-evaluation over a Tuple-shaped receiver. Each position binds its own
+      # constant to the block parameter, the body folds to the corresponding `Constant[String]`, and the assembled
+      # answer is `Tuple[Constant["1"], Constant["2"], Constant["3"]]` — strictly tighter than the previous
+      # `Array[union]` projection.
       type, _post = evaluate("[1, 2, 3].map { |n| n.to_s }")
       expect(type).to be_a(Rigor::Type::Tuple)
       expect(type.elements.map(&:value)).to eq(%w[1 2 3])
@@ -1383,12 +1329,9 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
 
   describe "downstream inference benefits" do
     it "lets methods on bound locals resolve through RBS" do
-      # Constant folding (v0.0.3 C) folds `1.succ` to
-      # `Constant[2]`, which is strictly more precise than
-      # the RBS-widened `Nominal[Integer]`. The RBS
-      # dispatch tier is still exercised — the same call
-      # on a non-constant receiver returns Nominal — see
-      # the wider-union tests in expression_typer_spec.rb.
+      # Constant folding (v0.0.3 C) folds `1.succ` to `Constant[2]`, which is strictly more precise than the RBS-widened
+      # `Nominal[Integer]`. The RBS dispatch tier is still exercised — the same call on a non-constant receiver returns
+      # Nominal — see the wider-union tests in expression_typer_spec.rb.
       type, _post = evaluate(<<~RUBY)
         x = 1
         x.succ
@@ -1398,8 +1341,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     end
 
     it "lets shape-typed locals resolve through dispatch" do
-      # Slice 5 phase 2 picks the first element directly rather than
-      # the projected union; the test asserts the precise answer.
+      # Slice 5 phase 2 picks the first element directly rather than the projected union; the test asserts the precise
+      # answer.
       type, _post = evaluate(<<~RUBY)
         xs = [1, 2, 3]
         xs.first
@@ -1489,8 +1432,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
         xs = [1, 2, 3]
         xs[100]
       RUBY
-      # The shape tier defers; RbsDispatch returns Array#[]'s projected
-      # type, which is Elem | nil under the value-lattice.
+      # The shape tier defers; RbsDispatch returns Array#[]'s projected type, which is Elem | nil under the
+      # value-lattice.
       expect(type).not_to eq(Rigor::Type::Combinator.constant_of(1))
     end
 
@@ -1573,19 +1516,16 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
         watch_v.call(node, s)
       end
       run_eval(default_env_scope, combined, "{ a: 1, b: 2 }.each { |k, v| k; v }")
-      # The receiver is a HashShape{a: 1, b: 2}; Hash#each yields
-      # `[K, V]` tuples and the binder receives the tuple slot type
-      # for each positional. We assert that the bindings are present
-      # rather than the exact tuple shape (which can vary across
-      # RBS revisions).
+      # The receiver is a HashShape{a: 1, b: 2}; Hash#each yields `[K, V]` tuples and the binder receives the tuple slot
+      # type for each positional. We assert that the bindings are present rather than the exact tuple shape (which can
+      # vary across RBS revisions).
       expect(events_k.first).not_to be_nil
       expect(events_v.first).not_to be_nil
     end
 
     it "defaults block parameters to Dynamic[Top] when the receiver has no RBS signature" do
       events, on_enter = watch_local_reads(:x)
-      # `foo` resolves to an implicit-self call without a known
-      # signature. The block param falls back to Dynamic[Top].
+      # `foo` resolves to an implicit-self call without a known signature. The block param falls back to Dynamic[Top].
       run_eval(default_env_scope, on_enter, "foo { |x| x }")
       expect(events).not_to be_empty
       expect(events.first).to eq(Rigor::Type::Combinator.untyped)
@@ -1612,9 +1552,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     end
 
     it "evaluates the block body's terminal statement under the bound block param" do
-      # `n + 1` is itself a CallNode, so the inner `n` read does not
-      # fire `on_enter`; we probe the entry scope at the CallNode
-      # level instead, which sees the bound `n` via `type_of`.
+      # `n + 1` is itself a CallNode, so the inner `n` read does not fire `on_enter`; we probe the entry scope at the
+      # CallNode level instead, which sees the bound `n` via `type_of`.
       events = []
       on_enter = lambda do |node, s|
         next unless node.is_a?(Prism::CallNode) && node.name == :+
@@ -1690,13 +1629,10 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
         )
       end
 
-      # Per Ruby's semantics, `;`-prefixed block-locals are
-      # freshly bound to `nil` at the start of each block
-      # invocation. Reading the name before writing it must
-      # therefore yield `Constant[nil]` — NOT the outer
-      # binding's value, which would be unsound (a runtime
-      # `nil.even?` would NoMethodError but the analyzer would
-      # claim the receiver is the outer Integer).
+      # Per Ruby's semantics, `;`-prefixed block-locals are freshly bound to `nil` at the start of each block
+      # invocation. Reading the name before writing it must therefore yield `Constant[nil]` — NOT the outer binding's
+      # value, which would be unsound (a runtime `nil.even?` would NoMethodError but the analyzer would claim the
+      # receiver is the outer Integer).
       it "binds block-locals to Constant[nil] at block entry, shadowing the outer value" do
         events, on_enter = watch_local_reads(:x)
         run_eval(
@@ -1711,10 +1647,9 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
         expect(events.last).to eq(Rigor::Type::Combinator.constant_of(nil))
       end
 
-      # The terminal `x` read is the block body's last expression:
-      # by then the block-local has been written from `x = i`, so
-      # the read should see the Tuple-element union, not the outer
-      # `Constant[100]` shadow that `nil`-init introduced.
+      # The terminal `x` read is the block body's last expression: by then the block-local has been written from `x =
+      # i`, so the read should see the Tuple-element union, not the outer `Constant[100]` shadow that `nil`-init
+      # introduced.
       it "exposes the written type after the block-local is written" do
         events, on_enter = watch_local_reads(:x)
         run_eval(default_env_scope, on_enter, "x = 100; [1, 2, 3].each do |i; x| x = i; x end")
@@ -1817,8 +1752,7 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
           @x
         end
       RUBY
-      # Inside the method body the outer @x = 99 binding MUST NOT
-      # be visible — `def` enters with a fresh scope.
+      # Inside the method body the outer @x = 99 binding MUST NOT be visible — `def` enters with a fresh scope.
       expect(observed.first).to be_nil
     end
   end
@@ -1876,10 +1810,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
 
   describe "cross-method ivar tracking via class accumulator (Slice 7 phase 2)" do
     it "seeds an instance method body's ivars from sibling-method writes when routed through ScopeIndexer" do
-      # `def initialize` (not `def init`) is the soundness gate
-      # for the B2.3 read-before-write nil contribution: a write
-      # in `initialize` runs before any other method body, so
-      # the analyzer does NOT widen `@cache` with nil here.
+      # `def initialize` (not `def init`) is the soundness gate for the B2.3 read-before-write nil contribution: a write
+      # in `initialize` runs before any other method body, so the analyzer does NOT widen `@cache` with nil here.
       ast = parse_program(<<~RUBY)
         class Foo
           def initialize; @cache = "hello"; end
@@ -1953,10 +1885,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       Rigor::Source::NodeWalker.each(ast) do |n|
         read_node = n if n.is_a?(Prism::InstanceVariableReadNode)
       end
-      # `def self.get`'s `@cache` is a class-level ivar of `Foo` the
-      # class object, NOT an instance ivar of a Foo instance. The
-      # accumulator tracks only instance defs, so this read stays
-      # unbound.
+      # `def self.get`'s `@cache` is a class-level ivar of `Foo` the class object, NOT an instance ivar of a Foo
+      # instance. The accumulator tracks only instance defs, so this read stays unbound.
       expect(index[read_node].ivar(:@cache)).to be_nil
     end
   end
@@ -2008,8 +1938,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     end
 
     it "invalidates the local_binding fact on the dropped local" do
-      # Pre-bind x with a fact, then escape; the with_local call inside
-      # the drop must invalidate the local_binding bucket entry.
+      # Pre-bind x with a fact, then escape; the with_local call inside the drop must invalidate the local_binding
+      # bucket entry.
       base = default_env_scope.with_local(:x, integer_constant(1))
       base = base.with_fact(
         Rigor::Analysis::FactStore::Fact.new(
@@ -2024,10 +1954,9 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
   end
 
   describe "rescue variable binding" do
-    # The rescue variable is only bound inside the rescue branch; the
-    # primary body's scope does not include it. After the begin/rescue join
-    # the post-scope nil-injects the variable, so the observable type is
-    # `ExcType | nil`.  These tests verify the exception-type component.
+    # The rescue variable is only bound inside the rescue branch; the primary body's scope does not include it. After
+    # the begin/rescue join the post-scope nil-injects the variable, so the observable type is `ExcType | nil`. These
+    # tests verify the exception-type component.
     it "binds the rescue reference to StandardError when no classes named" do
       _, post = evaluate(<<~RUBY)
         begin
@@ -2090,9 +2019,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
   end
 
   describe "case/in pattern variable binding" do
-    # Like rescue, captured pattern variables are only bound on the matched
-    # branch; nil-injection produces `MatchType | nil` in the post-scope.
-    # We verify the match-type component is present.
+    # Like rescue, captured pattern variables are only bound on the matched branch; nil-injection produces `MatchType |
+    # nil` in the post-scope. We verify the match-type component is present.
     it "binds a capture variable to the matched class type" do
       _, post = evaluate(<<~RUBY)
         case value
@@ -2232,11 +2160,9 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       expect(post.local(:b)).to be_a(Rigor::Type::Union)
     end
 
-    # `if /(?<x>...)/ =~ str` — Ruby guarantees the named
-    # capture is a `String` inside the truthy branch (the
-    # match succeeded; the capture group must have
-    # participated for the match to be truthy with a
-    # non-optional group). The else branch sees `nil`.
+    # `if /(?<x>...)/ =~ str` — Ruby guarantees the named capture is a `String` inside the truthy branch (the match
+    # succeeded; the capture group must have participated for the match to be truthy with a non-optional group). The
+    # else branch sees `nil`.
     describe "narrowing through `if regex =~ str`" do
       let(:string_t) { Rigor::Type::Combinator.nominal_of("String") }
       let(:nil_t) { Rigor::Type::Combinator.constant_of(nil) }
@@ -2256,9 +2182,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
         events.first
       end
 
-      # When the named-capture body is outside the v0.1.1 recogniser
-      # table (e.g. `.+`), the truthy branch still narrows to plain
-      # `String` per the v0.1.0 baseline.
+      # When the named-capture body is outside the v0.1.1 recogniser table (e.g. `.+`), the truthy branch still narrows
+      # to plain `String` per the v0.1.0 baseline.
       it "narrows the capture to String inside the truthy branch (recogniser fallback)" do
         observed = first_local_seen(:rest, <<~RUBY)
           if /(?<rest>.+)/ =~ str
@@ -2279,10 +2204,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
         expect(observed).to eq(nil_t)
       end
 
-      # `\d+` triggers the v0.1.1 recogniser, so the truthy edge
-      # carries `decimal-int-string`; rejoining with the falsey
-      # `nil` edge widens back to a `decimal-int-string | nil`
-      # union (still tighter than the v0.1.0 `String | nil`).
+      # `\d+` triggers the v0.1.1 recogniser, so the truthy edge carries `decimal-int-string`; rejoining with the falsey
+      # `nil` edge widens back to a `decimal-int-string | nil` union (still tighter than the v0.1.0 `String | nil`).
       it "joins back to <refinement> | nil after the if" do
         _, post = default_env_scope.evaluate(parse_program(<<~RUBY))
           if /(?<year>\\d+)/ =~ str
@@ -2391,10 +2314,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
         expect(first_local_seen(:rest, source)).to eq(string_t)
       end
 
-      # `\d*` admits the empty string, which is not a valid
-      # `decimal-int-string` (the carrier excludes `""`). The
-      # recogniser rejects unbounded-zero quantifiers and the
-      # fallback to plain `String` keeps the carrier sound.
+      # `\d*` admits the empty string, which is not a valid `decimal-int-string` (the carrier excludes `""`). The
+      # recogniser rejects unbounded-zero quantifiers and the fallback to plain `String` keeps the carrier sound.
       it "falls back to String for `\\d*` and other zero-length-admitting forms" do
         observed = first_local_seen(:n, <<~RUBY)
           if /(?<n>\\d*)/ =~ str
@@ -2406,10 +2327,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     end
   end
 
-  # Survey item (b) — `=~` with a regex literal binds the
-  # match-data globals (`$~`, `$&`, `$\``, `$'`, `$+`, `$1..$N`)
-  # on each predicate edge so subsequent reads inside an
-  # `unless ... raise` guard see the tightened type.
+  # Survey item (b) — `=~` with a regex literal binds the match-data globals (`$~`, `$&`, `$\``, `$'`, `$+`, `$1..$N`)
+  # on each predicate edge so subsequent reads inside an `unless ... raise` guard see the tightened type.
   describe "regex `=~` predicate narrowing (numbered globals)" do
     let(:string_t) { Rigor::Type::Combinator.nominal_of("String") }
     let(:nil_t) { Rigor::Type::Combinator.constant_of(nil) }
@@ -2421,8 +2340,7 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
           raise "bad"
         end
       RUBY
-      # After `unless ... raise`, only the predicate-truthy edge
-      # survives — $1 and $2 are narrowed to String.
+      # After `unless ... raise`, only the predicate-truthy edge survives — $1 and $2 are narrowed to String.
       expect(post.global(:$1)).to eq(string_t)
       expect(post.global(:$2)).to eq(string_t)
     end
@@ -2496,8 +2414,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     end
 
     it "joins a `flag = true; break` binding into a `for` loop continuation" do
-      # Pre-fix `flag` typed `false` here (a later `if flag` false-fired
-      # always-falsey); the break path's `true` is now joined in.
+      # Pre-fix `flag` typed `false` here (a later `if flag` false-fired always-falsey); the break path's `true` is now
+      # joined in.
       flag = local_after(<<~RUBY, :flag)
         flag = false
         for i in [1, 2, 3]
@@ -2536,8 +2454,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     end
 
     it "does NOT pollute the loop local with a break inside a nested block" do
-      # `break` inside `each { ... }` targets `each`, not the `while`; its
-      # scope must not join the while continuation — `flag` stays false.
+      # `break` inside `each { ... }` targets `each`, not the `while`; its scope must not join the while continuation —
+      # `flag` stays false.
       flag = local_after(<<~RUBY, :flag)
         flag = false
         while true
@@ -2550,8 +2468,8 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     end
 
     it "does not leak a transient overwritten before the break (no over-widening)" do
-      # `out = nil; out = real; break` — the break scope captures the real
-      # value, never the transient nil, so `out` is not falsely nilable.
+      # `out = nil; out = real; break` — the break scope captures the real value, never the transient nil, so `out` is
+      # not falsely nilable.
       out = local_after(<<~RUBY, :out)
         out = []
         for i in [1]

--- a/spec/rigor/inference/struct_fold_safety_spec.rb
+++ b/spec/rigor/inference/struct_fold_safety_spec.rb
@@ -4,8 +4,7 @@ require "spec_helper"
 require "rigor/inference/struct_fold_safety"
 
 RSpec.describe Rigor::Inference::StructFoldSafety do
-  # Resolves `Point` / `Line` to a member list for the constant-receiver form;
-  # everything else is unknown (nil).
+  # Resolves `Point` / `Line` to a member list for the constant-receiver form; everything else is unknown (nil).
   let(:layout_lookup) do
     ->(name) { { "Point" => %i[x y], "Line" => %i[from to] }[name] }
   end
@@ -98,8 +97,8 @@ RSpec.describe Rigor::Inference::StructFoldSafety do
     end
 
     it "does not let a nested def's same-named local affect the outer scope" do
-      # The outer `p` is fold-safe; the inner `p` (a different binding) is not
-      # scanned, so its unsafe use must not disqualify the outer one.
+      # The outer `p` is fold-safe; the inner `p` (a different binding) is not scanned, so its unsafe use must not
+      # disqualify the outer one.
       expect(safe(<<~RUBY)).to eq(Set[:p])
         p = Point.new(1, 2)
         p.x

--- a/spec/rigor/language_server/completion_provider_spec.rb
+++ b/spec/rigor/language_server/completion_provider_spec.rb
@@ -52,8 +52,7 @@ RSpec.describe Rigor::LanguageServer::CompletionProvider do
 
       expect(items).not_to be_nil
       labels = items.map { |i| i[:label] }
-      # `new` is a singleton method on String (well, on Class —
-      # inherited but still enumerated).
+      # `new` is a singleton method on String (well, on Class — inherited but still enumerated).
       expect(labels).to include("new")
     end
 
@@ -74,8 +73,7 @@ RSpec.describe Rigor::LanguageServer::CompletionProvider do
 
     describe "composite-receiver handling (slice B3)" do
       it "enumerates Array's methods for a tuple-shape receiver" do
-        # `[1, 2, 3]` infers to a Tuple carrier; method completion
-        # should fall through to Array's instance methods.
+        # `[1, 2, 3]` infers to a Tuple carrier; method completion should fall through to Array's instance methods.
         buffer_table.open(uri: uri, bytes: "[1, 2, 3].length\n", version: 1)
         items = provider.provide(uri: uri, line: 0, character: 11)
 
@@ -96,8 +94,7 @@ RSpec.describe Rigor::LanguageServer::CompletionProvider do
 
     describe "constant-path completion (slice B2)" do
       it "returns child constants for `Foo::Bar` when cursor is on `Bar`" do
-        # `Process::Status` — Status is a known child of Process
-        # in the bundled stdlib RBS. Cursor on `Status` should
+        # `Process::Status` — Status is a known child of Process in the bundled stdlib RBS. Cursor on `Status` should
         # surface every immediate child of `Process`.
         buffer_table.open(uri: uri, bytes: "Process::Status\n", version: 1)
         items = provider.provide(uri: uri, line: 0, character: 12)
@@ -134,9 +131,8 @@ RSpec.describe Rigor::LanguageServer::CompletionProvider do
 
     describe "hash-key completion (slice D1)" do
       it "returns the HashShape's keys for `hash[:|` mid-edit" do
-        # Buffer: `h = {a: 1, b: 2, ccc: 3}; h[:` (incomplete).
-        # The provider should patch `__rigor_lsp_key__]` and surface
-        # the three keys from the HashShape carrier.
+        # Buffer: `h = {a: 1, b: 2, ccc: 3}; h[:` (incomplete). The provider should patch `__rigor_lsp_key__]` and
+        # surface the three keys from the HashShape carrier.
         source = "h = {a: 1, b: 2, ccc: 3}\nh[:\n"
         buffer_table.open(uri: uri, bytes: source, version: 1)
         items = provider.provide(uri: uri, line: 1, character: 3)
@@ -155,15 +151,14 @@ RSpec.describe Rigor::LanguageServer::CompletionProvider do
       end
 
       it "falls back to method completion when the receiver isn't a HashShape" do
-        # `[1, 2].[:foo` — receiver is Tuple, not HashShape. The
-        # provider should NOT return hash-key items; falls through
-        # to method completion (Array methods).
+        # `[1, 2].[:foo` — receiver is Tuple, not HashShape. The provider should NOT return hash-key items; falls
+        # through to method completion (Array methods).
         source = "[1, 2][:\n"
         buffer_table.open(uri: uri, bytes: source, version: 1)
         items = provider.provide(uri: uri, line: 0, character: 8)
 
-        # Either nil or Array method completions — but NOT hash
-        # keys. Hash-key items would have labels starting with `:`.
+        # Either nil or Array method completions — but NOT hash keys. Hash-key items would have labels starting with
+        # `:`.
         if items
           labels = items.map { |i| i[:label] }
           expect(labels.none? { |l| l.start_with?(":") }).to be(true)
@@ -173,8 +168,7 @@ RSpec.describe Rigor::LanguageServer::CompletionProvider do
 
     describe "parse-recovery sentinel (slice B4)" do
       it "completes after a trailing `.` even though the buffer doesn't parse" do
-        # `"hi".` is malformed Ruby; provider should patch with
-        # the method sentinel and return String's methods.
+        # `"hi".` is malformed Ruby; provider should patch with the method sentinel and return String's methods.
         buffer_table.open(uri: uri, bytes: "\"hi\".\n", version: 1)
         items = provider.provide(uri: uri, line: 0, character: 5)
 

--- a/spec/rigor/language_server/diagnostic_publisher_spec.rb
+++ b/spec/rigor/language_server/diagnostic_publisher_spec.rb
@@ -5,9 +5,8 @@ require "rigor/configuration"
 
 RSpec.describe Rigor::LanguageServer::DiagnosticPublisher do
   # In-memory writer collecting every payload pushed to it. Mirrors
-  # `LanguageServer::Protocol::Transport::Io::Writer#write` but
-  # captures the raw Hash so specs can inspect the wire shape
-  # without re-parsing.
+  # `LanguageServer::Protocol::Transport::Io::Writer#write` but captures the raw Hash so specs can inspect the wire
+  # shape without re-parsing.
   let(:writer) do
     Class.new do
       attr_reader :payloads
@@ -44,8 +43,7 @@ RSpec.describe Rigor::LanguageServer::DiagnosticPublisher do
       Dir.mktmpdir("rigor-lsp-publish-") do |tmpdir|
         path = File.join(tmpdir, "foo.rb")
         uri = "file://#{path}"
-        # Buffer has a parse error — should surface as an LSP
-        # diagnostic mapped from Rigor's :error severity.
+        # Buffer has a parse error — should surface as an LSP diagnostic mapped from Rigor's :error severity.
         buffer_table.open(uri: uri, bytes: "def broken\n", version: 1)
 
         Dir.chdir(tmpdir) { publisher.publish_for(uri) }
@@ -65,8 +63,7 @@ RSpec.describe Rigor::LanguageServer::DiagnosticPublisher do
       Dir.mktmpdir("rigor-lsp-publish-zerobased-") do |tmpdir|
         path = File.join(tmpdir, "foo.rb")
         uri = "file://#{path}"
-        # Parse error fires on line 1 of the buffer; LSP expects
-        # line: 0 (0-based).
+        # Parse error fires on line 1 of the buffer; LSP expects line: 0 (0-based).
         buffer_table.open(uri: uri, bytes: "def broken\n", version: 1)
 
         Dir.chdir(tmpdir) { publisher.publish_for(uri) }

--- a/spec/rigor/language_server/end_to_end_spec.rb
+++ b/spec/rigor/language_server/end_to_end_spec.rb
@@ -59,15 +59,13 @@ RSpec.describe "rigor lsp end-to-end session", type: :integration do
     expect(exit_status).to eq(0)
     expect(request_responses.map { |f| f[:id] }).to eq([1, 2, 3, 4])
 
-    # initialize — capabilities include textDocumentSync,
-    # hoverProvider, completionProvider, documentSymbolProvider.
+    # initialize — capabilities include textDocumentSync, hoverProvider, completionProvider, documentSymbolProvider.
     init = request_responses.find { |f| f[:id] == 1 }
     caps = init.dig(:result, :capabilities)
     expect(caps).to include(:textDocumentSync, :hoverProvider,
                             :completionProvider, :documentSymbolProvider)
 
-    # hover at the `upcase` position — CallNode renderer produces
-    # the # Receiver / # Method / # Return body.
+    # hover at the `upcase` position — CallNode renderer produces the # Receiver / # Method / # Return body.
     hover = request_responses.find { |f| f[:id] == 2 }
     expect(hover.dig(:result, :contents, :kind)).to eq("markdown")
     body = hover.dig(:result, :contents, :value)

--- a/spec/rigor/language_server/folding_range_provider_spec.rb
+++ b/spec/rigor/language_server/folding_range_provider_spec.rb
@@ -45,8 +45,7 @@ RSpec.describe Rigor::LanguageServer::FoldingRangeProvider do
 
       ranges = provider.provide(uri)
       expect(ranges.size).to eq(3) # outer class + two defs.
-      # Outer class spans lines 0..9 (LSP 0-based). endLine = 8
-      # (one line before `end` on line 9 in 0-based).
+      # Outer class spans lines 0..9 (LSP 0-based). endLine = 8 (one line before `end` on line 9 in 0-based).
       outer = ranges.max_by { |r| r[:endLine] - r[:startLine] }
       expect(outer[:startLine]).to eq(0)
       expect(outer[:endLine]).to be >= 7

--- a/spec/rigor/language_server/hover_provider_spec.rb
+++ b/spec/rigor/language_server/hover_provider_spec.rb
@@ -33,16 +33,15 @@ RSpec.describe Rigor::LanguageServer::HoverProvider do
 
       expect(hover).not_to be_nil
       expect(hover[:contents][:kind]).to eq("markdown")
-      # Slice A4 replaces the slice-A1 `type: / erased: / node:`
-      # body with `# Type / # Erased` framing for literal nodes.
+      # Slice A4 replaces the slice-A1 `type: / erased: / node:` body with `# Type / # Erased` framing for literal
+      # nodes.
       expect(hover[:contents][:value]).to include("# Type")
       expect(hover[:contents][:value]).to include("42")
     end
 
     it "uses 0-based LSP line/character (no off-by-one against rigor's 1-based input)" do
-      # `42` sits at LSP (0, 0). rigor's NodeLocator expects (1, 1).
-      # HoverProvider must translate at the boundary; the literal
-      # at that position should resolve and produce a non-nil hover.
+      # `42` sits at LSP (0, 0). rigor's NodeLocator expects (1, 1). HoverProvider must translate at the boundary; the
+      # literal at that position should resolve and produce a non-nil hover.
       buffer_table.open(uri: uri, bytes: "42\n", version: 1)
       hover = provider.provide(uri: uri, line: 0, character: 0)
 

--- a/spec/rigor/language_server/hover_renderer_spec.rb
+++ b/spec/rigor/language_server/hover_renderer_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe Rigor::LanguageServer::HoverRenderer do
 
   describe "default body (unspecialised nodes)" do
     it "renders the slice-A1 type / erased / node body for an unspecialised node" do
-      # `BreakNode` has no specialisation in slices A1-A4; it
-      # exercises the default rendering path. The `break` keyword
+      # `BreakNode` has no specialisation in slices A1-A4; it exercises the default rendering path. The `break` keyword
       # has no inferable type so the renderer surfaces `untyped`.
       root = Prism.parse("loop { break 1 }").value
       break_node = nil
@@ -59,8 +58,7 @@ RSpec.describe Rigor::LanguageServer::HoverRenderer do
     end
 
     it "falls back to the default body for implicit-`self` calls (no receiver)" do
-      # `foo` with no receiver — implicit self is not specialised;
-      # the renderer falls through to the default body.
+      # `foo` with no receiver — implicit self is not specialised; the renderer falls through to the default body.
       root, index = parse_and_index("foo\n")
       call_node = root.statements.body.first
       scope = index[call_node]
@@ -71,9 +69,8 @@ RSpec.describe Rigor::LanguageServer::HoverRenderer do
     end
 
     it "falls back to the default body when the method isn't in the RBS env" do
-      # `1.totally_made_up_method` — receiver type known (Integer)
-      # but method doesn't resolve. Render falls through to the
-      # default body rather than emitting a bogus signature.
+      # `1.totally_made_up_method` — receiver type known (Integer) but method doesn't resolve. Render falls through to
+      # the default body rather than emitting a bogus signature.
       root, index = parse_and_index("1.totally_made_up_method\n")
       call_node = root.statements.body.first
       scope = index[call_node]
@@ -84,8 +81,7 @@ RSpec.describe Rigor::LanguageServer::HoverRenderer do
     end
 
     it "appends RBS documentation when the method has comments (slice C3)" do
-      # `String#upcase`'s RBS in core ships with rdoc comments;
-      # hover should surface them below the code block.
+      # `String#upcase`'s RBS in core ships with rdoc comments; hover should surface them below the code block.
       root, index = parse_and_index("\"hello\".upcase\n")
       call_node = root.statements.body.first
       scope = index[call_node]
@@ -93,8 +89,7 @@ RSpec.describe Rigor::LanguageServer::HoverRenderer do
       result = renderer.render(node: call_node, type: scope.type_of(call_node), node_scope_lookup: index)
       body = result[:contents][:value]
 
-      # The doc text contains rdoc-flavoured markup; just check
-      # the separator + at least one comment line is present.
+      # The doc text contains rdoc-flavoured markup; just check the separator + at least one comment line is present.
       expect(body).to include("---")
       expect(body).to match(/Returns|String/)
     end
@@ -107,8 +102,7 @@ RSpec.describe Rigor::LanguageServer::HoverRenderer do
       result = renderer.render(node: call_node, type: scope.type_of(call_node), node_scope_lookup: index)
       body = result[:contents][:value]
 
-      # Should surface receiver class + the dot separator that marks
-      # a singleton dispatch.
+      # Should surface receiver class + the dot separator that marks a singleton dispatch.
       expect(body).to include("String")
       expect(body).to include("String.new:")
     end
@@ -124,8 +118,8 @@ RSpec.describe Rigor::LanguageServer::HoverRenderer do
 
       expect(result).to include(:range)
       range = result[:range]
-      # `"hello".upcase` sits on LSP line 0; spans from col 0 to
-      # col 14 (length of the call expression including the dot).
+      # `"hello".upcase` sits on LSP line 0; spans from col 0 to col 14 (length of the call expression including the
+      # dot).
       expect(range[:start]).to eq(line: 0, character: 0)
       expect(range[:end][:line]).to eq(0)
       expect(range[:end][:character]).to be > 0
@@ -158,14 +152,10 @@ RSpec.describe Rigor::LanguageServer::HoverRenderer do
     end
 
     it "falls back to the default body for value constants (e.g. FOO = 42)" do
-      # Without seeing `FOO = 42` in the buffer the renderer can't
-      # know the constant is a value; we test with an unknown
-      # bare-Constant whose type isn't a Singleton — the renderer
-      # must still produce a body (the default one). For this we
-      # use a known not-in-RBS constant by constructing the type
-      # directly is over-mocking; instead test the negative path
-      # via the absence of `# Constant` framing when type isn't
-      # `Singleton`.
+      # Without seeing `FOO = 42` in the buffer the renderer can't know the constant is a value; we test with an unknown
+      # bare-Constant whose type isn't a Singleton — the renderer must still produce a body (the default one). For this
+      # we use a known not-in-RBS constant by constructing the type directly is over-mocking; instead test the negative
+      # path via the absence of `# Constant` framing when type isn't `Singleton`.
       root, index = parse_and_index("CONSTANT_DOES_NOT_EXIST\n")
       const_node = root.statements.body.first
       scope = index[const_node]
@@ -206,8 +196,7 @@ RSpec.describe Rigor::LanguageServer::HoverRenderer do
 
       expect(body).to include("# Type")
       expect(body).to include("# Erased")
-      # The string literal infers to `Constant<"hi">`; its
-      # erase_to_rbs is the inspected literal, not `::String`.
+      # The string literal infers to `Constant<"hi">`; its erase_to_rbs is the inspected literal, not `::String`.
       expect(body).to include("\"hi\"")
     end
 
@@ -219,17 +208,15 @@ RSpec.describe Rigor::LanguageServer::HoverRenderer do
       result = renderer.render(node: arr_node, type: scope.type_of(arr_node), node_scope_lookup: index)
       body = result[:contents][:value]
 
-      # Tuple<1, 2, 3> or similar carrier description; the exact
-      # shape comes from Type::Tuple#describe.
+      # Tuple<1, 2, 3> or similar carrier description; the exact shape comes from Type::Tuple#describe.
       expect(body).to include("# Type")
       expect(body).to include("# Erased")
     end
 
     it "surfaces the refinement name for refined carriers" do
-      # We construct a refined type directly because triggering
-      # narrowing through source requires more setup than the test
-      # needs; the renderer's surface contract is "if the type
-      # responds to canonical_name with a non-nil value, surface it."
+      # We construct a refined type directly because triggering narrowing through source requires more setup than the
+      # test needs; the renderer's surface contract is "if the type responds to canonical_name with a non-nil value,
+      # surface it."
       refined = Rigor::Type::Combinator.non_empty_string
       stub_node = Prism.parse("nil\n").value.statements.body.first
       stub_index = { stub_node => Rigor::Scope.empty }
@@ -252,8 +239,7 @@ RSpec.describe Rigor::LanguageServer::HoverRenderer do
 
       expect(body).to include("# Local\nx")
       expect(body).to include("# Type")
-      # `x` was assigned `42`; the inferred type for the read should
-      # be a Constant<42> or Nominal[Integer] form.
+      # `x` was assigned `42`; the inferred type for the read should be a Constant<42> or Nominal[Integer] form.
       expect(body).to match(/# Type\n\d+|# Type\nInteger/)
     end
 

--- a/spec/rigor/language_server/loop_spec.rb
+++ b/spec/rigor/language_server/loop_spec.rb
@@ -5,10 +5,8 @@ require "rigor/language_server"
 require "language_server-protocol"
 
 RSpec.describe Rigor::LanguageServer::Loop do
-  # Wraps one full `initialize → shutdown → exit` round-trip
-  # through the Loop, using IO.pipe pairs for the client → server
-  # and server → client streams. Returns the parsed server-side
-  # responses in order.
+  # Wraps one full `initialize → shutdown → exit` round-trip through the Loop, using IO.pipe pairs for the client →
+  # server and server → client streams. Returns the parsed server-side responses in order.
   def run_loop(messages)
     server_in_r, server_in_w = IO.pipe   # client writes here; server reads.
     server_out_r, server_out_w = IO.pipe # server writes here; client reads.
@@ -128,8 +126,8 @@ RSpec.describe Rigor::LanguageServer::Loop do
                                    { jsonrpc: "2.0", method: "exit" }
                                  ])
 
-      # Three inbound: initialize (request), initialized (notif),
-      # shutdown (request), exit (notif). Two responses expected.
+      # Three inbound: initialize (request), initialized (notif), shutdown (request), exit (notif). Two responses
+      # expected.
       expect(frames.size).to eq(2)
       expect(frames.map { |f| f[:id] }).to eq([1, 2])
     end

--- a/spec/rigor/language_server/selection_range_provider_spec.rb
+++ b/spec/rigor/language_server/selection_range_provider_spec.rb
@@ -30,8 +30,7 @@ RSpec.describe Rigor::LanguageServer::SelectionRangeProvider do
     end
 
     it "builds an outward-chained linked list from innermost to root" do
-      # `class Foo; def m; 42; end; end` — selecting on `42`
-      # gives [innermost=42, def m, class Foo, root].
+      # `class Foo; def m; 42; end; end` — selecting on `42` gives [innermost=42, def m, class Foo, root].
       source = <<~RUBY
         class Foo
           def m
@@ -45,8 +44,7 @@ RSpec.describe Rigor::LanguageServer::SelectionRangeProvider do
       range = result.first
       expect(range).not_to be_nil
 
-      # Walk the parent chain. Innermost should be the smallest
-      # range; each parent strictly contains its child.
+      # Walk the parent chain. Innermost should be the smallest range; each parent strictly contains its child.
       chain = []
       current = range
       while current
@@ -54,8 +52,7 @@ RSpec.describe Rigor::LanguageServer::SelectionRangeProvider do
         current = current[:parent]
       end
       expect(chain.size).to be >= 3 # at minimum integer + def + class
-      # Each parent should contain its child (start <= child.start
-      # and end >= child.end).
+      # Each parent should contain its child (start <= child.start and end >= child.end).
       chain.each_cons(2) do |child, parent|
         expect(parent[:start][:line]).to be <= child[:start][:line]
         expect(parent[:end][:line]).to be >= child[:end][:line]

--- a/spec/rigor/language_server/server_spec.rb
+++ b/spec/rigor/language_server/server_spec.rb
@@ -35,9 +35,8 @@ RSpec.describe Rigor::LanguageServer::Server do
     end
 
     it "exits with code 1 if `exit` is called without a preceding `shutdown`" do
-      # Per LSP § "exit": clients that exit without shutdown signal
-      # an abnormal termination; the server SHOULD set a non-zero
-      # exit code.
+      # Per LSP § "exit": clients that exit without shutdown signal an abnormal termination; the server SHOULD set a
+      # non-zero exit code.
       server.dispatch("initialize", {})
       server.dispatch("exit", nil)
 
@@ -74,8 +73,8 @@ RSpec.describe Rigor::LanguageServer::Server do
       server.dispatch("initialize", {})
       result = server.dispatch("textDocument/hover", {})
 
-      # `Server.new` here has no hover_provider wired, so
-      # the dispatcher returns MethodNotFound even for `textDocument/hover`.
+      # `Server.new` here has no hover_provider wired, so the dispatcher returns MethodNotFound even for
+      # `textDocument/hover`.
       expect(result.dig(:error, :code)).to eq(Rigor::LanguageServer::Server::ERROR_METHOD_NOT_FOUND)
     end
   end
@@ -203,8 +202,7 @@ RSpec.describe Rigor::LanguageServer::Server do
 
       it "advertises no hoverProvider capability" do
         server.dispatch("initialize", {})
-        # `initialize` already ran in before; dispatching again is
-        # an invalid-request, so re-construct.
+        # `initialize` already ran in before; dispatching again is an invalid-request, so re-construct.
         s = described_class.new
         result = s.dispatch("initialize", {})
         expect(result[:capabilities]).not_to include(:hoverProvider)

--- a/spec/rigor/language_server/signature_help_provider_spec.rb
+++ b/spec/rigor/language_server/signature_help_provider_spec.rb
@@ -28,10 +28,8 @@ RSpec.describe Rigor::LanguageServer::SignatureHelpProvider do
     end
 
     it "returns the method signature for `\"hi\".center(|`" do
-      # `"hi".center(` — buffer fails to parse; sentinel patches
-      # `__rigor_lsp_arg_sentinel__` after the `(` so Prism gets
-      # a complete CallNode. The signature should reflect
-      # String#center's first overload.
+      # `"hi".center(` — buffer fails to parse; sentinel patches `__rigor_lsp_arg_sentinel__` after the `(` so Prism
+      # gets a complete CallNode. The signature should reflect String#center's first overload.
       buffer_table.open(uri: uri, bytes: "\"hi\".center(\n", version: 1)
       result = provider.provide(uri: uri, line: 0, character: 12)
 
@@ -51,8 +49,7 @@ RSpec.describe Rigor::LanguageServer::SignatureHelpProvider do
     end
 
     it "returns the signature for a clean (already-complete) call" do
-      # `"hi".center(10, "*")` — buffer parses cleanly; cursor on
-      # an argument. The provider should still surface the
+      # `"hi".center(10, "*")` — buffer parses cleanly; cursor on an argument. The provider should still surface the
       # signature.
       buffer_table.open(uri: uri, bytes: "\"hi\".center(10, \"*\")\n", version: 1)
       result = provider.provide(uri: uri, line: 0, character: 12)
@@ -69,8 +66,7 @@ RSpec.describe Rigor::LanguageServer::SignatureHelpProvider do
 
     describe "RBS documentation field (slice C3)" do
       it "attaches the method's RBS comments to each SignatureInformation" do
-        # `String#center` ships with rdoc comments in core RBS;
-        # the documentation field should carry them.
+        # `String#center` ships with rdoc comments in core RBS; the documentation field should carry them.
         buffer_table.open(uri: uri, bytes: "\"hi\".center(\n", version: 1)
         result = provider.provide(uri: uri, line: 0, character: 12)
 
@@ -80,8 +76,7 @@ RSpec.describe Rigor::LanguageServer::SignatureHelpProvider do
       end
 
       it "omits the documentation field when the method has no RBS comments" do
-        # Most analyzer-internal classes ship without rdoc; use a
-        # definition known to be comment-less by stubbing a
+        # Most analyzer-internal classes ship without rdoc; use a definition known to be comment-less by stubbing a
         # minimal `RBS::Definition::Method`-shaped double.
         require "rbs"
         empty_comments_def = Class.new do
@@ -106,8 +101,7 @@ RSpec.describe Rigor::LanguageServer::SignatureHelpProvider do
 
     describe "per-parameter info (slice C4)" do
       it "populates `parameters` with one entry per parameter in the signature" do
-        # `String#center(int, ?string) -> String` — two params:
-        # required `width` (int) + optional `pad_string` (string).
+        # `String#center(int, ?string) -> String` — two params: required `width` (int) + optional `pad_string` (string).
         buffer_table.open(uri: uri, bytes: "\"hi\".center(\n", version: 1)
         result = provider.provide(uri: uri, line: 0, character: 12)
 
@@ -122,8 +116,7 @@ RSpec.describe Rigor::LanguageServer::SignatureHelpProvider do
 
     describe "multi-overload presentation (slice C2)" do
       it "surfaces every overload of a multi-signature method" do
-        # `Array#fetch` has multiple overloads in core RBS:
-        # `(int) -> Elem`, `(int, X) -> Elem | X`, etc.
+        # `Array#fetch` has multiple overloads in core RBS: `(int) -> Elem`, `(int, X) -> Elem | X`, etc.
         buffer_table.open(uri: uri, bytes: "[1, 2].fetch(\n", version: 1)
         result = provider.provide(uri: uri, line: 0, character: 13)
 
@@ -172,8 +165,7 @@ RSpec.describe Rigor::LanguageServer::SignatureHelpProvider do
     end
 
     it "byte_offset_for accumulates byte (not character) lengths across lines" do
-      # Line 0 ("あ\n") is 4 bytes but 2 characters, so a char-length
-      # mutation would compute the wrong offset for line 1.
+      # Line 0 ("あ\n") is 4 bytes but 2 characters, so a char-length mutation would compute the wrong offset for line 1.
       expect(provider.send(:byte_offset_for, "あ\ncd\n", 1, 1)).to eq(5)
     end
 

--- a/spec/rigor/language_server/synchronized_writer_spec.rb
+++ b/spec/rigor/language_server/synchronized_writer_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe Rigor::LanguageServer::SynchronizedWriter do
       end
 
       def write(payload)
-        # Simulate interleaving-prone work — two `<<` operations
-        # with a tiny gap. Without an outer mutex this would
+        # Simulate interleaving-prone work — two `<<` operations with a tiny gap. Without an outer mutex this would
         # produce torn output under concurrent writers.
         @write_mutex.synchronize { @payloads << [:start, payload] }
         sleep 0.001
@@ -39,10 +38,8 @@ RSpec.describe Rigor::LanguageServer::SynchronizedWriter do
     end
     threads.each(&:join)
 
-    # If `write` were unsynchronised, the per-call pair
-    # `[:start, msg]` then `[:end, msg]` could be interleaved
-    # with another writer's pair. With the mutex, every pair is
-    # contiguous in the payloads list.
+    # If `write` were unsynchronised, the per-call pair `[:start, msg]` then `[:end, msg]` could be interleaved with
+    # another writer's pair. With the mutex, every pair is contiguous in the payloads list.
     inner.payloads.each_slice(2) do |start_pair, end_pair|
       expect(start_pair[0]).to eq(:start)
       expect(end_pair[0]).to eq(:end)

--- a/spec/rigor/mcp/server_spec.rb
+++ b/spec/rigor/mcp/server_spec.rb
@@ -8,8 +8,8 @@ require "rigor/cli"
 RSpec.describe Rigor::MCP::Server do
   subject(:server) { described_class.new(err: StringIO.new) }
 
-  # Convenience: send a request and round-trip through JSON so all
-  # hash accesses use string keys (mirrors the wire format).
+  # Convenience: send a request and round-trip through JSON so all hash accesses use string keys (mirrors the wire
+  # format).
   def request(id:, method:, params: nil)
     req = { "id" => id, "method" => method }
     req["params"] = params if params
@@ -21,8 +21,7 @@ RSpec.describe Rigor::MCP::Server do
             params: { "name" => name, "arguments" => arguments })
   end
 
-  # ------------------------------------------------------------------ #
-  # Protocol lifecycle                                                    #
+  # ------------------------------------------------------------------ # Protocol lifecycle #
   # ------------------------------------------------------------------ #
 
   describe "initialize" do
@@ -64,8 +63,7 @@ RSpec.describe Rigor::MCP::Server do
     end
   end
 
-  # ------------------------------------------------------------------ #
-  # tools/list                                                            #
+  # ------------------------------------------------------------------ # tools/list #
   # ------------------------------------------------------------------ #
 
   describe "tools/list" do
@@ -89,8 +87,7 @@ RSpec.describe Rigor::MCP::Server do
     end
   end
 
-  # ------------------------------------------------------------------ #
-  # tools/call — unknown tool                                             #
+  # ------------------------------------------------------------------ # tools/call — unknown tool #
   # ------------------------------------------------------------------ #
 
   describe "tools/call with an unknown name" do
@@ -102,9 +99,8 @@ RSpec.describe Rigor::MCP::Server do
     end
   end
 
-  # ------------------------------------------------------------------ #
-  # tools/call — rigor_explain (fast, catalog-only, no file I/O)          #
-  # ------------------------------------------------------------------ #
+  # ------------------------------------------------------------------ # tools/call — rigor_explain (fast, catalog-only,
+  # no file I/O) # ------------------------------------------------------------------ #
 
   describe "rigor_explain" do
     it "returns a JSON catalog entry for a known rule" do
@@ -134,8 +130,7 @@ RSpec.describe Rigor::MCP::Server do
     end
   end
 
-  # ------------------------------------------------------------------ #
-  # tools/call — rigor_check                                              #
+  # ------------------------------------------------------------------ # tools/call — rigor_check #
   # ------------------------------------------------------------------ #
 
   describe "rigor_check" do
@@ -151,8 +146,7 @@ RSpec.describe Rigor::MCP::Server do
     end
   end
 
-  # ------------------------------------------------------------------ #
-  # tools/call — rigor_type_of                                            #
+  # ------------------------------------------------------------------ # tools/call — rigor_type_of #
   # ------------------------------------------------------------------ #
 
   describe "rigor_type_of" do
@@ -175,8 +169,7 @@ RSpec.describe Rigor::MCP::Server do
     end
   end
 
-  # ------------------------------------------------------------------ #
-  # tools/call — rigor_annotate                                           #
+  # ------------------------------------------------------------------ # tools/call — rigor_annotate #
   # ------------------------------------------------------------------ #
 
   describe "rigor_annotate" do
@@ -195,8 +188,7 @@ RSpec.describe Rigor::MCP::Server do
     end
   end
 
-  # ------------------------------------------------------------------ #
-  # tools/call — rigor_triage                                             #
+  # ------------------------------------------------------------------ # tools/call — rigor_triage #
   # ------------------------------------------------------------------ #
 
   describe "rigor_triage" do
@@ -216,8 +208,7 @@ RSpec.describe Rigor::MCP::Server do
     end
   end
 
-  # ------------------------------------------------------------------ #
-  # tools/call — rigor_coverage                                           #
+  # ------------------------------------------------------------------ # tools/call — rigor_coverage #
   # ------------------------------------------------------------------ #
 
   describe "rigor_coverage" do
@@ -232,8 +223,7 @@ RSpec.describe Rigor::MCP::Server do
     end
   end
 
-  # ------------------------------------------------------------------ #
-  # tools/call — rigor_sig_gen                                            #
+  # ------------------------------------------------------------------ # tools/call — rigor_sig_gen #
   # ------------------------------------------------------------------ #
 
   describe "rigor_sig_gen" do
@@ -243,8 +233,7 @@ RSpec.describe Rigor::MCP::Server do
     end
   end
 
-  # ------------------------------------------------------------------ #
-  # Session-level --config default propagation                            #
+  # ------------------------------------------------------------------ # Session-level --config default propagation #
   # ------------------------------------------------------------------ #
 
   describe "config_path session default" do
@@ -303,8 +292,8 @@ RSpec.describe Rigor::MCP::Server do
       expect(resp["result"]["isError"]).to be(true)
       expect(resp.dig("result", "content", 0, "text")).to include("kaboom")
       expect(err.string).to include("rigor mcp:").and include("kaboom")
-      # The backtrace is logged on its own lines (newline-joined), so the
-      # error output spans more than just the one "rigor mcp:" line.
+      # The backtrace is logged on its own lines (newline-joined), so the error output spans more than just the one
+      # "rigor mcp:" line.
       expect(err.string.lines.count).to be > 2
     end
   end

--- a/spec/rigor/plugin/base_spec.rb
+++ b/spec/rigor/plugin/base_spec.rb
@@ -2,10 +2,9 @@
 
 require "spec_helper"
 
-# Top-level named plugin class for the ADR-25 `#signature_paths`
-# tests — resolution needs `Object.const_source_location`, which
-# only resolves a named constant. Defined here so the file is
-# self-contained under `parallel_test`.
+# Top-level named plugin class for the ADR-25 `#signature_paths` tests — resolution needs
+# `Object.const_source_location`, which only resolves a named constant. Defined here so the file is self-contained under
+# `parallel_test`.
 class RigorPluginBaseSpecSigPlugin < Rigor::Plugin::Base
   manifest(id: "base-spec-sig", version: "0.0.1", signature_paths: ["sig"])
 end
@@ -83,8 +82,7 @@ RSpec.describe Rigor::Plugin::Base do
 
     it "resolves declared paths against the plugin gem root" do
       plugin = RigorPluginBaseSpecSigPlugin.new(services: services)
-      # The class is defined in this spec file (no `/lib/` segment),
-      # so the gem root falls back to the file's directory.
+      # The class is defined in this spec file (no `/lib/` segment), so the gem root falls back to the file's directory.
       expect(plugin.signature_paths).to eq([File.expand_path("sig", __dir__)])
     end
 
@@ -122,9 +120,8 @@ RSpec.describe Rigor::Plugin::Base do
     end
   end
 
-  # Private since ADR-60 WD3 — `producer watch:` is the declared way to
-  # cover a producer's glob; this remains its building block, exercised
-  # here via `send`.
+  # Private since ADR-60 WD3 — `producer watch:` is the declared way to cover a producer's glob; this remains its
+  # building block, exercised here via `send`.
   describe "#glob_descriptor" do
     let(:plugin_class) do
       Class.new(described_class) do
@@ -199,8 +196,7 @@ RSpec.describe Rigor::Plugin::Base do
       Dir.mktmpdir("rigor-glob-desc-") do |dir|
         FileUtils.mkdir_p(File.join(dir, "sub"))
         File.write(File.join(dir, "a.rb"), "")
-        # `**/*` matches both `sub` and `a.rb`; only `a.rb` should
-        # appear in the descriptor.
+        # `**/*` matches both `sub` and `a.rb`; only `a.rb` should appear in the descriptor.
         descriptor = plugin.send(:glob_descriptor, [dir], "**/*")
         names = descriptor.files.map(&:path).map { |p| File.basename(p) }
         expect(names).to contain_exactly("a.rb")
@@ -271,8 +267,8 @@ RSpec.describe Rigor::Plugin::Base do
       plugin = klass.new(services: services)
       root = Prism.parse("foo\nbar").value
       diags = plugin.node_rule_diagnostics(path: "d.rb", scope: Rigor::Scope.empty, root: root)
-      # Both CallNodes (foo, bar) see the same file context (statement
-      # count = 2), proving it was built before the walk and threaded.
+      # Both CallNodes (foo, bar) see the same file context (statement count = 2), proving it was built before the walk
+      # and threaded.
       expect(diags.map(&:message)).to eq(["count=2", "count=2"])
     end
 
@@ -573,9 +569,8 @@ RSpec.describe Rigor::Plugin::Base do
       end
 
       it "fires on the method name regardless of the receiver carrier shape" do
-        # A receiver carrier with no nominal class (untyped/Dynamic) —
-        # a receiver-gated rule could not match it, but a methods-only
-        # rule reads the shape inside its own block.
+        # A receiver carrier with no nominal class (untyped/Dynamic) — a receiver-gated rule could not match it, but a
+        # methods-only rule reads the shape inside its own block.
         type = plugin_methods_only.dynamic_return_type(
           call_node: call("100.kilometers"), scope: Rigor::Scope.empty,
           receiver_type: Rigor::Type::Combinator.untyped
@@ -614,9 +609,8 @@ RSpec.describe Rigor::Plugin::Base do
       let(:plugin_runtime) do
         Class.new(described_class) do
           manifest(id: "dr-rt", version: "0.1.0")
-          # The set the callable returns is built at run time — here a
-          # mutable accumulator the test fills after the class is defined,
-          # standing in for a `#prepare`-built index.
+          # The set the callable returns is built at run time — here a mutable accumulator the test fills after the
+          # class is defined, standing in for a `#prepare`-built index.
           def model_names = @model_names ||= []
 
           dynamic_return receivers: -> { model_names } do |_call_node, _scope|
@@ -742,8 +736,8 @@ RSpec.describe Rigor::Plugin::Base do
       let(:plugin_file_methods) do
         Class.new(described_class) do
           manifest(id: "dr-pfm", version: "0.1.0")
-          # The per-file name set — here a hand-seeded path → names map;
-          # in a real plugin a per-file index (rspec's LetScopeIndex).
+          # The per-file name set — here a hand-seeded path → names map; in a real plugin a per-file index (rspec's
+          # LetScopeIndex).
           def names_by_path = @names_by_path ||= {}
 
           dynamic_return file_methods: ->(path) { names_by_path[path] } do |_call_node, _scope|

--- a/spec/rigor/plugin/blueprint_spec.rb
+++ b/spec/rigor/plugin/blueprint_spec.rb
@@ -2,8 +2,8 @@
 
 require "spec_helper"
 
-# A top-level constant so the Blueprint's `Object.const_get` can
-# resolve it the same way it does inside a Ractor worker (ADR-15 Phase 4).
+# A top-level constant so the Blueprint's `Object.const_get` can resolve it the same way it does inside a Ractor worker
+# (ADR-15 Phase 4).
 class RigorPluginBlueprintSpecPlugin < Rigor::Plugin::Base
   manifest(id: "blueprint-spec", version: "0.1.0")
 

--- a/spec/rigor/plugin/box_spec.rb
+++ b/spec/rigor/plugin/box_spec.rb
@@ -9,8 +9,8 @@ require "spec_helper"
 # (non-box) behaviour is unchanged. To exercise the box path:
 #   RUBY_BOX=1 bundle exec rspec spec/rigor/plugin/box_spec.rb
 RSpec.describe Rigor::Plugin::Box do
-  # Helper to reset memoized ivars between examples when the box
-  # is active, since module_function stores them on the module.
+  # Helper to reset memoized ivars between examples when the box is active, since module_function stores them on the
+  # module.
   def reset_box!
     described_class.remove_instance_variable(:@shared) if described_class.instance_variable_defined?(:@shared)
     described_class.remove_instance_variable(:@required) if described_class.instance_variable_defined?(:@required)
@@ -85,10 +85,9 @@ RSpec.describe Rigor::Plugin::Box do
       expect(described_class.require_feature("active_support/inflector")).to be(true)
       # The shared box answers the call...
       expect(described_class.eval("ActiveSupport::Inflector.pluralize(\"person\")")).to eq("people")
-      # ...without ActiveSupport leaking into Rigor's main space. (Guarded:
-      # another example in this process may have loaded it via the `none`
-      # strategy, which pollutes this process-global check; the no-leak
-      # property holds when this spec runs standalone.)
+      # ...without ActiveSupport leaking into Rigor's main space. (Guarded: another example in this process may have
+      # loaded it via the `none` strategy, which pollutes this process-global check; the no-leak property holds when
+      # this spec runs standalone.)
       skip "ActiveSupport already loaded in this process" if defined?(ActiveSupport)
       expect(defined?(ActiveSupport)).to be_nil
     end

--- a/spec/rigor/plugin/cache_producer_spec.rb
+++ b/spec/rigor/plugin/cache_producer_spec.rb
@@ -3,10 +3,8 @@
 require "spec_helper"
 require "tmpdir"
 
-# ADR-7 § "Slice 6" end-to-end coverage for the plugin-side
-# cache producer surface — the `Plugin::Base.producer` DSL,
-# `Plugin::Base#cache_for` callable, automatic PluginEntry
-# attachment (6-B), and `plugin.<id>.` producer-id sandbox
+# ADR-7 § "Slice 6" end-to-end coverage for the plugin-side cache producer surface — the `Plugin::Base.producer` DSL,
+# `Plugin::Base#cache_for` callable, automatic PluginEntry attachment (6-B), and `plugin.<id>.` producer-id sandbox
 # prefix (6-C).
 RSpec.describe Rigor::Plugin::Base, # rubocop:disable RSpec/SpecFilePathFormat
                "cache producers (slice 6)" do # rubocop:disable RSpec/DescribeMethod
@@ -251,14 +249,11 @@ RSpec.describe Rigor::Plugin::Base, # rubocop:disable RSpec/SpecFilePathFormat
     end
   end
 
-  # ADR-60 WD3 — `cache_for` rides `Cache::Store#fetch_or_validate`:
-  # the entry is keyed on the stable identity inputs, and the
-  # dependency descriptor (boundary reads + `watch:` globs) is
-  # recorded AFTER the producer block runs. Each "session" below
-  # uses a FRESH `Cache::Store` (empty in-process memo) and a fresh
-  # plugin instance — the faithful simulation of a second
-  # `rigor check` process reading the same on-disk cache, per the
-  # established `pundit_plugin_spec` cross-process pattern.
+  # ADR-60 WD3 — `cache_for` rides `Cache::Store#fetch_or_validate`: the entry is keyed on the stable identity inputs,
+  # and the dependency descriptor (boundary reads + `watch:` globs) is recorded AFTER the producer block runs. Each
+  # "session" below uses a FRESH `Cache::Store` (empty in-process memo) and a fresh plugin instance — the faithful
+  # simulation of a second `rigor check` process reading the same on-disk cache, per the established
+  # `pundit_plugin_spec` cross-process pattern.
   describe "#cache_for record-and-validate (ADR-60 WD3)" do
     let(:cache_root) { File.join(tmpdir, ".rigor", "cache") }
 
@@ -276,10 +271,9 @@ RSpec.describe Rigor::Plugin::Base, # rubocop:disable RSpec/SpecFilePathFormat
       file = File.join(tmpdir, "data.txt")
       File.write(file, "v1")
 
-      # The structural hazard being fixed: the block performs the
-      # read, nothing primes the boundary beforehand. Under the old
-      # `fetch_or_compute` call-time snapshot this read was
-      # invisible to the descriptor and session 2 served stale "v1".
+      # The structural hazard being fixed: the block performs the read, nothing primes the boundary beforehand. Under
+      # the old `fetch_or_compute` call-time snapshot this read was invisible to the descriptor and session 2 served
+      # stale "v1".
       klass = Class.new(described_class) do
         manifest(id: "alpha", version: "0.1.0")
       end
@@ -323,8 +317,7 @@ RSpec.describe Rigor::Plugin::Base, # rubocop:disable RSpec/SpecFilePathFormat
         attr_reader :search_root
 
         def init(_services)
-          # `watch:` Procs run at cache_for time, so init-derived
-          # roots like this one are visible to them.
+          # `watch:` Procs run at cache_for time, so init-derived roots like this one are visible to them.
           @search_root = config.fetch("root")
         end
 
@@ -411,8 +404,8 @@ RSpec.describe Rigor::Plugin::Base, # rubocop:disable RSpec/SpecFilePathFormat
         plugin.instance_variable_set(:@io_boundary, boundary)
         expect(plugin.cache_for(:remote, params: {}).call).to eq("remote-body")
       end
-      # ConfigEntry rows in the dependency descriptor make fresh?
-      # false by design — sound (never stale), recompute every run.
+      # ConfigEntry rows in the dependency descriptor make fresh? false by design — sound (never stale), recompute every
+      # run.
       expect(calls).to eq(2)
     end
 

--- a/spec/rigor/plugin/contribution_index_spec.rb
+++ b/spec/rigor/plugin/contribution_index_spec.rb
@@ -2,10 +2,9 @@
 
 require "spec_helper"
 
-# ADR-52 WD1 — the compiled contribution table. These specs pin the
-# gate semantics that keep the engine's pruned walks byte-identical to
-# the ungated ones: a gate may only return false when every pruned
-# consultation would have produced nothing.
+# ADR-52 WD1 — the compiled contribution table. These specs pin the gate semantics that keep the engine's pruned walks
+# byte-identical to the ungated ones: a gate may only return false when every pruned consultation would have produced
+# nothing.
 RSpec.describe Rigor::Plugin::ContributionIndex do
   let(:services) do
     Rigor::Plugin::Services.new(
@@ -110,9 +109,8 @@ RSpec.describe Rigor::Plugin::ContributionIndex do
     end
 
     it "treats a run-time (callable) methods: rule as ungated by name (ADR-52 slice 4)" do
-      # A callable methods: set is unknown at registry-build time, so it
-      # cannot compile into the name gate — the plugin is consulted on
-      # every dispatch and filters in the instance path.
+      # A callable methods: set is unknown at registry-build time, so it cannot compile into the name gate — the plugin
+      # is consulted on every dispatch and filters in the instance path.
       runtime_methods_class = Class.new(Rigor::Plugin::Base) do
         manifest(id: "rtm", version: "0.0.1")
         dynamic_return methods: -> { [:evaluate] } do |_call_node, _scope|
@@ -195,12 +193,10 @@ RSpec.describe Rigor::Plugin::ContributionIndex do
     end
   end
 
-  # The `&:symbol` block path dispatches with the BlockArgumentNode
-  # itself as `call_node` (`ExpressionTyper#symbol_block_return_type`),
-  # so the collector's name gate must tolerate nodes without `#name` —
-  # a raise here is silently absorbed upstream and nils the block type
-  # (GitLab corpus regression: `select(&:presence)` flipped onto its
-  # no-block Enumerator overload).
+  # The `&:symbol` block path dispatches with the BlockArgumentNode itself as `call_node`
+  # (`ExpressionTyper#symbol_block_return_type`), so the collector's name gate must tolerate nodes without `#name` — a
+  # raise here is silently absorbed upstream and nils the block type (GitLab corpus regression: `select(&:presence)`
+  # flipped onto its no-block Enumerator overload).
   describe "dispatcher collection with a non-CallNode (ADR-52 slice-1 regression)" do
     def block_argument_node
       Prism.parse("foo(&:bar)").value.statements.body.first.block

--- a/spec/rigor/plugin/inflector_spec.rb
+++ b/spec/rigor/plugin/inflector_spec.rb
@@ -2,12 +2,10 @@
 
 require "spec_helper"
 
-# ADR-39 — the shared inflection helper. It inflects ONLY with the real
-# `ActiveSupport::Inflector` (no built-in approximation, which would be a
-# source of wrong facts → false positives). The repo bundle carries
-# `activesupport` as a development dependency (see rigortype.gemspec), so
-# the suite exercises the real path; absence is covered by stubbing the
-# loader to confirm it raises rather than guesses.
+# ADR-39 — the shared inflection helper. It inflects ONLY with the real `ActiveSupport::Inflector` (no built-in
+# approximation, which would be a source of wrong facts → false positives). The repo bundle carries `activesupport` as a
+# development dependency (see rigortype.gemspec), so the suite exercises the real path; absence is covered by stubbing
+# the loader to confirm it raises rather than guesses.
 RSpec.describe Rigor::Plugin::Inflector do
   describe "with the real ActiveSupport::Inflector (bundled in dev)" do
     it "is available in the repo bundle" do
@@ -23,9 +21,8 @@ RSpec.describe Rigor::Plugin::Inflector do
       expect(described_class.classify("blog_posts")).to eq("BlogPost")
     end
 
-    # The whole point of ADR-39: the irregulars a hand-rolled
-    # approximation gets wrong are authoritative because the real
-    # inflector answers.
+    # The whole point of ADR-39: the irregulars a hand-rolled approximation gets wrong are authoritative because the
+    # real inflector answers.
     it "resolves irregular inflections an approximation would miss" do
       expect(described_class.pluralize("person")).to eq("people")
       expect(described_class.pluralize("child")).to eq("children")
@@ -37,16 +34,15 @@ RSpec.describe Rigor::Plugin::Inflector do
     it "flattens namespaced names like Rails" do
       expect(described_class.underscore("Admin::DomainBlocksController"))
         .to eq("admin/domain_blocks_controller")
-      # tableize composes underscore + pluralize with ::->_ flattening,
-      # matching AR's real table name (NOT Inflector.tableize's admin/users).
+      # tableize composes underscore + pluralize with ::->_ flattening, matching AR's real table name (NOT
+      # Inflector.tableize's admin/users).
       expect(described_class.tableize("Admin::User")).to eq("admin_users")
     end
   end
 
   describe "when ActiveSupport::Inflector cannot be reached" do
-    # Simulate the library being unreachable under the configured isolation
-    # strategy: Isolation.call raises Unavailable, which Inflector re-raises
-    # as its own Unavailable (never approximating).
+    # Simulate the library being unreachable under the configured isolation strategy: Isolation.call raises Unavailable,
+    # which Inflector re-raises as its own Unavailable (never approximating).
     before do
       allow(Rigor::Plugin::Isolation).to receive(:call)
         .and_raise(Rigor::Plugin::Isolation::Unavailable, "...add `activesupport`...")
@@ -56,9 +52,8 @@ RSpec.describe Rigor::Plugin::Inflector do
       expect(described_class.available?).to be(false)
     end
 
-    # No approximation: every inflection raises a clear Unavailable error
-    # (the caller's per-plugin rescue turns this into silence — reduced
-    # coverage, never a wrong inflection / false positive).
+    # No approximation: every inflection raises a clear Unavailable error (the caller's per-plugin rescue turns this
+    # into silence — reduced coverage, never a wrong inflection / false positive).
     it "raises Unavailable instead of returning an approximation" do
       expect { described_class.pluralize("person") }
         .to raise_error(Rigor::Plugin::Inflector::Unavailable)

--- a/spec/rigor/plugin/io_boundary_spec.rb
+++ b/spec/rigor/plugin/io_boundary_spec.rb
@@ -147,10 +147,9 @@ RSpec.describe Rigor::Plugin::IoBoundary do
     end
   end
 
-  # The real-`Net::HTTP` wrapper the boundary injects-over in every other
-  # test (a fake `#get`); exercised here with stubbed transport so the
-  # success / non-success / oversize-body branches and their reason codes
-  # have a unit safety net without touching the network.
+  # The real-`Net::HTTP` wrapper the boundary injects-over in every other test (a fake `#get`); exercised here with
+  # stubbed transport so the success / non-success / oversize-body branches and their reason codes have a unit safety
+  # net without touching the network.
   describe Rigor::Plugin::DefaultHttpClient do
     subject(:client) { described_class.new }
 
@@ -159,8 +158,8 @@ RSpec.describe Rigor::Plugin::IoBoundary do
 
     before { allow(Net::HTTP).to receive(:start).and_yield(http) }
 
-    # Real response objects so `#is_a?(Net::HTTPSuccess)` and `#code` are
-    # genuine; only the socket-backed `#read_body` needs stubbing.
+    # Real response objects so `#is_a?(Net::HTTPSuccess)` and `#code` are genuine; only the socket-backed `#read_body`
+    # needs stubbing.
     def respond_with(response)
       allow(http).to receive(:request_get).and_yield(response)
     end

--- a/spec/rigor/plugin/isolation_spec.rb
+++ b/spec/rigor/plugin/isolation_spec.rb
@@ -2,11 +2,9 @@
 
 require "spec_helper"
 
-# ADR-39 slice 5 — the selectable isolation strategy for target-library
-# invocation (none / ruby_box / process). The strategy is read from
-# `RIGOR_PLUGIN_ISOLATION`; examples set it per-case. `process` (fork) is
-# exercised directly; `ruby_box` needs `RUBY_BOX=1` at process start, so
-# those examples skip unless the feature is active.
+# ADR-39 slice 5 — the selectable isolation strategy for target-library invocation (none / ruby_box / process). The
+# strategy is read from `RIGOR_PLUGIN_ISOLATION`; examples set it per-case. `process` (fork) is exercised directly;
+# `ruby_box` needs `RUBY_BOX=1` at process start, so those examples skip unless the feature is active.
 RSpec.describe Rigor::Plugin::Isolation do
   let(:feature) { "active_support/inflector" }
   let(:inflector) { "ActiveSupport::Inflector" }
@@ -93,8 +91,8 @@ RSpec.describe Rigor::Plugin::Isolation do
       end
     end
 
-    # The whole point of process isolation: a worker crash is contained —
-    # the parent survives, declines, and recovers on the next call.
+    # The whole point of process isolation: a worker crash is contained — the parent survives, declines, and recovers on
+    # the next call.
     it "contains a worker crash and recovers" do
       with_strategy("process") do
         described_class.call(feature: feature, receiver: inflector, method: :pluralize, args: ["post"])
@@ -116,10 +114,9 @@ RSpec.describe Rigor::Plugin::Isolation do
   end
 
   describe "ruby_box", if: Rigor::Plugin::Box.enabled? do
-    # The no-leak property (boxing does not load the library into the main
-    # space) is a process-global negative that other examples in the suite
-    # pollute, so it is asserted in box_spec (run standalone) rather than
-    # here; this checks the strategy returns the correct result.
+    # The no-leak property (boxing does not load the library into the main space) is a process-global negative that
+    # other examples in the suite pollute, so it is asserted in box_spec (run standalone) rather than here; this checks
+    # the strategy returns the correct result.
     it "answers correctly through the box" do
       with_strategy("ruby_box") do
         expect(described_class.call(feature: feature, receiver: inflector, method: :pluralize, args: ["person"]))
@@ -130,9 +127,8 @@ RSpec.describe Rigor::Plugin::Isolation do
     end
   end
 
-  # Unit-exercise the RubyBox backend's branches with a stubbed Box, so the
-  # error gates and the inspect-rendered expression are covered without the
-  # process-global `RUBY_BOX=1` the integration example above requires.
+  # Unit-exercise the RubyBox backend's branches with a stubbed Box, so the error gates and the inspect-rendered
+  # expression are covered without the process-global `RUBY_BOX=1` the integration example above requires.
   describe "RubyBox (unit, stubbed Box)" do
     let(:box) { Rigor::Plugin::Box }
 
@@ -160,8 +156,8 @@ RSpec.describe Rigor::Plugin::Isolation do
 
     it "joins multiple inspect-rendered args with ', ' in the expression" do
       allow(box).to receive_messages(enabled?: true, require_feature: true)
-      # Two args so the join separator is observable (a single arg renders the
-      # same under any separator, masking a dropped/altered one).
+      # Two args so the join separator is observable (a single arg renders the same under any separator, masking a
+      # dropped/altered one).
       allow(box).to receive(:eval).with('ActiveSupport::Inflector.camelize("a", "b")').and_return("ok")
       result = described_class::RubyBox.call(feature: feature, receiver: inflector, method: :camelize, args: %w[a b])
       expect(result).to eq("ok")

--- a/spec/rigor/plugin/loader_spec.rb
+++ b/spec/rigor/plugin/loader_spec.rb
@@ -2,10 +2,8 @@
 
 require "spec_helper"
 
-# ADR-25 — named plugin classes for the signature_paths
-# load-time-validation tests. Defined in this file, so the gem
-# root resolves (no `/lib/` segment) to this file's directory;
-# `"."` therefore points at an existing directory and the
+# ADR-25 — named plugin classes for the signature_paths load-time-validation tests. Defined in this file, so the gem
+# root resolves (no `/lib/` segment) to this file's directory; `"."` therefore points at an existing directory and the
 # bogus entry at a missing one.
 class LoaderSpecSigOkPlugin < Rigor::Plugin::Base
   manifest(id: "sigok", version: "0.1.0", signature_paths: ["."])
@@ -161,8 +159,8 @@ RSpec.describe Rigor::Plugin::Loader do
       registry = described_class.load(configuration: configuration, services: services, requirer: requirer)
 
       expect(registry.plugins).to be_empty
-      # The error must be actionable: name the meta-gem nature and how to
-      # list the individual plugins (the onboarding field-trial trap).
+      # The error must be actionable: name the meta-gem nature and how to list the individual plugins (the onboarding
+      # field-trial trap).
       message = registry.load_errors.first.message
       expect(message).to include("convenience meta-gem")
       expect(message).to match(/list the individual plugin gems/i)

--- a/spec/rigor/plugin/manifest_spec.rb
+++ b/spec/rigor/plugin/manifest_spec.rb
@@ -712,11 +712,10 @@ RSpec.describe Rigor::Plugin::Manifest do
     end
   end
 
-  # Pins the exact reject message of every Array-of-X field. The thirteen
-  # validators delegate to one `validate_array_of!`, so the message format
-  # and each per-field label live in a single place; this table guards
-  # against any of them drifting (the messages are part of the plugin-author
-  # experience even though no analysis path exercises them).
+  # Pins the exact reject message of every Array-of-X field. The thirteen validators delegate to one
+  # `validate_array_of!`, so the message format and each per-field label live in a single place; this table guards
+  # against any of them drifting (the messages are part of the plugin-author experience even though no analysis path
+  # exercises them).
   describe "array-field validation messages" do
     [
       [:produces, [123], "Symbol/String"],

--- a/spec/rigor/plugin/registry_spec.rb
+++ b/spec/rigor/plugin/registry_spec.rb
@@ -2,34 +2,29 @@
 
 require "spec_helper"
 
-# Top-level constant the `.materialize` tests use as a
-# `Blueprint#klass_name`. Defined locally so this spec file is
-# self-contained — under `parallel_test` two workers may split
-# `blueprint_spec.rb` and `registry_spec.rb` across processes,
-# and `registry_spec` previously borrowed
-# `RigorPluginBlueprintSpecPlugin` from the blueprint spec
-# which left it `NameError`-prone in isolation.
+# Top-level constant the `.materialize` tests use as a `Blueprint#klass_name`. Defined locally so this spec file is
+# self-contained — under `parallel_test` two workers may split `blueprint_spec.rb` and `registry_spec.rb` across
+# processes, and `registry_spec` previously borrowed `RigorPluginBlueprintSpecPlugin` from the blueprint spec which left
+# it `NameError`-prone in isolation.
 class RigorPluginRegistrySpecPlugin < Rigor::Plugin::Base
   manifest(id: "registry-spec-plugin", version: "0.0.1")
 end
 
-# ADR-25 — a named plugin class declaring `signature_paths:`, for
-# the `Registry#signature_paths` aggregation test (resolution
-# needs a named constant).
+# ADR-25 — a named plugin class declaring `signature_paths:`, for the `Registry#signature_paths` aggregation test
+# (resolution needs a named constant).
 class RigorPluginRegistrySpecSigPlugin < Rigor::Plugin::Base
   manifest(id: "registry-spec-sig-plugin", version: "0.0.1", signature_paths: ["sig"])
 end
 
-# ADR-26 — a named plugin class declaring `open_receivers:`, for
-# the `Registry#open_receivers` / `#open_receiver?` tests.
+# ADR-26 — a named plugin class declaring `open_receivers:`, for the `Registry#open_receivers` / `#open_receiver?`
+# tests.
 class RigorPluginRegistrySpecOpenPlugin < Rigor::Plugin::Base
   manifest(id: "registry-spec-open-plugin", version: "0.0.1",
            open_receivers: ["ActiveRecord::Relation"])
 end
 
-# ADR-28 — a named plugin class declaring `protocol_contracts:`,
-# for the `Registry#protocol_contracts` / `#contracts_for_path`
-# tests.
+# ADR-28 — a named plugin class declaring `protocol_contracts:`, for the `Registry#protocol_contracts` /
+# `#contracts_for_path` tests.
 class RigorPluginRegistrySpecContractPlugin < Rigor::Plugin::Base
   manifest(
     id: "registry-spec-contract-plugin", version: "0.0.1",
@@ -294,9 +289,8 @@ RSpec.describe Rigor::Plugin::Registry do
       registry = described_class.new(plugins: [dynamic_plugin, specifier_plugin])
       index = registry.contribution_index
 
-      # dynamic_gates: keyed per plugin instance, grouping happens by
-      # `p.class.dynamic_returns` — the gate reflects only THIS
-      # plugin's declared method names, not the other plugin's.
+      # dynamic_gates: keyed per plugin instance, grouping happens by `p.class.dynamic_returns` — the gate reflects only
+      # THIS plugin's declared method names, not the other plugin's.
       expect(index.dynamic_candidate_for?(dynamic_plugin, :unwrap)).to be(true)
       expect(index.dynamic_candidate_for?(dynamic_plugin, :unwrap!)).to be(true)
       expect(index.dynamic_candidate_for?(dynamic_plugin, :assert_kind_of)).to be(false)
@@ -326,8 +320,8 @@ RSpec.describe Rigor::Plugin::Registry do
       )
       index = registry.contribution_index
 
-      # The union gate must include names from BOTH plugins, proving
-      # `union_gate` actually merges (not just keeps the last plugin's set).
+      # The union gate must include names from BOTH plugins, proving `union_gate` actually merges (not just keeps the
+      # last plugin's set).
       expect(index.dispatch_candidate?(:unwrap)).to be(true)
       expect(index.dispatch_candidate?(:kilometers)).to be(true)
       expect(index.dispatch_candidate?(:nonexistent)).to be(false)
@@ -359,13 +353,12 @@ RSpec.describe Rigor::Plugin::Registry do
       registry = described_class.new(plugins: [klass_a.new(services: services), klass_b.new(services: services)])
       index = registry.contribution_index
 
-      # #each over entries + #method_names per entry populate BOTH
-      # names for entry_a and the one name for entry_b, in
+      # #each over entries + #method_names per entry populate BOTH names for entry_a and the one name for entry_b, in
       # (plugin, declaration) order.
       expect(index.block_entries_for(:get)).to eq([entry_a, entry_b])
       expect(index.block_entries_for(:post)).to eq([entry_a])
-      # #fetch's default value kicks in for an unknown key, and the
-      # SAME frozen empty array is returned every time (identity).
+      # #fetch's default value kicks in for an unknown key, and the SAME frozen empty array is returned every time
+      # (identity).
       expect(index.block_entries_for(:missing)).to eq([])
       expect(index.block_entries_for(:missing)).to be(index.block_entries_for(:never))
     end

--- a/spec/rigor/protection/mutation_scanner_spec.rb
+++ b/spec/rigor/protection/mutation_scanner_spec.rb
@@ -7,9 +7,8 @@ require "rigor/configuration"
 require "rigor/language_server/project_context"
 require "rigor/protection/mutation_scanner"
 
-# ADR-63 Tier 2 — the warm-loop per-file effectiveness measurement. Drives the
-# real analyzer (one shared environment + project scan) over each mutant and
-# reads a NEW diagnostic as a "caught breakage" (kill). This exercises the kill
+# ADR-63 Tier 2 — the warm-loop per-file effectiveness measurement. Drives the real analyzer (one shared environment +
+# project scan) over each mutant and reads a NEW diagnostic as a "caught breakage" (kill). This exercises the kill
 # criterion end-to-end, so it builds a real (if minimal) project context.
 RSpec.describe Rigor::Protection::MutationScanner do
   around do |example|
@@ -36,8 +35,8 @@ RSpec.describe Rigor::Protection::MutationScanner do
   end
 
   it "records a surviving site when a type-visible mutation is not caught" do
-    # `File.join` accepts any arguments in RBS, so dropping an arg to nil does
-    # not fire — a genuine missed-breakage candidate at a concrete receiver.
+    # `File.join` accepts any arguments in RBS, so dropping an arg to nil does not fire — a genuine missed-breakage
+    # candidate at a concrete receiver.
     File.write("joins.rb", %(def j\n  File.join("a", "b")\nend\n))
 
     result = scanner.scan_file("joins.rb")
@@ -64,8 +63,8 @@ RSpec.describe Rigor::Protection::MutationScanner do
     expect(result.ratio).to eq(1.0)
   end
 
-  # ADR-70 — the fused static∪dynamic measurement. A fake oracle stands in for
-  # the real test suite so the classification logic is exercised deterministically.
+  # ADR-70 — the fused static∪dynamic measurement. A fake oracle stands in for the real test suite so the classification
+  # logic is exercised deterministically.
   def fake_test_oracle(verdict)
     oracle = Object.new
     oracle.define_singleton_method(:killed?) { |**| verdict }
@@ -73,8 +72,8 @@ RSpec.describe Rigor::Protection::MutationScanner do
   end
 
   it "credits a type-survivor to the test axis when a test catches it (ADR-70)" do
-    # `File.join` survives the type pass (any args ok) — a type-survivor the test
-    # oracle then catches → test_killed, zero unprotected, fully protected.
+    # `File.join` survives the type pass (any args ok) — a type-survivor the test oracle then catches → test_killed,
+    # zero unprotected, fully protected.
     File.write("joins.rb", %(def j\n  File.join("a", "b")\nend\n))
 
     result = scanner.scan_file_fused("joins.rb", test_oracle: fake_test_oracle(true))
@@ -95,9 +94,8 @@ RSpec.describe Rigor::Protection::MutationScanner do
   end
 
   it "probes Dynamic-receiver dispatch sites under the :all selector and credits the test axis (Seam 2)" do
-    # `x` is an untyped param, so `x.save` is a Dynamic-receiver site the biteable
-    # filter drops entirely (nothing to measure). Under :all it is mutated and,
-    # being un-bite-able, falls straight to the test axis.
+    # `x` is an untyped param, so `x.save` is a Dynamic-receiver site the biteable filter drops entirely (nothing to
+    # measure). Under :all it is mutated and, being un-bite-able, falls straight to the test axis.
     File.write("dyn.rb", %(def f(x)\n  x.save\nend\n))
 
     biteable = scanner.scan_file_fused("dyn.rb", test_oracle: fake_test_oracle(true))
@@ -118,8 +116,8 @@ RSpec.describe Rigor::Protection::MutationScanner do
   end
 
   it "never reaches the suite when the type checker already kills the mutant (gradual short-circuit)" do
-    # `"hello".upcase` mutants are all type-killed → the test oracle is never
-    # consulted; an oracle that would raise if called proves the short-circuit.
+    # `"hello".upcase` mutants are all type-killed → the test oracle is never consulted; an oracle that would raise if
+    # called proves the short-circuit.
     File.write("greet.rb", %(def greet\n  "hello".upcase\nend\n))
     never = Class.new { def killed?(**) = raise("suite should not run on a type-killed mutant") }.new
 

--- a/spec/rigor/protection/mutator_spec.rb
+++ b/spec/rigor/protection/mutator_spec.rb
@@ -3,9 +3,8 @@
 require "spec_helper"
 require "rigor/protection/mutator"
 
-# ADR-63 Tier 2 — the type-visible mutation generator productized from the dev
-# harness. Generates byte-range source splices aimed at the call-rule families,
-# and (with the type-aware filter) keeps only mutations at sites where Rigor
+# ADR-63 Tier 2 — the type-visible mutation generator productized from the dev harness. Generates byte-range source
+# splices aimed at the call-rule families, and (with the type-aware filter) keeps only mutations at sites where Rigor
 # holds a concrete receiver type.
 RSpec.describe Rigor::Protection::Mutator do
   def mutations(source, **)

--- a/spec/rigor/protection/test_suite_oracle_spec.rb
+++ b/spec/rigor/protection/test_suite_oracle_spec.rb
@@ -5,8 +5,8 @@ require "tmpdir"
 
 require "rigor/protection/test_suite_oracle"
 
-# ADR-70 — the dynamic (test-suite) kill oracle. The runner is injected so the
-# kill logic + the file restore guarantee are exercised without shelling out.
+# ADR-70 — the dynamic (test-suite) kill oracle. The runner is injected so the kill logic + the file restore guarantee
+# are exercised without shelling out.
 RSpec.describe Rigor::Protection::TestSuiteOracle do
   it "is green when the runner reports the suite passed" do
     oracle = described_class.new(command: %w[noop], runner: ->(_) { true })
@@ -62,9 +62,8 @@ RSpec.describe Rigor::Protection::TestSuiteOracle do
     end
   end
 
-  # The default (shelling) runner must strip Bundler's env, or a `bundle exec`
-  # test command resolves Rigor's own bundle instead of the target's — which
-  # makes a green suite look red and aborts the run (found validating ADR-70).
+  # The default (shelling) runner must strip Bundler's env, or a `bundle exec` test command resolves Rigor's own bundle
+  # instead of the target's — which makes a green suite look red and aborts the run (found validating ADR-70).
   it "runs the default command inside a cleaned bundler env" do
     oracle = described_class.new(command: %w[true]) # default runner (no injection)
     cleaned = false

--- a/spec/rigor/public_api_drift_spec.rb
+++ b/spec/rigor/public_api_drift_spec.rb
@@ -450,10 +450,8 @@ module PublicApiDriftSnapshots # rubocop:disable Metrics/ModuleLength
     resolvers()
   ].freeze
 
-  # Drift-pinned namespaces that still lack a `sig/rigor/*.rbs`
-  # entry. Tracked here so the RBS sig drift spec can fail
-  # loudly when a sig is added but this list is forgotten —
-  # the bookkeeping stays honest and the sig backlog stays
+  # Drift-pinned namespaces that still lack a `sig/rigor/*.rbs` entry. Tracked here so the RBS sig drift spec can fail
+  # loudly when a sig is added but this list is forgotten — the bookkeeping stays honest and the sig backlog stays
   # visible.
   UNSIGNED_NAMESPACES = %w[
     Rigor::Plugin::FactStore::Fact
@@ -541,10 +539,8 @@ module PublicApiDriftSnapshots # rubocop:disable Metrics/ModuleLength
     widen_value_pinned(req:type)
   ].freeze
 
-  # `Rigor::Source::Literals` — the literal Symbol/String extraction
-  # helpers ADR-2 exposes to plugins so the
-  # `is_a?(Prism::SymbolNode)` extraction is written once. A
-  # `module_function` module, so its public surface is the
+  # `Rigor::Source::Literals` — the literal Symbol/String extraction helpers ADR-2 exposes to plugins so the
+  # `is_a?(Prism::SymbolNode)` extraction is written once. A `module_function` module, so its public surface is the
   # singleton method set.
   SOURCE_LITERALS_SINGLETON = %w[
     symbol(req:node)
@@ -563,12 +559,9 @@ RSpec.describe "Public API drift", :public_api_drift do
     "#{method.name}(#{params})"
   end
 
-  # When `klass` is `class Foo < Data.define(...)`, the Data-generated
-  # readers live on the anonymous parent class rather than on `Foo`
-  # itself. Walk through any anonymous (name == nil) parent so the
-  # surface snapshot is invariant to whether the carrier was authored
-  # as `Foo = Data.define(...) do ... end` or
-  # `class Foo < Data.define(...)`.
+  # When `klass` is `class Foo < Data.define(...)`, the Data-generated readers live on the anonymous parent class rather
+  # than on `Foo` itself. Walk through any anonymous (name == nil) parent so the surface snapshot is invariant to
+  # whether the carrier was authored as `Foo = Data.define(...) do ... end` or `class Foo < Data.define(...)`.
   def instance_signatures(klass)
     collected = []
     cursor = klass
@@ -864,19 +857,14 @@ RSpec.describe "Public API drift", :public_api_drift do
     end
   end
 
-  # RBS sig drift detection. The runtime drift snapshots above
-  # catch accidental changes to the public Ruby API; this block
-  # catches the dual: when a public Ruby method is added to a
-  # drift-pinned namespace but the matching `sig/rigor/*.rbs`
-  # entry is forgotten. The v0.0.9 cache regression hid for
-  # months because every runtime addition since v0.0.9 had drifted
-  # away from the RBS sigs without any check; landing this spec
-  # ensures the same gap cannot reopen silently.
+  # RBS sig drift detection. The runtime drift snapshots above catch accidental changes to the public Ruby API; this
+  # block catches the dual: when a public Ruby method is added to a drift-pinned namespace but the matching
+  # `sig/rigor/*.rbs` entry is forgotten. The v0.0.9 cache regression hid for months because every runtime addition
+  # since v0.0.9 had drifted away from the RBS sigs without any check; landing this spec ensures the same gap cannot
+  # reopen silently.
   #
-  # Skips namespaces that have no RBS sig at all (yet) — those
-  # are deliberate gaps tracked in the broader sig-coverage
-  # backlog (lib/rigor/plugin/, lib/rigor/flow_contribution/,
-  # lib/rigor/cache/, lib/rigor/analysis/, …).
+  # Skips namespaces that have no RBS sig at all (yet) — those are deliberate gaps tracked in the broader sig-coverage
+  # backlog (lib/rigor/plugin/, lib/rigor/flow_contribution/, lib/rigor/cache/, lib/rigor/analysis/, …).
   describe "RBS sig drift" do
     def sig_env
       @sig_env ||= begin
@@ -911,15 +899,13 @@ RSpec.describe "Public API drift", :public_api_drift do
           singleton << member.name.to_s
         end
       when RBS::AST::Members::AttrReader, RBS::AST::Members::AttrWriter, RBS::AST::Members::AttrAccessor
-        # `attr_reader name: T` declares an instance reader
-        # (and writer for AttrAccessor / AttrWriter).
+        # `attr_reader name: T` declares an instance reader (and writer for AttrAccessor / AttrWriter).
         instance << member.name.to_s
         if member.is_a?(RBS::AST::Members::AttrAccessor) || member.is_a?(RBS::AST::Members::AttrWriter)
           instance << "#{member.name}="
         end
       when RBS::AST::Members::Alias
-        # `alias eql? ==` declares an alias. Both target and
-        # new name resolve at runtime to the same method.
+        # `alias eql? ==` declares an alias. Both target and new name resolve at runtime to the same method.
         bucket = member.kind == :singleton ? singleton : instance
         bucket << member.new_name.to_s
       end
@@ -978,16 +964,13 @@ RSpec.describe "Public API drift", :public_api_drift do
                         snapshot: PublicApiDriftSnapshots::SOURCE_LITERALS_SINGLETON)
     end
 
-    # Namespaces without an RBS sig today — recorded so the
-    # absence is visible in test output, not silent. Adding a
-    # sig file removes the corresponding entry from this list.
+    # Namespaces without an RBS sig today — recorded so the absence is visible in test output, not silent. Adding a sig
+    # file removes the corresponding entry from this list.
     it "lists drift-pinned namespaces that still lack an RBS sig" do
       unsigned = PublicApiDriftSnapshots::UNSIGNED_NAMESPACES
       missing_sig = unsigned.reject { |name| sig_method_kinds_for(name) }
-      # Allow the list to be either fully missing (current state)
-      # or fully signed (someone added all sigs at once). A
-      # partial state means a sig was added but the list wasn't
-      # updated — fail so the bookkeeping stays honest.
+      # Allow the list to be either fully missing (current state) or fully signed (someone added all sigs at once). A
+      # partial state means a sig was added but the list wasn't updated — fail so the bookkeeping stays honest.
       next if missing_sig.empty?
 
       expect(missing_sig).to eq(unsigned)

--- a/spec/rigor/ractor_readiness_spec.rb
+++ b/spec/rigor/ractor_readiness_spec.rb
@@ -2,31 +2,20 @@
 
 require "spec_helper"
 
-# Ractor-readiness audit. Each constructor below SHOULD produce
-# a value that's `Ractor.shareable?` so it can cross a Ractor
-# boundary without `Ractor.make_shareable` retro-fitting at
-# every dispatch.
+# Ractor-readiness audit. Each constructor below SHOULD produce a value that's `Ractor.shareable?` so it can cross a
+# Ractor boundary without `Ractor.make_shareable` retro-fitting at every dispatch.
 #
-# The audit serves as a regression guard: when someone adds a
-# new value-object class to the inference / type-node /
-# flow-contribution surface, the matching `it` here documents
-# the shareability expectation. Adding a class to one of the
-# already-passing groups WITHOUT writing the spec leaves
-# Ractor-readiness silent until a later refactor crashes the
-# carrier at a Ractor boundary; the audit makes the gap
-# visible.
+# The audit serves as a regression guard: when someone adds a new value-object class to the inference / type-node
+# / flow-contribution surface, the matching `it` here documents the shareability expectation. Adding a class to one of
+# the already-passing groups WITHOUT writing the spec leaves Ractor-readiness silent until a later refactor crashes the
+# carrier at a Ractor boundary; the audit makes the gap visible.
 #
-# Phase 1 (this spec) covers the Type / TypeNode value-object
-# surface that downstream Ractor-isolated workers would carry
-# in the most common dispatch paths. Phase 2 (deferred) adds
-# `Rigor::Configuration`, `Rigor::Scope`, and
-# `Rigor::Environment` once the underlying `RbsLoader` cache
-# state is split into a frozen reflection surface plus a
-# per-Ractor mutable cache. Phase 3 (deferred) adds plugin
-# state.
+# Phase 1 (this spec) covers the Type / TypeNode value-object surface that downstream Ractor-isolated workers would
+# carry in the most common dispatch paths. Phase 2 (deferred) adds `Rigor::Configuration`, `Rigor::Scope`, and
+# `Rigor::Environment` once the underlying `RbsLoader` cache state is split into a frozen reflection surface plus a
+# per-Ractor mutable cache. Phase 3 (deferred) adds plugin state.
 #
-# See `docs/design/20260514-ractor-migration.md` for the
-# full staged plan.
+# See `docs/design/20260514-ractor-migration.md` for the full staged plan.
 RSpec.describe "Ractor readiness", :ractor_readiness do
   def shareable?(obj)
     Ractor.shareable?(obj)
@@ -149,24 +138,17 @@ RSpec.describe "Ractor readiness", :ractor_readiness do
   end
 
   describe "Phase 2 — Configuration / Scope / Environment" do
-    # Phase 2a (LANDED): `Configuration` deep-freezes its
-    # `@paths` Array + calls `freeze` on `self` at the end
-    # of `initialize`. Backward-compatible — every reader
-    # path treats the Configuration as immutable already.
+    # Phase 2a (LANDED): `Configuration` deep-freezes its `@paths` Array + calls `freeze` on `self` at the end of
+    # `initialize`. Backward-compatible — every reader path treats the Configuration as immutable already.
     it "Rigor::Configuration (Phase 2a)" do
       expect(shareable?(Rigor::Configuration.new(Rigor::Configuration::DEFAULTS))).to be(true)
     end
 
-    # Phase 2b (LANDED): `Environment::Reflection` extracts
-    # the loader's read-only RBS query surface into a
-    # frozen carrier. NOT `Ractor.shareable?` because the
-    # cached `RBS::Definition` objects transitively
-    # reference `RBS::Location` (C-extension state that
-    # `Ractor.make_shareable` rejects). The Phase 4 worker
-    # pool sidesteps the constraint by building one
-    # Reflection per worker from the shared `Cache::Store`;
-    # the cross-Ractor sharing point is the Store, NOT the
-    # Reflection.
+    # Phase 2b (LANDED): `Environment::Reflection` extracts the loader's read-only RBS query surface into a frozen
+    # carrier. NOT `Ractor.shareable?` because the cached `RBS::Definition` objects transitively reference
+    # `RBS::Location` (C-extension state that `Ractor.make_shareable` rejects). The Phase 4 worker pool sidesteps the
+    # constraint by building one Reflection per worker from the shared `Cache::Store`; the cross-Ractor sharing point is
+    # the Store, NOT the Reflection.
     it "Rigor::Environment::Reflection is frozen (Phase 2b)" do
       reflection = Rigor::Environment.for_project.reflection
       expect(reflection).not_to be_nil
@@ -178,11 +160,8 @@ RSpec.describe "Ractor readiness", :ractor_readiness do
       expect(shareable?(reflection)).to be(false)
     end
 
-    # Phase 2b residual targets — still pending. The
-    # blockers are documented in
-    # `docs/design/20260514-ractor-migration.md` and
-    # ADR-15; `skip` keeps the gap visible in
-    # `make verify` output.
+    # Phase 2b residual targets — still pending. The blockers are documented in
+    # `docs/design/20260514-ractor-migration.md` and ADR-15; `skip` keeps the gap visible in `make verify` output.
     it "Rigor::Scope.empty" do
       skip "Phase 2b residual: Scope.environment carries the non-shareable RbsLoader"
       expect(shareable?(Rigor::Scope.empty)).to be(true)
@@ -194,23 +173,16 @@ RSpec.describe "Ractor readiness", :ractor_readiness do
     end
   end
 
-  # Phase 3 (LANDED in part): the plugin contract carries a
-  # Ractor-shareable {Rigor::Plugin::Blueprint} replay carrier
-  # alongside live (mutable) plugin instances. A worker Ractor
-  # ships `blueprints` across the boundary, then calls
-  # {Rigor::Plugin::Registry.materialize} once at startup so the
-  # per-Ractor plugin instance (with its mutable accumulators)
-  # never escapes its owning Ractor.
+  # Phase 3 (LANDED in part): the plugin contract carries a Ractor-shareable {Rigor::Plugin::Blueprint} replay carrier
+  # alongside live (mutable) plugin instances. A worker Ractor ships `blueprints` across the boundary, then calls
+  # {Rigor::Plugin::Registry.materialize} once at startup so the per-Ractor plugin instance (with its mutable
+  # accumulators) never escapes its owning Ractor.
   #
-  # Plugin instances themselves are intentionally NOT
-  # `Ractor.shareable?` — they accumulate per-run state in
-  # ivars (`rigor-sorbet`'s `@reachable_absurd_nodes`,
-  # `@reveal_type_calls`, `@assert_type_mismatches` are the
-  # canonical examples). The blueprint+materialize pattern
-  # sidesteps that constraint without forcing every plugin
-  # author to refactor.
-  # Self-contained reference class so this spec doesn't depend
-  # on blueprint_spec.rb being loaded in the same run.
+  # Plugin instances themselves are intentionally NOT `Ractor.shareable?` — they accumulate per-run state in ivars
+  # (`rigor-sorbet`'s `@reachable_absurd_nodes`, `@reveal_type_calls`, `@assert_type_mismatches` are the canonical
+  # examples). The blueprint+materialize pattern sidesteps that constraint without forcing every plugin author to
+  # refactor. Self-contained reference class so this spec doesn't depend on blueprint_spec.rb being loaded in the same
+  # run.
   unless defined?(RigorRactorReadinessSpecPlugin)
     class ::RigorRactorReadinessSpecPlugin < Rigor::Plugin::Base
       manifest(id: "ractor-audit", version: "0.1.0")
@@ -246,15 +218,10 @@ RSpec.describe "Ractor readiness", :ractor_readiness do
     end
   end
 
-  # Phase 4a (LANDED): the per-worker analysis substrate
-  # {Rigor::Analysis::WorkerSession}. The session itself is
-  # NOT `Ractor.shareable?` — it intentionally owns mutable
-  # state (per-session reporters, materialised plugin
-  # instances with their accumulators). The contract is:
-  # the session's CONSTRUCTOR INPUTS are all
-  # `Ractor.shareable?` so a Phase 4b worker Ractor can
-  # receive them across the boundary, then build its own
-  # session inside the Ractor body.
+  # Phase 4a (LANDED): the per-worker analysis substrate {Rigor::Analysis::WorkerSession}. The session itself is NOT
+  # `Ractor.shareable?` — it intentionally owns mutable state (per-session reporters, materialised plugin instances with
+  # their accumulators). The contract is: the session's CONSTRUCTOR INPUTS are all `Ractor.shareable?` so a Phase 4b
+  # worker Ractor can receive them across the boundary, then build its own session inside the Ractor body.
   describe "Phase 4a — WorkerSession constructor inputs" do
     require "rigor/analysis/worker_session"
 
@@ -291,16 +258,11 @@ RSpec.describe "Ractor readiness", :ractor_readiness do
     end
   end
 
-  # Phase 4b (LANDED): the Runner now ships per-file analysis
-  # to a Ractor pool around `WorkerSession` when constructed
-  # with `workers: N > 0`. The class-level lazy memos every
-  # worker reads on its first `Environment.for_project` call
-  # MUST be `Ractor.shareable?` — `Environment::ClassRegistry.default`
-  # in particular, since lazy-initialising a class @ivar from
-  # a non-main Ractor would trip `Ractor::IsolationError`.
-  # Pre-warming the registry on the main Ractor is the
-  # `Runner#analyze_files_in_pool` contract; this audit
-  # asserts the underlying invariant.
+  # Phase 4b (LANDED): the Runner now ships per-file analysis to a Ractor pool around `WorkerSession` when constructed
+  # with `workers: N > 0`. The class-level lazy memos every worker reads on its first `Environment.for_project` call
+  # MUST be `Ractor.shareable?` — `Environment::ClassRegistry.default` in particular, since lazy-initialising a class
+  # @ivar from a non-main Ractor would trip `Ractor::IsolationError`. Pre-warming the registry on the main Ractor is the
+  # `Runner#analyze_files_in_pool` contract; this audit asserts the underlying invariant.
   describe "Phase 4b — Ractor pool readiness" do
     it "Environment::ClassRegistry.default is Ractor.shareable?" do
       expect(shareable?(Rigor::Environment::ClassRegistry.default)).to be(true)
@@ -313,10 +275,8 @@ RSpec.describe "Ractor readiness", :ractor_readiness do
       explain = false
 
       ractor = Ractor.new(configuration, cache_root, blueprints, explain) do |c, _r, b, e|
-        # Touch each input on the receiving side so the
-        # boundary crossing is exercised in full; return a
-        # Ractor.shareable? digest so the assertion compares
-        # apples to apples.
+        # Touch each input on the receiving side so the boundary crossing is exercised in full; return a
+        # Ractor.shareable? digest so the assertion compares apples to apples.
         [c.frozen?, b.frozen?, e == false].freeze
       end
 
@@ -324,21 +284,16 @@ RSpec.describe "Ractor readiness", :ractor_readiness do
     end
   end
 
-  # Phase 4b.x: module-level catalogs and canonical-name tables
-  # that worker Ractors read during ordinary dispatch. Each
-  # MUST be deep-`Ractor.shareable?`; a shallow `.freeze` is
-  # insufficient when the value graph contains nested Hash /
-  # Array / parsed-YAML payloads (whose inner nodes start out
-  # unfrozen). A regression here surfaces on real-world target
-  # projects as `Ractor::IsolationError` while reading the
-  # singleton-class ivar or constant from a non-main Ractor.
+  # Phase 4b.x: module-level catalogs and canonical-name tables that worker Ractors read during ordinary dispatch. Each
+  # MUST be deep-`Ractor.shareable?`; a shallow `.freeze` is insufficient when the value graph contains nested Hash
+  # /Array / parsed-YAML payloads (whose inner nodes start out unfrozen). A regression here surfaces on real-world
+  # target projects as `Ractor::IsolationError` while reading the singleton-class ivar or constant from a non-main
+  # Ractor.
   describe "Phase 4b.x — module catalog shareability" do
     it "NUMERIC_CATALOG (MethodCatalog instance + its @catalog graph) is Ractor.shareable?" do
-      # NUMERIC_CATALOG is now an ordinary MethodCatalog instance (folded
-      # off its former bespoke module); like the other per-class catalogs
-      # it is deep-frozen via `Ractor.make_shareable(CATALOG_BY_CLASS)` in
-      # ConstantFolding, so the instance and its parsed-YAML @catalog must
-      # both be shareable.
+      # NUMERIC_CATALOG is now an ordinary MethodCatalog instance (folded off its former bespoke module); like the other
+      # per-class catalogs it is deep-frozen via `Ractor.make_shareable(CATALOG_BY_CLASS)` in ConstantFolding, so the
+      # instance and its parsed-YAML @catalog must both be shareable.
       expect(shareable?(Rigor::Inference::Builtins::NUMERIC_CATALOG)).to be(true)
     end
 
@@ -353,21 +308,16 @@ RSpec.describe "Ractor readiness", :ractor_readiness do
     end
 
     it "MethodDispatcher::ShapeDispatch::REFINED_STRING_PROJECTIONS is Ractor.shareable?" do
-      # Defined inside `class << self`, so it lives on the
-      # singleton class of `ShapeDispatch`, not directly on the
+      # Defined inside `class << self`, so it lives on the singleton class of `ShapeDispatch`, not directly on the
       # module. `singleton_class.const_get` is the access path.
       table = Rigor::Inference::MethodDispatcher::ShapeDispatch.singleton_class.const_get(:REFINED_STRING_PROJECTIONS)
       expect(shareable?(table)).to be(true)
     end
 
-    # `CONSTANT_CONSTRUCTORS` carries `Proc` values; a shallow
-    # `.freeze` leaves the lambdas non-shareable and
-    # `constant_constructor_lift`'s `rescue StandardError` quietly
-    # swallows the resulting `Ractor::IsolationError`. The result
-    # is a precision divergence (`Constant<Pathname>` under
-    # sequential, `Nominal[Pathname]` under pool), which then
-    # surfaces downstream as a spurious `call.argument-type-mismatch`
-    # diagnostic. Surfaced on GitLab FOSS via
+    # `CONSTANT_CONSTRUCTORS` carries `Proc` values; a shallow `.freeze` leaves the lambdas non-shareable and
+    # `constant_constructor_lift`'s `rescue StandardError` quietly swallows the resulting `Ractor::IsolationError`. The
+    # result is a precision divergence (`Constant<Pathname>` under sequential, `Nominal[Pathname]` under pool), which
+    # then surfaces downstream as a spurious `call.argument-type-mismatch` diagnostic. Surfaced on GitLab FOSS via
     # `lib/gitlab/mail_room.rb:17`.
     it "MethodDispatcher::CONSTANT_CONSTRUCTORS is Ractor.shareable? (Proc values + outer Hash)" do
       table = Rigor::Inference::MethodDispatcher.const_get(:CONSTANT_CONSTRUCTORS)

--- a/spec/rigor/rbs_extended/conformance_checker_spec.rb
+++ b/spec/rigor/rbs_extended/conformance_checker_spec.rb
@@ -21,13 +21,10 @@ RSpec.describe Rigor::RbsExtended::ConformanceChecker do
     end
   end
 
-  # Builds a real `Rigor::Environment::RbsLoader` over a tmpdir containing
-  # `rbs`, mirroring the fixture pattern in
-  # `spec/rigor/environment/rbs_loader_spec.rb` (`signature_paths:` +
-  # `Dir.mktmpdir` + `File.write`). Exercises `.scan` end-to-end (real
-  # `each_class_decl_annotation_with_name` / `instance_definition` /
-  # `interface_definition`), rather than stubbing the loader, so it drives
-  # `check_one` and the signature-mismatch detail generators for real.
+  # Builds a real `Rigor::Environment::RbsLoader` over a tmpdir containing `rbs`, mirroring the fixture pattern in
+  # `spec/rigor/environment/rbs_loader_spec.rb` (`signature_paths:` + `Dir.mktmpdir` + `File.write`). Exercises `.scan`
+  # end-to-end (real `each_class_decl_annotation_with_name` / `instance_definition` / `interface_definition`), rather
+  # than stubbing the loader, so it drives `check_one` and the signature-mismatch detail generators for real.
   def scan_rbs(rbs)
     Dir.mktmpdir("rigor-conformance-checker-spec-") do |tmpdir|
       File.write(File.join(tmpdir, "fixture.rbs"), rbs)
@@ -122,9 +119,8 @@ RSpec.describe Rigor::RbsExtended::ConformanceChecker do
         end
       RBS
 
-      # Only `Buffers::_Stream` exists (no top-level `_Stream`); resolution
-      # must walk the class's own namespace prefixes to find it, rather
-      # than falling through to UnresolvedInterface.
+      # Only `Buffers::_Stream` exists (no top-level `_Stream`); resolution must walk the class's own namespace prefixes
+      # to find it, rather than falling through to UnresolvedInterface.
       expect(records.none?(described_class::UnresolvedInterface)).to be(true)
       unsatisfied = records.find { |r| r.is_a?(described_class::Unsatisfied) }
       expect(unsatisfied).not_to be_nil
@@ -151,8 +147,8 @@ RSpec.describe Rigor::RbsExtended::ConformanceChecker do
         expect(incompatible.class_name).to eq("WidensReturn")
         expect(incompatible.interface_name).to eq("_ReaderDemo")
         expect(incompatible.method_name).to eq(:read)
-        # Load-bearing substrings a consumer depends on: both type names
-        # and the "not a subtype" relation — not the exact prose framing.
+        # Load-bearing substrings a consumer depends on: both type names and the "not a subtype" relation — not the
+        # exact prose framing.
         expect(incompatible.detail).to include("return type")
         expect(incompatible.detail).to match(/String.*Integer|Integer.*String/)
         expect(incompatible.detail).to include("not a subtype")
@@ -479,10 +475,9 @@ RSpec.describe Rigor::RbsExtended::ConformanceChecker do
           end
         RBS
 
-        # signature_mismatch short-circuits to nil for a multi-method-type
-        # required signature, before any of the detail generators run —
-        # even though the single provided overload would otherwise
-        # contravariantly-fail against either required overload.
+        # signature_mismatch short-circuits to nil for a multi-method-type required signature, before any of the detail
+        # generators run — even though the single provided overload would otherwise contravariantly-fail against either
+        # required overload.
         expect(records.none?(described_class::IncompatibleSignature)).to be(true)
       end
 
@@ -504,9 +499,8 @@ RSpec.describe Rigor::RbsExtended::ConformanceChecker do
     end
 
     it "checks missing-method presence and signature compatibility independently per interface method" do
-      # collect_missing and collect_incompatible both run over the same
-      # (required, provided) pair; a class can simultaneously be missing
-      # one required method and provide an incompatible second one.
+      # collect_missing and collect_incompatible both run over the same (required, provided) pair; a class can
+      # simultaneously be missing one required method and provide an incompatible second one.
       records = scan_rbs(<<~RBS)
         interface _Combo
           def rewind: () -> void

--- a/spec/rigor/rbs_extended_spec.rb
+++ b/spec/rigor/rbs_extended_spec.rb
@@ -230,8 +230,7 @@ RSpec.describe Rigor::RbsExtended do
     end
 
     it "tolerates the `is` glue word being absent" do
-      # The grammar is `param: <name> <payload>`; the existing
-      # surface in the codebase keeps `<name> <payload>` rather
+      # The grammar is `param: <name> <payload>`; the existing surface in the codebase keeps `<name> <payload>` rather
       # than requiring a dedicated `is` keyword. Accept either.
       expect(described_class.parse_param_annotation("rigor:v1:param: id non-empty-string"))
         .to be_a(Rigor::RbsExtended::ParamOverride)
@@ -445,8 +444,8 @@ RSpec.describe Rigor::RbsExtended do
         %a{rigor:v1:assert value is String}
       ANNOT
         bundle = described_class.read_flow_contribution(method_def)
-        # The bundle reflects only the assert directive; param: stays
-        # on read_param_type_overrides / param_type_override_map.
+        # The bundle reflects only the assert directive; param: stays on read_param_type_overrides /
+        # param_type_override_map.
         expect(bundle.post_return_facts.size).to eq(1)
         expect(bundle.return_type).to be_nil
         expect(bundle.truthy_facts).to be_nil

--- a/spec/rigor/reflection_spec.rb
+++ b/spec/rigor/reflection_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe Rigor::Reflection do
     end
 
     it "returns false for an unknown name" do
-      # Use a class registry without the RBS loader to avoid the
-      # stdlib RBS picking up well-known names that the test
+      # Use a class registry without the RBS loader to avoid the stdlib RBS picking up well-known names that the test
       # author did not intend.
       env = Rigor::Environment.new
       scope = Rigor::Scope.empty(environment: env)
@@ -44,10 +43,8 @@ RSpec.describe Rigor::Reflection do
 
   describe ".class_ordering" do
     it "delegates to Environment#class_ordering and returns the trinary ordering" do
-      # `Integer < Numeric` in Ruby's class hierarchy, so the
-      # ordering is :subclass. Asserting the concrete value
-      # rather than the membership keeps the rubocop
-      # `RSpec/ExpectActual` cop satisfied.
+      # `Integer < Numeric` in Ruby's class hierarchy, so the ordering is :subclass. Asserting the concrete value rather
+      # than the membership keeps the rubocop `RSpec/ExpectActual` cop satisfied.
       result = described_class.class_ordering("Integer", "Numeric")
       expect(result).to eq(:subclass)
     end
@@ -62,8 +59,7 @@ RSpec.describe Rigor::Reflection do
     end
 
     it "falls back to the Environment's RBS-side constant" do
-      # Pick a constant that ships with the bundled RBS so the
-      # default Environment can resolve it.
+      # Pick a constant that ships with the bundled RBS so the default Environment can resolve it.
       type = described_class.constant_type_for("ARGV")
       expect(type).not_to be_nil
     end

--- a/spec/rigor/sig_gen/generator_spec.rb
+++ b/spec/rigor/sig_gen/generator_spec.rb
@@ -573,11 +573,9 @@ RSpec.describe Rigor::SigGen::Generator do
 
     # attr_reader + initialize-param observations
     #
-    # When `--params=observed` is active and the observation scan sees
-    # `Person.new("Alice")`, the observed String type flows through the
-    # ivar pre-pass fallback so that `attr_reader :name` can emit a
-    # concrete return type even though the ivar pre-pass itself only
-    # sees `@name = name` with an untyped `name` parameter.
+    # When `--params=observed` is active and the observation scan sees `Person.new("Alice")`, the observed String type
+    # flows through the ivar pre-pass fallback so that `attr_reader :name` can emit a concrete return type even though
+    # the ivar pre-pass itself only sees `@name = name` with an untyped `name` parameter.
     it "resolves attr_reader type from initialize positional-param observations" do
       path = write_fixture("lib/person.rb", <<~RUBY)
         class Person

--- a/spec/rigor/sig_gen/typeprof_compat_spec.rb
+++ b/spec/rigor/sig_gen/typeprof_compat_spec.rb
@@ -6,18 +6,15 @@ require "rbs"
 
 # TypeProf compatibility tests for Rigor::SigGen::Generator.
 #
-# Each fixture pairs a Ruby source with the RBS TypeProf would emit for it.
-# The assertion is: Rigor covers at least as many methods and returns a type
-# at least as specific for every shared method.
+# Each fixture pairs a Ruby source with the RBS TypeProf would emit for it. The assertion is: Rigor covers at least as
+# many methods and returns a type at least as specific for every shared method.
 #
-# TypeProf uses nominal class names (String, Integer) for literal returns;
-# Rigor emits RBS literal types ("hello", 42). A literal is considered more
-# specific than its base class, so the ordering is preserved.
+# TypeProf uses nominal class names (String, Integer) for literal returns; Rigor emits RBS literal types ("hello", 42).
+# A literal is considered more specific than its base class, so the ordering is preserved.
 #
-# TypeProf is not invoked at test time — its output is hardcoded based on the
-# upstream scenario corpus (test/typeprof/core/class/) and confirmed against
-# TypeProf 2.x behaviour. If TypeProf changes its output format, update the
-# fixture strings.
+# TypeProf is not invoked at test time — its output is hardcoded based on the upstream scenario corpus
+# (test/typeprof/core/class/) and confirmed against TypeProf 2.x behaviour. If TypeProf changes its output format,
+# update the fixture strings.
 
 # ── fixture data ───────────────────────────────────────────────────────────────
 
@@ -33,8 +30,8 @@ TYPEPROF_COMPAT_FIXTURES = [
         def tag; :done; end
       end
     RUBY
-    # TypeProf infers nominal types for String / Integer / Float literals;
-    # it does preserve Symbol and nil literal types.
+    # TypeProf infers nominal types for String / Integer / Float literals; it does preserve Symbol and nil literal
+    # types.
     typeprof_rbs: <<~RBS
       class Literals
         def greet: () -> String
@@ -102,9 +99,8 @@ TYPEPROF_COMPAT_FIXTURES = [
   }
 ].freeze
 
-# Rigor emits RBS literal types (42, "hello") where TypeProf emits nominal
-# class names (Integer, String). A Rigor literal is considered at least as
-# specific as the corresponding base class.
+# Rigor emits RBS literal types (42, "hello") where TypeProf emits nominal class names (Integer, String). A Rigor
+# literal is considered at least as specific as the corresponding base class.
 TYPEPROF_LITERAL_TO_BASE = {
   /\A-?\d+\z/ => "Integer", # integer literals: 0, 42, 200, 201
   /\A"/ => "String",    # string literals:  "hello", "ok"
@@ -132,8 +128,7 @@ RSpec.describe "Rigor::SigGen::Generator TypeProf compatibility" do
     Rigor::SigGen::Generator.new(configuration: configuration, paths: paths)
   end
 
-  # Run Rigor sig-gen on a Ruby source string.
-  # Returns a Hash keyed by [kind, method_name] → Candidate.
+  # Run Rigor sig-gen on a Ruby source string. Returns a Hash keyed by [kind, method_name] → Candidate.
   def run_rigor(ruby_source)
     path = write_fixture("lib/subject.rb", ruby_source)
     make_generator(paths: [path])
@@ -142,17 +137,16 @@ RSpec.describe "Rigor::SigGen::Generator TypeProf compatibility" do
       .to_h { |c| [[c.kind, c.method_name], c] }
   end
 
-  # Extract the return type string from a Rigor candidate's `.rbs` line by
-  # wrapping it in a dummy class and parsing with RBS::Parser.
-  # Returns the canonical `.to_s` form (e.g. "42", '"hello"', "Integer").
+  # Extract the return type string from a Rigor candidate's `.rbs` line by wrapping it in a dummy class and parsing with
+  # RBS::Parser. Returns the canonical `.to_s` form (e.g. "42", '"hello"', "Integer").
   def rigor_return_type(candidate)
     buf = RBS::Buffer.new(name: "rigor.rbs", content: "class X\n  #{candidate.rbs}\nend\n")
     _, _, decls = RBS::Parser.parse_signature(buf)
     decls.first.members.first.overloads.first.method_type.type.return_type.to_s
   end
 
-  # Parse a TypeProf-style RBS string into a Hash keyed by [kind, method_name]
-  # → return_type_string. Recurses into nested class / module declarations.
+  # Parse a TypeProf-style RBS string into a Hash keyed by [kind, method_name] → return_type_string. Recurses into
+  # nested class / module declarations.
   def parse_typeprof_methods(rbs_source)
     buf = RBS::Buffer.new(name: "typeprof.rbs", content: rbs_source)
     _, _, decls = RBS::Parser.parse_signature(buf)

--- a/spec/rigor/sig_gen/writer_spec.rb
+++ b/spec/rigor/sig_gen/writer_spec.rb
@@ -490,18 +490,12 @@ RSpec.describe Rigor::SigGen::Writer do
     end
   end
 
-  # Regression: a subdirectory file declaring `class Foo::Bar`
-  # (a compact constant path) never names `Foo`, so the
-  # generator records no kind for the `Foo` wrapper segment.
-  # The writer used to default that children-only wrapper to
-  # `module Foo` while the sibling `foo.rb` (declaring
-  # `class Foo`) wrote `class Foo` — and loading both `.rbs`
-  # files raised `RBS::DuplicatedDeclarationError`, aborting
-  # the whole RBS env build. `write_all` now folds every
-  # candidate's per-file kinds into one run-level view where
-  # the authoritative `class Foo` governs the wrapper keyword
-  # across files. (Found on whitequark/parser's
-  # `source/comment.rb` + `source/comment/associator.rb`.)
+  # Regression: a subdirectory file declaring `class Foo::Bar` (a compact constant path) never names `Foo`, so the
+  # generator records no kind for the `Foo` wrapper segment. The writer used to default that children-only wrapper to
+  # `module Foo` while the sibling `foo.rb` (declaring `class Foo`) wrote `class Foo` — and loading both `.rbs` files
+  # raised `RBS::DuplicatedDeclarationError`, aborting the whole RBS env build. `write_all` now folds every candidate's
+  # per-file kinds into one run-level view where the authoritative `class Foo` governs the wrapper keyword across files.
+  # (Found on whitequark/parser's `source/comment.rb` + `source/comment/associator.rb`.)
   describe "cross-file class/module reconciliation (compact constant path)" do
     def write_source(rel_path, contents)
       full = File.join(tmpdir, rel_path)
@@ -518,8 +512,7 @@ RSpec.describe Rigor::SigGen::Writer do
       Rigor::SigGen::Generator.new(configuration: config, paths: [lib]).run
     end
 
-    # Replays `rigor check`'s env-build step: the duplicate is
-    # detected at `add_source`, so a clean build means the
+    # Replays `rigor check`'s env-build step: the duplicate is detected at `add_source`, so a clean build means the
     # generated tree no longer mixes `class` / `module`.
     def build_environment(*sources)
       env = RBS::Environment.new

--- a/spec/rigor/source/constant_path_spec.rb
+++ b/spec/rigor/source/constant_path_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe Rigor::Source::ConstantPath do
     Prism.parse(source).value.statements.body.first
   end
 
-  # A constant path whose base is a runtime expression (`expr::Bar`).
-  # Prism models the left side as the dynamic node; the trailing `::Bar`
-  # is a ConstantPathNode whose parent is that non-constant node.
+  # A constant path whose base is a runtime expression (`expr::Bar`). Prism models the left side as the dynamic node;
+  # the trailing `::Bar` is a ConstantPathNode whose parent is that non-constant node.
   def dynamic_base_path
     node("bar::Baz")
   end

--- a/spec/rigor/source/require_hygiene_spec.rb
+++ b/spec/rigor/source/require_hygiene_spec.rb
@@ -3,26 +3,19 @@
 require "spec_helper"
 require "prism"
 
-# Guards the per-consumer require discipline for the `Rigor::Source::*`
-# helpers.
+# Guards the per-consumer require discipline for the `Rigor::Source::*` helpers.
 #
-# `lib/rigor.rb` requires the `source.rb` aggregator, which pulls in every
-# `source/*` helper. But the CLI entry point never loads `lib/rigor.rb` —
-# `exe/rigor` does `require "rigor/cli"`, which lazily requires only the
-# command it runs, and each engine file requires its own dependencies. So a
-# lib file that *uses* a Source helper while leaning on the aggregator to load
-# it raises `uninitialized constant Rigor::Source::X` at analyzer runtime,
-# even though the spec suite (which boots via `require "rigor"` in
-# spec_helper, loading the aggregator) hides the gap entirely.
+# `lib/rigor.rb` requires the `source.rb` aggregator, which pulls in every `source/*` helper. But the CLI entry point
+# never loads `lib/rigor.rb` — `exe/rigor` does `require "rigor/cli"`, which lazily requires only the command it runs,
+# and each engine file requires its own dependencies. So a lib file that *uses* a Source helper while leaning on the
+# aggregator to load it raises `uninitialized constant Rigor::Source::X` at analyzer runtime, even though the spec suite
+# (which boots via `require "rigor"` in spec_helper, loading the aggregator) hides the gap entirely.
 #
-# `make check` catches such a gap only when the constant is loaded nowhere
-# else on the CLI path; a helper already pulled in by some earlier require is
-# masked by load order. This spec closes both holes by asserting, statically,
-# that every file referencing a Source helper requires it directly. Add a row
-# to `helpers` when a new `source/*` helper lands.
-# Source helper constant name => its file basename under lib/rigor/source/.
-# Lives in a module (not inside the example group) so it can drive example
-# generation without tripping the no-constant-in-block / leaky-local cops.
+# `make check` catches such a gap only when the constant is loaded nowhere else on the CLI path; a helper already pulled
+# in by some earlier require is masked by load order. This spec closes both holes by asserting, statically, that every
+# file referencing a Source helper requires it directly. Add a row to `helpers` when a new `source/*` helper lands.
+# Source helper constant name => its file basename under lib/rigor/source/. Lives in a module (not inside the example
+# group) so it can drive example generation without tripping the no-constant-in-block / leaky-local cops.
 module SourceRequireHygiene
   HELPERS = {
     NodeWalker: "node_walker",
@@ -41,9 +34,9 @@ RSpec.describe "Rigor::Source helper require hygiene" do
     Dir.glob(File.join(lib_root, "rigor", "**", "*.rb"))
   end
 
-  # Every helper from `names` referenced in `ast` (AST only — a mention in a
-  # comment or string is not a ConstantPathNode, so it never counts). Both the
-  # lexical `Source::X` and the fully-qualified `Rigor::Source::X` forms count.
+  # Every helper from `names` referenced in `ast` (AST only — a mention in a comment or string is not a
+  # ConstantPathNode, so it never counts). Both the lexical `Source::X` and the fully-qualified `Rigor::Source::X` forms
+  # count.
   def source_helpers_referenced(ast, names)
     referenced = []
     visit = lambda do |node|
@@ -58,8 +51,7 @@ RSpec.describe "Rigor::Source helper require hygiene" do
     referenced.uniq
   end
 
-  # True when `parent` is the `Source` segment of a `Source::X` / `*::Source::X`
-  # path.
+  # True when `parent` is the `Source` segment of a `Source::X` / `*::Source::X` path.
   def rooted_in_source?(parent)
     (parent.is_a?(Prism::ConstantReadNode) || parent.is_a?(Prism::ConstantPathNode)) &&
       parent.name == :Source

--- a/spec/rigor/triage_spec.rb
+++ b/spec/rigor/triage_spec.rb
@@ -3,13 +3,11 @@
 require "rigor/triage"
 require "rigor/analysis/diagnostic"
 
-# ADR-23 — `Rigor::Triage` is pure over the diagnostic stream, so
-# the aggregation and the six-recogniser catalogue are covered here
-# with synthetic `Diagnostic` arrays (no Runner / no analysis pass).
+# ADR-23 — `Rigor::Triage` is pure over the diagnostic stream, so the aggregation and the six-recogniser catalogue are
+# covered here with synthetic `Diagnostic` arrays (no Runner / no analysis pass).
 RSpec.describe Rigor::Triage do
-  # normalize_receiver is a private module_function — exercised
-  # indirectly through selectors and directly via .send for the
-  # patterns that build_selectors does not reach with synthetic data.
+  # normalize_receiver is a private module_function — exercised indirectly through selectors and directly via .send for
+  # the patterns that build_selectors does not reach with synthetic data.
   def normalize_receiver(token)
     described_class.send(:normalize_receiver, token)
   end
@@ -61,10 +59,9 @@ RSpec.describe Rigor::Triage do
   end
 
   describe "WD6 — info excluded from the volume views by default" do
-    # A real Rails project's info is dominated by plugin recognition
-    # trace (model-call / helper / …) — positive "resolved this call"
-    # records, not problems. The volume views must route only the
-    # actionable error/warning signal by default.
+    # A real Rails project's info is dominated by plugin recognition trace (model-call / helper / …) — positive
+    # "resolved this call" records, not problems. The volume views must route only the actionable error/warning signal
+    # by default.
     def trace(rule, path: "a.rb", method_name: nil)
       diag(rule: rule, severity: :info, method_name: method_name, path: path)
     end
@@ -204,9 +201,8 @@ RSpec.describe Rigor::Triage do
   end
 
   describe "WD3 — structured receiver_type / method_name fields (slice 4)" do
-    # Carries the structured pair but a message the `undefined
-    # method ...` parser cannot match — proves the recogniser reads
-    # the fields rather than the message.
+    # Carries the structured pair but a message the `undefined method ...` parser cannot match — proves the recogniser
+    # reads the fields rather than the message.
     def structured(method, receiver, **)
       diag(message: "(wording the message parser cannot match)",
            receiver_type: receiver, method_name: method, **)

--- a/spec/rigor/type/app_spec.rb
+++ b/spec/rigor/type/app_spec.rb
@@ -93,9 +93,8 @@ RSpec.describe Rigor::Type::App do
   end
 
   describe "reduce (delegates to a registry)" do
-    # A minimal registry stand-in: records the fuel it was handed and
-    # returns a sentinel, so the test pins the delegation + the default-fuel
-    # wiring without depending on a real reduction rule.
+    # A minimal registry stand-in: records the fuel it was handed and returns a sentinel, so the test pins the
+    # delegation + the default-fuel wiring without depending on a real reduction rule.
     let(:fake_registry) do
       Class.new do
         attr_reader :received_app, :received_fuel

--- a/spec/rigor/type/bot_spec.rb
+++ b/spec/rigor/type/bot_spec.rb
@@ -42,9 +42,8 @@ RSpec.describe Rigor::Type::Bot do
 
   describe "value semantics" do
     it "is equal (by ==) to any Bot, matching structurally not just by identity" do
-      # `new` is private, so the only way to get a second reference is
-      # reflective construction — this is what pins that `==` checks
-      # `is_a?(Bot)` rather than accidentally degrading to `equal?`.
+      # `new` is private, so the only way to get a second reference is reflective construction — this is what pins that
+      # `==` checks `is_a?(Bot)` rather than accidentally degrading to `equal?`.
       other = described_class.allocate
       expect(described_class.instance).to eq(other)
     end

--- a/spec/rigor/type/combinator_spec.rb
+++ b/spec/rigor/type/combinator_spec.rb
@@ -731,10 +731,8 @@ RSpec.describe Rigor::Type::Combinator do
     describe "partial_of / required_of / readonly_of on Tuple (no-op degrade)" do
       let(:tuple) { described_class.tuple_of(string_t, integer_t) }
 
-      # ADR-13 § "Required-ness flips" doesn't commit to Tuple
-      # semantics; Tuples have positional required-by-structure
-      # entries with no read-only marker carrier. Each function
-      # returns the input unchanged for now.
+      # ADR-13 § "Required-ness flips" doesn't commit to Tuple semantics; Tuples have positional required-by-structure
+      # entries with no read-only marker carrier. Each function returns the input unchanged for now.
       it "partial_of returns the tuple unchanged" do
         expect(described_class.partial_of(tuple)).to eq(tuple)
       end

--- a/spec/rigor/type/difference_spec.rb
+++ b/spec/rigor/type/difference_spec.rb
@@ -54,10 +54,9 @@ RSpec.describe Rigor::Type::Difference do
     end
   end
 
-  # Subtracting a second value from an existing Difference layers rather
-  # than flattening into one multi-removal carrier: the outer Difference
-  # keeps the inner one as its base. Display composes — the inner renders
-  # by its canonical refinement name, the outer appends the new exclusion.
+  # Subtracting a second value from an existing Difference layers rather than flattening into one multi-removal carrier:
+  # the outer Difference keeps the inner one as its base. Display composes — the inner renders by its canonical
+  # refinement name, the outer appends the new exclusion.
   describe "repeated subtraction (layering)" do
     it "wraps `(String - \"\") - \"x\"` as a Difference whose base is the inner Difference" do
       inner = Rigor::Type::Combinator.difference(nominal_of("String"), constant_of(""))
@@ -103,8 +102,7 @@ RSpec.describe Rigor::Type::Difference do
     end
 
     it "rejects the universal nominal because it could be the removed value" do
-      # `Nominal[String]` includes `""` so the difference cannot
-      # accept the wider base.
+      # `Nominal[String]` includes `""` so the difference cannot accept the wider base.
       expect(nes.accepts(nominal_of("String")).no?).to be(true)
     end
   end

--- a/spec/rigor/type/singleton_spec.rb
+++ b/spec/rigor/type/singleton_spec.rb
@@ -62,9 +62,8 @@ RSpec.describe Rigor::Type::Singleton do
       expect(described_class.new("String")).not_to eq(described_class.new("Integer"))
     end
 
-    # `Singleton[Foo]` and `Nominal[Foo]` share a class_name but describe
-    # disjoint values (the class object vs. instances) — they must never
-    # compare equal even though they'd share a value_fields key.
+    # `Singleton[Foo]` and `Nominal[Foo]` share a class_name but describe disjoint values (the class object vs.
+    # instances) — they must never compare equal even though they'd share a value_fields key.
     it "is never equal to a Nominal with the same class_name" do
       singleton = described_class.new("String")
       nominal = Rigor::Type::Nominal.new("String")

--- a/spec/rigor/type/top_spec.rb
+++ b/spec/rigor/type/top_spec.rb
@@ -42,9 +42,8 @@ RSpec.describe Rigor::Type::Top do
 
   describe "value semantics" do
     it "is equal (by ==) to any Top, matching structurally not just by identity" do
-      # `new` is private, so the only way to get a second reference is
-      # reflective construction — this is what pins that `==` checks
-      # `is_a?(Top)` rather than accidentally degrading to `equal?`.
+      # `new` is private, so the only way to get a second reference is reflective construction — this is what pins that
+      # `==` checks `is_a?(Top)` rather than accidentally degrading to `equal?`.
       other = described_class.allocate
       expect(described_class.instance).to eq(other)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,10 +15,9 @@ if ENV["COVERAGE"]
     end
     report = rows.sort_by { |_, total, hit| hit.to_f / [total, 1].max }
 
-    # Opt-in structured dump for the self-mutation harness (tool/mutation/
-    # self_mutate.rb --coverage-gap): {lib-relative path => [executed line
-    # numbers]}. A mutation site on a line absent here is run by no spec, so it
-    # is provably test-unprotected without a per-mutant suite run.
+    # Opt-in structured dump for the self-mutation harness (tool/mutation/self_mutate.rb --coverage-gap): {lib-relative
+    # path => [executed line numbers]}. A mutation site on a line absent here is run by no spec, so it is provably
+    # test-unprotected without a per-mutant suite run.
     if ENV["COVERAGE_JSON"]
       require "json"
       covered = lib_files.to_h do |path, data|
@@ -45,19 +44,15 @@ end
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 
-# Silence MRI's once-per-process "Ractor API is experimental" warning
-# during test runs. Rigor uses Ractors as a committed production
-# feature (ADR-15 Phase 4 — `Analysis::Runner` worker pool), so the
-# warning is informational noise on every `make verify`. Suppressed
-# only here — downstream `rigortype` users keep the warning.
+# Silence MRI's once-per-process "Ractor API is experimental" warning during test runs. Rigor uses Ractors as a
+# committed production feature (ADR-15 Phase 4 — `Analysis::Runner` worker pool), so the warning is informational noise
+# on every `make verify`. Suppressed only here — downstream `rigortype` users keep the warning.
 Warning[:experimental] = false if Warning.respond_to?(:[]=)
 
-# ADR-51 WD7 — disable CI auto-detection for the whole suite so the many
-# `rigor check` text-output specs are deterministic regardless of whether
-# the suite itself runs under a CI (Rigor's own CI is GitHub Actions, which
-# would otherwise make `rigor check` augment its output with `::error`
-# annotations). The CiDetector specs opt back in per-example by setting the
-# platform env var + `RIGOR_CI_DETECT=1` and restoring both after.
+# ADR-51 WD7 — disable CI auto-detection for the whole suite so the many `rigor check` text-output specs are
+# deterministic regardless of whether the suite itself runs under a CI (Rigor's own CI is GitHub Actions, which would
+# otherwise make `rigor check` augment its output with `::error` annotations). The CiDetector specs opt back in
+# per-example by setting the platform env var + `RIGOR_CI_DETECT=1` and restoring both after.
 ENV["RIGOR_CI_DETECT"] = "0"
 
 require "rigor"
@@ -73,17 +68,12 @@ RSpec.configure do |config|
     meta[:type] = :runner
   end
 
-  # ADR-15 Phase 4b — `spec/rigor/analysis/runner_pool_spec.rb` is
-  # excluded from the default suite and runs as its own rspec
-  # process via `make test-ractor-pool` (part of `make verify` and
-  # CI). The original reason was real Ractor spawns destabilising
-  # LATER same-process specs (Bus Error in the inference path —
-  # likely RBS C-extension state interacting with main-Ractor GC
-  # after Ractor cleanup). Since the fork-backend default
-  # (86ed9129, `Runner#pool_backend`) the file spawns no Ractors
-  # unless RIGOR_POOL_BACKEND=ractor is exported; the exclusion is
-  # kept so an exported backend override can never destabilise the
-  # main suite. Set `RIGOR_INCLUDE_RACTOR_POOL=1` to opt the file
-  # back in to a same-process run.
+  # ADR-15 Phase 4b — `spec/rigor/analysis/runner_pool_spec.rb` is excluded from the default suite and runs as its own
+  # rspec process via `make test-ractor-pool` (part of `make verify` and CI). The original reason was real Ractor spawns
+  # destabilising LATER same-process specs (Bus Error in the inference path — likely RBS C-extension state interacting
+  # with main-Ractor GC after Ractor cleanup). Since the fork-backend default (86ed9129, `Runner#pool_backend`) the file
+  # spawns no Ractors unless RIGOR_POOL_BACKEND=ractor is exported; the exclusion is kept so an exported backend
+  # override can never destabilise the main suite. Set `RIGOR_INCLUDE_RACTOR_POOL=1` to opt the file back in to a
+  # same-process run.
   config.exclude_pattern = "spec/rigor/analysis/runner_pool_spec.rb" unless ENV["RIGOR_INCLUDE_RACTOR_POOL"]
 end

--- a/spec/support/call_context_helpers.rb
+++ b/spec/support/call_context_helpers.rb
@@ -2,10 +2,9 @@
 
 require "rigor/inference/method_dispatcher/call_context"
 
-# Shared helper for the dispatch-tier unit specs. Every tier entry point
-# takes a `CallContext` (Finding 3 interface unification); `cc` builds one
-# from the call quartet so specs need not spell out the wider context
-# fields they do not exercise.
+# Shared helper for the dispatch-tier unit specs. Every tier entry point takes a `CallContext` (Finding 3 interface
+# unification); `cc` builds one from the call quartet so specs need not spell out the wider context fields they do not
+# exercise.
 module CallContextHelpers
   def cc(receiver:, method_name:, args:, **rest)
     Rigor::Inference::MethodDispatcher::CallContext.build(

--- a/spec/support/runner_helpers.rb
+++ b/spec/support/runner_helpers.rb
@@ -58,13 +58,10 @@ module RunnerHelpers
       @sig_cache_root ||= Dir.mktmpdir("rigor-spec-sig-")
     end
 
-    # Materialises a `sig:` hash to a content-keyed directory
-    # under {.sig_cache_root}. Returns the directory path so
-    # the caller can thread it into `Configuration` as
-    # `signature_paths:`. Idempotent: once a digest's directory
-    # exists, the files are not rewritten — every subsequent
-    # caller observes the same `(path, sha256)` tuple and the
-    # cached RBS environment hits.
+    # Materialises a `sig:` hash to a content-keyed directory under {.sig_cache_root}. Returns the directory path so the
+    # caller can thread it into `Configuration` as `signature_paths:`. Idempotent: once a digest's directory exists, the
+    # files are not rewritten — every subsequent caller observes the same `(path, sha256)` tuple and the cached RBS
+    # environment hits.
     def materialise_sig(sig_hash)
       return nil if sig_hash.nil? || sig_hash.empty?
 
@@ -78,12 +75,9 @@ module RunnerHelpers
       sig_root
     end
 
-    # Empties the shared workspace's top-level `.rb` files so
-    # the runner's `Dir.glob(<workspace>/**/*.rb)` only finds
-    # the file the current call writes. The workspace is reused
-    # across calls; nested directories created by `files:` callers
-    # are removed wholesale so leftover fixtures from a prior call
-    # cannot leak into the current one.
+    # Empties the shared workspace's top-level `.rb` files so the runner's `Dir.glob(<workspace>/**/*.rb)` only finds
+    # the file the current call writes. The workspace is reused across calls; nested directories created by `files:`
+    # callers are removed wholesale so leftover fixtures from a prior call cannot leak into the current one.
     def reset_shared_workspace
       Dir.glob(File.join(shared_workspace_root, "*")).each do |entry|
         FileUtils.rm_rf(entry)
@@ -139,15 +133,12 @@ module RunnerHelpers
   def analyze(source = nil, files: {}, sig: {}, config: {}, explain: false, cache_store: :shared, &)
     effective_cache = cache_store == :shared ? RunnerHelpers.shared_cache_store : cache_store
 
-    # Fastest path: a bare `analyze(source)` with no sig / config / files /
-    # block analyses the source IN MEMORY (no workspace file write, no
-    # chdir) via `Runner#run_source`, which is diagnostic-equivalent to the
-    # workspace run for a single file. This is the dominant call shape.
+    # Fastest path: a bare `analyze(source)` with no sig / config / files / block analyses the source IN MEMORY (no
+    # workspace file write, no chdir) via `Runner#run_source`, which is diagnostic-equivalent to the workspace run for a
+    # single file. This is the dominant call shape.
     if !source.nil? && files.empty? && sig.empty? && config.empty? && !block_given?
-      # Disable bundler / rbs-collection auto-detection: the workspace path
-      # `chdir`s into an empty dir with no Gemfile.lock, so matching its
-      # diagnostics means NOT picking up the repo's lockfiles from the spec
-      # process's cwd.
+      # Disable bundler / rbs-collection auto-detection: the workspace path `chdir`s into an empty dir with no
+      # Gemfile.lock, so matching its diagnostics means NOT picking up the repo's lockfiles from the spec process's cwd.
       memory_config = Rigor::Configuration.new(
         "bundler" => { "auto_detect" => false }, "rbs_collection" => { "auto_detect" => false }
       )
@@ -169,13 +160,10 @@ module RunnerHelpers
 
   private
 
-  # The shared workspace path is reused across calls; any config
-  # that pins `paths:` or `signature_paths:` to caller-supplied
-  # entries cannot share it because the runner's expansion would
-  # see the override, not the workspace. The `files:` shape also
-  # falls back because callers may write into nested paths whose
-  # cleanup is harder to reason about than a tmpdir's wholesale
-  # rmtree.
+  # The shared workspace path is reused across calls; any config that pins `paths:` or `signature_paths:` to
+  # caller-supplied entries cannot share it because the runner's expansion would see the override, not the workspace.
+  # The `files:` shape also falls back because callers may write into nested paths whose cleanup is harder to reason
+  # about than a tmpdir's wholesale rmtree.
   def shared_workspace_safe?(files:, config:)
     return false unless files.empty?
     return false if config.key?("paths") || config.key?(:paths)

--- a/tool/bench.rb
+++ b/tool/bench.rb
@@ -3,14 +3,12 @@
 
 # ADR-50 WD4 — perf-regression benchmark for `make bench-perf` / the release gate.
 #
-# Runs `rigor check` in-process over one or more targets, measures wall time,
-# total allocated objects, and peak RSS (Linux only), then gates against a
-# committed baseline within a tunable tolerance band (bench/thresholds.yml).
+# Runs `rigor check` in-process over one or more targets, measures wall time, total allocated objects, and peak RSS
+# (Linux only), then gates against a committed baseline within a tunable tolerance band (bench/thresholds.yml).
 #
-# First run (baseline uncalibrated): writes a SUGGESTED baseline to a
-# `.updated.json` sibling and passes — the same calibrate-on-first-run
-# pattern as tool/oss_sweep_compare.rb. The committed baseline is never
-# overwritten implicitly; commit a CI-measured baseline to activate the gate.
+# First run (baseline uncalibrated): writes a SUGGESTED baseline to a `.updated.json` sibling and passes — the same
+# calibrate-on-first-run pattern as tool/oss_sweep_compare.rb. The committed baseline is never overwritten implicitly;
+# commit a CI-measured baseline to activate the gate.
 #
 # Usage:
 #   ruby tool/bench.rb [--target PATH ...] \
@@ -38,10 +36,9 @@ OptionParser.new do |o|
 end.parse!
 options[:targets] = ["lib"] if options[:targets].empty?
 
-# Peak RSS is read from /proc on Linux (the CI runner, which is the
-# authoritative measurement host). On macOS / other hosts there is no
-# /proc/self/status, so RSS is reported nil and the gate skips it — local
-# `make bench-perf` still measures wall + allocations, which are portable.
+# Peak RSS is read from /proc on Linux (the CI runner, which is the authoritative measurement host). On macOS / other
+# hosts there is no /proc/self/status, so RSS is reported nil and the gate skips it — local `make bench-perf` still
+# measures wall + allocations, which are portable.
 def peak_rss_kb
   status = "/proc/self/status"
   return nil unless File.readable?(status)

--- a/tool/catalog_diff.rb
+++ b/tool/catalog_diff.rb
@@ -1,16 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Compares two snapshots of a `data/builtins/ruby_core/<topic>.yml`
-# catalog and prints the surface-level diff: per-class additions
-# / removals / purity changes / arity changes / cfunc renames.
+# Compares two snapshots of a `data/builtins/ruby_core/<topic>.yml` catalog and prints the surface-level diff: per-class
+# additions / removals / purity changes / arity changes / cfunc renames.
 #
-# The motivating use is a `references/ruby` submodule bump: when
-# CRuby moves its public API around, individual cfunc names (and
-# occasionally classifications) shift. The full YAML diff is
-# noisy because it interleaves prose comments, RBS pulls, and
-# `defined_at` line numbers; this tool extracts the catalog-
-# semantic deltas that a reviewer actually has to look at.
+# The motivating use is a `references/ruby` submodule bump: when CRuby moves its public API around, individual cfunc
+# names (and occasionally classifications) shift. The full YAML diff is noisy because it interleaves prose comments, RBS
+# pulls, and `defined_at` line numbers; this tool extracts the catalog- semantic deltas that a reviewer actually has to
+# look at.
 #
 # Usage:
 #
@@ -45,9 +42,8 @@ end
 before = YAML.safe_load_file(before_path, permitted_classes: [Symbol])
 after = YAML.safe_load_file(after_path, permitted_classes: [Symbol])
 
-# Compares two `instance_methods` / `singleton_methods` hashes
-# under a single class and yields the diff records. Each record
-# is `[kind, *details]` where `kind` is one of:
+# Compares two `instance_methods` / `singleton_methods` hashes under a single class and yields the diff records. Each
+# record is `[kind, *details]` where `kind` is one of:
 #
 # - `:added`   — selector present only in `after`.
 # - `:removed` — selector present only in `before`.

--- a/tool/extract_builtin_catalog.rb
+++ b/tool/extract_builtin_catalog.rb
@@ -1,10 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Extracts a PHPStan-functionMap-style catalog of CRuby built-in
-# methods from the reference checkout at `references/ruby` and the
-# RBS core signatures at `references/rbs`. Topics handled by this
-# tool today: Numeric/Integer/Float, String/Symbol, and Array.
+# Extracts a PHPStan-functionMap-style catalog of CRuby built-in methods from the reference checkout at
+# `references/ruby` and the RBS core signatures at `references/rbs`. Topics handled by this tool today:
+# Numeric/Integer/Float, String/Symbol, and Array.
 #
 # Usage:
 #   ruby tool/extract_builtin_catalog.rb              # all topics
@@ -52,12 +51,10 @@ require "set"
 ROOT = File.expand_path("..", __dir__)
 
 # ---------------------------------------------------------------------
-# Per-topic configuration table. Adding a new topic is purely a
-# data change here — no class needs editing.
+# Per-topic configuration table. Adding a new topic is purely a data change here — no class needs editing.
 # ---------------------------------------------------------------------
 
-# Class-variable globals that show up in any Init_* block. Each
-# topic merges its own additions on top of this base.
+# Class-variable globals that show up in any Init_* block. Each topic merges its own additions on top of this base.
 BASE_CLASS_VARS = {
   "rb_cObject" => "Object",
   "rb_cBasicObject" => "BasicObject",
@@ -176,11 +173,9 @@ TOPICS = {
     output_path: "data/builtins/ruby_core/range.yml"
   },
   "set" => {
-    # Set was rewritten in C and folded into CRuby for Ruby 3.2+.
-    # On the `ruby_4_0` reference branch the Init function lives
-    # in `set.c`; there is no `set.rb` prelude (the C side calls
-    # `rb_provide("set.rb")` at the end of Init_Set so a top-level
-    # `require "set"` is a no-op against the built-in).
+    # Set was rewritten in C and folded into CRuby for Ruby 3.2+. On the `ruby_4_0` reference branch the Init function
+    # lives in `set.c`; there is no `set.rb` prelude (the C side calls `rb_provide("set.rb")` at the end of Init_Set so
+    # a top-level `require "set"` is a no-op against the built-in).
     init_function: "Init_Set",
     ruby_c_path: "references/ruby/set.c",
     ruby_prelude_path: nil,
@@ -191,12 +186,10 @@ TOPICS = {
     output_path: "data/builtins/ruby_core/set.yml"
   },
   "time" => {
-    # Time is a pure-C built-in: `Init_Time` registers the class
-    # body, and the Ruby-side prelude lives in `timev.rb` (compiled
-    # to `timev.rbinc` and `#include`d at the bottom of `time.c`).
-    # The prelude carries the class-side surface (`Time.now`,
-    # `Time.at`, `Time.new`) through Primitive cexpr stubs, so it
-    # MUST be parsed for the catalog to capture those entries.
+    # Time is a pure-C built-in: `Init_Time` registers the class body, and the Ruby-side prelude lives in `timev.rb`
+    # (compiled to `timev.rbinc` and `#include`d at the bottom of `time.c`). The prelude carries the class-side surface
+    # (`Time.now`, `Time.at`, `Time.new`) through Primitive cexpr stubs, so it MUST be parsed for the catalog to capture
+    # those entries.
     init_function: "Init_Time",
     ruby_c_path: "references/ruby/time.c",
     ruby_prelude_path: "references/ruby/timev.rb",
@@ -207,13 +200,10 @@ TOPICS = {
     output_path: "data/builtins/ruby_core/time.yml"
   },
   "date" => {
-    # Date is a stdlib gem (date_core.c) bundled with CRuby. The
-    # single Init function `Init_date_core` registers BOTH `Date`
-    # and `DateTime` (the latter inheriting from the former), so a
-    # single topic suffices — `rbs_paths` carries one entry per
-    # class. The Ruby-side prelude (`lib/date.rb`) only contributes
-    # `Date#infinite?` and the nested `Date::Infinity` class; the
-    # bulk of the surface is in C.
+    # Date is a stdlib gem (date_core.c) bundled with CRuby. The single Init function `Init_date_core` registers BOTH
+    # `Date` and `DateTime` (the latter inheriting from the former), so a single topic suffices — `rbs_paths` carries
+    # one entry per class. The Ruby-side prelude (`lib/date.rb`) only contributes `Date#infinite?` and the nested
+    # `Date::Infinity` class; the bulk of the surface is in C.
     init_function: "Init_date_core",
     ruby_c_path: "references/ruby/ext/date/date_core.c",
     ruby_prelude_path: "references/ruby/ext/date/lib/date.rb",
@@ -285,13 +275,10 @@ TOPICS = {
     output_path: "data/builtins/ruby_core/random.yml"
   },
   "struct" => {
-    # Class registration lives in `InitVM_Struct` — the outer
-    # `Init_Struct` only sets up symbol IDs and forwards to
-    # `InitVM(Struct)`. The same `InitVM_*` indirection that
-    # Random and Pathname use. `InitVM_Struct` defines both
-    # `Struct` and `Data` in one pass, so the YAML carries
-    # both classes; only `Struct` is wired into
-    # `CATALOG_BY_CLASS` today.
+    # Class registration lives in `InitVM_Struct` — the outer `Init_Struct` only sets up symbol IDs and forwards to
+    # `InitVM(Struct)`. The same `InitVM_*` indirection that Random and Pathname use. `InitVM_Struct` defines both
+    # `Struct` and `Data` in one pass, so the YAML carries both classes; only `Struct` is wired into `CATALOG_BY_CLASS`
+    # today.
     init_function: "InitVM_Struct",
     ruby_c_path: "references/ruby/struct.c",
     ruby_prelude_path: nil,
@@ -312,10 +299,8 @@ TOPICS = {
     output_path: "data/builtins/ruby_core/encoding.yml"
   },
   "re" => {
-    # `Init_Regexp` registers BOTH `Regexp` and `MatchData` (and the
-    # `RegexpError` exception class) in a single C init block, so a
-    # single topic suffices — `rbs_paths` carries one entry per class.
-    # There is no Ruby-side prelude.
+    # `Init_Regexp` registers BOTH `Regexp` and `MatchData` (and the `RegexpError` exception class) in a single C init
+    # block, so a single topic suffices — `rbs_paths` carries one entry per class. There is no Ruby-side prelude.
     init_function: "Init_Regexp",
     ruby_c_path: "references/ruby/re.c",
     ruby_prelude_path: nil,
@@ -327,11 +312,9 @@ TOPICS = {
     output_path: "data/builtins/ruby_core/re.yml"
   },
   "proc" => {
-    # `Init_Proc` registers `Proc`, `Method`, AND `UnboundMethod`
-    # in a single C init block (plus the `LocalJumpError` /
-    # `SystemStackError` exception classes), so a single topic
-    # suffices — `rbs_paths` carries one entry per class. There is
-    # no Ruby-side prelude.
+    # `Init_Proc` registers `Proc`, `Method`, AND `UnboundMethod` in a single C init block (plus the `LocalJumpError` /
+    # `SystemStackError` exception classes), so a single topic suffices — `rbs_paths` carries one entry per class. There
+    # is no Ruby-side prelude.
     init_function: "Init_Proc",
     ruby_c_path: "references/ruby/proc.c",
     ruby_prelude_path: nil,
@@ -361,15 +344,13 @@ TOPICS = {
 
 class CInitParser
   CLASS_DEFINE_RE = /^\s*(\w+)\s*=\s*rb_define_class\(\s*"([^"]+)"\s*,\s*(\w+)\s*\)\s*;/
-  # `rb_mFoo = rb_define_module("Foo");` — module registration. Modules
-  # have no parent class, so the captured field reduces to a one-arg
-  # form. Recorded with `parent: "Module"` so downstream tools that
-  # iterate `classes` get a stable parent slot.
+  # `rb_mFoo = rb_define_module("Foo");` — module registration. Modules have no parent class, so the captured field
+  # reduces to a one-arg form. Recorded with `parent: "Module"` so downstream tools that iterate `classes` get a stable
+  # parent slot.
   MODULE_DEFINE_RE = /^\s*(\w+)\s*=\s*rb_define_module\(\s*"([^"]+)"\s*\)\s*;/
-  # Range/Struct-style class registration. The first arg is the class name,
-  # the second is the parent (a `rb_c*` global), the rest are the struct
-  # accessor names which we ignore. Multi-line forms are joined into a
-  # single logical line by `init_region` before the regex runs.
+  # Range/Struct-style class registration. The first arg is the class name, the second is the parent (a `rb_c*` global),
+  # the rest are the struct accessor names which we ignore. Multi-line forms are joined into a single logical line by
+  # `init_region` before the regex runs.
   STRUCT_DEFINE_RE =
     /^\s*(\w+)\s*=\s*rb_struct_define_without_accessor\(\s*"([^"]+)"\s*,\s*(\w+)\s*,.*?\)\s*;/
   DEFINE_METHOD_RE = /^\s*rb_define_method\(\s*(\w+)\s*,\s*"([^"]+)"\s*,\s*(\w+)\s*,\s*(-?\d+)\s*\)\s*;/
@@ -386,12 +367,9 @@ class CInitParser
     @init_function = init_function
     @class_var_map = class_var_map
     @relative_path = path.sub("#{ROOT}/", "")
-    # Pre-strip block comments from the source so multi-line
-    # `/* ... */` rdoc blocks (very common right above a class
-    # registration) do not leak unbalanced parens into
-    # `join_continuations`'s state machine. Line numbers MUST be
-    # preserved — we replace comment characters with spaces and
-    # keep newlines intact rather than collapsing the file.
+    # Pre-strip block comments from the source so multi-line `/* ... */` rdoc blocks (very common right above a class
+    # registration) do not leak unbalanced parens into `join_continuations`'s state machine. Line numbers MUST be
+    # preserved — we replace comment characters with spaces and keep newlines intact rather than collapsing the file.
     @lines = strip_block_comments(File.read(path, encoding: "UTF-8")).each_line.to_a
   end
 
@@ -448,11 +426,9 @@ class CInitParser
     join_continuations(raw)
   end
 
-  # Joins consecutive lines whose paren depth has not yet returned to
-  # zero into a single logical line, keyed by the first line's number.
-  # This lets the per-statement regexes recognise multi-line forms
-  # like `rb_struct_define_without_accessor( … , "begin", "end", NULL);`
-  # without each regex having to deal with newlines.
+  # Joins consecutive lines whose paren depth has not yet returned to zero into a single logical line, keyed by the
+  # first line's number. This lets the per-statement regexes recognise multi-line forms like
+  # `rb_struct_define_without_accessor( … , "begin", "end", NULL);` without each regex having to deal with newlines.
   def join_continuations(raw)
     out = []
     buffer = nil
@@ -479,13 +455,10 @@ class CInitParser
     line.gsub(%r{/\*.*?\*/}, "").gsub(%r{//[^\n]*}, "")
   end
 
-  # Replaces `/* ... */` block-comment contents with spaces while
-  # preserving newlines so per-line indexing stays valid. Without
-  # this, multi-line rdoc blocks (e.g. the long `/* ... */` above
-  # `cDateTime = rb_define_class(...)` in `date_core.c`) leak
-  # unbalanced parens into `join_continuations`, which then merges
-  # the next code line into the comment buffer and prevents the
-  # class-registration regex from matching.
+  # Replaces `/* ... */` block-comment contents with spaces while preserving newlines so per-line indexing stays valid.
+  # Without this, multi-line rdoc blocks (e.g. the long `/* ... */` above `cDateTime = rb_define_class(...)` in
+  # `date_core.c`) leak unbalanced parens into `join_continuations`, which then merges the next code line into the
+  # comment buffer and prevents the class-registration regex from matching.
   def strip_block_comments(text)
     out = +""
     i = 0
@@ -527,11 +500,9 @@ class CInitParser
     true
   end
 
-  # `rb_mFoo = rb_define_module("Foo")` — Comparable / Enumerable
-  # / Kernel / etc. live here. Modules have no class parent;
-  # downstream readers that iterate `classes` get `"Module"` as
-  # the stable parent slot so the per-class shape stays uniform
-  # with class entries.
+  # `rb_mFoo = rb_define_module("Foo")` — Comparable / Enumerable / Kernel / etc. live here. Modules have no class
+  # parent; downstream readers that iterate `classes` get `"Module"` as the stable parent slot so the per-class shape
+  # stays uniform with class entries.
   def module_definition(line, lineno, var_to_class, classes)
     return false unless (m = line.match(MODULE_DEFINE_RE))
 
@@ -541,10 +512,8 @@ class CInitParser
     true
   end
 
-  # Range registers itself with `rb_struct_define_without_accessor`
-  # (see `Init_Range` in references/ruby/range.c). Treat it as a
-  # plain class declaration so downstream method/include definitions
-  # land in the right bucket.
+  # Range registers itself with `rb_struct_define_without_accessor` (see `Init_Range` in references/ruby/range.c). Treat
+  # it as a plain class declaration so downstream method/include definitions land in the right bucket.
   def struct_definition(line, lineno, var_to_class, classes)
     return false unless (m = line.match(STRUCT_DEFINE_RE))
 
@@ -651,10 +620,8 @@ class CBodyIndex
     @bodies[target]
   end
 
-  # Returns the set of cfunc names whose bodies are mutation-
-  # gate helpers — the per-class wrappers (`time_modify`,
-  # `str_modifiable`, …) that the C-body classifier MUST treat
-  # the same way as `rb_check_frozen` itself.
+  # Returns the set of cfunc names whose bodies are mutation- gate helpers — the per-class wrappers (`time_modify`,
+  # `str_modifiable`, …) that the C-body classifier MUST treat the same way as `rb_check_frozen` itself.
   #
   # Two seeding rules feed the set:
   #
@@ -675,9 +642,8 @@ class CBodyIndex
   #    that the previous "frozen-check only" recogniser
   #    missed.
   #
-  # Cross-source helpers and complex wrappers that don't
-  # match either rule still need a per-class blocklist entry
-  # in the corresponding `*_catalog.rb` file.
+  # Cross-source helpers and complex wrappers that don't match either rule still need a per-class blocklist entry in the
+  # corresponding `*_catalog.rb` file.
   def mutator_helpers
     @mutator_helpers ||= compute_mutator_helpers
   end
@@ -690,41 +656,27 @@ class CBodyIndex
     bodies
   end
 
-  # A body counts as a mutation-gate wrapper iff its text after
-  # stripping comments contains exactly `rb_check_frozen(...)`
-  # and no other tokens that would smell like real work
-  # (assignments, control flow, function calls other than
-  # `rb_check_frozen`). Bodies that just forward to
-  # `rb_check_frozen` are safe to treat as mutators because
-  # their callers are by definition about to mutate the same
-  # receiver — the wrapper exists only to centralise the
-  # frozen-check call pattern.
+  # A body counts as a mutation-gate wrapper iff its text after stripping comments contains exactly
+  # `rb_check_frozen(...)` and no other tokens that would smell like real work (assignments, control flow, function
+  # calls other than `rb_check_frozen`). Bodies that just forward to `rb_check_frozen` are safe to treat as mutators
+  # because their callers are by definition about to mutate the same receiver — the wrapper exists only to centralise
+  # the frozen-check call pattern.
   def compute_mutator_helpers
     @bodies ||= build
     helpers = Set.new
 
-    # Seed-only recognition: a function is a mutator helper
-    # iff its body matches the pure-frozen-check shape OR its
-    # name follows the `_modify` / `_modifiable` convention
-    # AND its body issues a frozen-check call.
+    # Seed-only recognition: a function is a mutator helper iff its body matches the pure-frozen-check shape OR its name
+    # follows the `_modify` / `_modifiable` convention AND its body issues a frozen-check call.
     #
-    # Earlier iterations of this slice tried a "transitive
-    # closure on first-arg-is-formal-param" rule to chain
-    # through helpers like `time_localtime -> time_modify`.
-    # The closure caught a few real cases (`Time#localtime`
-    # via `time_localtime_m`) but also false-positived on
-    # functions where the first arg is a formal param yet the
-    # helper doesn't actually mutate that arg (`rb_ary_reject`
-    # passes `ary` to `ary_reject` which iterates `ary` and
-    # pushes to a separately-passed array). Static C-level
-    # analysis can't distinguish "uses formal as receiver" from
-    # "uses formal as input"; the closure was too permissive
-    # for v0.1.x conservatism. The seed-only recogniser is the
-    # principled middle ground — it catches the gates the
-    # original v0.0.5 fix missed (`str_modifiable`,
-    # `rb_struct_modify`, `rb_class_modify_check`, …) without
-    # the over-classification risk. Per-class blocklists in
-    # `*_catalog.rb` continue to absorb anything still missing.
+    # Earlier iterations of this slice tried a "transitive closure on first-arg-is-formal-param" rule to chain through
+    # helpers like `time_localtime -> time_modify`. The closure caught a few real cases (`Time#localtime` via
+    # `time_localtime_m`) but also false-positived on functions where the first arg is a formal param yet the helper
+    # doesn't actually mutate that arg (`rb_ary_reject` passes `ary` to `ary_reject` which iterates `ary` and pushes to
+    # a separately-passed array). Static C-level analysis can't distinguish "uses formal as receiver" from "uses formal
+    # as input"; the closure was too permissive for v0.1.x conservatism. The seed-only recogniser is the principled
+    # middle ground — it catches the gates the original v0.0.5 fix missed (`str_modifiable`, `rb_struct_modify`,
+    # `rb_class_modify_check`, …) without the over-classification risk. Per-class blocklists in `*_catalog.rb` continue
+    # to absorb anything still missing.
     @bodies.each do |name, body|
       stripped = CBodyClassifier.strip_comments(body.text)
       helpers << name if pure_frozen_check_wrapper?(stripped) || naming_convention_helper?(name, stripped)
@@ -733,12 +685,9 @@ class CBodyIndex
     helpers
   end
 
-  # Parses the parenthesised argument list off a function
-  # signature like `static VALUE \nfoo(VALUE x, int y)\n`. The
-  # caller passes the joined header text up to (but not
-  # including) the opening brace. Returns an Array of formal
-  # parameter names, or [] when the parse fails or the
-  # signature is `(void)` / unparseable.
+  # Parses the parenthesised argument list off a function signature like `static VALUE \nfoo(VALUE x, int y)\n`. The
+  # caller passes the joined header text up to (but not including) the opening brace. Returns an Array of formal
+  # parameter names, or [] when the parse fails or the signature is `(void)` / unparseable.
   def parse_signature_params(header_text)
     match = header_text.match(/\(([^)]*)\)/m)
     return [] unless match
@@ -747,9 +696,8 @@ class CBodyIndex
     return [] if raw.empty? || raw == "void"
 
     raw.split(",").filter_map do |chunk|
-      # Take the last identifier of each comma-separated
-      # parameter slot — that's the formal name (the rest is
-      # the type, possibly with `*` or `[]` decoration).
+      # Take the last identifier of each comma-separated parameter slot — that's the formal name (the rest is the type,
+      # possibly with `*` or `[]` decoration).
       ident = chunk.gsub(/[*\[\]]/, " ").split.last
       ident if ident && ident.match?(/\A[A-Za-z_]\w*\z/)
     end
@@ -762,10 +710,8 @@ class CBodyIndex
   \z/x
   private_constant :PURE_FROZEN_CHECK_RE
 
-  # Matches names like `str_modifiable`, `time_modify`,
-  # `rb_struct_modify`, `rb_class_modify_check`, `range_modify`,
-  # `str_modify_keep_cr`. Requires word boundaries around the
-  # `_modify` / `_modifiable` token so unrelated names like
+  # Matches names like `str_modifiable`, `time_modify`, `rb_struct_modify`, `rb_class_modify_check`, `range_modify`,
+  # `str_modify_keep_cr`. Requires word boundaries around the `_modify` / `_modifiable` token so unrelated names like
   # `something_modifier` don't accidentally match.
   NAMING_HELPER_RE = /(?:_(?:modify|modifiable))(?:\b|_)/
   private_constant :NAMING_HELPER_RE
@@ -774,12 +720,9 @@ class CBodyIndex
     PURE_FROZEN_CHECK_RE.match?(text)
   end
 
-  # Naming-convention helper: function name matches the
-  # `_modify` / `_modifiable` convention AND its body issues
-  # a `rb_check_frozen` / `rb_check_lockedtmp` call. The
-  # body-content guard rules out a function that just happens
-  # to have `_modify` in its name without actually being a
-  # mutation gate.
+  # Naming-convention helper: function name matches the `_modify` / `_modifiable` convention AND its body issues a
+  # `rb_check_frozen` / `rb_check_lockedtmp` call. The body-content guard rules out a function that just happens to have
+  # `_modify` in its name without actually being a mutation gate.
   def naming_convention_helper?(name, stripped_text)
     return false unless NAMING_HELPER_RE.match?(name)
 
@@ -921,14 +864,10 @@ module CBodyClassifier
     calls_helper_on_own_param?(text, mutator_helpers, formal_params)
   end
 
-  # Formal parameter names that the convention reserves for
-  # variadic-method bookkeeping (`int argc, VALUE *argv, VALUE
-  # self`). The "self" position in such a signature is the
-  # final formal, not `argc` / `argv` — and only the self
-  # position is what a downstream mutator helper would target.
-  # Filtering these out prevents false-positive matches on
-  # `helper(argc, ...)` patterns that have nothing to do with
-  # mutation.
+  # Formal parameter names that the convention reserves for variadic-method bookkeeping (`int argc, VALUE *argv, VALUE
+  # self`). The "self" position in such a signature is the final formal, not `argc` / `argv` — and only the self
+  # position is what a downstream mutator helper would target. Filtering these out prevents false-positive matches on
+  # `helper(argc, ...)` patterns that have nothing to do with mutation.
   VARARG_FORMAL_NAMES = %w[argc argv _argc _argv].freeze
 
   def calls_helper_on_own_param?(body_text, helpers, formal_params)
@@ -947,19 +886,13 @@ module CBodyClassifier
     end
   end
 
-  # Detects `<param> = ...` (excluding `==` / `>=` / `<=` / `!=`)
-  # — the C shadowing pattern that lets a body locally
-  # reassign a formal parameter (`time = time_dup(time);`).
-  # When a formal is reassigned, downstream uses of the same
-  # identifier no longer refer to the caller's value, so a
-  # syntactic `helper(<formal>, ...)` match would falsely
-  # imply the caller's value is mutated.
+  # Detects `<param> = ...` (excluding `==` / `>=` / `<=` / `!=`) — the C shadowing pattern that lets a body locally
+  # reassign a formal parameter (`time = time_dup(time);`). When a formal is reassigned, downstream uses of the same
+  # identifier no longer refer to the caller's value, so a syntactic `helper(<formal>, ...)` match would falsely imply
+  # the caller's value is mutated.
   #
-  # The negative lookbehind on `[.\w>]` excludes struct
-  # field initialisers (`.self = self`), arrow-deref
-  # initialisers (`x->self = ...`), and identifier prefix
-  # matches (`myself = ...`) — none of those reassign the
-  # formal binding.
+  # The negative lookbehind on `[.\w>]` excludes struct field initialisers (`.self = self`), arrow-deref initialisers
+  # (`x->self = ...`), and identifier prefix matches (`myself = ...`) — none of those reassign the formal binding.
   def formal_param_reassigned?(text, param)
     text.match?(/(?<![.\w>])#{Regexp.escape(param)}\s*=(?![=])/)
   end
@@ -1046,10 +979,8 @@ class PreludeParser
   def analyse_body(body)
     return [[], "empty", nil] unless body
 
-    # `def foo; …; rescue; …; end` gives a `Prism::BeginNode`
-    # body wrapping the actual statements. The classifier
-    # only inspects the top-level statement list, so we descend
-    # into the begin-block's `statements` for the rescue-on-def
+    # `def foo; …; rescue; …; end` gives a `Prism::BeginNode` body wrapping the actual statements. The classifier only
+    # inspects the top-level statement list, so we descend into the begin-block's `statements` for the rescue-on-def
     # idiom (used widely in `pathname_builtin.rb`).
     statements_node = body.is_a?(Prism::BeginNode) ? body.statements : body
     return [[], "empty", nil] if statements_node.nil?
@@ -1352,13 +1283,10 @@ class CatalogBuilder # rubocop:disable Metrics/ClassLength
     return "leaf" if prelude_method.attrs.include?("leaf")
     return "inline_block" if prelude_method.attrs.intersect?(%w[inline_block use_block])
     return "trivial" if %w[trivial_self trivial_literal].include?(prelude_method.body_kind)
-    # `composed` prelude bodies (every prelude method whose body is
-    # neither `Primitive.attr!(:leaf)`, a literal return, nor `self`)
-    # invariably end in a Ruby method dispatch — and Ruby methods are
-    # all user-overridable, so the catalog must treat them as
-    # `dispatch` for folding-safety. Same effect as the previous
-    # `unknown` classification (both fall outside `FOLDABLE_PURITIES`)
-    # but more accurate self-documentation.
+    # `composed` prelude bodies (every prelude method whose body is neither `Primitive.attr!(:leaf)`, a literal return,
+    # nor `self`) invariably end in a Ruby method dispatch — and Ruby methods are all user-overridable, so the catalog
+    # must treat them as `dispatch` for folding-safety. Same effect as the previous `unknown` classification (both fall
+    # outside `FOLDABLE_PURITIES`) but more accurate self-documentation.
     return "dispatch" if prelude_method.body_kind == "composed"
 
     "unknown"

--- a/tool/mutation/mutate.rb
+++ b/tool/mutation/mutate.rb
@@ -4,35 +4,30 @@
 # Mutation-testing harness for Rigor — a *prototype* for the "壊したら壊れる"
 # (break-the-code / does-the-checker-bite) question.
 #
-# Idea: take a file Rigor currently reports clean, inject a *type-visible*
-# mutation (a literal flipped to nil, a literal's type swapped, a call renamed
-# to a missing method, an arg appended), re-run `rigor check` on the mutated
-# SOURCE, and see whether a NEW diagnostic appears. A surviving mutant — one
-# that produces no new diagnostic — is a candidate false-negative blind spot.
+# Idea: take a file Rigor currently reports clean, inject a *type-visible* mutation (a literal flipped to nil, a
+# literal's type swapped, a call renamed to a missing method, an arg appended), re-run `rigor check` on the mutated
+# SOURCE, and see whether a NEW diagnostic appears. A surviving mutant — one that produces no new diagnostic — is a
+# candidate false-negative blind spot.
 #
-# This is NOT classic mutation testing of a test suite. A type checker only
-# sees a subset of behavioural bugs, so most random mutations are equivalent
-# mutants (type-invariant) and survival is *correct*. We therefore restrict
-# ourselves to mutations that SHOULD be type-visible and read the survival of
+# This is NOT classic mutation testing of a test suite. A type checker only sees a subset of behavioural bugs, so most
+# random mutations are equivalent mutants (type-invariant) and survival is *correct*. We therefore restrict ourselves to
+# mutations that SHOULD be type-visible and read the survival of
 # *those* as signal — effectively a teeth-regression probe over the diagnostic
 # taxonomy. See tool/mutation/README.md.
 #
-# Efficiency (the "editor mode + cache" path): the expensive builds — the RBS
-# environment and the whole-project pre-pass (ProjectScan) — are paid ONCE via
-# LanguageServer::ProjectContext, then every mutant reuses them through
-# `Runner.new(environment:, prebuilt:)` + `#run_source` (in-memory overlay, no
-# disk write). Passing `prebuilt:` also disables the run-result cache, whose
-# key digests the *disk* file — so a mutant is never served a stale clean hit.
+# Efficiency (the "editor mode + cache" path): the expensive builds — the RBS environment and the whole-project pre-pass
+# (ProjectScan) — are paid ONCE via LanguageServer::ProjectContext, then every mutant reuses them through
+# `Runner.new(environment:, prebuilt:)` + `#run_source` (in-memory overlay, no disk write). Passing `prebuilt:` also
+# disables the run-result cache, whose key digests the *disk* file — so a mutant is never served a stale clean hit.
 # Marginal cost per mutant ≈ re-analysing one file's body.
 #
 # Run inside the Flake:
 #   nix --extra-experimental-features 'nix-command flakes' develop -c \
 #     bundle exec ruby tool/mutation/mutate.rb lib/rigor/<some_file>.rb
 #
-# By default a type-aware filter (Phase 1.5) keeps only mutations whose
-# anchor — the call receiver whose contract the mutation could violate — types
-# to a concrete, non-Dynamic type. That focuses the run on sites where Rigor
-# actually holds a contract; `--no-type-filter` disables it (A/B the filter).
+# By default a type-aware filter (Phase 1.5) keeps only mutations whose anchor — the call receiver whose contract the
+# mutation could violate — types to a concrete, non-Dynamic type. That focuses the run on sites where Rigor actually
+# holds a contract; `--no-type-filter` disables it (A/B the filter).
 #
 # Flags: --config PATH  --limit N  --seed N  --operators a,b
 #        --no-type-filter  --dry-run  --verbose
@@ -48,17 +43,15 @@ require "rigor/language_server"        # ProjectContext lives here (editor-mode 
 require "rigor/protection/mutator"     # the type-visible mutator, productized into lib (ADR-63)
 
 module RigorMutation
-  # The mutation generator + type-aware filter live in `lib/` now (ADR-63 Tier 2
-  # productized the per-file effectiveness measurement). This dev harness keeps
-  # only the survivor *clustering* / sweep / fuzz tooling (dev-only per ADR-62
-  # WD4) and reuses the lib mutator so there is one source of truth. The aliases
-  # keep the rest of this file (which says `Mutator` / `Mutation`) untouched.
+  # The mutation generator + type-aware filter live in `lib/` now (ADR-63 Tier 2 productized the per-file effectiveness
+  # measurement). This dev harness keeps only the survivor *clustering* / sweep / fuzz tooling (dev-only per ADR-62 WD4)
+  # and reuses the lib mutator so there is one source of truth. The aliases keep the rest of this file (which says
+  # `Mutator` / `Mutation`) untouched.
   Mutator = Rigor::Protection::Mutator
   Mutation = Rigor::Protection::Mutation
 
-  # Builds the warm session once: config + ProjectContext (RBS environment +
-  # whole-project ProjectScan memoised). Progress goes to stderr so a sweep's
-  # `--json` stdout stays clean.
+  # Builds the warm session once: config + ProjectContext (RBS environment + whole-project ProjectScan memoised).
+  # Progress goes to stderr so a sweep's `--json` stdout stays clean.
   module Session
     module_function
 
@@ -231,9 +224,8 @@ module RigorMutation
     end
   end
 
-  # Corpus sweep: one warm session, every file's survivors aggregated and
-  # clustered into a ranked false-negative backlog for the engine.
-  # Expand file / directory / glob arguments to a sorted, unique `.rb` list.
+  # Corpus sweep: one warm session, every file's survivors aggregated and clustered into a ranked false-negative backlog
+  # for the engine. Expand file / directory / glob arguments to a sorted, unique `.rb` list.
   module Paths
     module_function
 
@@ -335,13 +327,11 @@ module RigorMutation
     end
   end
 
-  # Broad-fuzz mode — the soundness / robustness sibling of the teeth sweep.
-  # Not "does Rigor bite" but "can Rigor be broken": stress the analyzer with
-  # aggressive, un-filtered mutation (every operator, every site) and report
-  # mutants that make it CRASH (a rescued `internal analyzer error:`
-  # diagnostic), HANG (per-mutant timeout), or — with `--repeat` — return
-  # NON-DETERMINISTIC diagnostics (which would break the cache's byte-identical
-  # contract, ADR-45/54). A clean run finds nothing; a finding is a bug.
+  # Broad-fuzz mode — the soundness / robustness sibling of the teeth sweep. Not "does Rigor bite" but "can Rigor be
+  # broken": stress the analyzer with aggressive, un-filtered mutation (every operator, every site) and report mutants
+  # that make it CRASH (a rescued `internal analyzer error:` diagnostic), HANG (per-mutant timeout), or — with
+  # `--repeat` — return NON-DETERMINISTIC diagnostics (which would break the cache's byte-identical contract,
+  # ADR-45/54). A clean run finds nothing; a finding is a bug.
   class Fuzz
     CRASH_PREFIX = "internal analyzer error:"
 

--- a/tool/mutation/self_mutate.rb
+++ b/tool/mutation/self_mutate.rb
@@ -1,24 +1,20 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Self-mutation testing of `lib/rigor/` — Product C (see
-# docs/notes/20260618-self-mutation-testing-plan.md). Points the productized
-# mutation machinery INWARD at Rigor's own implementation and fuses two kill
-# oracles:
+# Self-mutation testing of `lib/rigor/` — Product C (see docs/notes/20260618-self-mutation-testing-plan.md). Points the
+# productized mutation machinery INWARD at Rigor's own implementation and fuses two kill oracles:
 #
 #   * the TYPE axis  — Rigor's own self-check (`DiagnosticOracle`): does a
 #     type-visible breakage make `rigor check lib` newly complain?
 #   * the TEST axis  — Rigor's own RSpec suite (`TestSuiteOracle`): does the
 #     covering spec go red when the implementation is broken?
 #
-# A mutation killed by neither is an *implementation hole* — code that can be
-# broken without either the type net or a test noticing. The report attributes
-# each survivor so the cheaper missing guard is obvious: add a spec, or add a
-# type / sharpen a self-check rule.
+# A mutation killed by neither is an *implementation hole* — code that can be broken without either the type net or a
+# test noticing. The report attributes each survivor so the cheaper missing guard is obvious: add a spec, or add a type
+# / sharpen a self-check rule.
 #
-# This is a thin driver over `Rigor::Protection::{MutationScanner,TestSuiteOracle}`
-# (one source of truth with ADR-63 Tier 2 / ADR-70). It adds only the two things
-# Product C needs over Product B (mutating a *user's* code):
+# This is a thin driver over `Rigor::Protection::{MutationScanner,TestSuiteOracle}` (one source of truth with ADR-63
+# Tier 2 / ADR-70). It adds only the two things Product C needs over Product B (mutating a *user's* code):
 #
 #   1. The TEST runner uses Rigor's OWN bundle. `TestSuiteOracle`'s default
 #      runner strips Bundler's env (right for a *foreign* project's Gemfile,
@@ -28,12 +24,10 @@
 #      `lib/rigor/a/b.rb -> spec/rigor/a/b_spec.rb`), so the test axis runs only
 #      the relevant spec instead of the ~6,300-example suite per mutant.
 #
-# The TYPE oracle here is the IN-PROCESS worktree engine, which is sound and the
-# most rule-accurate choice: the engine is loaded once (clean) at startup and a
-# mutation is only ever analysed *input* (the type axis never writes to disk) —
-# so mutating the analyzer cannot corrupt the loaded oracle. The plan's
-# independent (mise / clean-HEAD) oracle is for the broad-fuzz / robustness
-# variant where rule-parity does not matter; not needed for this fused measure.
+# The TYPE oracle here is the IN-PROCESS worktree engine, which is sound and the most rule-accurate choice: the engine
+# is loaded once (clean) at startup and a mutation is only ever analysed *input* (the type axis never writes to disk) —
+# so mutating the analyzer cannot corrupt the loaded oracle. The plan's independent (mise / clean-HEAD) oracle is for
+# the broad-fuzz / robustness variant where rule-parity does not matter; not needed for this fused measure.
 #
 # Run inside the Flake:
 #   nix --extra-experimental-features 'nix-command flakes' develop -c \
@@ -58,10 +52,9 @@ require "rigor/protection/mutation_scanner"
 require "rigor/protection/test_suite_oracle"
 
 module RigorSelfMutation
-  # Maps a `lib/rigor/**.rb` path to its convention spec, or nil when none
-  # exists. Tier 0 of the plan's coverage-guided selection — cheap and exact
-  # for the 1:1 majority; a full `{line -> specs}` coverage index is the
-  # precise fallback (future).
+  # Maps a `lib/rigor/**.rb` path to its convention spec, or nil when none exists. Tier 0 of the plan's coverage-guided
+  # selection — cheap and exact for the 1:1 majority; a full `{line -> specs}` coverage index is the precise fallback
+  # (future).
   module SpecMap
     module_function
 
@@ -71,9 +64,8 @@ module RigorSelfMutation
     end
   end
 
-  # The in-bundle spec runner: plain `system` so the rspec subprocess inherits
-  # Rigor's OWN Bundler env (the SUT bundle is Rigor's). Output suppressed
-  # unless --verbose.
+  # The in-bundle spec runner: plain `system` so the rspec subprocess inherits Rigor's OWN Bundler env (the SUT bundle
+  # is Rigor's). Output suppressed unless --verbose.
   class BundledRunner
     def initialize(verbose:)
       @opts = verbose ? {} : { out: File::NULL, err: File::NULL }
@@ -109,13 +101,11 @@ module RigorSelfMutation
       report(outcomes)
     end
 
-    # Whole-tree backlog without a per-mutant suite run (the efficient pass).
-    # For each file, the cheap in-process TYPE axis over EVERY dispatch site
-    # (`:all`); a type-survivor whose line the suite never executed (per the
-    # `--coverage-gap` index) is provably test-unprotected — a high-confidence
-    # implementation hole. A type-survivor on a covered line is only *maybe*
-    # killed (covered ≠ asserted), so it is reported separately as needing the
-    # expensive fused verification.
+    # Whole-tree backlog without a per-mutant suite run (the efficient pass). For each file, the cheap in-process TYPE
+    # axis over EVERY dispatch site (`:all`); a type-survivor whose line the suite never executed (per the
+    # `--coverage-gap` index) is provably test-unprotected — a high-confidence implementation hole. A type-survivor on a
+    # covered line is only *maybe* killed (covered ≠ asserted), so it is reported separately as needing the expensive
+    # fused verification.
     def coverage_gap_sweep(files)
       holes = []
       needs_check = 0
@@ -133,8 +123,7 @@ module RigorSelfMutation
           end
         end
         holes.concat(file_holes)
-        # Stream a per-file JSONL line, flushed, so a killed run keeps its
-        # partial backlog (the sweep is the slow part).
+        # Stream a per-file JSONL line, flushed, so a killed run keeps its partial backlog (the sweep is the slow part).
         out&.puts(JSON.generate(path: path, holes: file_holes))
         out&.flush
       end
@@ -143,25 +132,20 @@ module RigorSelfMutation
       report_coverage_gap(holes, needs_check)
     end
 
-    # A type-survivor is a high-confidence hole only when its ENCLOSING METHOD
-    # is entirely uncovered (a never-executed def). Ruby line-coverage
-    # attributes a multi-line expression's execution to its first line, so a
-    # bare "line ∉ covered set" check false-flags the continuation lines of a
-    # covered expression — e.g. a tested `to_h`'s hash-literal entries read as
-    # uncovered. Method-level coldness removes that artifact: every site inside
-    # a warm method is treated as covered. (Trade-off: a cold branch inside a
-    # warm method is not flagged — accepted, this favours precision over recall
-    # for a trustworthy backlog.) Class-body / constant sites have no enclosing
-    # def to anchor on, suffer the same artifact, and are data not logic — they
-    # are never high-confidence holes.
+    # A type-survivor is a high-confidence hole only when its ENCLOSING METHOD is entirely uncovered (a never-executed
+    # def). Ruby line-coverage attributes a multi-line expression's execution to its first line, so a bare "line ∉
+    # covered set" check false-flags the continuation lines of a covered expression — e.g. a tested `to_h`'s
+    # hash-literal entries read as uncovered. Method-level coldness removes that artifact: every site inside a warm
+    # method is treated as covered. (Trade-off: a cold branch inside a warm method is not flagged — accepted, this
+    # favours precision over recall for a trustworthy backlog.) Class-body / constant sites have no enclosing def to
+    # anchor on, suffer the same artifact, and are data not logic — they are never high-confidence holes.
     def cold_site_classifier(source, executed)
       defs = method_ranges(source).map { |r| [r, r.none? { |ln| executed.include?(ln) }] }
       lambda do |line|
         enclosing = defs.select { |r, _| r.cover?(line) }.min_by { |r, _| r.size }
-        # A site with no enclosing def is class-body/constant data — not a
-        # high-confidence hole (it suffers the multi-line attribution artifact
-        # with no method to anchor on). The signal is trustworthy only inside
-        # a def, where coldness means the whole method never ran.
+        # A site with no enclosing def is class-body/constant data — not a high-confidence hole (it suffers the
+        # multi-line attribution artifact with no method to anchor on). The signal is trustworthy only inside a def,
+        # where coldness means the whole method never ran.
         enclosing ? enclosing.last : false
       end
     end
@@ -188,10 +172,9 @@ module RigorSelfMutation
       candidates.select { |f| f.end_with?(".rb") && File.file?(f) }
     end
 
-    # The test axis temporarily overwrites the real lib file on disk (the
-    # scanner restores per-mutant in an `ensure`). Refuse to start with those
-    # files already dirty so an aborted run cannot be confused with the user's
-    # own edits, and so the restore trap cannot stomp uncommitted work.
+    # The test axis temporarily overwrites the real lib file on disk (the scanner restores per-mutant in an `ensure`).
+    # Refuse to start with those files already dirty so an aborted run cannot be confused with the user's own edits, and
+    # so the restore trap cannot stomp uncommitted work.
     def guard_clean!(files)
       return if @options[:type_only]
 
@@ -202,9 +185,8 @@ module RigorSelfMutation
             "#{dirty.join("\n  ")}\n(or pass --type-only, which never writes to disk)"
     end
 
-    # Belt-and-suspenders over the scanner's per-mutant `ensure`: a hard
-    # interrupt mid-suite would leave a mutant on disk, so restore the targets
-    # from git on the way out.
+    # Belt-and-suspenders over the scanner's per-mutant `ensure`: a hard interrupt mid-suite would leave a mutant on
+    # disk, so restore the targets from git on the way out.
     def install_restore_trap(files)
       return if @options[:type_only]
 

--- a/tool/oss_sweep_compare.rb
+++ b/tool/oss_sweep_compare.rb
@@ -1,8 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Compare a fresh OSS sweep result against stored thresholds.
-# Exits 0 (pass) or 1 (regression).
+# Compare a fresh OSS sweep result against stored thresholds. Exits 0 (pass) or 1 (regression).
 #
 # Usage:
 #   ruby tool/oss_sweep_compare.rb \
@@ -11,8 +10,7 @@
 #     --thresholds-json PATH \
 #     [--write-thresholds PATH]
 #
-# If --write-thresholds is given and the thresholds file is
-# uncalibrated ("calibrated": false), this script writes fresh
+# If --write-thresholds is given and the thresholds file is uncalibrated ("calibrated": false), this script writes fresh
 # thresholds derived from the current run and exits 0.
 
 require "json"

--- a/tool/scaffold_builtin_catalog.rb
+++ b/tool/scaffold_builtin_catalog.rb
@@ -12,8 +12,7 @@
 # - the matching integration `describe` block in
 #   `spec/integration/type_construction_spec.rb`
 #
-# Manual follow-ups the script intentionally leaves to the
-# operator (the per-class judgement calls):
+# Manual follow-ups the script intentionally leaves to the operator (the per-class judgement calls):
 # - blocklist curation in the loader file (read the generated
 #   YAML and add false-positive `:leaf` entries with one-line
 #   comments naming the indirect mutator helper);
@@ -165,11 +164,9 @@ end
 # Templates
 # ---------------------------------------------------------------------
 
-# Matches the existing two-space indentation inside the TOPICS
-# hash literal. `<<~` strips the heredoc's common leading
-# whitespace, so we re-add a uniform two-space prefix afterwards
-# (the body's natural indent is already correct relative to the
-# entry's own brace).
+# Matches the existing two-space indentation inside the TOPICS hash literal. `<<~` strips the heredoc's common leading
+# whitespace, so we re-add a uniform two-space prefix afterwards (the body's natural indent is already correct relative
+# to the entry's own brace).
 topics_block = <<~ENTRY.chomp.gsub(/^/, "  ")
   "#{topic}" => {
     init_function: "#{init_fn}",
@@ -310,9 +307,8 @@ edit_file!(EXTRACTOR_PATH, dry_run: dry_run) do |body|
     end
   end
 
-  # Insert before the `}.freeze` that closes TOPICS. The TOPICS hash's
-  # last entry has no trailing comma, so we add one to its closing
-  # brace before appending the new block.
+  # Insert before the `}.freeze` that closes TOPICS. The TOPICS hash's last entry has no trailing comma, so we add one
+  # to its closing brace before appending the new block.
   new_body.sub(/(TOPICS = \{\n.*?  \})(\n\}\.freeze)/m) do
     "#{::Regexp.last_match(1)},\n#{topics_block}#{::Regexp.last_match(2)}"
   end
@@ -332,17 +328,13 @@ edit_file!(DISPATCHER_PATH, dry_run: dry_run) do |body|
     "\\1require_relative \"../builtins/#{topic}_catalog\"\n"
   )
 
-  # Module catalogs (`--module`) are not receiver classes, so the
-  # constant-fold dispatcher does not route through them today.
-  # The require_relative above keeps the singleton reachable for
-  # future include-aware lookup; the CATALOG_BY_CLASS row stays
-  # absent.
+  # Module catalogs (`--module`) are not receiver classes, so the constant-fold dispatcher does not route through them
+  # today. The require_relative above keeps the singleton reachable for future include-aware lookup; the
+  # CATALOG_BY_CLASS row stays absent.
   next body if options[:module_kind]
 
-  # Append the CATALOG_BY_CLASS row before the closing bracket.
-  # The exact column padding inside each row is hand-aligned;
-  # the script ships a sensibly-spaced default and the operator
-  # can re-align later if desired.
+  # Append the CATALOG_BY_CLASS row before the closing bracket. The exact column padding inside each row is
+  # hand-aligned; the script ships a sensibly-spaced default and the operator can re-align later if desired.
   catalog_row = %(          [#{class_name}, [Builtins::#{CATALOG_CONST}, "#{class_name}"]])
   body.sub(/(CATALOG_BY_CLASS = \[\n.*?)\n        \]\.freeze/m) do
     "#{::Regexp.last_match(1)},\n#{catalog_row}\n        ].freeze"


### PR DESCRIPTION
## Summary

Phase 2 of the comment audit (follow-up to #40), extending the 120-column reflow + stale-commentary pruning to the rest of the repo: `examples/` (incl. demo files), all 33 `plugins/`, `spec/` (unit + integration + docs + support), and the `tool/` standalone scripts and mutation harness. 5 commits, 406 files, ~4,750 comment lines removed. `spec/fixtures/` and the vendored `tool/steep/` / `tool/sorbet/` bundles are untouched.

- Almost entirely verbatim reflow; the corpus carried the same load-bearing density as lib/rigor.
- Deletions (2, each verified against code): a factually false visibility-tracking claim in rails_routes' helper_discoverer (contradicted by the adjacent accurate sentence, which stays), and a duplicated markdown self-link in rigor-graphql collapsed to a plain path.
- Spec safety: comment edits identified via `Prism.parse_comments`, so heredoc-embedded analyzed sources were structurally unreachable; verified no integration spec anchors demo/diagnostic expectations to line numbers before reflowing demo files.

## Verification

- Per-tranche machine audit: changed lines comment-only; non-comment byte stream identical to HEAD (covers heredocs); ≤120 chars (character count); magic directives (`# frozen_string_literal` / `# rigor:` / `# rubocop:` / `# steep:`) untouched; comment word stream verbatim modulo rejoined hyphen/path wraps. The audit caught and fixed six slash-list gluings a path-join heuristic introduced in spec comments.
- `make verify` (test / lint / self-check / check-plugins) green; `git diff --check` clean.