### PR TITLE
Allocation-free AST child iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Changed
+
+- **[engine]** AST tree walks no longer allocate a throwaway array per node visited, cutting total allocations on every `rigor check` run — most sharply on leaf-heavy sources.
+  - `Prism::Node#compact_child_nodes` builds a fresh `Array` on every call, and Rigor's walkers called it unconditionally on every node of every walk. On a Ragel-generated parser (mail's `lib`, with hundreds of thousands of integer-literal leaf nodes) those arrays were over half of all allocations. A new `Rigor::Source::NodeChildren.each_child` yields the same children in the same order without the array — reading each child field directly and reusing list fields' stored arrays — and the engine's tree walkers (the shared node walker, the plugin/check-rule walk, the scope-discovery seed pass, the collectors, and the sig-gen / dependency / mutation scanners) now use it. Diagnostics are byte-identical; the field map is derived from `Prism::Reflection` so it tracks the installed `prism`.
+
 ## [0.2.9] - 2026-07-11
 
 v0.2.9 sharpens Rigor on large Rails applications, with GitLab-scale projects as the proving ground: PostgreSQL `db/structure.sql` is accepted as a schema source, the strong-parameters chain stays typed, several route-helper and ActiveSupport coverage gaps close, and module facades now resolve across files. Protection-coverage tooling gets faster with a fork-parallel scan and more actionable — it now names when a missing-RBS gem is the cause of a hole ([ADR-82](docs/adr/82-dynamic-provenance-wiring.md)). Other fixes strengthen control-flow narrowing around `present?` / `blank?` guards and in-body mutation, and make the persistent cache robust across upgrades.

--- a/lib/rigor/analysis/check_rules/always_truthy_condition_collector.rb
+++ b/lib/rigor/analysis/check_rules/always_truthy_condition_collector.rb
@@ -2,6 +2,8 @@
 
 require "prism"
 
+require_relative "../../source/node_children"
+
 module Rigor
   module Analysis
     module CheckRules
@@ -81,7 +83,7 @@ module Rigor
           visit(node) if conditional_node?(node) && !in_loop_or_block
 
           child_in_loop_or_block = in_loop_or_block || enters_loop_or_block?(node)
-          node.compact_child_nodes.each { |child| walk(child, in_loop_or_block: child_in_loop_or_block) }
+          Source::NodeChildren.each_child(node) { |child| walk(child, in_loop_or_block: child_in_loop_or_block) }
         end
 
         def conditional_node?(node)

--- a/lib/rigor/analysis/check_rules/dead_assignment_collector.rb
+++ b/lib/rigor/analysis/check_rules/dead_assignment_collector.rb
@@ -2,6 +2,8 @@
 
 require "prism"
 
+require_relative "../../source/node_children"
+
 module Rigor
   module Analysis
     module CheckRules
@@ -65,7 +67,7 @@ module Rigor
           return unless node.is_a?(Prism::Node)
 
           collect_def_assignments(node) if node.is_a?(Prism::DefNode)
-          node.compact_child_nodes.each { |child| walk_for_def_nodes(child) }
+          Source::NodeChildren.each_child(node) { |child| walk_for_def_nodes(child) }
         end
 
         def collect_def_assignments(def_node)
@@ -92,7 +94,7 @@ module Rigor
           # / similar shapes don't trip the rule.
           accumulator << node.name if reading_assignment?(node)
 
-          node.compact_child_nodes.each { |child| gather_read_names(child, accumulator) }
+          Source::NodeChildren.each_child(node) { |child| gather_read_names(child, accumulator) }
           accumulator
         end
 
@@ -110,7 +112,7 @@ module Rigor
           # outer walker visits them separately.
           return accumulator if node.is_a?(Prism::DefNode) && !accumulator.last.equal?(node)
 
-          node.compact_child_nodes.each { |child| gather_write_nodes(child, accumulator) }
+          Source::NodeChildren.each_child(node) { |child| gather_write_nodes(child, accumulator) }
           accumulator
         end
 

--- a/lib/rigor/analysis/check_rules/ivar_write_collector.rb
+++ b/lib/rigor/analysis/check_rules/ivar_write_collector.rb
@@ -3,6 +3,7 @@
 require "prism"
 
 require_relative "../../source/constant_path"
+require_relative "../../source/node_children"
 
 module Rigor
   module Analysis
@@ -78,7 +79,7 @@ module Rigor
             return
           end
 
-          node.compact_child_nodes.each { |child| walk(child, qualified_prefix) }
+          Source::NodeChildren.each_child(node) { |child| walk(child, qualified_prefix) }
         end
 
         def collect_def_writes(def_node, qualified_prefix)
@@ -95,7 +96,7 @@ module Rigor
           record_write(node, class_name) if node.is_a?(Prism::InstanceVariableWriteNode)
           return if BARRIER_NODES.any? { |klass| node.is_a?(klass) }
 
-          node.compact_child_nodes.each { |child| gather_writes(child, class_name) }
+          Source::NodeChildren.each_child(node) { |child| gather_writes(child, class_name) }
         end
 
         def record_write(node, class_name)

--- a/lib/rigor/analysis/check_rules/rule_walk.rb
+++ b/lib/rigor/analysis/check_rules/rule_walk.rb
@@ -3,6 +3,7 @@
 require "prism"
 
 require_relative "../../source/constant_path"
+require_relative "../../source/node_children"
 
 module Rigor
   module Analysis
@@ -145,7 +146,7 @@ module Rigor
 
             dispatch(node, hooks, context)
             child_context = descend(node, context)
-            node.compact_child_nodes.each { |child| walk(child, hooks, child_context) }
+            Source::NodeChildren.each_child(node) { |child| walk(child, hooks, child_context) }
           end
 
           def dispatch(node, hooks, context)

--- a/lib/rigor/analysis/check_rules/self_closedness_scanner.rb
+++ b/lib/rigor/analysis/check_rules/self_closedness_scanner.rb
@@ -3,6 +3,7 @@
 require "prism"
 
 require_relative "../../source/constant_path"
+require_relative "../../source/node_children"
 
 module Rigor
   module Analysis
@@ -52,7 +53,7 @@ module Rigor
             names << child_prefix.join("::") if name && class_surface_open?(node)
             walk(node.body, child_prefix, names) if node.body
           else
-            node.compact_child_nodes.each { |child| walk(child, prefix, names) }
+            Source::NodeChildren.each_child(node) { |child| walk(child, prefix, names) }
           end
         end
 

--- a/lib/rigor/analysis/check_rules/unreachable_clause_collector.rb
+++ b/lib/rigor/analysis/check_rules/unreachable_clause_collector.rb
@@ -2,6 +2,8 @@
 
 require "prism"
 
+require_relative "../../source/node_children"
+
 module Rigor
   module Analysis
     module CheckRules
@@ -85,7 +87,7 @@ module Rigor
           visit(node) if case_like?(node) && !in_loop_or_block
 
           child_in_loop_or_block = in_loop_or_block || enters_loop_or_block?(node)
-          node.compact_child_nodes.each { |child| walk(child, in_loop_or_block: child_in_loop_or_block) }
+          Source::NodeChildren.each_child(node) { |child| walk(child, in_loop_or_block: child_in_loop_or_block) }
         end
 
         # `case/when` is a `CaseNode`; `case/in` is a `CaseMatchNode`. Both carry `predicate` + `conditions`

