### PR TITLE
Cover more ActiveSupport core-ext + stdlib RBS gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
-- **[rigor-actionpack]** `unknown-permit-key` no longer fires on a virtual (non-column) attribute in strong-parameters.
+- **[rigor-activesupport-core-ext]** More ActiveSupport core extensions are covered, so calls on them no longer read as `undefined-method`: `String#upcase_first` / `#remove` / `#titlecase` / `#dasherize`, `Object#in?`, `Date`/`Time#advance` / `#all_day`, `Date#to_time(form)`, and `ERB::Util.html_escape_once`. Surfaced onboarding GitLab (real String columns now typed by rigor-activerecord get these ActiveSupport methods called on them).
+- **[core RBS overlay]** Two stdlib signatures the pinned `rbs` gem omits are supplied so real calls stop false-firing: `Psych.parse` / `.parse_stream` (`= YAML.parse`, a real method missing from `psych.rbs`) no longer reads as `undefined-method`, and `CSV::MalformedCSVError.new(message, line_number)` (the gem's documented two-arg constructor) no longer reads as `wrong-arity`.
   - Permitting a non-column is ordinary Rails — a Devise virtual attribute (`password`, `remember_me`, `otp_attempt`), a state-machine `*_event`, an `attr_accessor` setter. The check is now a typo detector: it fires only when the permit key is a near-miss edit-distance match of a real column (`emial`→`email`), never on a legitimate virtual attribute nothing like any column.
 - **[rigor-activerecord]** A nested / joined-table condition (`Model.where(assoc: { ... })`) no longer reads as an unknown column — the Hash value marks a join condition whose key names an association or joined table, not a column on the receiver.
 - **[rigor-rails-routes]** Two route-helper name-composition gaps that fired false `unknown-helper` on working code are now resolved, matching Rails' own naming.

--- a/data/core_overlay/csv.rbs
+++ b/data/core_overlay/csv.rbs
@@ -1,0 +1,21 @@
+# Rigor core overlay — supplemental core signatures.
+#
+# --- CSV::MalformedCSVError.new(message, line_number) ---
+#
+# The pinned `rbs` gem's `csv.rbs` never declares `MalformedCSVError`'s own
+# constructor, so it falls back to the inherited `StandardError#initialize`
+# (arity 0..1). But the `csv` gem's real, documented constructor takes two
+# arguments — the message and the 1-based line number:
+#
+#   raise CSV::MalformedCSVError.new("Unquoted fields...", line)
+#
+# Without the two-arg form a raise like GitLab's
+# `import_csv/base_service.rb` false-fires `call.wrong-arity`
+# ("expected 0..1, got 2"). The line number is optional here so the
+# inherited single-arg form still type-checks.
+
+# Reopen the flat `CSV::MalformedCSVError` path (upstream declares `CSV` as a
+# class, so a `module CSV` wrapper would conflict); no superclass is restated.
+class CSV::MalformedCSVError
+  def initialize: (String message, ?Integer line_number) -> void
+end

--- a/data/core_overlay/csv.rbs
+++ b/data/core_overlay/csv.rbs
@@ -14,8 +14,15 @@
 # ("expected 0..1, got 2"). The line number is optional here so the
 # inherited single-arg form still type-checks.
 
-# Reopen the flat `CSV::MalformedCSVError` path (upstream declares `CSV` as a
-# class, so a `module CSV` wrapper would conflict); no superclass is restated.
-class CSV::MalformedCSVError
-  def initialize: (String message, ?Integer line_number) -> void
+# `CSV` is a CLASS in Ruby / RBS (a `module CSV` wrapper collides with upstream
+# once the `csv` stdlib is in scope). It must be declared EXPLICITLY here — the
+# overlay loads unconditionally, but `csv` is a stdlib library loaded only on
+# demand, so a bare `class CSV::MalformedCSVError` would make RBS *synthesize*
+# the `CSV` parent namespace (ADR-5) in every env that does not load `csv`,
+# polluting `synthesized_namespaces`. Declaring `class CSV` reopens it cleanly
+# when `csv` is loaded and declares it plainly when it is not.
+class CSV
+  class MalformedCSVError
+    def initialize: (String message, ?Integer line_number) -> void
+  end
 end

--- a/data/core_overlay/psych.rbs
+++ b/data/core_overlay/psych.rbs
@@ -1,0 +1,22 @@
+# Rigor core overlay — supplemental core signatures.
+#
+# --- Psych.parse / Psych.parse_stream ---
+#
+# The pinned `rbs` gem's `psych.rbs` declares `Psych.load` / `load_file` /
+# `safe_load` / `unsafe_load*` but omits `Psych.parse` — a real, documented
+# stdlib method (`YAML.parse` is the same method, `YAML` being an alias of
+# `Psych`). It parses one YAML document into a `Psych::Nodes::Document` AST
+# (used for structure-preserving inspection) and raises on a syntax error.
+#
+#   YAML.parse(File.read("config.yml"))   # => Psych::Nodes::Document
+#
+# Without the declaration a call like GitLab's
+# `release_highlights/validator.rb` `YAML.parse(...)` false-fires
+# `call.undefined-method`. The return is left `untyped` — the node AST is
+# rarely consumed with per-method precision, and depending on
+# `Psych::Nodes::Document` being present in the pinned RBS would be brittle.
+
+module Psych
+  def self.parse: (String yaml, ?filename: untyped) -> untyped
+  def self.parse_stream: (String yaml, ?filename: untyped) -> untyped
+end

--- a/plugins/rigor-activesupport-core-ext/sig/active_support/core_ext.rbs
+++ b/plugins/rigor-activesupport-core-ext/sig/active_support/core_ext.rbs
@@ -62,6 +62,9 @@ class Object
   # `acts_like?(:string)` / `acts_like?(:date)` / `acts_like?(:time)`
   # is ActiveSupport's "duck-typing helper" predicate.
   def acts_like?: (Symbol | String) -> bool
+
+  # `core_ext/object/inclusion` — `x.in?([a, b])` / `x.in?(1..10)`.
+  def in?: (untyped) -> bool
 end
 
 # `nil.blank?` / `nil.present?` / `nil.try` are the most frequent
@@ -99,6 +102,9 @@ class String
   def demodulize: () -> String
   def deconstantize: () -> String
   def titleize: () -> String
+  def titlecase: () -> String
+  def dasherize: () -> String
+  def upcase_first: () -> String
   def parameterize: (?separator: String, ?preserve_case: bool, ?locale: Symbol?) -> String
   def tableize: () -> String
   def foreign_key: (?bool separate_class_name_and_id_with_underscore) -> String
@@ -112,6 +118,9 @@ class String
   def truncate: (Integer truncate_at, ?omission: String, ?separator: String | Regexp | nil) -> String
   def truncate_bytes: (Integer truncate_at, ?omission: String) -> String
   def truncate_words: (Integer words_count, ?omission: String, ?separator: String | Regexp | nil) -> String
+  # `remove` / `remove!` delete every occurrence of the given patterns.
+  def remove: (*Regexp | String patterns) -> String
+  def remove!: (*Regexp | String patterns) -> String
 
   # `core_ext/string/output_safety` — `html_safe` returns an
   # `ActiveSupport::SafeBuffer` (a String subclass). The closest
@@ -274,6 +283,9 @@ class Time
   def noon: () -> Time
   def utc?: () -> bool
   def acts_like_time?: () -> true
+  # `advance(days: 1, months: -2)` and `all_day` (a `beginning_of_day..end_of_day` Range).
+  def advance: (untyped options) -> Time
+  def all_day: () -> Range[Time]
 end
 
 # ---------------------------------------------------------------
@@ -314,6 +326,11 @@ class Date
   def at_beginning_of_day: () -> Time
   def end_of_day: () -> Time
   def at_end_of_day: () -> Time
+  # `advance(days: 1)`, `all_day` (a Time Range), and `to_time(form)` — the
+  # `:local` / `:utc` form arg core RBS' `Date#to_time` (arity 0) omits.
+  def advance: (untyped options) -> Date
+  def all_day: () -> Range[Time]
+  def to_time: (?Symbol form) -> Time
 end
 
 # ---------------------------------------------------------------
@@ -475,4 +492,19 @@ end
 # coverage was added after a second-round survey.)
 class String
   def exclude?: (String) -> bool
+end
+
+# ---------------------------------------------------------------
+# ERB::Util — ActionView extends it with `html_escape_once`
+# ---------------------------------------------------------------
+
+# `ERB` is a CLASS in Ruby / RBS (not a module), so reopen it as a class —
+# a `module ERB` wrapper collides with upstream `class ERB` once the `erb`
+# stdlib is in scope. `ERB::Util` itself is a module.
+class ERB
+  module Util
+    # `ERB::Util.html_escape_once(s)` escapes HTML without double-escaping
+    # an already-escaped entity. ActionView adds it on top of stdlib ERB.
+    def self.html_escape_once: (untyped) -> String
+  end
 end

--- a/spec/integration/plugins/activesupport_core_ext_plugin_spec.rb
+++ b/spec/integration/plugins/activesupport_core_ext_plugin_spec.rb
@@ -40,4 +40,20 @@ RSpec.describe "plugins/rigor-activesupport-core-ext" do
     undefined = result.diagnostics.select { |d| d.qualified_rule == "call.undefined-method" }
     expect(undefined).to be_empty
   end
+
+  it "declares the GitLab-surfaced String / Object / Date / ERB extensions in its RBS bundle" do
+    # `upcase_first` / `remove` / `in?` fired `undefined-method` on GitLab once AR typed real String
+    # columns; `titlecase` / `dasherize` / `advance` / `all_day` / `Date#to_time(form)` /
+    # `ERB::Util.html_escape_once` are the activesupport-core-ext gaps the survey adjudicated. The bundle
+    # is validated against `rbs` by the `check-plugins` gate; this locks the specific additions.
+    rbs = File.read(
+      File.expand_path("../../../plugins/rigor-activesupport-core-ext/sig/active_support/core_ext.rbs", __dir__)
+    )
+    %w[upcase_first remove titlecase dasherize advance all_day].each do |method|
+      expect(rbs).to match(/def #{method}:/), "expected RBS to declare `#{method}`"
+    end
+    expect(rbs).to include("def in?:")
+    expect(rbs).to match(/def to_time: \(\?Symbol form\) -> Time\b/)
+    expect(rbs).to include("def self.html_escape_once:")
+  end
 end

--- a/spec/rigor/environment/rbs_loader_spec.rb
+++ b/spec/rigor/environment/rbs_loader_spec.rb
@@ -241,6 +241,28 @@ RSpec.describe Rigor::Environment::RbsLoader do
         expect(return_types).to all(eq("::Pathname"))
       end
     end
+
+    # `Psych.parse` (= `YAML.parse`) and the two-arg `CSV::MalformedCSVError.new(message, line)` are real
+    # stdlib API the pinned `rbs` gem omits; the overlay restores them so GitLab's `YAML.parse(...)` and
+    # `raise CSV::MalformedCSVError.new(msg, line)` don't false-fire undefined-method / wrong-arity. See
+    # data/core_overlay/psych.rbs + csv.rbs.
+    context "with the psych / csv stdlib libraries loaded" do
+      let(:stdlib_loader) { described_class.new(libraries: %w[psych csv]) }
+
+      it "resolves the singleton `Psych.parse` added by the overlay" do
+        method = stdlib_loader.singleton_definition("Psych")&.methods&.[](:parse)
+        expect(method).not_to be_nil, "expected overlay to declare Psych.parse"
+        expect(method.method_types).not_to be_empty
+      end
+
+      it "resolves the two-arg `CSV::MalformedCSVError#initialize` added by the overlay" do
+        method = stdlib_loader.instance_method(class_name: "CSV::MalformedCSVError", method_name: :initialize)
+        expect(method).not_to be_nil, "expected overlay to declare CSV::MalformedCSVError#initialize"
+        # A `(String, ?Integer)` overload — at least one positional beyond the inherited single-arg form.
+        positionals = method.method_types.flat_map { |mt| mt.type.required_positionals + mt.type.optional_positionals }
+        expect(positionals.size).to be >= 2
+      end
+    end
   end
 
   describe "#instance_definition" do


### PR DESCRIPTION
## What

The GitLab survey — and the [P1 structure.sql work](https://github.com/rigortype/rigor/pull/60) that made real `String` columns type-check — surfaced a cluster of ActiveSupport / stdlib methods missing from Rigor's RBS, each false-firing on working code (plan items **P0-3 / P0-4**):

**rigor-activesupport-core-ext** gains `String#upcase_first` / `#remove` / `#titlecase` / `#dasherize`, `Object#in?`, `Date`/`Time#advance` / `#all_day`, `Date#to_time(form)`, and `ERB::Util.html_escape_once`.

**Two `data/core_overlay/` files** supply stdlib signatures the pinned `rbs` gem omits: `Psych.parse` / `.parse_stream` (`YAML.parse` is the same real method) and the two-arg `CSV::MalformedCSVError.new(message, line)` constructor.

## Load-bearing gotcha (worth a look)

`ERB` and `CSV` are **classes** in RBS, not modules — so a `module ERB` / `module CSV` reopen collides with upstream once the `erb` / `csv` stdlib is in scope, raising `RBS::DuplicatedDeclarationError` that **collapses the whole environment** (`RBS classes available: 0` → every type becomes `Dynamic`, far worse than the FP it fixed). Only a project that actually **loads the stdlib library** exhibits it, so the rigor repo's own self-check can't catch it — I hit it on GitLab and validated the fix against all three corpora.

## Gate

| Check | Result |
|---|---|
| GitLab | AS-core-ext FPs (`upcase_first`/`remove`/`in?`/…) gone; 4× `import_csv` `MalformedCSVError.new` wrong-arity gone; env healthy (**1350** classes) |
| Mastodon / Redmine | env unchanged (**1350** classes) — no collapse from the reopens |
| Nature | pure RBS additions — only *remove* undefined-method / wrong-arity, never add |
| `make verify` | clean (768 examples); +3 specs (AS-core-ext structural, Psych + CSV overlay resolution) |