### PR TITLE
Guard rule documentation_url anchors in the docs-drift check

### DIFF
--- a/spec/docs/manual_drift_spec.rb
+++ b/spec/docs/manual_drift_spec.rb
@@ -6,6 +6,9 @@
 #   2. Config keys — every top-level key in Configuration::DEFAULTS must be mentioned in the configuration reference.
 #   3. Rule IDs — every ID in CheckRules::ALL_RULES must appear in the diagnostic catalogue or the handbook
 #      errors chapter.
+#   4. Rule documentation_url anchors — every RuleCatalog entry's `documentation_url` (ADR-65, a frozen public
+#      contract) points at `04-diagnostics.md#rule-<id>`, so the catalogue must carry the matching anchor or the
+#      published URL silently 404s within the page.
 #
 # These checks are purely textual — no Rigor analysis needed.
 
@@ -14,6 +17,7 @@ require "spec_helper"
 require "rigor/cli"
 require "rigor/configuration"
 require "rigor/analysis/check_rules"
+require "rigor/analysis/rule_catalog"
 
 # Constants at file scope so nested describe/let blocks can resolve them.
 MANUAL_DRIFT_DOCS_ROOT    = File.expand_path("../../docs", __dir__)
@@ -75,6 +79,26 @@ RSpec.describe "manual accuracy" do
       expect(missing).to be_empty,
                          "Rule IDs in ALL_RULES not mentioned in diagnostic docs: #{missing.inspect}\n" \
                          "Add each rule to manual/04-diagnostics.md or handbook/08-understanding-errors.md."
+    end
+  end
+
+  # ── 4. Rule documentation_url anchor integrity (ADR-65) ──────────
+
+  describe "rule documentation_url anchors (04-diagnostics.md)" do
+    let(:catalogue_doc) { File.read(File.join(MANUAL_DRIFT_MANUAL_DIR, "04-diagnostics.md"), encoding: "utf-8") }
+
+    # `RuleCatalog#documentation_url` is a frozen public contract (ADR-65): it points every built-in rule at
+    # `04-diagnostics.md#rule-<id-dashed>`, resolved on GitHub by an explicit `<a id="rule-…">` anchor (the
+    # rule ids do not slugify to their headings, so the anchor tag is the only thing that makes the URL land).
+    # A rule added or renamed without its anchor ships a URL that 404s within the page — this guards it.
+    it "every RuleCatalog entry's documentation_url anchor exists in the catalogue" do
+      missing = Rigor::Analysis::RuleCatalog.all.reject do |entry|
+        catalogue_doc.include?(%(id="#{Rigor::Analysis::RuleCatalog.doc_anchor(entry.id)}"))
+      end
+      expect(missing.map(&:id)).to be_empty,
+                                   "RuleCatalog rules whose documentation_url anchor is missing from " \
+                                   "04-diagnostics.md: #{missing.map(&:id).inspect}\n" \
+                                   "Add `<a id=\"rule-<id-with-dots-as-dashes>\"></a>` for each."
     end
   end
 end


### PR DESCRIPTION
## Summary

Extends the existing L0 docs-drift harness (`spec/docs/manual_drift_spec.rb`) with a fourth axis: **every built-in rule's `documentation_url` anchor must exist in `04-diagnostics.md`.**

## Why

`RuleCatalog#documentation_url` is a frozen public contract (ADR-65): it points every rule at `04-diagnostics.md#rule-<id-dashed>`. GitHub resolves that fragment **only** via an explicit `<a id="rule-…">` anchor — the rule ids (`call.undefined-method`) do not slugify to their headings — so a rule added or renamed without its anchor ships a URL that 404s within the page, silently. The harness already checked CLI subcommands, config keys, and rule-id mentions, but not this.

All 19 rules pass today; the guard catches future drift. Verified it has teeth (against an empty doc it flags all 19).

## Note

The L0 harness (`spec/docs/`, `make docs-check`, CI-wired via the `test` suite) already existed and was comprehensive — this is a single gap-closer, not new infrastructure. Purely textual, no analysis.

## Verification

`make docs-check` green (96 examples, was 95). Rubocop clean.