--- a/lib/rigor/analysis/dependency_source_inference/walker.rb
+++ b/lib/rigor/analysis/dependency_source_inference/walker.rb
@@ -4,6 +4,7 @@ require "prism"
 
 require_relative "return_type_heuristic"
 require_relative "../../source/constant_path"
+require_relative "../../source/node_children"
 
 module Rigor
   module Analysis
@@ -125,7 +126,7 @@ module Rigor
         end
 
         def walk_children(node, qualified_prefix, in_singleton_class, accumulator, budget)
-          node.compact_child_nodes.each do |child|
+          Source::NodeChildren.each_child(node) do |child|
             break if accumulator.size >= budget
 
             walk_node(child, qualified_prefix, in_singleton_class, accumulator, budget)

--- a/lib/rigor/cli/annotate_command.rb
+++ b/lib/rigor/cli/annotate_command.rb
@@ -9,6 +9,7 @@ require_relative "../configuration"
 require_relative "options"
 require_relative "../environment"
 require_relative "../scope"
+require_relative "../source/node_children"
 require_relative "../inference/def_return_typer"
 require_relative "../inference/scope_indexer"
 require_relative "../inference/statement_evaluator"
@@ -247,7 +248,7 @@ module Rigor
             block.call(stmt)
           end
         else
-          node.compact_child_nodes.each { |child| each_statement(child, &block) }
+          Source::NodeChildren.each_child(node) { |child| each_statement(child, &block) }
         end
       end
 
@@ -298,7 +299,7 @@ module Rigor
         return if node.nil?
 
         block.call(node)
-        node.compact_child_nodes.each { |child| walk(child, &block) }
+        Source::NodeChildren.each_child(node) { |child| walk(child, &block) }
       end
 
       # Types the node through the flow evaluator (not the bare expression typer) under its recorded entry scope, so
@@ -331,7 +332,7 @@ module Rigor
         return if node.nil?
 
         block.call(node) if node.is_a?(Prism::DefNode)
-        node.compact_child_nodes.each { |child| each_def_node(child, &block) }
+        Source::NodeChildren.each_child(node) { |child| each_def_node(child, &block) }
       end
     end
   end

--- a/lib/rigor/inference/def_return_typer.rb
+++ b/lib/rigor/inference/def_return_typer.rb
@@ -3,6 +3,7 @@
 require "prism"
 
 require_relative "../type"
+require_relative "../source/node_children"
 
 module Rigor
   module Inference
@@ -62,7 +63,7 @@ module Rigor
         return if RETURN_BARRIER_NODES.any? { |klass| node.is_a?(klass) }
 
         type_return_node(node, scope_index, out) if node.is_a?(Prism::ReturnNode)
-        node.compact_child_nodes.each { |c| collect_return_types(c, scope_index, out) }
+        Source::NodeChildren.each_child(node) { |c| collect_return_types(c, scope_index, out) }
       end
 
       def type_return_node(return_node, scope_index, out)

--- a/lib/rigor/inference/expression_typer.rb
+++ b/lib/rigor/inference/expression_typer.rb
@@ -5,6 +5,7 @@ require "prism"
 require_relative "../type"
 require_relative "../ast"
 require_relative "../source/constant_path"
+require_relative "../source/node_children"
 require_relative "../analysis/self_call_resolution_recorder"
 require_relative "block_parameter_binder"
 require_relative "body_fixpoint"
@@ -1962,7 +1963,14 @@ module Rigor
         return false if RETURN_BARRIER_NODES.any? { |klass| node.is_a?(klass) }
         return true if node.is_a?(Prism::ReturnNode)
 
-        node.compact_child_nodes.any? { |child| body_has_explicit_return?(child) }
+        found = false
+        Source::NodeChildren.each_child(node) do |child|
+          next unless body_has_explicit_return?(child)
+
+          found = true
+          break
+        end
+        found
       end
 
       # Returns the current assumed summary for `plain_signature`, recording that it was consulted (so the

--- a/lib/rigor/inference/mutation_widening.rb
+++ b/lib/rigor/inference/mutation_widening.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../type"
+require_relative "../source/node_children"
 
 module Rigor
   module Inference
@@ -160,7 +161,7 @@ module Rigor
         # scope's locals) trigger widening, so descending into nested blocks is safe and
         # necessary for the hkt_registry-shape case (an outer collection mutated inside an
         # iterator block whose body is itself inside another block).
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           scope = walk_for_outer_mutations(child, scope)
         end
         scope

--- a/lib/rigor/inference/project_patched_scanner.rb
+++ b/lib/rigor/inference/project_patched_scanner.rb
@@ -5,6 +5,7 @@ require "prism"
 require_relative "project_patched_methods"
 require_relative "../analysis/dependency_source_inference/return_type_heuristic"
 require_relative "../source/constant_path"
+require_relative "../source/node_children"
 
 module Rigor
   module Inference
@@ -141,7 +142,7 @@ module Rigor
       private_class_method :walk_node
 
       def walk_children(node, qualified_prefix, in_singleton_class, source_path, entries)
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           walk_node(child, qualified_prefix, in_singleton_class, source_path, entries)
         end
       end

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -5,6 +5,7 @@ require "prism"
 require_relative "../scope"
 require_relative "../type"
 require_relative "../source/constant_path"
+require_relative "../source/node_children"
 require_relative "mutation_widening"
 require_relative "narrowing"
 require_relative "statement_evaluator"
@@ -310,7 +311,7 @@ module Rigor
         end
       end
 
