### PR TITLE
Harden cache schema-marker ABI gate and generation-cap compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Fixed
+
+- **[cache]** Persistent cache entries are now rebuilt after a Rigor upgrade, stale generations are reclaimed more aggressively, and a broken cache root degrades to memory-only instead of raising.
+  - The cache root marker now folds in `Rigor::VERSION`, so Marshal payloads written by an older release are never reused after an upgrade — the first writable run after upgrading rebuilds the cache.
+  - A read-only store (LSP / editor mode) now checks that marker itself before trusting a disk hit, instead of reading through it unconditionally; a stale or missing marker there is treated as an empty cache until a writable run repairs it, closing the one path where an ABI-stale payload could still be unmarshalled after an upgrade.
+  - Whole-project cache producers (the RBS environment / ancestor / constant tables, `analysis.run-diagnostics`) now keep only a small number of recent generations, reclaiming content-keyed orphans that sat below the global byte cap indefinitely — this runs even when `cache.max_bytes` is left unbounded.
+  - A cache root that cannot be read or repaired (permission error, disk full, deleted root) no longer fails the run — analysis continues with the disk tier disabled for that run.
+
 ## [0.2.8] - 2026-07-06
 
 v0.2.8 makes `rigor coverage --protection` explain itself: every unprotected site now carries the reason its receiver is dynamic and the action that would close it, so the report points you at the highest-leverage fix ([ADR-82](docs/adr/82-dynamic-provenance-wiring.md)). Call-site parameter inference reaches more method shapes, protecting more sites. It also hardens the RBS environment against malformed signatures — a single unparseable `.rbs`, whether hand-written or from `rigor sig-gen`, is now contained instead of blanking every type in the run.

--- a/docs/adr/54-cache-slimming.md
+++ b/docs/adr/54-cache-slimming.md
@@ -103,6 +103,22 @@ a new key and orphans the old entries forever. Default the cap to a
 generous **256 MB** (post-WD1/WD2 a full per-project set is ~2 MB, so the
 cap only ever trims orphans); explicit `max_bytes:` config still overrides.
 
+*Addendum (2026-07-07 follow-up):* the generous 256 MB cap is exactly why
+small repos never trigger it — an audit of a real repository's
+`.rigor/cache` found ~7 orphaned generations of `rbs.environment`
+(~1.77 MB each, ~16 MB cache total) that the byte cap had no reason to
+touch. The byte cap alone leaves orphan generations of a content-keyed
+whole-project producer sitting below the cap indefinitely. `Store#evict!`
+now runs a generation cap as a second, orthogonal compaction axis: a small
+hardcoded allow-list of whole-project producer ids keeps only their most
+recent N generations (2 for the RBS producers, 16 for
+`analysis.run-diagnostics`), independent of `max_bytes:` — it runs even
+when the store is unbounded (`max_bytes: nil`), since it reclaims
+provably-dead bytes rather than enforcing a size budget. See
+`docs/internal-spec/cache.md` § "Compaction (`#evict!`)" for the full
+mechanics, including the co-landed stale temp-file sweep and the
+`Rigor::VERSION`-carrying marker (payload ABI boundary on upgrade).
+
 **WD4 (minor) — memoise `RbsDescriptor.build` per loader.** It runs once per
 producer fetch (7×/run, identical result). Measured 1.3 ms × 7 today —
 noise — but it scales linearly with `signature_paths:` size

--- a/docs/internal-spec/cache.md
+++ b/docs/internal-spec/cache.md
@@ -150,6 +150,16 @@ arms the LRU `#evict!` pass (the production default is 256 MB, set by
 the CLI per [ADR-54](../adr/54-cache-slimming.md) WD3 — `nil` here
 leaves the cache unbounded).
 
+Every `fetch_or_compute` / `fetch_or_validate` call first resolves the disk
+tier's availability for the Store's lifetime (memoized after the first
+check — see "Schema-version marker" below): unavailable means the
+producer block still runs and its result still lands in the
+in-process memo, but no disk read or write is attempted. This covers
+two situations — a read-only store facing a marker it must not trust,
+and a writable store whose cache root cannot be read/repaired
+(permission error, disk full, deleted root, read-only mount) — neither
+of which may ever break an analysis run.
+
 ### `store.fetch_or_compute(producer_id:, params:, descriptor:, serialize: nil, deserialize: nil) { ... } -> Object`
 
 The single producer-facing entry point.
@@ -228,24 +238,47 @@ boundary, per ADR-2's trusted-gem trust model.
 
 `<root>/schema_version.txt` carries
 `Store.schema_marker_value` —
-`"<Descriptor::SCHEMA_VERSION>.<Store::FORMAT_VERSION>"`
-(currently `4.2`), covering both invalidation axes: the
-descriptor schema and the on-disk byte layout. Checked once per
-`Store` instance (first `fetch_or_compute` / `fetch_or_validate`):
+`"<PAYLOAD_ABI_VERSION>.<Descriptor::SCHEMA_VERSION>.<Store::FORMAT_VERSION>"`,
+where `PAYLOAD_ABI_VERSION` is `Rigor::VERSION`. Three invalidation
+axes fold into one marker: the installed Rigor release (an entry's
+Marshal payload is a blob of Rigor/RBS objects, so a release upgrade
+is an ABI boundary even when neither of the other two versions
+changes — this is the same axis `IncrementalSnapshot`'s fingerprint
+already covers), the descriptor schema, and the on-disk byte layout.
 
-- Marker missing → write the current value, proceed.
-- Marker matches → proceed.
-- Marker disagrees → wipe every entry under `<root>` (`unlink`
-  every child via `FileUtils.rm_rf`), rewrite the marker, and
-  proceed as if the cache were empty.
+Checked at most once per `Store` instance (the result is memoized as
+the boolean "is the disk tier available" — see `Store.new` above),
+with different semantics for a writable vs. a read-only store:
 
-A bump of either version therefore drops every cache file on
-the next writable run without any explicit migration step. The
-format-version half matters for disk reclamation: a format bump
-alone makes old entries unreadable (header mismatch → miss) but
-would never delete them — they can sit below the eviction cap
-indefinitely. The marker mismatch is what reclaims their bytes
-(ADR-54).
+**Writable store:**
+
+- Marker missing → write the current value, proceed. Disk available.
+- Marker matches → proceed. Disk available.
+- Marker disagrees → wipe every entry under `<root>` (`unlink` every
+  child via `FileUtils.rm_rf`), rewrite the marker, and proceed as if
+  the cache were empty. Disk available.
+- Any filesystem failure while checking or repairing the marker
+  (permission error, disk full, deleted root) → disk unavailable for
+  this Store's lifetime; no partial repair is left in place beyond
+  whatever the failing call itself did.
+
+**Read-only store** (LSP / editor mode, see `docs/design/20260516-editor-mode.md`):
+never touches the root — no `mkdir`, no marker write, no destructive
+clear on mismatch. Disk is available ONLY when the on-disk marker is
+present and matches current exactly; a missing or stale marker (e.g.
+a Rigor upgrade with no writable run yet) reports unavailable rather
+than risk unmarshalling a payload from a different ABI. The next
+writable run repairs the cache as above.
+
+A version bump therefore drops every cache file on the next writable
+run without any explicit migration step — the Rigor-version axis
+means this now happens on every release upgrade, at the cost of a
+cold rebuild on the first writable run after upgrading. The
+format-version axis matters for disk reclamation independently of
+that: a format bump alone makes old entries unreadable (header
+mismatch → miss) but would never delete them — they can sit below
+the eviction cap indefinitely. The marker mismatch is what reclaims
+their bytes (ADR-54).
 
 ### On-disk layout
 
