### PR TITLE
Document the perf-arc config, env, and cache surfaces

### DIFF
--- a/docs/internal-spec/cache.md
+++ b/docs/internal-spec/cache.md
@@ -1,15 +1,17 @@
 # Cache Layer — `Rigor::Cache`
 
-Status: **Stable (introduced v0.0.8; current descriptor schema v4).**
+Status: **Stable (introduced v0.0.8; current descriptor schema v5).**
 This document tracks the cache layer's public read shape. The
 slices below all landed and are stable across v0.1.x; the descriptor
 `SCHEMA_VERSION` was bumped to `2` for the ADR-10 per-gem-version
 `dependencies` slot, to `3` when `RbsLoader.build_env_for` began
 synthesizing missing `signature_paths:` namespaces (so an RBS env
 marshalled by an older Rigor — which would leave those signatures
-inert — is rebuilt), and to `4` when [ADR-60](../adr/60-pre-freeze-plugin-contract-consolidation.md)
+inert — is rebuilt), to `4` when [ADR-60](../adr/60-pre-freeze-plugin-contract-consolidation.md)
 WD3 added the `globs` slot (`GlobEntry`) for the record-and-validate
-plugin-producer cache. Slices 1–2 are in place:
+plugin-producer cache, and to `5` when [ADR-87](../adr/87-null-build-floor.md)
+WD1 added the `:stat` `FileEntry` comparator (stat-then-digest
+validation). Slices 1–2 are in place:
 `Rigor::Cache::Descriptor` (the substrate every cached value
 attaches to) and `Rigor::Cache::Store` (the filesystem-backed
 storage that consumes a descriptor + producer + params and
@@ -30,7 +32,7 @@ slots, every slot an array of typed entries.
 ### Slot entries
 
 ```
-FileEntry       :: { path: String, comparator: :digest|:mtime|:exists, value: String }
+FileEntry       :: { path: String, comparator: :digest|:stat|:mtime|:exists, value: String }
 GemEntry        :: { name: String, requirement: String, locked: String? }
 PluginEntry     :: { id: String, version: String, config_hash: String? }
 ConfigEntry     :: { key: String, value_hash: String }
@@ -50,7 +52,28 @@ dependency-source-inference cache slice so a `Gemfile.lock` bump or a
 `GlobEntry` is the ADR-60 WD3 record-and-validate slot: its `value`
 is a digest of every file matching `root`/`pattern` (built via
 `GlobEntry.compute`), re-validated by re-globbing so a plugin producer's
-`watch:` glob coverage stays fresh across edits.
+`watch:` glob coverage stays fresh across edits. Post-[ADR-87](../adr/87-null-build-floor.md)
+WD2 that per-glob digest is a SHA-256 over sorted **stat tuples**
+(`"<path>\0<size>\0<mtime_ns>\0<ctime_ns>\0<inode>\n"` rows), not file
+content — re-validation re-globs and re-stats, reading zero content bytes
+on an unchanged tree while any edit (which moves mtime + ctime) still moves
+the signature.
+
+The `:stat` comparator is the ADR-87 WD1 stat-then-digest tier for
+individual `FileEntry` slots. Its `value` packs `"<digest> <size>
+<mtime_ns> <ctime_ns> <inode> <recording_instant_ns>"`: validation
+(`FileDigest.stat_fresh?`) stats the file first and only falls back to a
+full content hash (`FileDigest.hexdigest`) when the tuple moved, or when a
+racy-window guard fires (the file's mtime is not strictly older than the
+entry's recording instant). The SHA-256 digest packed in the value remains
+the sole change **authority** — an unmoved stat only lets validation skip
+recomputing it; a `:stat` entry whose stat moved but whose content is
+identical (a bare `touch`) is re-hashed and correctly found fresh. The
+`:stat` tier rides validation-only descriptors (the ADR-45 dependency
+descriptor, plugin `watch:` globs); cache-KEY descriptors keep the
+deterministic `:digest` comparator. `cache.validation: digest` (or the
+`RIGOR_STRICT_VALIDATION=1` env, which wins) forces every entry back to
+`:digest` for a filesystem whose stat cannot be trusted.
 
 ### `Descriptor.new(files: [], gems: [], plugins: [], configs: [], dependencies: [], globs: [])`
 
@@ -89,12 +112,14 @@ choosing one contribution silently.
 Returns the canonical hex SHA-256 cache key for a producer +
 input + descriptor combination. The key incorporates:
 
-1. `Descriptor::SCHEMA_VERSION` (currently `4` — v2 added the
+1. `Descriptor::SCHEMA_VERSION` (currently `5` — v2 added the
    `dependencies` slot for the ADR-10 per-gem-version cache slice;
    v3 invalidates RBS envs marshalled before `build_env_for` began
    synthesizing missing `signature_paths:` namespaces; v4 added the
    `globs` slot for the ADR-60 WD3 record-and-validate plugin-producer
-   cache). Bumping this constant invalidates every cached value.
+   cache; v5 added the `:stat` `FileEntry` comparator for ADR-87 WD1
+   stat-then-digest validation). Bumping this constant invalidates every
+   cached value.
 2. `producer_id` (a stable string that namespaces the cache
    slice).
 3. `params` (the producer's input hash). Recursively
@@ -126,8 +151,13 @@ with `==` so descriptors are usable as Hash keys.
 The constructor signatures and composition semantics are stable
 as a v0.0.x public read shape. Adding new slot kinds (e.g.
 `env_vars`) is a schema-version bump per the taxonomy doc and
-ADR-6. Adding new comparators to `FileEntry::VALID_COMPARATORS`
-is additive and does not require a bump.
+ADR-6. Adding a comparator to `FileEntry::VALID_COMPARATORS`
+(currently `%i[digest stat mtime exists]`) is behaviourally additive,
+but because the comparator is folded into the cache key via
+`cache_key_for`, the ADR-87 `:stat` addition took a
+`SCHEMA_VERSION` bump (4 → 5) so pre-`:stat` entries read as clean
+misses rather than being trusted under a comparator the old writer
+never used.
 
 The persistence layer ([`Rigor::Cache::Store`](#cache-store-v008-slice-2),
 v0.0.8 slice 2) and the cached-producer integrations follow.
@@ -389,6 +419,94 @@ enforcing a size budget, so an explicitly unbounded store
 (`max_bytes: nil`) still benefits from them. Only pass 3 is gated on
 `max_bytes:` being set. Any filesystem error during any pass is
 swallowed — `evict!` must never break a run.
+
+## `Rigor::Cache::IncrementalSnapshot` (ADR-46)
+
+The persistent artefact behind `rigor check --incremental`. Distinct from
+the entry store above: a single per-project blob (zlib-deflated `Marshal`,
+under the cache root) that records enough of the previous run to re-derive
+only the affected files' diagnostics on the next run. Every operation is
+fault-tolerant — a missing, unreadable, schema-mismatched,
+fingerprint-mismatched, or corrupt snapshot loads as `nil` and forces a
+full run, so the snapshot can never wedge or stale an analysis.
+
+### Two-level gating
+
+1. **Global fingerprint (gates the load).** `IncrementalSnapshot.fingerprint(configuration:, roots:)`
+   is a SHA-256 over the engine version + `SCHEMA`, the configuration hash,
+   the analysis **roots** (not the expanded file list — so adding/removing a
+   file under a root does not drop the snapshot), `Gemfile.lock`,
+   `rbs_collection.lock.yaml`, and the project's `signature_paths` RBS —
+   but **not** the analyzed source contents. A mismatch drops the snapshot.
+2. **Per-file digests (drive the decision).** When the fingerprint matches,
+   the `Payload` is loaded unconditionally and its per-file content digests
+   determine the changed set `ΔF`; the affected closure `ΔF ∪ dependents[ΔF]`
+   is re-analysed and the rest served from `Payload#cache`.
+
+### `Payload` (current `SCHEMA = 10`)
+
+```
+Payload :: Data[
+  cache, sources, digests, analyzed,          # per-file diagnostics, read-sets, content digests, analyzed set
+  symbol_sources, ancestry_sources,           # the ADR-46 dependency edges (method-symbol and class-ancestry)
+  symbol_fingerprints,                        # path -> { "Class#method" => sha256 } — per-method source fingerprints
+  missing, class_decls,                       # negative (unresolved) edges + per-file declared-class sets
+  seed_bundles,                               # ADR-85 per-file pre-pass contribution (plain data + def-node handles)
+  plugin_fact_digest,                         # ADR-88 plugin-fact surface fingerprint (see below)
+  return_summaries                            # ADR-89 observed-key return summaries (see below)
+]
+```
+
+Schema history worth pinning: `6` stored the seed bundles as
+`(node_id, name, fingerprint)` def-node handles (ADR-85); `8` added each
+bundle's comment-stripped `code_fingerprint` for the B1 comment-only gate;
+`9` added `plugin_fact_digest` (ADR-88); `10` added `return_summaries`
+(ADR-89). A blob from an older schema mismatches the `SCHEMA` gate and loads
+as `nil` — a clean cold rebuild, never a migration.
+
+### `plugin_fact_digest` — plugin-fact soundness ([ADR-88](../adr/88-incremental-plugin-fact-soundness.md))
+
+Plugin-contributed types (a Sorbet catalog signature, a dry-types alias, an
+ActiveRecord column type) are consumed through the ADR-52 compiled-dispatch
+path, which never crosses the `DependencyRecorder` choke points that build
+the `symbol_sources` / `ancestry_sources` edges — so a plugin fact records
+no cross-file edge, and an edit that changes one could otherwise leave a
+consumer stale. `plugin_fact_digest` closes this: it fingerprints the plugin
+fact **surface** the global fingerprint cannot see — (a) every ADR-9
+fact-store publication, (b) every ADR-60 producer's computed **value** (the
+value, deliberately, not its watched inputs — a whole-tree `watch:` glob
+would otherwise invalidate on every edit), and (c) each plugin's optional
+`Plugin::Base#incremental_state_fingerprint` hook (see
+[`plugin-cache-producers.md`](plugin-cache-producers.md)). A change to the
+digest drops the snapshot (a conservative full re-analysis). A plugin that
+contributes types but exposes none of (a)/(b)/(c) makes the snapshot
+un-reusable and is named — a forcing function to declare its surface rather
+than a silent stale reuse.
+
+### `return_summaries` — semantic propagation gates ([ADR-89](../adr/89-semantic-propagation-gates.md))
+
+Generalises the B1 comment-only gate to body edits: a dependent of a changed
+file is re-analysed only when something it can consume actually changed.
+Two persisted summaries prove "nothing changed":
+
+- **Declaration shape** (consumed by ancestry / file-level dependents) — the
+  ADR-85 seed bundle carries per-def signature shape (name, kind,
+  parameter structure, visibility) plus superclass / include / layout. A
+  body edit leaves it equal; an arity, visibility, or added/removed-method
+  edit does not. A declaration-stable changed file drops its ancestry /
+  file-level dependents from the closure.
+- **Observed-key return summaries** — per-def `(receiver, args) → return`
+  descriptors harvested from the ADR-84 memo, plus the ADR-56 content-mutation
+  effect set (the callee-visible surface beyond the return). On a recheck a
+  declaration-stable changed def is re-evaluated at each stored key through
+  the memo; all-equal returns **and** equal effects drop the def's symbol
+  dependents. Any mismatch, a changed signature, a missing def, an
+  ineligible def (one that also exposes ivar/cvar writes or `yield` values),
+  or a cap overflow keeps the dependents — the conservative direction.
+
+Both gates are premised on a `plugin_fact_digest` match for the run (asserted
+in code, not assumed); `--verify-incremental` is the standing byte-identity
+backstop for the whole mechanism.
 
 ## Bundled RBS producer contract
 

--- a/docs/internal-spec/plugin-cache-producers.md
+++ b/docs/internal-spec/plugin-cache-producers.md
@@ -193,6 +193,48 @@ Identity inputs (gem versions, sibling-plugin config, external
 state the boundary can't read) compose into the **key** via the
 `descriptor:` kwarg; a key change is a cache miss.
 
+### `Rigor::Plugin::Base#incremental_state_fingerprint` — the `--incremental` fact surface ([ADR-88](../adr/88-incremental-plugin-fact-soundness.md))
+
+The `--incremental` snapshot's `plugin_fact_digest` (see
+[`cache.md` § IncrementalSnapshot](cache.md#plugin_fact_digest--plugin-fact-soundness-adr-88))
+must cover every cross-file value a cached diagnostic can depend on, or a
+plugin edit could leave a consumer stale. Two channels are automatic — every
+ADR-9 fact-store publication and every `producer` value are digested without
+plugin cooperation. This **optional** hook is the third channel, for a
+plugin whose `dynamic_return` / `narrowing_facts` contributions read from an
+internal catalog that is neither a fact-store publication nor a `producer`
+value:
+
+```ruby
+class MyPlugin < Rigor::Plugin::Base
+  # Return a stable, Marshal-clean value that CHANGES exactly when this
+  # plugin's cross-file contribution surface changes, and is STABLE across
+  # runs when it does not.
+  def incremental_state_fingerprint
+    catalog_digest   # e.g. a SHA-256 over the plugin's parsed sig catalog
+  end
+end
+```
+
+Contract:
+
+- The hook is **optional** — a plugin that defines it is consulted (via
+  `respond_to?`), one that does not is not. There is no default on
+  `Plugin::Base`.
+- A plugin whose contributions derive **only** from each analysed file's own
+  content (already re-analysed when that file changes) has no *own* cross-file
+  surface. It should still define the hook returning a **stable sentinel
+  string** (e.g. `"per-file-lets"`) — this positively declares "no cross-file
+  fact surface", keeping the plugin incremental-capable. Bundled `rigor-rspec`,
+  `rigor-minitest`, and `rigor-mangrove` do exactly this.
+- A plugin that registers `dynamic_return` / `narrowing_facts` contributions
+  and provides **none** of the three channels makes the snapshot un-reusable
+  for the run and is named in the run output — incremental degrades to a full
+  analysis rather than risk a stale reuse.
+- `--verify-incremental` is the standing backstop: a hook that fails to move
+  when the plugin's real contribution moved surfaces there as a byte
+  mismatch.
+
 ## Cache-id sandbox (6-C)
 
 `Plugin::Base#cache_for` rewrites the producer id to

--- a/docs/manual/02-cli-reference.md
+++ b/docs/manual/02-cli-reference.md
@@ -41,7 +41,7 @@ the `paths:` list from the configuration file.
 | `--cache-stats` | Print the on-disk cache inventory when finished. |
 | `--[no-]stats` | Print a run summary (files, classes, memory, wall time) to stderr. Default on. |
 | `--coverage` | Add a type-precision coverage block to the output (`coverage` object under `--format json`; a one-line summary in text mode). Off by default — it is a second precision pass over the analyzed files, the same scan [`rigor coverage`](#rigor-coverage) runs, so it is opt-in. |
-| `--workers=N` | Dispatch analysis across `N` parallel worker processes (fork-based pool today; ADR-15). Default `0` (sequential). |
+| `--workers=N` | Dispatch analysis across `N` parallel worker processes (fork-based pool today; ADR-15). Default `0` (sequential). Applies to `--incremental` re-checks as well as full runs. |
 | `--baseline=PATH` | Load a baseline file, overriding config. |
 | `--no-baseline` | Ignore any configured baseline. |
 | `--baseline-strict` | Fail the run on any baseline drift — a CI gate. |
@@ -618,6 +618,9 @@ operational knobs read the environment instead.
 | `RIGOR_RACTOR_WORKERS=N` | Worker count for parallel analysis. Sits between the CLI flag and the config key in precedence: `--workers=N` > `RIGOR_RACTOR_WORKERS` > `parallel.workers:` > `0` (sequential). |
 | `RIGOR_POOL_BACKEND=ractor` | Opt back into the (off-by-default) Ractor worker pool instead of the active fork-based pool ([ADR-15](../adr/15-ractor-concurrency.md)). Only relevant with a non-zero worker count; the fork pool is the supported backend. |
 | `RIGOR_PLUGIN_ISOLATION=none\|process\|ruby_box` | How a plugin's direct calls into its target library are isolated. Default `process`. See [Using plugins § Isolation strategy](07-plugins.md). `RIGOR_BOX` is a legacy alias for `ruby_box`. |
+| `RIGOR_STRICT_VALIDATION=1` | Force full-content cache validation for one run (the same as `cache.validation: digest`, and winning over it) — re-hash every file's content instead of trusting its stat metadata. Use it if a filesystem's timestamps or inode numbers cannot be trusted. See [Caching § How a file is checked for changes](12-caching.md#how-a-file-is-checked-for-changes). |
+| `RIGOR_DISABLE_YJIT=1` | Opt out of Rigor's deferred YJIT enablement. Rigor turns YJIT on partway through a long `check` / `coverage` run so short runs never pay the JIT warm-up; this variable leaves it off entirely. Diagnostics and allocations are identical either way — the effect is wall-time only. |
+| `RIGOR_YJIT_DEADLINE=<seconds>` | Advanced: tune how long a run must last before deferred YJIT enables (default `5.0`). Lower it if your runs are long and you want the JIT sooner; raise it to protect short runs. Ignored when `RIGOR_DISABLE_YJIT=1` is set or YJIT is unavailable. |
 
 Three further variables (`RIGOR_BUDGET_TRACE`,
 `RIGOR_HEAP_PROFILE`, `RIGOR_HEAP_TRACE`) enable developer-facing

--- a/docs/manual/03-configuration.md
+++ b/docs/manual/03-configuration.md
@@ -128,7 +128,8 @@ explicitly with `bundler.bundle_path:`, or supply signatures another way:
 | --- | --- | --- | --- |
 | `cache.path` | String | `.rigor/cache` | Persistent cache directory. See [Caching](12-caching.md). |
 | `cache.max_bytes` | Integer or `null` | `268435456` (256 MB) | LRU eviction cap for the cache directory; `null` disables eviction. See [Caching § Size and eviction](12-caching.md#size-and-eviction). |
-| `parallel.workers` | Integer | `0` | Parallel worker processes for per-file analysis (fork-based pool today; ADR-15); `0` is sequential. CLI `--workers` and `RIGOR_RACTOR_WORKERS` take precedence. |
+| `cache.validation` | String | `"stat"` | How the cache checks whether a file is unchanged: `stat` compares size + nanosecond timestamps + inode and only re-hashes a file whose stat moved; `digest` re-hashes every file's content every run. Both keep the content hash as the sole change authority — `stat` just skips the hash when the stat proves a file untouched. See [Caching § How a file is checked for changes](12-caching.md#how-a-file-is-checked-for-changes). The `RIGOR_STRICT_VALIDATION=1` environment variable forces `digest` for one run and wins over this key. |
+| `parallel.workers` | Integer | `0` | Parallel worker processes for per-file analysis (fork-based pool today; ADR-15); `0` is sequential. CLI `--workers` and `RIGOR_RACTOR_WORKERS` take precedence. Applies to `--incremental` re-checks as well as full runs. |
 | `plugins_io.network` | String | `"disabled"` | Plugin network policy — `disabled` or `allowlist`. |
 | `plugins_io.allowed_paths` | Array | `[]` | Filesystem paths plugins may read. |
 | `plugins_io.allowed_url_hosts` | Array | `[]` | URL hosts plugins may fetch from when `network: allowlist`. |

--- a/docs/manual/12-caching.md
+++ b/docs/manual/12-caching.md
@@ -38,6 +38,34 @@ The cache is also schema-versioned: after a Rigor upgrade that
 changes the cache format, the stale cache is purged on the
 first writable run.
 
+## How a file is checked for changes
+
+To decide whether a cached entry is still valid, Rigor needs to
+know which of your files changed since the entry was written. By
+default it checks each file's **stat metadata** first — size,
+nanosecond modification and change timestamps, and inode — and
+only re-hashes a file's content when that metadata moved. On a
+large project an unchanged run then reads *zero* content bytes to
+validate the cache, instead of re-hashing every file.
+
+The content hash stays the sole authority on whether a file
+actually changed: the stat check only decides whether the hash
+needs recomputing. A file that was merely `touch`ed (new
+timestamp, identical content) is re-hashed once and correctly
+found unchanged. Editing a file always moves its timestamps, so
+an edit is never missed.
+
+If you work on a filesystem whose timestamps or inode numbers
+cannot be trusted, switch to hashing every file every run:
+
+```yaml
+cache:
+  validation: digest    # default is "stat"
+```
+
+or, for a single run, set `RIGOR_STRICT_VALIDATION=1` (which
+wins over the config key).
+
 ## Controlling the cache
 
 | Flag | Effect |
@@ -89,6 +117,28 @@ exactly which files an edit can affect. A continuous-integration
 gate, `rigor check --verify-incremental`, asserts this on every
 build: it runs the incremental analyzer and a full analysis and
 fails if they disagree on a single diagnostic.
+
+Rigor is also precise about *what* an edit changed. Re-checking a
+file that many others depend on — a base class, a widely-used
+concern, a shared utility — used to re-check every dependent.
+Now, if your edit did not change the file's declaration shape
+(the signatures of its methods, its superclass and includes) or
+the types its methods return, the files that only depend on those
+things are left untouched: a comment, a formatting change, or an
+internal refactor that preserves every method's return type stops
+at the edited file. An edit that *does* change a return type or a
+signature still propagates to the dependents that consume it, so
+the result stays identical to a full run.
+
+Types contributed by plugins (a Sorbet signature, an
+ActiveRecord column type, a dry-types alias) are validated too:
+if a plugin's cross-file contributions change between runs, the
+snapshot is dropped and the next run is a full one, so a plugin
+edit can never leave a dependent stale.
+
+An `--incremental` re-check honours `--workers=N` (and
+`RIGOR_RACTOR_WORKERS` / `parallel.workers:`), analysing the
+affected files in parallel just as a full run does.
 
 The snapshot lives under the cache directory (`.rigor/cache`)
 and is keyed by a fingerprint of your configuration, your locked


### PR DESCRIPTION
Additive documentation for the surfaces the v0.3.0 performance arc (PRs #75/#85/#87/#88/#89/#90) added. Docs-only; grounded in the merged code (versions/constants verified against `descriptor.rb`, `incremental_snapshot.rb`, `jit.rb`, `configuration.rb`, the plugin hooks), not the PR summaries.

## Manual (user-facing)
- **03-configuration.md** — `cache.validation` key (stat/digest) in the Execution table; noted `parallel.workers` applies to `--incremental`.
- **02-cli-reference.md** — env vars `RIGOR_STRICT_VALIDATION`, `RIGOR_DISABLE_YJIT`, `RIGOR_YJIT_DEADLINE`; `--workers` now applies to `--incremental`.
- **12-caching.md** — new "How a file is checked for changes" section (stat-then-digest; the content hash stays the sole authority); the incremental chapter's new precision (declaration/return-preserving edits don't propagate, plugin-typed returns are revalidated, `--workers` honoured).

## Internal-spec (contract)
- **cache.md** — the `:stat` `FileEntry` comparator + descriptor `SCHEMA_VERSION` 4→5; a new `IncrementalSnapshot` section (SCHEMA 10, two-level fingerprint gating, the `Payload` slot map, `plugin_fact_digest` for ADR-88, `return_summaries` for ADR-89).
- **plugin-cache-producers.md** — the optional `incremental_state_fingerprint` plugin hook (ADR-88 channel (c)): when to define it, the sentinel-string convention, the un-declared-surface degradation.

`make docs-check` green (237 examples, link-integrity gate included). `git diff --check` clean. Master untouched (explicit-refspec push).