-      def walk_class_ivars(node, qualified_prefix, default_scope, accumulator, mutated_ivars, # rubocop:disable Metrics/CyclomaticComplexity,Metrics/ParameterLists
+      def walk_class_ivars(node, qualified_prefix, default_scope, accumulator, mutated_ivars, # rubocop:disable Metrics/ParameterLists
                            read_before_write = nil, init_writes = nil, method_assign_effects = nil)
         return unless node.is_a?(Prism::Node)
 
@@ -346,7 +347,7 @@ module Rigor
           end
         end
 
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           walk_class_ivars(child, qualified_prefix, default_scope, accumulator,
                            mutated_ivars, read_before_write, init_writes, method_assign_effects)
         end
@@ -511,7 +512,7 @@ module Rigor
           (init_writes[class_name] ||= Set.new) << node.name
         end
 
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           collect_class_body_ivar_writes(child, class_name, init_writes)
         end
       end
@@ -523,9 +524,9 @@ module Rigor
         read_first << node.name if node.is_a?(Prism::InstanceVariableReadNode) && !seen_writes.include?(node.name)
 
         # Descend BEFORE recording a write — `@x = @x + 1`'s RHS is an `InstanceVariableReadNode` that runs before the
-        # write is committed; the read is therefore read-before-write semantically. Prism's `compact_child_nodes`
-        # returns the value child before the lvalue target, matching this order.
-        node.compact_child_nodes.each do |c|
+        # write is committed; the read is therefore read-before-write semantically. `each_child` yields the value
+        # child before the lvalue target (`compact_child_nodes` field order), matching this order.
+        Source::NodeChildren.each_child(node) do |c|
           detect_read_before_write(c, seen_writes, read_first)
         end
 
@@ -568,7 +569,7 @@ module Rigor
           return
         end
 
-        node.compact_child_nodes.each do |c|
+        Source::NodeChildren.each_child(node) do |c|
           gather_ivar_writes(c, scope, class_name, accumulator, guarded_ivars, mutated_ivars, dead_writes)
         end
       end
@@ -742,7 +743,7 @@ module Rigor
           return acc
         end
 
-        root.compact_child_nodes.each { |c| collect_class_method_defs(c, prefix, acc) }
+        Source::NodeChildren.each_child(root) { |c| collect_class_method_defs(c, prefix, acc) }
         acc
       end
 
@@ -773,7 +774,7 @@ module Rigor
         return acc unless node.is_a?(Prism::Node)
 
         acc << node.name if node.is_a?(Prism::InstanceVariableWriteNode) && !nil_literal_value?(node.value)
-        node.compact_child_nodes.each { |c| ivar_write_targets(c, acc) }
+        Source::NodeChildren.each_child(node) { |c| ivar_write_targets(c, acc) }
         acc
       end
 
@@ -1106,7 +1107,7 @@ module Rigor
           return
         end
 
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           walk_class_cvars(child, qualified_prefix, default_scope, accumulator)
         end
       end
@@ -1125,7 +1126,7 @@ module Rigor
         record_cvar_write(node, scope, class_name, accumulator) if node.is_a?(Prism::ClassVariableWriteNode)
         return if IVAR_BARRIER_NODES.any? { |klass| node.is_a?(klass) }
 
-        node.compact_child_nodes.each { |c| gather_cvar_writes(c, scope, class_name, accumulator) }
+        Source::NodeChildren.each_child(node) { |c| gather_cvar_writes(c, scope, class_name, accumulator) }
       end
 
       def record_cvar_write(node, scope, class_name, accumulator)
@@ -1149,7 +1150,7 @@ module Rigor
         return unless node.is_a?(Prism::Node)
 
         record_global_write(node, scope, accumulator) if node.is_a?(Prism::GlobalVariableWriteNode)
-        node.compact_child_nodes.each { |c| gather_global_writes(c, scope, accumulator) }
+        Source::NodeChildren.each_child(node) { |c| gather_global_writes(c, scope, accumulator) }
       end
 
       def record_global_write(node, scope, accumulator)
@@ -1189,7 +1190,7 @@ module Rigor
           return
         end
 
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           walk_constant_writes(child, qualified_prefix, default_scope, accumulator)
         end
       end
@@ -1249,7 +1250,7 @@ module Rigor
         end
       end
 
-      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize
       # Combined `walk_methods` + `walk_def_nodes` descent. The two walks had identical class / module / singleton-class
       # / meta-block traversals and both stopped at `DefNode`; the only divergences are leaf actions (recorded into the
       # right accumulator) and the original `walk_methods` returning at `AliasMethodNode` (its symbol-only children
@@ -1295,7 +1296,7 @@ module Rigor
           end
         end
 
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           walk_methods_and_def_nodes(child, qualified_prefix, in_singleton_class, methods_acc, def_nodes_acc)
         end
       end
@@ -1323,7 +1324,7 @@ module Rigor
           end
         end
       end
-      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize
 
       # v0.1.2 — when a `Const = Data.define(*sym) do ... end` / `Const = Struct.new(*sym) do ... end` constant write
       # carries a block, the block body holds method overrides whose canonical class is `Const`. Survey item (e)
@@ -1474,7 +1475,7 @@ module Rigor
           return
         end
 
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           walk_singleton_def_nodes(child, qualified_prefix, in_singleton_class, accumulator)
         end
       end
@@ -1586,7 +1587,7 @@ module Rigor
           end
         end
 
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           walk_class_superclasses(child, qualified_prefix, accumulator)
         end
       end
@@ -1623,7 +1624,7 @@ module Rigor
           record_data_member_layout(accumulator, qualified_prefix + [node.name.to_s], node.value)
         end
 
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           walk_data_member_layouts(child, qualified_prefix, accumulator)
         end
       end
@@ -1670,7 +1671,7 @@ module Rigor
           record_struct_member_layout(accumulator, qualified_prefix + [node.name.to_s], node.value)
         end
 
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           walk_struct_member_layouts(child, qualified_prefix, accumulator)
         end
       end
@@ -1731,7 +1732,7 @@ module Rigor
           record_mixin_call(node, current_class, accumulator)
         end
 
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           walk_class_includes(child, qualified_prefix, current_class, accumulator)
         end
       end
@@ -1772,7 +1773,7 @@ module Rigor
         accumulator.transform_values(&:freeze).freeze
       end
 
-      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/AbcSize
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize
       def walk_method_visibilities(node, qualified_prefix, in_singleton_class, current_visibility, accumulator)
         return current_visibility unless node.is_a?(Prism::Node)
 
@@ -1810,18 +1811,18 @@ module Rigor
         # entry visibility unchanged.
         if node.is_a?(Prism::StatementsNode)
           local_visibility = current_visibility
-          node.compact_child_nodes.each do |child|
+          Source::NodeChildren.each_child(node) do |child|
             local_visibility = walk_method_visibilities(child, qualified_prefix, in_singleton_class,
                                                         local_visibility, accumulator)
           end
         else
-          node.compact_child_nodes.each do |child|
+          Source::NodeChildren.each_child(node) do |child|
             walk_method_visibilities(child, qualified_prefix, in_singleton_class, current_visibility, accumulator)
           end
         end
         current_visibility
       end
-      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/AbcSize
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize
 
       def record_def_visibility(def_node, qualified_prefix, in_singleton_class, current_visibility, accumulator)
         return if def_node.receiver.is_a?(Prism::SelfNode) || in_singleton_class
@@ -1922,7 +1923,7 @@ module Rigor
           return accumulator
         end
 
-        node.compact_child_nodes.each { |child| collect_class_alias_map(child, qualified_prefix, accumulator) }
+        Source::NodeChildren.each_child(node) { |child| collect_class_alias_map(child, qualified_prefix, accumulator) }
         accumulator
       end
 
@@ -2152,7 +2153,7 @@ module Rigor
           record_class_new_constant_decl(node, qualified_prefix, accumulator)
         end
 
-        node.compact_child_nodes.each { |child| collect_class_decls(child, qualified_prefix, accumulator) }
+        Source::NodeChildren.each_child(node) { |child| collect_class_decls(child, qualified_prefix, accumulator) }
       end
 
       # T1 (template-corpora survey) — record a `Const = Class.new(Super)` (and the bare `Class.new` / `Module.new`)
@@ -2219,7 +2220,7 @@ module Rigor
           return if record_meta_new_constant?(node, qualified_prefix, identity_table, discovered)
         end
 
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           record_declarations(child, qualified_prefix, identity_table, discovered)
         end
       end
@@ -2345,7 +2346,7 @@ module Rigor
         when Prism::UnlessNode
           propagate_unless_branches(node, table, current_scope)
         else
-          node.compact_child_nodes.each { |child| propagate(child, table, current_scope) }
+          Source::NodeChildren.each_child(node) { |child| propagate(child, table, current_scope) }
         end
       end
 

--- a/lib/rigor/inference/statement_evaluator.rb
+++ b/lib/rigor/inference/statement_evaluator.rb
@@ -6,6 +6,7 @@ require_relative "../reflection"
 require_relative "../type"
 require_relative "../analysis/fact_store"
 require_relative "../source/node_walker"
+require_relative "../source/node_children"
 require_relative "../source/constant_path"
 require_relative "block_parameter_binder"
 require_relative "body_fixpoint"
@@ -748,7 +749,14 @@ module Rigor
                         node.is_a?(Prism::ModuleNode) ||
                         node.is_a?(Prism::BlockNode)
 
-        node.compact_child_nodes.any? { |c| arm_contains_retry?(c) }
+        found = false
+        Source::NodeChildren.each_child(node) do |c|
+          next unless arm_contains_retry?(c)
+
+          found = true
+          break
+        end
+        found
       end
 
       def absorb_retry_rebinds(accumulator, entry_scope, arm_post_scope)
@@ -936,7 +944,7 @@ module Rigor
         return if node.nil?
 
         found[node] = true if node.is_a?(Prism::BreakNode)
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           next if BREAK_BOUNDARY_NODES.any? { |klass| child.is_a?(klass) }
 
           collect_direct_breaks(child, found)
@@ -1910,7 +1918,7 @@ module Rigor
         return if node.nil?
 
         yield node
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           next if child.is_a?(Prism::BlockNode) || child.is_a?(Prism::DefNode) || child.is_a?(Prism::LambdaNode)
 
           each_node_outside_nested_scopes(child, &)

--- a/lib/rigor/inference/struct_fold_safety.rb
+++ b/lib/rigor/inference/struct_fold_safety.rb
@@ -3,6 +3,7 @@
 require "prism"
 
 require_relative "../source/constant_path"
+require_relative "../source/node_children"
 
 module Rigor
   module Inference
@@ -156,7 +157,7 @@ module Rigor
       # Yields each child to recurse into, skipping the subtree of a nested local-variable-scope boundary (a `def` /
       # `class` / `module`).
       def each_local_scope_child(node)
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           next if scope_boundary?(child)
 
           yield child

--- a/lib/rigor/inference/synthetic_method_scanner.rb
+++ b/lib/rigor/inference/synthetic_method_scanner.rb
@@ -5,6 +5,7 @@ require "prism"
 require_relative "../plugin/macro/heredoc_template"
 require_relative "../plugin/macro/trait_registry"
 require_relative "../source/literals"
+require_relative "../source/node_children"
 require_relative "synthetic_method"
 require_relative "synthetic_method_index"
 
@@ -166,12 +167,12 @@ module Rigor
           name = class_name_from(node, scope_stack)
           yield name, node if name
           new_stack = scope_stack + [node]
-          node.body&.compact_child_nodes&.each { |child| walk_classes(child, new_stack, &) }
+          Source::NodeChildren.each_child(node.body) { |child| walk_classes(child, new_stack, &) }
         when Prism::ModuleNode
           new_stack = scope_stack + [node]
-          node.body&.compact_child_nodes&.each { |child| walk_classes(child, new_stack, &) }
+          Source::NodeChildren.each_child(node.body) { |child| walk_classes(child, new_stack, &) }
         else
-          node.compact_child_nodes.each { |child| walk_classes(child, scope_stack, &) }
+          Source::NodeChildren.each_child(node) { |child| walk_classes(child, scope_stack, &) }
         end
       end
 
@@ -303,12 +304,12 @@ module Rigor
           name = class_name_from(node, scope_stack)
           yield name, node.body
           new_stack = scope_stack + [node]
-          node.body&.compact_child_nodes&.each { |child| walk_module_decls(child, new_stack, &) }
+          Source::NodeChildren.each_child(node.body) { |child| walk_module_decls(child, new_stack, &) }
         when Prism::ClassNode
           new_stack = scope_stack + [node]
-          node.body&.compact_child_nodes&.each { |child| walk_module_decls(child, new_stack, &) }
+          Source::NodeChildren.each_child(node.body) { |child| walk_module_decls(child, new_stack, &) }
         else
-          node.compact_child_nodes.each { |child| walk_module_decls(child, scope_stack, &) }
+          Source::NodeChildren.each_child(node) { |child| walk_module_decls(child, scope_stack, &) }
         end
       end
 
@@ -372,7 +373,7 @@ module Rigor
         hierarchy.freeze
       end
 
-      def walk_class_decls(node, scope_stack, &) # rubocop:disable Metrics/PerceivedComplexity
+      def walk_class_decls(node, scope_stack, &)
         return unless node.respond_to?(:compact_child_nodes)
 
         if node.is_a?(Prism::ClassNode)
@@ -380,19 +381,19 @@ module Rigor
           parent = parent_name_from(node, scope_stack)
           yield name, parent if name
           new_stack = scope_stack + [node]
-          node.body&.compact_child_nodes&.each { |child| walk_class_decls(child, new_stack, &) }
+          Source::NodeChildren.each_child(node.body) { |child| walk_class_decls(child, new_stack, &) }
         elsif node.is_a?(Prism::ModuleNode)
           new_stack = scope_stack + [node]
-          node.body&.compact_child_nodes&.each { |child| walk_class_decls(child, new_stack, &) }
+          Source::NodeChildren.each_child(node.body) { |child| walk_class_decls(child, new_stack, &) }
         else
-          node.compact_child_nodes.each { |child| walk_class_decls(child, scope_stack, &) }
+          Source::NodeChildren.each_child(node) { |child| walk_class_decls(child, scope_stack, &) }
         end
       end
 
       # Yields `(class_name, call_node)` for every Prism::CallNode at class-body top level (singleton-context calls).
       # Nested method bodies, blocks, and conditionals are skipped — the Tier C call shapes the substrate targets all
       # live at the class body's top level.
-      def walk_class_bodies(node, scope_stack = [], &) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+      def walk_class_bodies(node, scope_stack = [], &)
         return unless node.respond_to?(:compact_child_nodes)
 
         if node.is_a?(Prism::ClassNode)
@@ -403,12 +404,12 @@ module Rigor
               yield name, stmt if stmt.is_a?(Prism::CallNode) && stmt.receiver.nil?
             end
           end
-          node.body&.compact_child_nodes&.each { |child| walk_class_bodies(child, new_stack, &) }
+          Source::NodeChildren.each_child(node.body) { |child| walk_class_bodies(child, new_stack, &) }
         elsif node.is_a?(Prism::ModuleNode)
           new_stack = scope_stack + [node]
-          node.body&.compact_child_nodes&.each { |child| walk_class_bodies(child, new_stack, &) }
+          Source::NodeChildren.each_child(node.body) { |child| walk_class_bodies(child, new_stack, &) }
         else
-          node.compact_child_nodes.each { |child| walk_class_bodies(child, scope_stack, &) }
+          Source::NodeChildren.each_child(node) { |child| walk_class_bodies(child, scope_stack, &) }
         end
       end
 

--- a/lib/rigor/language_server/completion_provider.rb
+++ b/lib/rigor/language_server/completion_provider.rb
@@ -8,6 +8,7 @@ require_relative "../environment"
 require_relative "../reflection"
 require_relative "../scope"
 require_relative "../source/node_locator"
+require_relative "../source/node_children"
 require_relative "../inference/scope_indexer"
 require_relative "../type/nominal"
 require_relative "../type/singleton"
@@ -187,7 +188,7 @@ module Rigor
              n.location.start_offset <= symbol_offset && symbol_offset <= n.location.end_offset
             result = n
           end
-          n.compact_child_nodes.each(&walk)
+          Source::NodeChildren.each_child(n, &walk)
         end
         walk.call(root)
         result

--- a/lib/rigor/language_server/document_symbol_provider.rb
+++ b/lib/rigor/language_server/document_symbol_provider.rb
@@ -4,6 +4,7 @@ require "prism"
 
 require_relative "uri"
 require_relative "buffer_resolution"
+require_relative "../source/node_children"
 
 module Rigor
   module LanguageServer
@@ -67,7 +68,7 @@ module Rigor
         when Prism::DefNode
           block.call(def_symbol(node, in_namespace: in_namespace))
         else
-          node.compact_child_nodes.each do |child|
+          Source::NodeChildren.each_child(node) do |child|
             each_decl(child, in_namespace: in_namespace, &block)
           end
         end

--- a/lib/rigor/language_server/folding_range_provider.rb
+++ b/lib/rigor/language_server/folding_range_provider.rb
@@ -4,6 +4,7 @@ require "prism"
 
 require_relative "uri"
 require_relative "buffer_resolution"
+require_relative "../source/node_children"
 
 module Rigor
   module LanguageServer
@@ -48,7 +49,7 @@ module Rigor
              Prism::BlockNode
           add_range(node, ranges)
         end
-        node.compact_child_nodes.each { |child| walk(child, ranges) }
+        Source::NodeChildren.each_child(node) { |child| walk(child, ranges) }
       end
 
       def add_range(node, ranges)

--- a/lib/rigor/language_server/selection_range_provider.rb
+++ b/lib/rigor/language_server/selection_range_provider.rb
@@ -4,6 +4,7 @@ require "prism"
 
 require_relative "uri"
 require_relative "buffer_resolution"
+require_relative "../source/node_children"
 
 module Rigor
   module LanguageServer
@@ -48,7 +49,7 @@ module Rigor
         return chain unless node.location && offset_in?(node.location, offset)
 
         chain << node
-        node.compact_child_nodes.each { |child| ancestor_chain(child, offset, chain) }
+        Source::NodeChildren.each_child(node) { |child| ancestor_chain(child, offset, chain) }
         chain
       end
 

--- a/lib/rigor/language_server/signature_help_provider.rb
+++ b/lib/rigor/language_server/signature_help_provider.rb
@@ -8,6 +8,7 @@ require_relative "../environment"
 require_relative "../reflection"
 require_relative "../scope"
 require_relative "../source/node_locator"
+require_relative "../source/node_children"
 require_relative "../inference/scope_indexer"
 require_relative "../type/nominal"
 require_relative "../type/singleton"
@@ -99,7 +100,7 @@ module Rigor
           if n.is_a?(Prism::CallNode) && n.arguments && offset_in?(n.arguments.location, cursor_offset)
             result = n # Innermost-wins because we keep walking children.
           end
-          n.compact_child_nodes.each(&walk)
+          Source::NodeChildren.each_child(n, &walk)
         end
         walk.call(root)
         result

--- a/lib/rigor/plugin/node_rule_walk.rb
+++ b/lib/rigor/plugin/node_rule_walk.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "node_context"
+require_relative "../source/node_children"
 require_relative "../source/node_walker"
 require_relative "../analysis/check_rules/rule_walk"
 
@@ -82,8 +83,9 @@ module Rigor
       # The single converged DFS pre-order traversal. Threads both the live `ancestors` stack (for plugin
       # {NodeContext}) and the immutable built-in {RuleWalk::Context} (for the collectors), derived together
       # as the walk descends — the cheap-ancestors option from the ADR-53 B4 design note. Identical pre-order
-      # over `compact_child_nodes` to both the legacy `Source::NodeWalker.each_with_ancestors` and
-      # `RuleWalk.walk`, so every node is visited in the same order each side saw before.
+      # over each node's children (`Source::NodeChildren.each_child`, which yields `compact_child_nodes` order) to
+      # both the legacy `Source::NodeWalker.each_with_ancestors` and `RuleWalk.walk`, so every node is visited in
+      # the same order each side saw before.
       def walk_node(node, ancestors, context, path, scope, states, collector_driver)
         return unless node.is_a?(Prism::Node)
 
@@ -92,7 +94,7 @@ module Rigor
 
         child_context = collector_driver&.descend(node, context)
         ancestors.push(node)
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           walk_node(child, ancestors, child_context, path, scope, states, collector_driver)
         end
         ancestors.pop

--- a/lib/rigor/protection/mutator.rb
+++ b/lib/rigor/protection/mutator.rb
@@ -4,6 +4,7 @@ require "prism"
 
 require_relative "../scope"
 require_relative "../inference/scope_indexer"
+require_relative "../source/node_children"
 
 module Rigor
   # ADR-63 Tier 2 — the productized subset of the dev-only mutation-testing harness (`tool/mutation/`, ADR-62).
@@ -111,7 +112,7 @@ module Rigor
         return if node.nil?
 
         blk.call(node)
-        node.compact_child_nodes.each { |child| walk(child, &blk) }
+        Source::NodeChildren.each_child(node) { |child| walk(child, &blk) }
       end
 
       def collect(node, out)
@@ -136,7 +137,7 @@ module Rigor
             @anchor_for[arg] = [node.receiver, node.name.to_s] if literal?(arg)
           end
         end
-        node.compact_child_nodes.each { |child| index_literal_anchors(child) }
+        Source::NodeChildren.each_child(node) { |child| index_literal_anchors(child) }
       end
 
       def literal?(node)

--- a/lib/rigor/sig_gen/generator.rb
+++ b/lib/rigor/sig_gen/generator.rb
@@ -8,6 +8,7 @@ require_relative "../scope"
 require_relative "../reflection"
 require_relative "../type"
 require_relative "../source/literals"
+require_relative "../source/node_children"
 require_relative "../inference/def_return_typer"
 require_relative "../inference/scope_indexer"
 require_relative "../inference/rbs_type_translator"
@@ -159,7 +160,7 @@ module Rigor
           return
         end
 
-        node.compact_child_nodes.each do |child|
+        Source::NodeChildren.each_child(node) do |child|
           walk_defs(child, prefix, in_singleton_class, module_function_active, out)
         end
       end
@@ -796,7 +797,7 @@ module Rigor
           collect_attr_call(node, prefix, in_singleton_class, ctx)
         end
 
-        node.compact_child_nodes.each { |child| walk_attr_calls(child, prefix, in_singleton_class, ctx) }
+        Source::NodeChildren.each_child(node) { |child| walk_attr_calls(child, prefix, in_singleton_class, ctx) }
       end
 
       def collect_attr_call(call_node, prefix, in_singleton_class, ctx)
@@ -872,7 +873,7 @@ module Rigor
           return
         end
 
-        node.compact_child_nodes.each { |c| collect_init_ivar_obs(c, prefix, result) }
+        Source::NodeChildren.each_child(node) { |c| collect_init_ivar_obs(c, prefix, result) }
       end
 
       # Derive { attr_name_sym => Type } for a single `def initialize` by matching `@ivar = param_name`
@@ -950,7 +951,7 @@ module Rigor
                   node.is_a?(Prism::ClassNode) ||
                   node.is_a?(Prism::ModuleNode)
 
-        node.compact_child_nodes.each { |c| scan_ivar_param_assignments(c, param_names, result) }
+        Source::NodeChildren.each_child(node) { |c| scan_ivar_param_assignments(c, param_names, result) }
       end
 
       def build_attr_candidates(call_name, class_name, attr_name, ivar_type, ctx)

--- a/lib/rigor/sig_gen/observation_collector.rb
+++ b/lib/rigor/sig_gen/observation_collector.rb
@@ -6,6 +6,7 @@ require_relative "../environment"
 require_relative "../scope"
 require_relative "../type"
 require_relative "../source/literals"
+require_relative "../source/node_children"
 require_relative "../inference/scope_indexer"
 
 module Rigor
@@ -126,7 +127,7 @@ module Rigor
           end
         end
 
-        node.compact_child_nodes.each { |child| walk_class_decls(child, prefix, accumulator) }
+        Source::NodeChildren.each_child(node) { |child| walk_class_decls(child, prefix, accumulator) }
       end
 
       def qualified_constant_path(constant_path)
@@ -146,7 +147,7 @@ module Rigor
         return unless node.is_a?(Prism::Node)
 
         record_call(node, scope_index, bindings, observations) if node.is_a?(Prism::CallNode)
-        node.compact_child_nodes.each { |child| walk_calls(child, scope_index, bindings, observations) }
+        Source::NodeChildren.each_child(node) { |child| walk_calls(child, scope_index, bindings, observations) }
       end
 
       def record_call(call_node, scope_index, bindings, observations)
@@ -244,7 +245,7 @@ module Rigor
         recognise_describe(node, bindings)
         recognise_subject_or_let(node, bindings, scope_index)
 
-        node.compact_child_nodes.each { |child| walk_rspec_bindings(child, bindings, scope_index) }
+        Source::NodeChildren.each_child(node) { |child| walk_rspec_bindings(child, bindings, scope_index) }
       end
 
       def recognise_describe(node, bindings)

--- a/lib/rigor/source.rb
+++ b/lib/rigor/source.rb
@@ -10,6 +10,7 @@ module Rigor
   end
 end
 
+require_relative "source/node_children"
 require_relative "source/node_locator"
 require_relative "source/node_walker"
 require_relative "source/literals"

--- a/lib/rigor/source/node_children.rb
+++ b/lib/rigor/source/node_children.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "prism"
+
+module Rigor
+  module Source
+    # Allocation-free replacement for the `node.compact_child_nodes.each { … }` idiom.
+    #
+    # `Prism::Node#compact_child_nodes` allocates a fresh Array on every call — for the ~43 leaf node classes
+    # (`IntegerNode`, `LocalVariableReadNode`, `NilNode`, …) it is literally `def compact_child_nodes; []; end`.
+    # Rigor's tree walkers call it unconditionally on every node of every walk, so one full-tree walk allocates one
+    # Array per node visited. On leaf-heavy sources (a Ragel-generated parser has hundreds of thousands of
+    # integer-literal leaves) these throwaway arrays are the single largest allocation source in a run — over half of
+    # all allocations on mail's `lib`.
+    #
+    # {each_child} yields the same child nodes, in the same order, without materialising the intermediate array. It
+    # reads each child-bearing field directly and iterates a `NodeListField`'s already-materialised array in place
+    # (the reader returns the stored array, not a copy). Nil optional children and nil list elements are skipped,
+    # mirroring `compact_child_nodes`'s "compact" semantics.
+    #
+    # Field access is compiled, not reflective: a per-class method with the field readers inlined as direct calls
+    # (`node.receiver`, `node.arguments`, …) is generated once at load and dispatched by node class, so iteration
+    # costs one method dispatch per node rather than one per field. A `public_send(reader)`-per-field loop was
+    # measured ~45 % slower than `compact_child_nodes` on a full-tree walk — the dynamic-dispatch-per-field cost
+    # swamps the allocation win; the compiled form stays within a few percent while dropping the allocations.
+    #
+    # The field map is derived once at load from `Prism::Reflection`, so it tracks whatever `prism` version resolves
+    # at runtime (ADR-79) instead of a hand-maintained table. `spec/rigor/source/node_children_spec.rb` is the
+    # binding contract: over a corpus of real source it asserts {each_child}'s output is element-for-element
+    # identical (object identity and order) to `compact_child_nodes` for every node reached — the equivalence this
+    # optimisation rests on.
+    module NodeChildren
+      module_function
+
+      # The concrete `Prism::*Node` classes (`< Prism::Node`).
+      NODE_CLASSES =
+        Prism.constants.grep(/Node\z/).filter_map do |name|
+          const = Prism.const_get(name)
+          const if const.is_a?(Class) && const < Prism::Node
+        end.freeze
+
+      # Shared frozen empty entry for leaf classes, so a single hash lookup covers them with no per-leaf array.
+      # Identity (`equal?`) distinguishes a leaf entry from a childless-in-practice non-leaf.
+      EMPTY = [].freeze
+
+      # node class => frozen Array of `[reader_symbol, :node | :list]` pairs, in field declaration order (the order
+      # `compact_child_nodes` emits its children). Leaf classes map to {EMPTY}. This is the source of truth the
+      # dispatch methods are generated from, and is exposed for introspection / the equivalence spec.
+      CHILD_READERS =
+        NODE_CLASSES.each_with_object({}) do |klass, map|
+          pairs = Prism::Reflection.fields_for(klass).filter_map do |field|
+            case field
+            when Prism::Reflection::NodeField, Prism::Reflection::OptionalNodeField
+              [field.name, :node].freeze
+            when Prism::Reflection::NodeListField
+              [field.name, :list].freeze
+            end
+          end
+          map[klass] = pairs.empty? ? EMPTY : pairs.freeze
+        end.freeze
+
+      # The leaf classes — no child-bearing field, so `compact_child_nodes` is always `[]`. Exposed for the
+      # equivalence spec and introspection; a leaf has no dispatch entry, so {each_child} no-ops on it.
+      LEAF_CLASSES = NODE_CLASSES.select { |klass| CHILD_READERS[klass].equal?(EMPTY) }.to_set.freeze
+
+      # Holds the generated per-class child-yielding methods, one per non-leaf node class, so their names can never
+      # collide with anything. Each reads its class's child fields directly and `yield`s each non-nil child.
+      module Dispatch
+      end
+
+      # node class => Symbol naming the {Dispatch} method that yields that class's children. Absent for leaf classes
+      # and for non-node keys (e.g. `NilClass`), so {each_child} is a no-op on both.
+      DISPATCH =
+        NODE_CLASSES.each_with_object({}) do |klass, map|
+          readers = CHILD_READERS[klass]
+          next if readers.equal?(EMPTY)
+
+          method_name = :"yield_children_#{klass.name.gsub('::', '__')}"
+          statements = readers.map do |reader, kind|
+            if kind == :list
+              "node.#{reader}.each { |child| yield child unless child.nil? }"
+            else
+              "child = node.#{reader}; yield child unless child.nil?"
+            end
+          end
+          # Codegen (not per-call reflection) so iteration reads fields directly — see the class comment on why this
+          # beats a `public_send`-per-field loop. For a `CallNode` (one optional-node field per non-nil child) the
+          # emitted source is:
+          #
+          #   def self.yield_children_Prism__CallNode(node)
+          #     child = node.receiver; yield child unless child.nil?
+          #     child = node.arguments; yield child unless child.nil?
+          #     child = node.block; yield child unless child.nil?
+          #   end
+          Dispatch.module_eval(<<~RUBY, __FILE__, __LINE__ + 1) # rubocop:disable Style/DocumentDynamicEvalDefinition
+            def self.#{method_name}(node)
+              #{statements.join("\n  ")}
+            end
+          RUBY
+          map[klass] = method_name
+        end.freeze
+
+      # Yield each direct child `Prism::Node` of `node` in `compact_child_nodes` order, without allocating an
+      # intermediate array. Leaf nodes and non-node input yield nothing. Pure and re-entrant; `break` / `next` /
+      # `return` in the block behave exactly as they would with `compact_child_nodes.each`.
+      #
+      # @yieldparam child [Prism::Node]
+      def each_child(node, &)
+        method_name = DISPATCH[node.class]
+        Dispatch.send(method_name, node, &) if method_name
+      end
+    end
+  end
+end

--- a/lib/rigor/source/node_locator.rb
+++ b/lib/rigor/source/node_locator.rb
@@ -2,6 +2,8 @@
 
 require "prism"
 
+require_relative "node_children"
+
 module Rigor
   module Source
     # Locates the deepest Prism AST node enclosing a given source position.
@@ -83,7 +85,7 @@ module Rigor
         return nil unless node.is_a?(Prism::Node)
         return nil unless contains?(node, offset)
 
-        node.compact_child_nodes.each do |child|
+        NodeChildren.each_child(node) do |child|
           deeper = descend(child, offset)
           return deeper if deeper
         end

--- a/lib/rigor/source/node_walker.rb
+++ b/lib/rigor/source/node_walker.rb
@@ -2,6 +2,8 @@
 
 require "prism"
 
+require_relative "node_children"
+
 module Rigor
   module Source
     # Yields every `Prism::Node` reachable from a root in DFS pre-order.
@@ -28,7 +30,7 @@ module Rigor
         return unless node.is_a?(Prism::Node)
 
         yield node
-        node.compact_child_nodes.each { |child| walk(child, &) }
+        NodeChildren.each_child(node) { |child| walk(child, &) }
       end
 
       # Like {.each}, but also yields the node's lexical ancestor chain (outermost first, EXCLUDING the node
@@ -51,7 +53,7 @@ module Rigor
 
         block.call(node, ancestors)
         ancestors.push(node)
-        node.compact_child_nodes.each { |child| walk_with_ancestors(child, ancestors, &block) }
+        NodeChildren.each_child(node) { |child| walk_with_ancestors(child, ancestors, &block) }
         ancestors.pop
       end
     end

--- a/spec/rigor/source/node_children_spec.rb
+++ b/spec/rigor/source/node_children_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require "prism"
+
+RSpec.describe Rigor::Source::NodeChildren do
+  # Real analyzer source — large files whose ASTs exercise a broad span of node classes, so the equivalence corpus
+  # tracks the shapes Rigor actually walks.
+  let(:corpus_files) do
+    root = File.expand_path("../../..", __dir__)
+    %w[
+      lib/rigor/inference/statement_evaluator.rb
+      lib/rigor/inference/expression_typer.rb
+      lib/rigor/inference/scope_indexer.rb
+    ].map { |rel| File.join(root, rel) }
+  end
+
+  # Hand-written source adding the node classes the analyzer files happen not to contain — pattern matching, every
+  # abbreviated-assignment variant (`&&= ||= +=` on ivar/cvar/gvar/constant/const-path/call/index), multiple-assignment
+  # targets, flip-flops, alias/undef, BEGIN/END, argument forwarding, numbered / `it` block params, xstring, and the
+  # regexp-in-condition match nodes — so the contract is proven over (close to) the whole Prism node zoo, not only what
+  # the three analyzer files use. Single-quoted heredoc so `#{…}` stays literal source text.
+  let(:exotic_source) do
+    <<~'RUBY'
+      case obj
+      in [1, *rest, last] then a
+      in {name: String => n, **opts} then b
+      in [Integer, Float] | String then c
+      in ^pinned then d
+      in ^(1 + 2) then e
+      in Point(x:, y:) then f
+      in [*, 3, *post] then g
+      end
+      for i in 1..10 do puts i end
+      x = 1 if (a..b)
+      y = 1 if (a...b)
+      BEGIN { init }
+      END { teardown }
+      alias foo bar
+      alias $g1 $g2
+      undef meth1, meth2
+      @iv &&= 1; @iv ||= 2; @iv += 3
+      @@cv &&= 1; @@cv ||= 2; @@cv += 3
+      $gv &&= 1; $gv ||= 2; $gv += 3
+      CONST &&= 1; CONST ||= 2; CONST += 3
+      Mod::Path &&= 1; Mod::Path ||= 2; Mod::Path += 3
+      recv.attr &&= 1; recv.attr ||= 2; recv.attr += 3
+      arr[0] &&= 1; arr[0] ||= 2; arr[0] += 3
+      r = 1r; i = 2i; ri = 3ri
+      nums = [1, 2].map { _1 + _2 }
+      it_blk = [1].each { it.to_s }
+      cmd = `echo hi`
+      /regexp #{x}/ =~ line
+      "str" =~ /lit/
+      %w[a b c]
+      ->(a, b) { a + b }
+      h => {key:}
+      val in Integer
+      class C
+        @@cvar = 1
+        @@cvar2 = @@cvar
+        def m(...) = other(...)
+        def n(**nil); end
+        def blk = [1].each { |x; local| x }
+      end
+      $global_w = 42
+      a, b.attr, c::Path, d[0], @@cv, $gv, Const = *arr
+      if /(?<name>\w+)/ =~ input then name end
+      if /literal/ then aa end
+      if /interp #{y} end/ then bb end
+      __ENCODING__
+    RUBY
+  end
+
+  # each_child's output as an array, so the spec can compare it against compact_child_nodes.
+  def collect_children(node)
+    out = []
+    described_class.each_child(node) { |child| out << child }
+    out
+  end
+
+  # each_child MUST be element-for-element identical (object identity + order) to compact_child_nodes for this node,
+  # and a leaf class MUST have no children.
+  def verify_node(node, label)
+    expected = node.compact_child_nodes
+    actual = collect_children(node)
+    expect(actual.length).to eq(expected.length), -> { "#{label}: #{node.class} arity — #{actual} vs #{expected}" }
+    actual.each_index { |i| expect(actual[i]).to be(expected[i]) }
+    expect(expected).to be_empty if described_class::LEAF_CLASSES.include?(node.class)
+  end
+
+  # Walk `root` in pre-order, verifying every node. Returns the node count.
+  def assert_equivalent(source, label)
+    count = 0
+    stack = [Prism.parse(source).value]
+    until stack.empty?
+      node = stack.pop
+      next unless node.is_a?(Prism::Node)
+
+      count += 1
+      verify_node(node, label)
+      node.compact_child_nodes.each { |child| stack.push(child) }
+    end
+    count
+  end
+
+  describe "reflection-derived tables" do
+    it "maps every leaf class to the shared empty entry and every non-leaf to a non-empty frozen array" do
+      described_class::NODE_CLASSES.each do |klass|
+        readers = described_class::CHILD_READERS.fetch(klass)
+        expect(readers).to be_frozen
+        if described_class::LEAF_CLASSES.include?(klass)
+          expect(readers).to be(described_class::EMPTY)
+        else
+          expect(readers).not_to be_empty
+          readers.each do |reader, kind|
+            expect(reader).to be_a(Symbol)
+            expect(kind).to(satisfy { |k| %i[node list].include?(k) })
+          end
+        end
+      end
+    end
+
+    it "recognises the expected order of magnitude of leaf classes" do
+      # ~43 in prism 1.x; asserted as a loose band so a prism upgrade that adds/removes a leaf does not break the
+      # contract (ADR-79 — Rigor tracks the installed prism).
+      expect(described_class::LEAF_CLASSES.size).to be_between(30, 60)
+    end
+  end
+
+  describe ".each_child" do
+    it "is object-identical to compact_child_nodes for every node in the analyzer corpus" do
+      total = corpus_files.sum { |path| assert_equivalent(File.read(path), File.basename(path)) }
+      expect(total).to be > 10_000 # the corpus really is large — guards against a silently-empty walk
+    end
+
+    it "is object-identical to compact_child_nodes across the exotic-syntax corpus" do
+      expect(assert_equivalent(exotic_source, "exotic")).to be > 100
+    end
+
+    it "exercises the full breadth of node classes across both corpora" do
+      seen = Set.new
+      (corpus_files.map { |path| File.read(path) } + [exotic_source]).each do |src|
+        stack = [Prism.parse(src).value]
+        until stack.empty?
+          node = stack.pop
+          next unless node.is_a?(Prism::Node)
+
+          seen << node.class
+          node.compact_child_nodes.each { |child| stack.push(child) }
+        end
+      end
+      # The corpora between them must reach the large majority of the node zoo, otherwise the equivalence claim is
+      # thin. (Not every class is reachable from parseable source — some are synthesised only in edge cases.)
+      expect(seen.size).to be >= 130
+    end
+
+    it "yields nothing for a leaf node" do
+      leaf = Prism.parse("42").value.statements.body.first
+      expect(leaf).to be_a(Prism::IntegerNode)
+      expect(collect_children(leaf)).to be_empty
+    end
+
+    it "yields nothing for non-node input (defensive nil child slot)" do
+      expect { |probe| described_class.each_child(nil, &probe) }.not_to yield_control
+    end
+
+    it "propagates break out of the yielder, stopping early like compact_child_nodes.each" do
+      array = Prism.parse("[10, 20, 30]").value.statements.body.first
+      expect(array.compact_child_nodes.length).to eq(3)
+      seen = []
+      described_class.each_child(array) do |child|
+        seen << child
+        break if seen.size == 2
+      end
+      expect(seen.size).to eq(2) # broke at the 2nd of 3 children — break unwound out of each_child
+    end
+  end
+end


### PR DESCRIPTION
## Allocation-free AST child iteration

`Prism::Node#compact_child_nodes` allocates a fresh `Array` on every call — for the ~43 leaf node classes (`IntegerNode`, `LocalVariableReadNode`, `NilNode`, …) it is literally `def compact_child_nodes; []; end`. Rigor's tree walkers call it unconditionally on every node of every walk, so one full-tree walk allocates one throwaway array per node visited. On leaf-heavy sources (mail's Ragel-generated parsers have hundreds of thousands of integer-literal leaves, and the engine walks the tree many times) these arrays are **over half of all allocations** in a run; on Rails corpora and kramdown they are ~10–19%.