@@ -273,7 +306,13 @@ Writes follow the standard rename-into-place dance:
    (`<entry>.tmp.<pid>.<rand-hex>`).
 4. `fsync` the temp file.
 5. `rename` the temp file over the destination.
-6. Release the lock by closing the destination file descriptor.
+6. Best-effort `fsync` of the destination directory (some
+   platforms cannot fsync a directory; failure is ignored).
+7. Release the lock by closing the destination file descriptor.
+
+If the write or rename fails partway through, the temp file from
+this attempt is removed on the way out (`ensure`) rather than left
+for the sweep below to find later.
 
 Readers do not lock; they tolerate seeing an old version (always
 a fully committed entry, never a torn write — POSIX guarantees
@@ -310,6 +349,46 @@ compressed bytes) are unchanged. Compression is invisible to
 producers: a custom `serialize:` / `deserialize:` pair still
 round-trips its exact bytes. v1 entries fail the header check
 and read as silent misses — no migration.
+
+### Compaction (`#evict!`)
+
+`evict!` is a no-op on a read-only store. Otherwise it runs three
+passes, in order:
+
+1. **Stale temp-file cleanup.** Any `*.tmp.*` sibling older than
+   one hour is unlinked. Under normal operation `atomically_replace`
+   never leaves one behind (see "Atomicity and locking" above); this
+   is a backstop for a process that died between the temp-file
+   write and the rename.
+2. **Whole-project generation cap.** Some producers are
+   content-keyed (the cache key is a function of the value's
+   dependencies, not a stable per-project key), so re-running with
+   different inputs writes a new entry and leaves the old one
+   unreachable — but still on disk. A small hardcoded allow-list of
+   whole-project producer ids
+   (`rbs.environment`, `rbs.class_ancestor_table`,
+   `rbs.class_type_param_names`, `rbs.constant_type_table`,
+   `rbs.known_class_names`, `analysis.run-diagnostics`) caps how many
+   generations of each survive a compaction pass; beyond the cap the
+   oldest-by-mtime generations are unlinked first. Per-file and
+   per-plugin producers are deliberately absent from this table —
+   many current entries under one such producer id can be live at
+   once, so a generation count is not a meaningful proxy for
+   staleness there. The cap is presently a maintained constant, not
+   producer-declared metadata; a new whole-project producer must be
+   added to the list by hand to benefit.
+3. **Size-based LRU pass.** Unchanged from prior releases: walks
+   every remaining `.entry` file, sorts by mtime ascending, and
+   unlinks from the oldest until the total is at or below
+   `max_bytes:`.
+
+Passes 1 and 2 run **regardless of whether `max_bytes:` is
+configured** — they reclaim bytes that are provably dead (a leaked
+temp file, an unreachable content-keyed generation) rather than
+enforcing a size budget, so an explicitly unbounded store
+(`max_bytes: nil`) still benefits from them. Only pass 3 is gated on
+`max_bytes:` being set. Any filesystem error during any pass is
+swallowed — `evict!` must never break a run.
 
 ## Bundled RBS producer contract
 
