### PR TITLE
Type the strong-parameters fluent chain in rigor-actionpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Added
+
+- **[rigor-actionpack]** The strong-parameters fluent chain now stays typed, so `coverage --protection` counts the chained sites as protected.
+  - `params` typed to `ActionController::Parameters`, but `params.require(:user)` / `.permit(:name)` returned `Dynamic` at the first hop (the class ships no bundled RBS), leaking every downstream site (`.permit`, `.to_h`, `.each`). `require` / `permit` / `permit!` on a `Parameters` receiver now re-type to the same lenient nominal, keeping the chain a concrete receiver end-to-end. Precision-additive and FP-safe — the value stays engine-lenient (no `undefined-method`), and this types the container, never a caller's argument. Surfaced onboarding GitLab (one controller's protected sites went 2 → 9).
+
 ### Fixed
 
 - **[rigor-rails-routes]** Two route-helper name-composition gaps that fired false `unknown-helper` on working code are now resolved, matching Rails' own naming.

--- a/plugins/rigor-actionpack/lib/rigor/plugin/actionpack.rb
+++ b/plugins/rigor-actionpack/lib/rigor/plugin/actionpack.rb
@@ -182,6 +182,27 @@ module Rigor
         Rigor::Type::Combinator.nominal_of(class_name)
       end
 
+      # Phase 5b (2026-07-10) — keep the strong-parameters fluent chain typed. `params` types to
+      # `ActionController::Parameters` (above), but the chained `params.require(:user).permit(:name)` /
+      # `params.permit(...)` calls returned `Dynamic` at the first hop (Parameters ships no bundled RBS,
+      # so a call on it resolves lenient-to-Dynamic), leaking every downstream site (`.permit`, `.to_h`,
+      # `.each`) to unprotected. These three methods return another `Parameters`, so gate on a
+      # `Parameters` receiver and re-type the result as the same lenient nominal — the chain stays a
+      # concrete receiver end-to-end and `coverage --protection` counts the sites as protected.
+      #
+      # `require` may return a scalar for a flat key at runtime (`params.require(:id) → String`), but
+      # typing it as the RBS-less `Parameters` is FP-safe by the same argument as the readers: every
+      # method on a Parameters value stays engine-lenient (no `undefined-method`), and this types the
+      # container only, never a caller's argument (ADR-5). The GitLab strong-params survey (108 leaked
+      # `.permit` sites) is the demand.
+      STRONG_PARAMS_CHAIN_METHODS = %i[require permit permit!].freeze
+
+      dynamic_return receivers: [REQUEST_CONTEXT_READER_TYPES[:params]], methods: STRONG_PARAMS_CHAIN_METHODS do |call_node, _scope|
+        next nil unless call_node.is_a?(Prism::CallNode)
+
+        Rigor::Type::Combinator.nominal_of(REQUEST_CONTEXT_READER_TYPES[:params])
+      end
+
       private
 
       # True when the current `self` is a controller — the enclosing class is one the discoverer

--- a/spec/integration/plugins/actionpack_plugin_spec.rb
+++ b/spec/integration/plugins/actionpack_plugin_spec.rb
@@ -193,6 +193,43 @@ RSpec.describe "plugins/rigor-actionpack" do
         expect(dump.message).not_to include("ActionController::Parameters")
       end
     end
+
+    it "keeps `require` / `permit` chained off `params` typed as Parameters (Phase 5b)" do
+      # Pre-fix `params.require(:user)` returned Dynamic (Parameters ships no RBS), leaking the chained
+      # `.permit` and every downstream site to unprotected. The chain now stays a concrete Parameters
+      # receiver end-to-end.
+      source = <<~RUBY
+        class C
+          def create
+            Rigor.dump_type(params.require(:user))
+            Rigor.dump_type(params.require(:user).permit(:name))
+            Rigor.dump_type(params.permit(:q))
+          end
+        end
+      RUBY
+      with_demo(source) do |result|
+        dumps = result.diagnostics.select { |d| d.rule == "dump.type" }.map(&:message)
+        expect(dumps.size).to eq(3)
+        expect(dumps).to all(include("ActionController::Parameters"))
+      end
+    end
+
+    it "does not re-type `require` / `permit` on a non-Parameters receiver" do
+      # The receiver gate is `ActionController::Parameters` — a bare `require 'x'` (Kernel) or a `permit`
+      # on some other object must not become Parameters.
+      source = <<~RUBY
+        class C
+          def create
+            Rigor.dump_type(require("set"))
+          end
+        end
+      RUBY
+      with_demo(source) do |result|
+        dump = result.diagnostics.find { |d| d.rule == "dump.type" }
+        expect(dump).not_to be_nil
+        expect(dump.message).not_to include("ActionController::Parameters")
+      end
+    end
   end
 
   describe "helper-call error diagnostics (canonically delegated to rigor-rails-routes)" do


### PR DESCRIPTION
## What

`params` types to `ActionController::Parameters`, but the chained `params.require(:user).permit(:name)` / `params.permit(...)` calls returned `Dynamic` at the first hop — the class ships no bundled RBS, so a call on it resolves lenient-to-`Dynamic` — leaking every downstream site (`.permit`, `.to_h`, `.each`) to unprotected. The [GitLab onboarding survey](docs/notes/20260708-gitlab-type-coverage-improvement-plan.md) measured **108** such leaked `.permit` sites (plan item **P0-2**).

`require` / `permit` / `permit!` return another `Parameters`, so this gates a `dynamic_return` on a `Parameters` receiver and re-types the result as the same lenient nominal. The chain now stays a concrete receiver end-to-end and `coverage --protection` counts the sites as protected.

## FP-safety

Same argument as the landed request-context readers (Phase 5): `require` may return a scalar for a flat key at runtime, but typing it as the RBS-less `Parameters` keeps every method on the value engine-lenient (no `undefined-method`), and this types the container, never a caller's argument ([ADR-5](docs/adr/5-robustness-principle.md)).

## Gate

| Check | Result |
|---|---|
| GitLab `app/controllers` error+warning diagnostics | byte-identical (**zero new firings**) |
| `abuse_reports_controller.rb` protected sites | 2 → **9** (ratio 0.08 → 0.36) |
| `require`/`permit` in `add_a_type_here` (unprotected) | gone |
| `make verify` (test / lint / check / check-plugins) | clean |

+2 integration specs (chain typed as Parameters; non-Parameters receiver like `Kernel#require` not re-typed).