### What changed

Loading `Rigor::Source::NodeChildren` compiles a **`#rigor_each_child` method onto every Prism node class** (additive reopening of a dependency class — the `Cache::RbsEnvironmentMarshalPatch` precedent; the `rigor_` prefix keeps it collision-free) that yields the same children, in the same order, without materialising the array. Each generated statement mirrors `compact_child_nodes`' own form for that field kind exactly: required node fields yield unconditionally, optional fields behind a truthiness guard, list fields iterate the stored array in place. That makes iteration **one virtual send per node with zero allocation** — the same dispatch mechanism `compact_child_nodes` itself uses. The field map is derived once at load from `Prism::Reflection`, so it tracks the installed `prism` (ADR-79).

**Dispatch variant history** (why a method on the node class): a `public_send`-per-field loop measured ~45% *slower* than `compact_child_nodes` on a full-tree walk (dynamic dispatch per field swamps the allocation win), and a central generated-method table dispatched via `Module#send` + per-class Hash lookup was wall-neutral on the interpreter but still cost ~5% on Rails-corpus walks under YJIT. The compiled node-method form beats or matches `compact_child_nodes` everywhere measured.

Every unconditional `node.compact_child_nodes.each { … }` walker in `lib/` is migrated to `node.rigor_each_child { … }`: the shared node walker, the engine-owned plugin / check-rule node walk, the `ScopeIndexer` discovery-seed and cross-file pre-pass descents, the five check-rule collectors, the inference walkers, the sig-gen collectors, the dependency-source walker, the protection mutator, the node locator, the annotate command, and the five language-server providers. Traversal order, per-walker child-type guards, and `break` / `next` / `return` semantics are preserved exactly, so **diagnostics are byte-identical**. A nil-tolerant `NodeChildren.each_child(node)` wrapper remains the public entry for callers holding a maybe-nil slot.

