### PR TITLE
Cache the dry-types alias scan across runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Changed
+
+- **[rigor-dry-types]** The dry-types alias scan is now cached across runs, so a warm `rigor check` re-validates file digests instead of re-parsing the whole project ([ADR-60](docs/adr/60-pre-freeze-plugin-contract-consolidation.md) WD3).
+  - The plugin's `#prepare` used to Prism-parse every `.rb` file under the project's `paths:` on every invocation — cold and warm alike — to find `include Dry.Types()` declarations, which dominated warm-run wall time on large Rails apps (measured at roughly a third of GitLab `app/models` warm time). The scan now rides a cached `producer` with a `watch:` glob covering the same tree: a warm run re-globs and re-digests the watched files (a cheap SHA over file bytes, no AST build) and reuses the cached alias table, recomputing only when a source file under those paths is edited, added, or removed. The empty result for a project that ships no dry-types module is cached too. `--no-cache` recomputes fresh, exactly as before.
+
 ## [0.2.9] - 2026-07-11
 
 v0.2.9 sharpens Rigor on large Rails applications, with GitLab-scale projects as the proving ground: PostgreSQL `db/structure.sql` is accepted as a schema source, the strong-parameters chain stays typed, several route-helper and ActiveSupport coverage gaps close, and module facades now resolve across files. Protection-coverage tooling gets faster with a fork-parallel scan and more actionable — it now names when a missing-RBS gem is the cause of a hole ([ADR-82](docs/adr/82-dynamic-provenance-wiring.md)). Other fixes strengthen control-flow narrowing around `present?` / `blank?` guards and in-body mutation, and make the persistent cache robust across upgrades.

--- a/plugins/rigor-dry-types/lib/rigor/plugin/dry_types.rb
+++ b/plugins/rigor-dry-types/lib/rigor/plugin/dry_types.rb
@@ -63,12 +63,28 @@ module Rigor
         produces: [:dry_type_aliases]
       )
 
-      # Walks every project file once during `prepare(services)` to build the alias table, then publishes
-      # via the ADR-9 fact store. The walk is bounded by the configured `paths:` surface; each file's
-      # parse error degrades to "no contribution" without polluting the user-visible diagnostic stream.
+      # Cached alias-table producer (ADR-60 WD3 record-and-validate). The scan Prism-parses every `.rb` file
+      # under the project's `paths:` tree to find `include Dry.Types()` declarations — an expensive pass that
+      # ran on EVERY invocation (cold and warm) because `#prepare` called {AliasScanner.scan} directly, with
+      # no cache. It now rides `cache_for`: a warm run re-globs + re-digests the watched tree (cheap SHA over
+      # file bytes, no AST build) and reuses the cached table instead of re-parsing. This is the dominant win
+      # even for a project that ships no dry-types module — the parse still has to run to prove that, and now
+      # the empty result is cached too.
+      #
+      # `watch:` covers exactly the files the scan reads: one glob per project `paths:` entry, co-extensive
+      # with {#scannable_paths}. A {Cache::Descriptor::GlobEntry} digests every file matching its glob, so a
+      # content edit, a file addition, and a file removal anywhere under those paths all move the digest and
+      # invalidate the entry. The scan reads no file individually through the `IoBoundary`, so the evaluated
+      # `watch:` globs are the entire dependency descriptor — and they fully cover the scan's input.
+      producer :dry_type_aliases, watch: -> { alias_watch_globs } do |_params|
+        AliasScanner.scan(paths: scannable_paths)
+      end
+
+      # Builds the (cached) alias table and publishes it via the ADR-9 fact store. `producer_value` runs the
+      # producer through `cache_for` and memoises the result — including a rescued nil — for the run.
       def prepare(services)