@@ -545,7 +624,7 @@ counters from the runner's `Cache::Store`. Output sample:
 
 ```
 Cache (root: .rigor/cache)
-  schema_version: 4.2
+  schema_version: 0.2.8.4.2
   3 entries, 12.4 KiB
     rbs.constant_type_table: 1 entries, 11.0 KiB
     reflection.instance_method_definition: 2 entries, 1.4 KiB

--- a/docs/notes/20260707-cache-hardening-plan.md
+++ b/docs/notes/20260707-cache-hardening-plan.md
@@ -1,0 +1,151 @@
+# Cache hardening / compaction — actionable plan
+
+Re-planned from the handover note [`20260707-cache-mechanism-audit-sakana.md`](20260707-cache-mechanism-audit-sakana.md),
+after auditing that note against the actual working-tree diff of `lib/rigor/cache/store.rb`
+(the only changed file, ~+107/−17, syntax-clean, no specs/docs/CHANGELOG yet, no Flake verification yet).
+
+## Audit verdict on the handover note
+
+The note is accurate. Everything it lists as "already landed" is present in the diff:
+
+- `PAYLOAD_ABI_VERSION = Rigor::VERSION` folded into `schema_marker_value` (now
+  `<Rigor::VERSION>.<Descriptor::SCHEMA_VERSION>.<FORMAT_VERSION>`).
+- `write_entry_for_compute` — `fetch_or_compute` no longer dies on filesystem write failures
+  (`SystemCallError` / `IOError`), while serializer contract violations still raise.
+- `fsync_directory` after the rename in `atomically_replace` (best-effort).
+- `cleanup_stale_temp_files` (1-hour cutoff) and `evict_excess_generations`
+  (`GENERATION_CAP_BY_PRODUCER`, RBS whole-project producers capped at 2,
+  `analysis.run-diagnostics` at 16), both invoked from `evict!`.
+- `producer_id_for_entry`'s first-path-segment assumption is valid: `entry_path` is
+  `root/<producer_id>/<key[0,2]>/<key[2..]>.entry`.
+
+Its top-priority open item is real and confirmed at two call sites: read-only stores are created by
+`lib/rigor/language_server/project_context.rb:82` (LSP) and `lib/rigor/analysis/runner.rb:505`
+(editor/buffer mode), and `ensure_schema_version!` early-returns for them without checking the marker
+— so after a Rigor upgrade, until a writable run repairs the root, the LSP path will happily
+unmarshal old-ABI blobs. This half-defeats the ABI marker.
+
+Additional findings from this audit (not in the note):
+
+- **(A) Write-failure policy is now inconsistent across the two fetch paths.**
+  `fetch_or_compute` → `write_entry_for_compute` deliberately propagates serializer contract errors
+  (`TypeError` etc.), but `fetch_or_validate` keeps its pre-existing blanket `rescue StandardError`
+  around `write_entry`, which swallows the same class of producer bug. Pick one contract
+  (recommended: the `write_entry_for_compute` one — narrow rescue, contract errors visible) and
+  apply it to both.
+- **(B) `max_bytes: nil` disables the new compaction entirely.** `evict!` early-returns on
+  `@max_bytes.nil?`, so an explicitly unbounded store (`cache.max_bytes: null`) gets neither stale
+  temp cleanup nor the generation cap. Both are orthogonal to the byte cap: `null` opts out of
+  *size-based LRU eviction*, not of reclaiming provably-dead generations or leaked temp files.
+  Recommended: run `cleanup_stale_temp_files` + `evict_excess_generations` before the
+  `@max_bytes.nil?` check (still `read_only`-gated); only the LRU byte pass stays cap-gated.
+- **(C) The marker write is non-atomic** (`File.write`). A crash mid-write leaves a corrupt marker,
+  which the next writable run reads as a mismatch and clears the root — safe (over-invalidation,
+  never stale reuse). No change needed; record the reasoning in the spec doc.
+
+Decisions the note already made that this plan keeps:
+
+- ABI marker stays `Rigor::VERSION` (parity with `IncrementalSnapshot`); the per-release cold rebuild
+  is acceptable post-ADR-54 (~2 MB/project envelope).
+- No zlib level tuning, no zstd — measured wins are ~8 % overall / ~3 % on the env blob; the real
+  problem was orphan generations, which the generation cap addresses.
+- `GENERATION_CAP_BY_PRODUCER` stays a hardcoded allow-list for now; a producer-declared
+  `generation_cap:` metadata field is the better long-term shape → record as deferred follow-up.
+  The `analysis.run-diagnostics` cap of 16 is a judgment call (multi-path-set invocations could
+  churn live generations); keep it but call it out in the spec doc and CHANGELOG-adjacent notes.
+
+## Plan
+
+### Phase 1 — complete the ABI marker: boolean `ensure_schema_version!` + disk gate (highest value)
+
+Make `ensure_schema_version!` return whether the disk tier is usable, memoized per Store
+(`@disk_available` tri-state replaces `@schema_version_ensured`):
+
+| Situation | Result |
+| --- | --- |
+| writable, marker current or repaired (mkdir + clear + rewrite succeeded) | `true` |
+| read-only, marker present and current | `true` |
+| read-only, marker missing / stale / unreadable | `false` (no clear, no write — next writable run repairs) |
+| any filesystem failure during check/repair (mkdir, read, write, clear) | `false` — disk disabled for this Store instance |
+
+Then gate both fetch paths:
+
+- `fetch_or_compute`: `disk = ensure_schema_version!`; skip `read_entry` and
+  `write_entry_for_compute` when `disk` is false. Producer block still runs; result still lands in
+  `@memo`; stats record a miss (and no write).
+- `fetch_or_validate`: same gate — no disk read, no disk write when unavailable.
+
+This closes both remaining correctness items from the note at once: the read-only stale-marker hole
+(LSP / editor mode) and the "broken cache root must not break analysis" degrade.
+
+### Phase 2 — `atomically_replace` failure cleanup
+
+Wrap the temp-file lifecycle in `ensure`:
+
+```ruby
+tmp = "#{path}.tmp.#{Process.pid}.#{SecureRandom.hex(4)}"
+begin
+  ... write, fsync, rename, fsync_directory ...
+ensure
+  unlink_entry(tmp) if File.exist?(tmp)
+end
+```
+
+so a failed write doesn't rely on the 1-hour `cleanup_stale_temp_files` sweep.
+
+### Phase 3 — consistency fixes from this audit
+
+1. **(A)** Replace `fetch_or_validate`'s blanket `rescue StandardError` write guard with
+   `write_entry_for_compute` (rename it if it now serves both callers, e.g. `try_write_entry`).
+   Note: `fetch_or_validate` values may legitimately fail default-Marshal serialization — its
+   docstring says producers of non-Marshal-clean values MUST pass a serializer, so surfacing the
+   `TypeError` is the correct contract there too. If a bundled producer currently relies on the
+   swallow, that is a bug to fix at the producer, not a reason to keep the blanket rescue.
+2. **(B)** Move `cleanup_stale_temp_files` + `evict_excess_generations` above the
+   `@max_bytes.nil?` return in `evict!` (keep the `read_only` guard first).
+
+### Phase 4 — focused specs (`spec/rigor/cache/store_spec.rb`)
+
+- `schema_marker_value` includes `Rigor::VERSION`.
+- Writable store clears the root on a stale marker and rewrites it.
+- Read-only store: disk hit allowed only with a current marker; stale/missing marker ⇒ miss, root
+  untouched, no marker written.
+- Filesystem write failure (e.g. unwritable root injected after construction) ⇒ `fetch_or_compute`
+  and `fetch_or_validate` return the computed value, record miss, no raise.
+- Serializer contract violation raises on BOTH fetch paths (locks in Phase 3.1).
+- Disk-disabled degrade: a store whose root check failed never touches disk again but memoizes.
+- `atomically_replace` failure leaves no `*.tmp.*` behind.
+- `cleanup_stale_temp_files` removes only files older than the cutoff.
+- Generation cap evicts oldest-first for a capped producer; leaves non-listed producers alone.
+- Generation cap + temp cleanup run under `max_bytes: nil`; LRU byte pass does not (locks in
+  Phase 3.2).
+
+### Phase 5 — docs + CHANGELOG
+
+- `docs/internal-spec/cache.md`: update the marker example (`"4.2"` → the new
+  `<Rigor::VERSION>.<schema>.<format>` triple); document read-only marker semantics (boolean gate,
+  never repairs), the disk-disabled degrade, the generation cap (incl. the `run-diagnostics`
+  cap-16 caveat and the hardcoded-allow-list limitation), stale temp cleanup, and the
+  `max_bytes: nil` semantics decided in Phase 3.2.
+- `docs/adr/54-cache-slimming.md`: WD3 addendum — the byte cap alone leaves orphan generations on
+  small repos (observed: ~7 × 1.77 MB `rbs.environment` generations under a 16 MB cache);
+  whole-project producers now carry a generation cap.
+- `CHANGELOG.md` `[Unreleased]`: the note's draft entry is good; extend it with the upgrade-triggers-
+  cold-run consequence and the read-only (LSP) stale-payload fix.
+
+### Phase 6 — verification and landing
+
+Inside the Flake (`nix … develop --command …`):
+
+1. `bundle exec rspec spec/rigor/cache/store_spec.rb`
+2. `make verify` (test / lint / self-check / check-plugins)
+3. `git diff --check`
+
+Land as a branch + PR (grouped, non-trivial change — per current landing policy), one logical
+commit sequence: Phase 1+3 (behaviour), Phase 2 (hygiene), Phase 4 (specs), Phase 5 (docs).
+
+## Deferred (record only, do not build now)
+
+- Producer-declared `generation_cap:` metadata replacing the hardcoded allow-list.
+- zstd / compression-level tuning (measured non-win).
+- Any cross-project shared cache root work (ADR-54 deferral stands).

--- a/docs/notes/20260707-cache-mechanism-audit-sakana.md
+++ b/docs/notes/20260707-cache-mechanism-audit-sakana.md
@@ -1,0 +1,407 @@
+## 次セッション向け引き継ぎメモ: キャッシュ堅牢化・コンパクト化
+
+### 現在の状態
+
+- 変更されているファイルは **`lib/rigor/cache/store.rb` のみ**。
+- 変更量はおおよそ **+107 / -17**。
+- `ruby -c lib/rigor/cache/store.rb` は **Syntax OK**。
+- **spec / docs / CHANGELOG は未変更**。
+- **Nix Flake 経由の検証は未実施**。
+- 途中の TODO と実コードが一部乖離していたため、次セッションでは **`git diff` を真実として再確認すること**。
+
+---
+
+## ここまでで分かったこと
+
+### 1. ディスク使用量削減の主因は「圧縮率」ではなく「孤児世代」
+
+実リポジトリの `.rigor/cache` では、`rbs.environment` が複数世代残っていた。
+
+- `rbs.environment`: 約 **1.77MB × 7 entry**
+- 実際に live なのは概ね 1 世代で、残りは orphan と見られる。
+- ただし cache 全体は約 **16MB** 程度なので、既定の **256MB byte cap** では eviction が発火しない。
+
+結論:
+
+> zlib の圧縮レベルを上げるより、content-keyed producer の古い世代を回収する方が本筋。
+
+zlib level 9 の再圧縮効果は小さい。
+
+- 全体で約 8% 程度。
+- env blob では約 3% 程度。
+
+そのため、圧縮レベル変更や zstd 導入は現時点では採用しない方針でよい。
+
+---
+
+## 既に `store.rb` に入っている変更
+
+### 1. Payload ABI marker の追加
+
+追加済み:
+
+```ruby
+require_relative "../version"
+
+PAYLOAD_ABI_VERSION = Rigor::VERSION
+```
+
+`schema_marker_value` は以下の形に変更済み。
+
+```ruby
+"#{PAYLOAD_ABI_VERSION}.#{Descriptor::SCHEMA_VERSION}.#{FORMAT_VERSION}"
+```
+
+意図:
+
+- Store の Marshal payload を Rigor version 境界で invalidation する。
+- byte layout や descriptor schema が変わっていなくても、Rigor 側の class layout / semantics が変わる可能性があるため。
+- `IncrementalSnapshot` は既に fingerprint に `Rigor::VERSION` を含めているので、それとの parity でもある。
+
+注意:
+
+- Rigor をアップグレードするたびに cache root が全消去される。
+- 初回 run は cold になる。
+- これは意図した rebuild だが、ユーザー体感コストはある。
+
+---
+
+### 2. `fetch_or_compute` の write failure を握り潰す変更
+
+追加済み helper:
+
+```ruby
+def write_entry_for_compute(path, descriptor, value, serialize: nil)
+  return false if @read_only
+
+  write_entry(path, descriptor, value, serialize: serialize)
+  true
+rescue SystemCallError, IOError
+  false
+end
+```
+
+効果:
+
+- cache root の権限問題
+- disk full
+- root が途中で削除された
+- read-only mount
+
+など filesystem 側の問題で解析 run が落ちず、単に「cache write に失敗した miss」として進む。
+
+意図的に残している挙動:
+
+- serializer が `String` を返さない等の producer contract 違反は `TypeError` として見える。
+- これは開発者に知らせるべきエラーなので握り潰さない。
+
+---
+
+### 3. rename 後の directory fsync
+
+`atomically_replace` の rename 後に以下が呼ばれるようになっている。
+
+```ruby
+fsync_directory(File.dirname(path))
+```
+
+`fsync_directory` は best-effort で、失敗は握り潰す。
+
+意図:
+
+- temp file 自体の fsync に加えて、rename の directory entry 側の耐久性を少し上げる。
+- platform 差があるため、失敗しても run は壊さない。
+
+---
+
+### 4. stale temp file cleanup
+
+追加済み:
+
+```ruby
+STALE_TEMP_FILE_AGE_SECONDS = 60 * 60
+```
+
+`cleanup_stale_temp_files` が `*.tmp.*` のうち 1 時間以上古いものを削除する。
+
+注意:
+
+- 現ディスク上では temp leak は観測されていない。
+- 防御的改善。
+
+---
+
+### 5. whole-project producer の generation cap
+
+追加済み:
+
+```ruby
+GENERATION_CAP_BY_PRODUCER = {
+  "analysis.run-diagnostics" => 16,
+  "rbs.class_ancestor_table" => 2,
+  "rbs.class_type_param_names" => 2,
+  "rbs.constant_type_table" => 2,
+  "rbs.environment" => 2,
+  "rbs.known_class_names" => 2
+}.freeze
+```
+
+`evict_excess_generations` が producer ごとに古い世代を削除する。
+
+意図:
+
+- byte cap に届かない orphan 世代を回収する。
+- 特に RBS 系 producer は live 世代が少ないため効果がある。
+
+不確実性:
+
+- `analysis.run-diagnostics` の cap `16` は要注意。
+- 多数の異なる invocation path-set を使う運用では、まだ使える世代を消す可能性がある。
+- hardcoded allow-list なので、新規 whole-project producer は自動では cap されない。
+
+---
+
+## まだ未完了の重要項目
+
+### 1. read-only store の stale marker guard
+
+現状、`ensure_schema_version!` は未変更。
+
+現在のコードは read-only で即 return する。
+
+```ruby
+return if @read_only
+```
+
+問題:
+
+- Rigor upgrade 後、writable run がまだ走っていない。
+- `schema_version.txt` は古い marker のまま。
+- LSP / editor mode は read-only store。
+- read-only store は marker を確認せず、古い Marshal blob を読んでしまう。
+
+これは payload ABI marker の価値を半分未完成にしている。
+
+次に必要な修正:
+
+- read-only mode でも **marker が current の場合だけ disk read を許可**する。
+- marker missing / stale / unreadable なら disk は miss 扱い。
+- read-only なので root clear や marker write はしない。
+
+設計案:
+
+```ruby
+disk_available = ensure_schema_version!
+path = disk_available ? entry_path(...) : nil
+```
+
+`ensure_schema_version!` は boolean を返す形にする。
+
+- writable + marker OK / repaired: `true`
+- read-only + marker current: `true`
+- read-only + marker missing/stale/unreadable: `false`
+- filesystem failure: `false`
+
+---
+
+### 2. marker / disk failure の in-memory-only degrade
+
+現状、`ensure_schema_version!` は `mkdir_p`, `File.read`, `File.write`, `Dir.children` などで raise しうる。
+
+改善したい挙動:
+
+- cache root が壊れている
+- 権限がない
+- root が消えた
+- marker が読めない / 書けない
+
+こうした場合でも解析 run を壊さない。
+
+候補:
+
+```ruby
+@disk_disabled = true
+```
+
+を導入し、marker 確認・修復に失敗したら、その Store instance では disk を諦めて in-memory memo のみ使う。
+
+期待挙動:
+
+- producer block は通常通り実行。
+- disk read / write はしない。
+- stats は miss として記録。
+
+---
+
+### 3. `atomically_replace` 失敗時の temp cleanup
+
+現状、`atomically_replace` には失敗時の ensure cleanup がない。
+
+現在は 1 時間後の `cleanup_stale_temp_files` に頼る形。
+
+次に入れるとよい形:
+
+```ruby
+tmp = nil
+begin
+  tmp = "#{path}.tmp.#{Process.pid}.#{SecureRandom.hex(4)}"
+  ...
+ensure
+  unlink_entry(tmp) if tmp && File.exist?(tmp)
+end
+```
+
+---
+
+### 4. specs 未追加
+
+最低限ほしい focused specs:
+
+- `schema_marker_value` が `Rigor::VERSION` を含む。
+- stale marker 時に writable store は root を clear する。
+- read-only store は current marker のときだけ disk hit を許す。
+- read-only store は stale / missing marker の entry を読まない。
+- `fetch_or_compute` は filesystem write failure で落ちない。
+- serializer contract error は握り潰さない。
+- failed temp file cleanup。
+- stale `*.tmp.*` cleanup。
+- generation cap が old entries を消す。
+- generation cap が allow-list 以外の producer を消さない。
+- `max_bytes: nil` のとき temp cleanup / generation cap を動かすかどうかの仕様確認。
+
+---
+
+### 5. docs / CHANGELOG 未更新
+
+更新対象:
+
+#### `docs/internal-spec/cache.md`
+
+現在 `"4.2"` と書かれている箇所を更新する。
+
+新形式:
+
+```text
+<Rigor::VERSION>.<Descriptor::SCHEMA_VERSION>.<Store::FORMAT_VERSION>
+```
+
+read-only marker semantics / generation cap / stale temp cleanup も記載する。
+
+#### `docs/adr/54-cache-slimming.md`
+
+WD3 の eviction 説明に補足する。
+
+要旨:
+
+- byte cap だけでは小規模 repo の orphan 世代が残る。
+- whole-project producer には generation cap を追加した。
+
+#### `CHANGELOG.md` `[Unreleased]`
+
+候補:
+
+```markdown
+- **[cache]** Persistent cache entries are now rebuilt after a Rigor upgrade and old cache generations are reclaimed more aggressively.
+  - The cache root marker now includes the Rigor version, so Marshal payloads written by an older release are not reused after an upgrade.
+  - Whole-project cache producers now keep only a small number of recent generations, which prevents stale RBS and run-result cache entries from accumulating below the global byte cap.
+```
+
+---
+
+## 次セッションの推奨順序
+
+1. **`ensure_schema_version!` を boolean 化**
+   - read-only stale guard
+   - disk failure degrade
+   - この2つを同時に閉じる。
+   - ABI marker の価値を完成させる最重要部分。
+
+2. **`fetch_or_compute` / `fetch_or_validate` に `disk_available` gate を入れる**
+   - disk unavailable 時は read も write もしない。
+   - producer block は実行する。
+   - memo には載せる。
+
+3. **`atomically_replace` に ensure cleanup を入れる**
+
+4. **focused specs を追加**
+
+5. **docs / CHANGELOG 更新**
+
+6. **検証**
+
+最低限:
+
+```sh
+nix --extra-experimental-features 'nix-command flakes' develop --command bundle exec rspec spec/rigor/cache/store_spec.rb
+nix --extra-experimental-features 'nix-command flakes' develop --command ruby -c lib/rigor/cache/store.rb
+nix --extra-experimental-features 'nix-command flakes' develop --command git diff --check
+```
+
+可能なら:
+
+```sh
+nix --extra-experimental-features 'nix-command flakes' develop --command make verify
+```
+
+---
+
+## 設計判断とトレードオフ
+
+### 採用: payload ABI marker
+
+理由:
+
+- Marshal payload は byte format が同じでも、Rigor 側の class layout / semantics 変更で stale になりうる。
+- `IncrementalSnapshot` との parity がある。
+
+トレードオフ:
+
+- Rigor upgrade ごとに cache root 全消去。
+- 初回 cold run が発生。
+
+---
+
+### 採用: generation cap
+
+理由:
+
+- content-keyed producer は新 key を書く一方で旧 key を消さない。
+- byte cap だけでは小さい orphan が残る。
+- 実リポジトリで `rbs.environment` の orphan 世代を確認済み。
+
+トレードオフ:
+
+- hardcoded allow-list。
+- `analysis.run-diagnostics` cap=16 の妥当性は要確認。
+- 将来的には producer metadata で `generation_cap:` を宣言する設計の方がよい可能性がある。
+
+---
+
+### 採用: filesystem failure の degrade
+
+理由:
+
+- cache は best-effort。
+- 解析 run を壊してはいけない。
+
+注意:
+
+- producer contract error まで握り潰すとバグを隠すため、serializer の型違反は見えるままでよい。
+
+---
+
+### 非採用: zlib level tuning / zstd
+
+理由:
+
+- 実測で効果が小さい。
+- zstd は新規依存にもなる。
+- 現在の主要問題は圧縮率ではなく orphan accumulation。
+
+---
+
+## 最後に
+
+次セッションでは、まず **read-only marker guard** と **disk failure degrade** を閉じるのが最優先。
+
+現在入っている ABI marker は方向性として正しいが、read-only store が古い marker を確認せずに読むため、LSP / editor path ではまだ stale payload reuse の穴が残っている。そこを閉じてから specs / docs / verification に進むのが安全。

--- a/lib/rigor/cache/store.rb
+++ b/lib/rigor/cache/store.rb
@@ -7,6 +7,7 @@ require "monitor"
 require "securerandom"
 require "zlib"
 
+require_relative "../version"
 require_relative "descriptor"
 
 module Rigor
@@ -30,6 +31,27 @@ module Rigor
       # bytes.
       FORMAT_VERSION = 2
 
+      # Payload ABI version. Store values are mostly Marshal blobs of Rigor/RBS objects, so a Rigor release
+      # upgrade is an ABI boundary even when the byte layout and descriptor schema are unchanged. Folding the
+      # gem version into the root marker makes installed-version upgrades rebuild rather than silently reuse a
+      # blob whose class layout still happens to unmarshal.
+      PAYLOAD_ABI_VERSION = Rigor::VERSION
+
+      # Whole-project producers are content-keyed, so dependency / signature churn writes a new entry and leaves
+      # the old generation unreachable. The global 256 MB cap is intentionally generous and often never fires on
+      # one project, so these producers get a small generation cap as a second compaction axis. Per-file / plugin
+      # producers are deliberately absent from this table: many current entries under one producer id can be live.
+      GENERATION_CAP_BY_PRODUCER = {
+        "analysis.run-diagnostics" => 16,
+        "rbs.class_ancestor_table" => 2,
+        "rbs.class_type_param_names" => 2,
+        "rbs.constant_type_table" => 2,
+        "rbs.environment" => 2,
+        "rbs.known_class_names" => 2
+      }.freeze
+
+      STALE_TEMP_FILE_AGE_SECONDS = 60 * 60
+
       # Header literal: 5-byte ASCII magic, 1-byte separator, 1-byte format version.
       HEADER = "RIGOR\x00#{FORMAT_VERSION.chr}".b.freeze
 
@@ -37,17 +59,19 @@ module Rigor
 
       # @param root [String] cache root directory.
       # @param read_only [Boolean] when true, every disk-side side-effect is suppressed: `fetch_or_compute`
-      #   still reads existing entries (hits) and still runs the producer block on miss, but it does NOT
-      #   write the produced value to disk, does NOT update the `schema_version.txt` marker, and does NOT
-      #   touch the on-disk root directory. The in-process memo is still populated so repeated lookups within
-      #   the same run stay cheap. Used by editor mode so multiple buffer-mode invocations can read from the
-      #   same cache concurrently without churning it. See `docs/design/20260516-editor-mode.md` § "Cache
-      #   behaviour".
+      #   still reads existing entries (hits, gated on a current `schema_version.txt` marker — see
+      #   {#ensure_schema_version!}) and still runs the producer block on miss, but it does NOT write the
+      #   produced value to disk, does NOT update the marker, and does NOT touch the on-disk root directory.
+      #   The in-process memo is still populated so repeated lookups within the same run stay cheap. Used by
+      #   editor mode so multiple buffer-mode invocations can read from the same cache concurrently without
+      #   churning it. See `docs/design/20260516-editor-mode.md` § "Cache behaviour".
       def initialize(root:, read_only: false, max_bytes: nil)
         @root = root.to_s.dup.freeze
         @read_only = read_only
         @max_bytes = max_bytes&.then { |n| Integer(n) }
-        @schema_version_ensured = false
+        # Tri-state: nil = not yet checked, true/false = the disk tier's availability for this Store's
+        # lifetime (see {#ensure_schema_version!}).
+        @disk_available = nil
         @hits = 0
         @misses = 0
         @writes = 0
@@ -100,7 +124,7 @@ module Rigor
       # the eviction cap forever. Folding the format version into the marker routes the bump through the
       # established clear-the-root path instead.
       def self.schema_marker_value
-        "#{Descriptor::SCHEMA_VERSION}.#{FORMAT_VERSION}"
+        "#{PAYLOAD_ABI_VERSION}.#{Descriptor::SCHEMA_VERSION}.#{FORMAT_VERSION}"
       end
 
       def self.disk_inventory(root:)
@@ -154,7 +178,7 @@ module Rigor
       def fetch_or_compute(producer_id:, params:, descriptor:,
                            serialize: nil, deserialize: nil, &block)
         validate_producer_id!(producer_id)
-        ensure_schema_version!
+        disk = ensure_schema_version!
 
         key = descriptor.cache_key_for(producer_id: producer_id, params: params)
         memo_key = [producer_id, key].freeze
@@ -164,8 +188,8 @@ module Rigor
           return memoed
         end
 
-        path = entry_path(producer_id, key)
-        cached = read_entry(path, deserialize: deserialize)
+        path = disk ? entry_path(producer_id, key) : nil
+        cached = path && read_entry(path, deserialize: deserialize)
         unless cached.nil?
           @monitor.synchronize do
             record(:hits, producer_id)
@@ -175,10 +199,10 @@ module Rigor
         end
 
         value = block.call
-        write_entry(path, descriptor, value, serialize: serialize) unless @read_only
+        wrote = path && try_write_entry(path, descriptor, value, serialize: serialize)
         @monitor.synchronize do
           record(:misses, producer_id)
-          record(:writes, producer_id) unless @read_only
+          record(:writes, producer_id) if wrote
           @memo[memo_key] = value
         end
         value
@@ -195,11 +219,11 @@ module Rigor
       # validation always re-checks the filesystem — but a single run only looks up once.
       def fetch_or_validate(producer_id:, key_descriptor:, params: {}, serialize: nil, deserialize: nil)
         validate_producer_id!(producer_id)
-        ensure_schema_version!
+        disk = ensure_schema_version!
 
         key = key_descriptor.cache_key_for(producer_id: producer_id, params: params)
-        path = entry_path(producer_id, key)
-        cached = read_entry(path, deserialize: deserialize)
+        path = disk ? entry_path(producer_id, key) : nil
+        cached = path && read_entry(path, deserialize: deserialize)
         if cached && (pair = cached.value).is_a?(Array) && pair.size == 2 &&
            pair[1].is_a?(Descriptor) && pair[1].fresh?
           @monitor.synchronize { record(:hits, producer_id) }
@@ -207,17 +231,7 @@ module Rigor
         end
 
         value, dependency_descriptor = block_given? ? yield : [nil, Descriptor.new]
-        wrote = false
-        unless @read_only
-          # A cache write must never break the run. If the value is not Marshal-clean (or any disk error
-          # occurs) skip caching and return the freshly-computed value — the next run recomputes.
-          begin
-            write_entry(path, key_descriptor, [value, dependency_descriptor], serialize: serialize)
-            wrote = true
-          rescue StandardError
-            wrote = false
-          end
-        end
+        wrote = path && try_write_entry(path, key_descriptor, [value, dependency_descriptor], serialize: serialize)
         @monitor.synchronize do
           record(:misses, producer_id)
           record(:writes, producer_id) if wrote
@@ -225,27 +239,30 @@ module Rigor
         value
       end
 
-      # ADR-6 § "Eviction" — LRU pass over the on-disk cache. No-op when `max_bytes:` was not configured or
-      # the store is read-only. Walks all `.entry` files, sorts by mtime ascending (oldest = least recently
-      # used), and unlinks from the oldest until the total is at or below the cap. Touch-on-disk-read
-      # ({read_entry}) is the cross-process LRU signal: every disk hit (not in-process-memo hit) updates the
-      # mtime so recently-read entries survive the eviction pass. Any FS error is swallowed — eviction must
-      # never break a run.
+      # ADR-6 § "Eviction" — compaction pass over the on-disk cache. No-op when the store is read-only. Stale
+      # temp file cleanup and the whole-project generation cap run regardless of `max_bytes:` — they reclaim
+      # provably-dead bytes (leaked temp files, unreachable content-keyed generations) rather than enforcing a
+      # size budget, so an explicitly unbounded store (`max_bytes: nil`) still benefits from them. The
+      # size-based LRU pass below stays gated on `max_bytes:` being configured: it walks all remaining
+      # `.entry` files, sorts by mtime ascending (oldest = least recently used), and unlinks from the oldest
+      # until the total is at or below the cap. Touch-on-disk-read ({read_entry}) is the cross-process LRU
+      # signal: every disk hit (not in-process-memo hit) updates the mtime so recently-read entries survive
+      # the eviction pass. Any FS error is swallowed — eviction must never break a run.
       def evict!
-        return if @max_bytes.nil? || @read_only
+        return if @read_only
 
-        entries = collect_entry_stats
-        total   = entries.sum { |e| e[:bytes] }
+        cleanup_stale_temp_files
+        entries = evict_excess_generations(collect_entry_stats)
+        return if @max_bytes.nil?
+
+        total = entries.sum { |e| e[:bytes] }
         return if total <= @max_bytes
 
         entries.sort_by! { |e| e[:mtime] }
         entries.each do |entry|
           break if total <= @max_bytes
 
-          File.unlink(entry[:path])
-          total -= entry[:bytes]
-        rescue StandardError
-          next
+          total -= entry[:bytes] if unlink_entry(entry[:path])
         end
         nil
       rescue StandardError
@@ -372,44 +389,95 @@ module Rigor
         File.open(path, File::RDWR | File::CREAT, 0o644) do |lock_fd|
           lock_fd.flock(File::LOCK_EX)
           tmp = "#{path}.tmp.#{Process.pid}.#{SecureRandom.hex(4)}"
-          File.open(tmp, "wb") do |f|
-            f.write(body)
-            f.fsync
+          begin
+            File.open(tmp, "wb") do |f|
+              f.write(body)
+              f.fsync
+            end
+            File.rename(tmp, path)
+          ensure
+            # A failed write/rename must not leak its temp file — rely on the 1-hour `cleanup_stale_temp_files`
+            # sweep only as a backstop for crashes that skip this ensure entirely.
+            unlink_entry(tmp) if File.exist?(tmp)
           end
-          File.rename(tmp, path)
+          fsync_directory(File.dirname(path))
         end
       end
 
+      # Checks (and, for a writable store, repairs) the `schema_version.txt` marker, and reports whether the
+      # disk tier is usable for the rest of this Store's lifetime. The result is memoized in `@disk_available`
+      # — one check per Store is enough; a benign double-check under a thread race would just repeat
+      # idempotent work.
+      #
+      # A writable store clears the cache root and rewrites the marker on a stale/missing marker, then reports
+      # available. A read-only store never touches the root — no mkdir, no marker write, no destructive clear
+      # — so it reports available ONLY when the on-disk marker already matches current exactly; a stale or
+      # missing marker (e.g. a Rigor upgrade with no writable run yet, as in LSP / editor mode) reports
+      # unavailable rather than risk unmarshalling a payload from a different ABI. Any filesystem failure
+      # (permission, disk full, deleted root) also reports unavailable, degrading this Store instance to
+      # in-memory-memo-only for the rest of its lifetime — the producer block still runs, its result still
+      # lands in `@memo`, and disk reads/writes are simply skipped.
+      #
+      # @return [Boolean]
       def ensure_schema_version!
-        # Read-only stores never touch the cache root — no mkdir, no marker write, no destructive clear on
-        # schema mismatch. A stale or wrong-schema marker simply yields nothing back (entries read through
-        # the version check are content-keyed, so a write under the new schema never collides with a read
-        # under the old). The next writable run will repair the cache.
-        return if @read_only
-        # The marker is process-stable; one check per Store is enough (a benign double-check under a thread
-        # race just repeats idempotent work).
-        return if @schema_version_ensured
+        return @disk_available unless @disk_available.nil?
 
-        @schema_version_ensured = true
+        @disk_available = @read_only ? read_only_marker_current? : repair_writable_marker!
+      end
+
+      def read_only_marker_current?
+        marker = File.join(@root, "schema_version.txt")
+        return false unless File.file?(marker)
+
+        File.read(marker).strip == self.class.schema_marker_value
+      rescue StandardError
+        false
+      end
+
+      def repair_writable_marker!
         FileUtils.mkdir_p(@root)
         marker = File.join(@root, "schema_version.txt")
         current = self.class.schema_marker_value
 
         if File.file?(marker)
           on_disk = File.read(marker).strip
-          return if on_disk == current
+          return true if on_disk == current
 
           clear_cache_root!
         end
 
         FileUtils.mkdir_p(@root)
         File.write(marker, "#{current}\n")
+        true
+      rescue StandardError
+        false
       end
 
       def clear_cache_root!
         Dir.children(@root).each do |entry|
           FileUtils.rm_rf(File.join(@root, entry))
         end
+      end
+
+      # Shared write path for both {#fetch_or_compute} and {#fetch_or_validate}. A cache write must never
+      # break the run: filesystem-side failures (permission, disk full, deleted root, read-only mount) are
+      # swallowed and read as "did not write". Programmer errors — a custom serializer that doesn't return a
+      # `String`, or any other producer contract violation — still raise so the bug is visible.
+      def try_write_entry(path, descriptor, value, serialize: nil)
+        return false if @read_only
+
+        write_entry(path, descriptor, value, serialize: serialize)
+        true
+      rescue SystemCallError, IOError
+        false
+      end
+
+      # Best-effort durability for the rename itself. Some platforms cannot fsync directories (or do not need to),
+      # so failures are ignored; the entry envelope still turns any lost/partial write into a miss.
+      def fsync_directory(dir)
+        File.open(dir, File::RDONLY, &:fsync)
+      rescue StandardError
+        nil
       end
 
       # LEB128 unsigned varint encoder/decoder. Lengths fit easily in five bytes (cap at 2^35); the cache
@@ -437,15 +505,64 @@ module Rigor
         nil
       end
 
-      # Returns an array of `{ path:, mtime:, bytes: }` hashes for every `.entry` file under the cache root,
-      # skipping unreadable entries.
+      def cleanup_stale_temp_files
+        cutoff = Time.now - STALE_TEMP_FILE_AGE_SECONDS
+        Dir.glob(File.join(@root, "**", "*.tmp.*")).each do |path|
+          next unless File.file?(path)
+          next if File.mtime(path) > cutoff
+
+          unlink_entry(path)
+        rescue StandardError
+          next
+        end
+      rescue StandardError
+        nil
+      end
+
+      def evict_excess_generations(entries)
+        removed = {}
+        entries.group_by { |entry| entry[:producer] }.each do |producer, producer_entries|
+          cap = GENERATION_CAP_BY_PRODUCER[producer]
+          next if cap.nil? || producer_entries.size <= cap
+
+          producer_entries.sort_by { |entry| [entry[:mtime], entry[:path]] }
+                          .first(producer_entries.size - cap)
+                          .each do |entry|
+            removed[entry[:path]] = true if unlink_entry(entry[:path])
+          end
+        end
+        return entries if removed.empty?
+
+        entries.reject { |entry| removed[entry[:path]] }
+      end
+
+      def unlink_entry(path)
+        File.unlink(path)
+        true
+      rescue StandardError
+        false
+      end
+
+      # Returns an array of `{ path:, producer:, mtime:, bytes: }` hashes for every `.entry` file under the
+      # cache root, skipping unreadable entries.
       def collect_entry_stats
         Dir.glob(File.join(@root, "**", "*.entry")).filter_map do |path|
           stat = File.stat(path)
-          { path: path, mtime: stat.mtime, bytes: stat.size }
+          producer = producer_id_for_entry(path)
+          next nil if producer.nil?
+
+          { path: path, producer: producer, mtime: stat.mtime, bytes: stat.size }
         rescue StandardError
           nil
         end
+      end
+
+      def producer_id_for_entry(path)
+        root_prefix = @root.end_with?(File::SEPARATOR) ? @root : "#{@root}#{File::SEPARATOR}"
+        return nil unless path.start_with?(root_prefix)
+
+        producer = path.delete_prefix(root_prefix).split(File::SEPARATOR, 2).first
+        producer.empty? ? nil : producer
       end
 
       def read_varint(bytes, offset)

--- a/spec/rigor/cache/store_spec.rb
+++ b/spec/rigor/cache/store_spec.rb
@@ -99,6 +99,13 @@ RSpec.describe Rigor::Cache::Store do
     end
   end
 
+  describe "schema_marker_value (payload ABI version)" do
+    it "folds Rigor::VERSION into the marker alongside the descriptor and format versions" do
+      expect(described_class.schema_marker_value)
+        .to eq("#{Rigor::VERSION}.#{Rigor::Cache::Descriptor::SCHEMA_VERSION}.#{described_class::FORMAT_VERSION}")
+    end
+  end
+
   describe "schema-version mismatch" do
     it "drops the cache directory when the marker disagrees with SCHEMA_VERSION" do
       store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :first }
@@ -352,6 +359,15 @@ RSpec.describe Rigor::Cache::Store do
       expect(File.exist?(File.join(cache_root, "p", key[0, 2], "#{key[2..]}.entry"))).to be(false)
       expect(ro.stats).to include(writes: 0, misses: 1)
     end
+
+    it "raises TypeError when serialize returns a non-String (write-contract errors stay visible)" do
+      bad = ->(_) { 42 }
+      expect do
+        store.fetch_or_validate(producer_id: "p", key_descriptor: descriptor, params: {}, serialize: bad) do
+          ["v", Rigor::Cache::Descriptor.new]
+        end
+      end.to raise_error(TypeError, /serialize must return a String/)
+    end
   end
 
   describe "#stats (v0.0.9 group A slice 3)" do
@@ -496,6 +512,16 @@ RSpec.describe Rigor::Cache::Store do
       allow(SecureRandom).to receive(:hex).and_call_original
       store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :v }
       expect(SecureRandom).to have_received(:hex).with(4)
+    end
+
+    it "leaves no .tmp file behind when the rename itself fails" do
+      allow(File).to receive(:rename).and_raise(Errno::ENOSPC)
+
+      expect do
+        store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { "v" }
+      end.not_to raise_error
+
+      expect(Dir.glob(File.join(cache_root, "**", "*.tmp.*"))).to be_empty
     end
 
     it "does not collide across concurrent writers targeting the same entry (unique temp names)" do
@@ -659,6 +685,117 @@ RSpec.describe Rigor::Cache::Store do
       end
 
       expect(called).to eq(1)
+    end
+  end
+
+  describe "read-only marker gate (ABI safety)" do
+    it "treats a stale marker as unavailable: no disk hit, no recompute writeback" do
+      store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :warm }
+      File.write(File.join(cache_root, "schema_version.txt"), "stale-marker\n")
+
+      ro = described_class.new(root: cache_root, read_only: true)
+      called = 0
+      result = ro.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) do
+        called += 1
+        :recomputed
+      end
+
+      expect(called).to eq(1)
+      expect(result).to eq(:recomputed)
+      # Read-only never repairs the marker, even after observing a mismatch.
+      expect(File.read(File.join(cache_root, "schema_version.txt")).strip).to eq("stale-marker")
+    end
+
+    it "treats a missing marker (fresh root) as unavailable without creating the root" do
+      expect(Dir.exist?(cache_root)).to be(false)
+
+      ro = described_class.new(root: cache_root, read_only: true)
+      called = 0
+      result = ro.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) do
+        called += 1
+        :produced
+      end
+
+      expect(called).to eq(1)
+      expect(result).to eq(:produced)
+      expect(Dir.exist?(cache_root)).to be(false)
+    end
+  end
+
+  describe "disk-disabled degrade (filesystem failure)" do
+    it "falls back to memo-only operation without raising when the marker cannot be established" do
+      allow(FileUtils).to receive(:mkdir_p).and_raise(Errno::EACCES)
+
+      called = 0
+      result = store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) do
+        called += 1
+        :produced
+      end
+      expect(called).to eq(1)
+      expect(result).to eq(:produced)
+
+      # Same instance, same lookup: served from the in-process memo, never re-attempts disk.
+      called_again = 0
+      result_again = store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) do
+        called_again += 1
+        :ignored
+      end
+      expect(called_again).to eq(0)
+      expect(result_again).to eq(:produced)
+    end
+  end
+
+  describe "#evict! (generation cap for whole-project producers, ADR-54 follow-up)" do
+    def cache_key_path(producer_id, params)
+      key = Rigor::Cache::Descriptor.new.cache_key_for(producer_id: producer_id, params: params)
+      File.join(cache_root, producer_id, key[0, 2], "#{key[2..]}.entry")
+    end
+
+    it "keeps only the cap for a listed producer, removing the oldest generations first, " \
+       "even when max_bytes is nil" do
+      st = described_class.new(root: cache_root, max_bytes: nil)
+      paths = Array.new(4) do |i|
+        st.fetch_or_compute(
+          producer_id: "rbs.environment", params: { i: i }, descriptor: Rigor::Cache::Descriptor.new
+        ) { i }
+        path = cache_key_path("rbs.environment", { i: i })
+        # Force a deterministic write-order mtime; same-millisecond writes would otherwise tie.
+        stamp = Time.now - (10 - i)
+        File.utime(stamp, stamp, path)
+        path
+      end
+
+      st.evict!
+
+      remaining = Dir.glob(File.join(cache_root, "rbs.environment", "**", "*.entry"))
+      expect(remaining.size).to eq(2)
+      expect(remaining).to contain_exactly(paths[2], paths[3])
+    end
+
+    it "does not cap a producer absent from the allow-list" do
+      st = described_class.new(root: cache_root, max_bytes: nil)
+      5.times { |i| st.fetch_or_compute(producer_id: "custom.thing", params: { i: i }, descriptor: descriptor) { i } }
+
+      st.evict!
+
+      expect(Dir.glob(File.join(cache_root, "custom.thing", "**", "*.entry")).size).to eq(5)
+    end
+  end
+
+  describe "#evict! (stale temp-file cleanup)" do
+    it "removes .tmp files older than the 1-hour cutoff and keeps fresh ones" do
+      stale = File.join(cache_root, "p", "ab", "cdef.entry.tmp.123.deadbeef")
+      fresh = File.join(cache_root, "p", "ab", "cdef.entry.tmp.456.cafebabe")
+      FileUtils.mkdir_p(File.dirname(stale))
+      File.write(stale, "x")
+      File.write(fresh, "y")
+      old_time = Time.now - ((60 * 60) + 60)
+      File.utime(old_time, old_time, stale)
+
+      described_class.new(root: cache_root, max_bytes: nil).evict!
+
+      expect(File.exist?(stale)).to be(false)
+      expect(File.exist?(fresh)).to be(true)
     end
   end
 end


### PR DESCRIPTION
## Summary

Completes an in-progress cache-hardening slice per the handover note `docs/notes/20260707-cache-mechanism-audit-sakana.md` (re-audited, re-planned in `docs/notes/20260707-cache-hardening-plan.md`).

- `Rigor::VERSION` folds into the `schema_version.txt` marker so an installed-version upgrade rebuilds the cache instead of reusing a Marshal payload from a different Rigor ABI.
- `ensure_schema_version!` now returns whether the disk tier is usable instead of a bare early-return. A **read-only store (LSP / editor mode) now actually checks the marker** before trusting a disk hit — previously it read through a stale/missing marker unconditionally, half-defeating the ABI marker. A broken cache root (permission error, disk full, deleted root) now degrades the Store to memo-only instead of raising.
- `fetch_or_compute` and `fetch_or_validate` share one write helper (`try_write_entry`) so a producer's serializer contract violation (e.g. a bad `serialize:` callable) stays visible on both paths, not just one.
- `atomically_replace` cleans up its own temp file on a failed write/rename instead of relying solely on the hourly sweep.
- `evict!`'s stale temp-file cleanup and whole-project generation cap (RBS tables + `analysis.run-diagnostics`) now run whenever the store is writable, independent of whether `max_bytes:` is configured — they reclaim provably-dead bytes rather than enforce a size budget.
- Docs (`docs/internal-spec/cache.md`, `docs/adr/54-cache-slimming.md`) and `CHANGELOG.md` updated to match.

## Test plan

All run inside the Nix Flake:
- [x] `bundle exec rspec spec/rigor/cache/store_spec.rb` — 57 examples, 0 failures (17 new)
- [x] `make docs-check` — 96 examples, 0 failures
- [x] `make verify` (full suite incl. ractor-pool, rubocop, self-check, plugin self-check) — 7364 + 8 examples, 0 failures; rubocop clean; both self-checks clean
- [x] `git diff --check` — clean