Bundled `plugins/*/lib` walkers are intentionally left for a separate slice; only the engine-owned plugin node walk was migrated. A project `sig/prism_node_children.rbs` declares the reopening so Rigor's own self-check resolves the method statically — its teeth flagged all 51 call sites as `undefined-method` until the runtime definition was declared to the RBS universe, which is the discipline working as designed.

### Equivalence contract

`spec/rigor/source/node_children_spec.rb` asserts, over the analyzer's own source plus an exotic-syntax corpus spanning ≥130 Prism node classes, that **both** `#rigor_each_child` and `each_child` are element-for-element identical (object identity + order) to `compact_child_nodes` for every node reached, and that every concrete node class carries the compiled method.

### A/B — interpreter (cold `--no-cache`, order-alternating interleaved pairs, best-of)

| target | allocs master→branch | wall master→branch | diagnostics |
| --- | --- | --- | --- |
| mail (`lib`) | 21,025,502 → 9,197,438 (**−56.3%**) | 4.84s → 4.37s (**−9.8%**) | 26 = 26 ✓ |
| kramdown (`lib`) | 4,150,403 → 3,362,009 (**−19.0%**) | 1.63s → 1.59s (−2.5%) | 68 = 68 ✓ |
| liquid (`lib`) | 4,556,749 → 4,112,243 (**−9.8%**) | 1.44s → 1.40s (−2.8%) | 5 = 5 ✓ |
| mastodon (`app/models`) | 10,092,492 → 8,554,210 (**−15.2%**) | 4.16s → 3.86s (**−7.2%**) | 267 = 267 ✓ |
| redmine (`app/models`) | 13,709,303 → 11,270,595 (**−17.8%**) | 6.87s → 6.74s (−2.0%) | 55 = 55 ✓ |