-        aliases = AliasScanner.scan(paths: scannable_paths(services))
-        return if aliases.empty?
+        aliases = producer_value(:dry_type_aliases)
+        return if aliases.nil? || aliases.empty?
 
         services.fact_store.publish(
           plugin_id: manifest.id,
@@ -86,7 +102,7 @@ module Rigor
       # Resolves the project's `paths:` to a flat list of `.rb` files the scanner walks. Mirrors
       # `Analysis::Runner`'s `expand_paths` floor; we don't need the runner's full exclude/sort surface
       # because the alias table is a union — any duplicate scan is a no-op.
-      def scannable_paths(services)
+      def scannable_paths
         @scannable_paths ||= services.configuration.paths.flat_map do |entry|
           if File.directory?(entry)
             Dir.glob(File.join(entry, "**", "*.rb"), sort: true)
@@ -96,6 +112,22 @@ module Rigor
             []
           end
         end.uniq.freeze
+      end
+
+      # The `watch:` glob tuples covering the scan's entire input — one `[root, pattern]` per project `paths:`
+      # entry. A directory entry watches its whole `**/*.rb` subtree; a single-file `.rb` entry watches
+      # exactly that file (`[dir, basename]`). Roots are expanded to absolute paths by
+      # `Plugin::Base#watch_glob_entries`, so a relative CLI path (`app/models`) re-validates against the same
+      # tree from the project root on the next run. Co-extensive with {#scannable_paths}: every `.rb` the scan
+      # would read is watched, so any edit / addition / removal under those paths invalidates the cache.
+      def alias_watch_globs
+        services.configuration.paths.filter_map do |entry|
+          if File.directory?(entry)
+            [entry, "**/*.rb"]
+          elsif File.file?(entry) && entry.end_with?(".rb")
+            [File.dirname(entry), File.basename(entry)]
+          end
+        end
       end
     end
 

--- a/spec/integration/plugins/dry_types_plugin_spec.rb
+++ b/spec/integration/plugins/dry_types_plugin_spec.rb
@@ -157,6 +157,143 @@ RSpec.describe "rigor-dry-types integration" do
     expect(aliases).to be_nil
   end
 
+  # Regression (ADR-60 WD3 / ADR-45 pundit precedent): the `:dry_type_aliases` producer replaced the old
+  # uncached `#prepare` scan, which Prism-parsed the whole project tree on every invocation. The producer's
+  # `watch:` glob must cover every `.rb` file the alias scan reads, so a change to any file under the
+  # project's `paths:` tree — a content edit OR a file addition — invalidates the cross-process cache. A
+  # stale alias table served across two `rigor check` processes sharing one on-disk cache is the exact
+  # manufactured-stale-result failure the watch machinery exists to prevent.
+  describe "cross-process cache invalidation" do
+    after { Rigor::Plugin.unregister! }
+
+    # A dry-types module whose `Email` composition resolves to `underlying`. Flipping `underlying` between
+    # processes is the single-key mutation the freshness assertion keys on.
+    def types_module(underlying:)
+      <<~RUBY
+        module Types
+          include Dry.Types()
+          Email = #{underlying}.constrained(min_size: 1)
+        end
+      RUBY
+    end
+
+    # Runs the dry-types plugin against `models_dir` (the project `paths:`) using a FRESH `Cache::Store` at
+    # `cache_root` — a fresh store with an empty in-process memo is the faithful stand-in for a second
+    # `rigor check` process reading the same on-disk cache, the only configuration in which a missing watch
+    # entry surfaces as stale output. Returns `[alias_table_or_nil, cache_store]`.
+    def run_dry_types(project_dir:, models_dir:, cache_root:)
+      Rigor::Plugin.unregister!
+      captured_fact_store = nil
+      allow(Rigor::Plugin::Services).to receive(:new).and_wrap_original do |original, **kwargs|
+        services = original.call(**kwargs)
+        captured_fact_store = services.fact_store
+        services
+      end
+
+      cache_store = Rigor::Cache::Store.new(root: cache_root)
+      configuration = Rigor::Configuration.new(
+        Rigor::Configuration::DEFAULTS.merge(
+          "paths" => [models_dir],
+          "plugins" => ["rigor-dry-types"]
+        )
+      )
+      Dir.chdir(project_dir) do
+        Rigor::Analysis::Runner.new(
+          configuration: configuration,
+          cache_store: cache_store,
+          plugin_requirer: lambda do |_name|
+            Rigor::Plugin.register(plugin_class)
+            true
+          end
+        ).run
+      end
+      [captured_fact_store&.read(plugin_id: "dry-types", name: :dry_type_aliases), cache_store]
+    end
+
+    def producer_stats(cache_store)
+      cache_store.stats[:by_producer].fetch(
+        "plugin.dry-types.dry_type_aliases", { hits: 0, misses: 0, writes: 0 }
+      )
+    end
+
+    # Lays out `<project>/models/` (the analyzed `paths:`) + a sibling `sig/` so `Dry.Types()` resolves, then
+    # yields the project / models / cache roots. Mirrors the pundit cross-process fixture layout.
+    def with_project
+      Dir.mktmpdir do |project_dir|
+        Dir.mktmpdir do |cache_root|
+          models_dir = File.join(project_dir, "models")
+          FileUtils.mkdir_p(models_dir)
+          FileUtils.mkdir_p(File.join(project_dir, "sig"))
+          File.write(File.join(project_dir, "sig", "dry_types.rbs"), dry_types_rbs)
+          yield(project_dir, models_dir, cache_root)
+        end
+      end
+    end
+
+    it "recomputes the alias table when a watched source file's content changes between processes" do
+      with_project do |project_dir, models_dir, cache_root|
+        types_path = File.join(models_dir, "types.rb")
+
+        # Process 1: Email resolves to String. This warms the on-disk cache.
+        File.write(types_path, types_module(underlying: "String"))
+        first, first_store = run_dry_types(project_dir: project_dir, models_dir: models_dir, cache_root: cache_root)
+        expect(first.fetch("Types::Email")).to eq("String")
+        expect(producer_stats(first_store)[:writes]).to be >= 1
+
+        # Change Email's underlying class. The watched glob's digest moves, so a fresh process must recompute
+        # and publish the NEW table rather than serving last session's "String".
+        File.write(types_path, types_module(underlying: "Integer"))
+        second, second_store = run_dry_types(project_dir: project_dir, models_dir: models_dir, cache_root: cache_root)
+        expect(second.fetch("Types::Email")).to eq("Integer")
+        expect(producer_stats(second_store)[:misses]).to be >= 1
+        expect(producer_stats(second_store)[:hits]).to eq(0)
+      end
+    end
+
+    it "recomputes when a new dry-types source file is ADDED under the watched tree" do
+      with_project do |project_dir, models_dir, cache_root|
+        # This is the case an IoBoundary read-history descriptor alone would miss: the added file was never
+        # read by the prior process, so only the `watch:` glob (which re-globs the whole tree) catches it.
+        File.write(File.join(models_dir, "types.rb"), <<~RUBY)
+          module Types
+            include Dry.Types()
+          end
+        RUBY
+        first, = run_dry_types(project_dir: project_dir, models_dir: models_dir, cache_root: cache_root)
+        expect(first).not_to have_key("Types::Email")
+
+        # A brand-new file the first process never read. Its composition must appear after invalidation.
+        File.write(File.join(models_dir, "more_types.rb"), <<~RUBY)
+          module Types
+            include Dry.Types()
+            Email = String.constrained(min_size: 1)
+          end
+        RUBY
+        second, second_store = run_dry_types(project_dir: project_dir, models_dir: models_dir, cache_root: cache_root)
+        expect(second.fetch("Types::Email")).to eq("String")
+        expect(producer_stats(second_store)[:misses]).to be >= 1
+        expect(producer_stats(second_store)[:hits]).to eq(0)
+      end
+    end
+
+    it "serves the alias table from cache on an unchanged second process (no re-scan)" do
+      with_project do |project_dir, models_dir, cache_root|
+        File.write(File.join(models_dir, "types.rb"), types_module(underlying: "String"))
+
+        _first, first_store = run_dry_types(project_dir: project_dir, models_dir: models_dir, cache_root: cache_root)
+        expect(producer_stats(first_store)[:misses]).to be >= 1
+        expect(producer_stats(first_store)[:writes]).to be >= 1
+
+        # Nothing changed: the second process must validate the watch digest and serve the cached table — a
+        # HIT, never a recompute — while still returning the correct value.
+        second, second_store = run_dry_types(project_dir: project_dir, models_dir: models_dir, cache_root: cache_root)
+        expect(producer_stats(second_store)[:hits]).to be >= 1
+        expect(producer_stats(second_store)[:misses]).to eq(0)
+        expect(second.fetch("Types::Email")).to eq("String")
+      end
+    end
+  end
+
   # Runs the plugin against a single-file project and returns the `:dry_type_aliases` fact value (or `nil` if
   # the plugin didn't publish it). Captures the per-run `Plugin::Services` instance via `wrap_original` so we
   # can read the fact store after `prepare(services)` ran — same pattern as the rigor-rails-routes integration spec.


### PR DESCRIPTION
## Summary

`rigor-dry-types` built its `:dry_type_aliases` fact by calling `AliasScanner.scan` **directly** in `#prepare`, with no cache. That scan Prism-parses every `.rb` file under the project's `paths:` on **every** invocation — cold and warm alike — to find `include Dry.Types()` declarations. On GitLab `app/models` that pass dominated warm-run wall time (profiled at ~37% of it): a full re-parse to re-derive a table the previous run already computed. It runs even for a project that ships no dry-types module, because the parse is what proves the absence.

This moves the scan onto the ADR-60 WD3 record-and-validate cache (the same idiom `rigor-activerecord` / `rigor-rails-routes` / `rigor-rails-i18n` already use):

```ruby
producer :dry_type_aliases, watch: -> { alias_watch_globs } do |_params|
  AliasScanner.scan(paths: scannable_paths)
end

def prepare(services)
  aliases = producer_value(:dry_type_aliases)
  return if aliases.nil? || aliases.empty?
  services.fact_store.publish(plugin_id: manifest.id, name: :dry_type_aliases, value: aliases)
end
```

A warm run re-globs and re-digests the watched tree (a cheap SHA over file bytes, no AST build) and reuses the cached alias table; it recomputes only when a source file under those paths is edited, added, or removed. The empty result for a no-dry-types project is cached too. `--no-cache` bypasses the store and recomputes fresh, unchanged.

The cached value is the plain `Hash{String => String}` alias map — already Marshal-clean (verified on disk at **553 B** for the GitLab entry). No Prism nodes cross the cache boundary.

## Watch-set coverage argument (correctness)

The one failure mode this repo will not accept is a manufactured stale result from an under-watched cache. The `watch:` globs are **co-extensive with the scan's input**:

- `scannable_paths` resolves each project `paths:` entry to `.rb` files — a directory is globbed `**/*.rb`, a single `.rb` file is taken verbatim.
- `alias_watch_globs` emits one `[root, pattern]` per entry over the **same** set — a directory watches its whole `**/*.rb` subtree, a single-file entry watches `[dir, basename]`.

A `Cache::Descriptor::GlobEntry` digests every file matching its glob, so a content edit, a file addition, **and** a file removal anywhere under those paths all move the digest and invalidate the entry (`Descriptor#fresh?` re-globs + re-digests). The scan reads no file individually through the `IoBoundary`, so the evaluated `watch:` globs are the entire dependency descriptor — and they fully cover the scan's input. Roots are `File.expand_path`ed by `Plugin::Base#watch_glob_entries`, so a relative CLI path re-validates against the same tree from the project root on the next run.

### Cross-process regression spec (mandatory, ADR-45 pundit precedent)

`spec/integration/plugins/dry_types_plugin_spec.rb` gains a `cross-process cache invalidation` block — a fresh `Cache::Store` per "process" over one shared on-disk cache root, the faithful simulation of two `rigor check` runs:

1. **content edit** — process 1 caches `Types::Email => "String"`; the file is rewritten to `Email = Integer...`; process 2 must publish `"Integer"` (not the stale `"String"`), with `misses >= 1` / `hits == 0`.
2. **file addition** — the case an `IoBoundary` read-history descriptor alone would miss: a brand-new dry-types file the prior process never read must surface its composition after invalidation. Only the re-globbing `watch:` catches it.
3. **unchanged run serves from cache** — a no-change second process records `hits >= 1` / `misses == 0` (asserted via `Cache::Store#stats[:by_producer]`, the instrumentable seam) and still returns the correct table.

## GitLab corpus gate — byte-identical + warm payoff

Measured on my assigned corpus (`rigor-survey/gitlab`, `app/models`) via the stash-swap recipe (before = `HEAD~1` = `origin/master`, after = `HEAD`; `trap`-restored):

**Correctness** (`--no-cache --no-baseline --format json`): **210 diagnostics both sides, byte-identical** (`diff` of the sorted `.diagnostics` arrays is empty). Expected, since `--no-cache` recomputes via the same `AliasScanner.scan`; the change only moves *where* the scan is called and whether its result is cached.

**Warm payoff** (real wall, default workers, 3 stable back-to-back warm runs each):

| side | warm runs | median |
| --- | --- | --- |
| before (uncached scan) | 6.422s, 6.284s, 6.272s | **6.28s** |
| after (cached scan) | 3.805s, 3.758s, 3.860s | **3.81s** |

**~40% / ~2.5s** reduction. The real wall carries a ~0.7s nix+bundler+VM boot floor (measured separately), so the analysis portion is ~5.6s → ~3.1s — matching the ~5.5s baseline and landing under the ≲3.7s target.

**Mechanism proof** (`--cache-stats`, after side, warm):

```
plugin.dry-types.dry_type_aliases: 1 entries, 553 B
plugin.dry-types.dry_type_aliases: 1 hit, 0 misses, 0 writes
```

The producer serves the alias table from cache on the warm run — the scan does not re-run.

## Audit: rigor-rails-routes / rigor-rails-i18n (no conversion applies)

The task flagged these for the same "uncached prepare" shape. **They are already on the
`cache_for` + `watch:` record-and-validate idiom** — nothing to convert:

- `plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes.rb:94` declares `producer :helper_table, watch: -> { ... "**/*.rb" }`; `#prepare` (`:156`) reads it via `helper_table_or_nil` → `cache_for(:helper_table).call` (`:214`).
- `plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n.rb:74` declares `producer :locale_index, watch: -> { ... "**/*.yml", "**/*.yaml" }` (plus `:view_diagnostics` at `:90`), consumed via `producer_value(:locale_index)`.

Their residual warm cost is the record-and-validate **freshness validation** (re-globbing + re-digesting the watched tree — e.g. rails-routes' default `helper_paths: ["app"]` digests the whole `app/` subtree each warm run), which is the sound, inherent cost of the design, not an uncached scan. Reducing that validation surface is a distinct optimization (tighter watch scope / cheaper comparators) and out of scope for this slice, which converts the one plugin (`rigor-dry-types`) that genuinely bypassed the cache.

## Gates

- `make verify` — green (7565 examples + 8 pool-runner; rubocop 858 files no offenses; `check` lib + `check-plugins` both clean).
- Cross-process regression spec — green (the 3 tests above; full dry-types spec 13/13).
- GitLab corpus — 210 diagnostics byte-identical before/after; warm 6.28s → 3.81s.
- `make bench-perf` — green (`lib wall_s 8.4 ≤ 25`, `lib allocations 29,330,333 ≤ 30,796,902`; essentially unchanged vs baseline — the change is orthogonal to `lib` self-analysis).