Allocations drop on every target and wall improves on every target. `mail` + `mastodon-models` diagnostics JSON arrays are byte-identical between engines (diffed, not just counted).

### A/B — YJIT (`RUBY_YJIT_ENABLE=1`, cold)

| target | allocs master→branch | wall | verdict |
| --- | --- | --- | --- |
| mail (`lib`), 2 pairs | 21,025,849 → 9,197,790 (**−56.3%**) | 4.04s → 3.93s (**−2.7%**) | faster |
| mastodon (`app lib`), 6 order-alternating pairs | 55,314,301 → 46,171,117 (**−16.5%**) | mean 14.90s → 14.84s; median 14.70s → 14.81s; per-pair deltas +10.1/−0.2/+1.2/−5.3/+2.3/−8.1% → **pair-mean −0.00%** | match (noise-dominated; master's own spread 13.5–16.9s) |

The mastodon "app lib" YJIT probe — the flagship criterion — shows a paired-delta mean of −0.00% with the branch mean (14.84s) below master's (14.90s) and inside the reference 14.87–15.20s band; diagnostics identical (2348) on all 12 runs.

### Gates

- Equivalence spec green (both dispatch layers, ≥130 node classes).
- `make verify` green (full suite; rubocop clean; self-check + `check-plugins` clean).
- Corpus diagnostics byte-identical vs master on all five targets (counts match; mail + mastodon JSON diffed).
- `make bench-perf` green — rigor's own `lib` allocations 29.3M → 15.1M (−48%).
