### PR TITLE
Evaluate YJIT vs ZJIT on Ruby 4.0 and add a JIT run-speed reference

### DIFF
--- a/docs/notes/20260714-jit-evaluation-yjit-zjit-ruby40.md
+++ b/docs/notes/20260714-jit-evaluation-yjit-zjit-ruby40.md
@@ -1,0 +1,89 @@
+# JIT evaluation for `rigor check` — YJIT vs ZJIT on Ruby 4.0 (2026-07-14)
+
+Status: measurement note, no spec/design commitments. Grounds the JIT
+guidance in [`skills/rigor-project-init/references/05-jit-performance.md`](../../skills/rigor-project-init/references/05-jit-performance.md)
+and confirms the [ADR-75-era deferred-YJIT decision](../adr/50-release-engineering-and-stability-strategy.md)
+(shipped as `Rigor::Runtime::Jit`, the 5 s deadline) still picks the right
+JIT now that Ruby 4.0 ships ZJIT alongside YJIT.
+
+## Question
+
+Ruby 4.0.5 ships **both** JITs compiled in (`RbConfig::CONFIG` reports
+`YJIT_SUPPORT="yes"` and `ZJIT_SUPPORT="yes"`; `ruby --yjit` / `ruby --zjit`
+each report `+YJIT` / `+ZJIT` and `RubyVM::{YJIT,ZJIT}.enabled? == true`).
+Rigor's deferred-JIT feature only knows YJIT. Now that ZJIT (the newer
+method-based JIT, [docs](https://docs.ruby-lang.org/en/master/jit/zjit_md.html))
+is available, should Rigor prefer it — and does a JIT help at all on the run
+sizes users actually see?
+
+## Method
+
+Real product workload: in-process `rigor check --no-cache` (cold) on
+`rigor-survey` targets spanning the size spectrum. The JIT is selected at
+process start via `RUBYOPT=--yjit` / `--zjit`; the interpreter arm sets
+neither. **Every arm sets `RIGOR_DISABLE_YJIT=1`** so Rigor's own
+deferred-YJIT never fires and the only JIT active is the arm's flag.
+Interleaved 3-pass reps, median reported. Wall is the metric (a JIT does
+not change allocations — verified — nor diagnostics: **all three arms
+produced byte-identical diagnostic counts on every target**, so both JITs
+are correctness-safe on Rigor). Shared dev host (arm64-darwin, Ruby 4.0.5);
+wall carries machine noise, but the pattern below is far larger than the
+run-to-run spread and min tracks median.
+
+## Result (cold `rigor check`, seconds, median of 3)
+
+| target (size) | interp | YJIT | ZJIT | YJIT vs interp | ZJIT vs interp | ZJIT vs YJIT | diag |
+|---|--:|--:|--:|--:|--:|--:|--:|
+| kramdown `lib` (~1.6 s, small) | 1.61 | 2.69 | 2.21 | **+67 %** | **+37 %** | −18 % | 68 |
+| mail `lib` (~4 s, medium) | 4.00 | 4.05 | 4.18 | +0 % | +4 % | +3 % | 26 |
+| rigor `lib` (~8 s) | 8.06 | 7.03 | 7.71 | **−13 %** | −4 % | +10 % | 1 |
+| gitlab `app/models` (~19 s) | 18.96 | 15.11 | 16.59 | **−20 %** | −13 % | +10 % | 210 |
+| mastodon `app`+`lib` (~17 s, large) | 16.58 | 11.86 | 14.29 | **−28 %** | −14 % | +21 % | 2348 |
+
+(mastodon interp is ~17 s, not the ~25 s of the session-start baseline,
+because the v0.3.0 perf arc — allocation-free AST iteration etc. — has since
+landed on master; this is current-master interp.)
+
+## Findings
+
+1. **Both JITs are correctness-safe.** Diagnostics are byte-identical across
+   interp / YJIT / ZJIT on every target. Neither JIT miscompiles Rigor.
+2. **A JIT only pays off once the run is long enough to amortize warm-up.**
+   Below ~4 s both JITs *lose* to the interpreter (kramdown: YJIT +67 %,
+   ZJIT +37 %). The crossover for YJIT is between ~4 s (mail, break-even) and
+   ~8 s (rigor `lib`, −13 %). This is exactly why Rigor defers YJIT behind a
+   5 s deadline rather than enabling it at boot.
+3. **On the runs that matter (large, cold), YJIT wins and beats ZJIT
+   everywhere.** YJIT −13 % to −28 %; ZJIT −4 % to −14 %; **YJIT is 10–21 %
+   faster than ZJIT on every target where both help.** ZJIT's peak win is
+   roughly half YJIT's.
+4. **ZJIT beats YJIT only on the smallest target** (kramdown, ZJIT −18 % vs
+   YJIT) — where *both* lose to the interpreter anyway. ZJIT's warm-up is
+   lighter, so it is less bad on short runs, but that is the zone where you
+   want no JIT at all.
+
+## Verdict
+
+**Keep YJIT as Rigor's JIT; do not adopt ZJIT at Ruby 4.0.** On every
+workload long enough for a JIT to be worth enabling, YJIT delivers ~1.5–2×
+more of the win than ZJIT. The result is consistent with the two JITs'
+maturity at this point: YJIT (lazy basic-block versioning, mature) optimizes
+Rigor's allocation-heavy, branchy, polymorphic-dispatch hot loops better in
+steady state; ZJIT (newer method-based JIT) has a lighter warm-up but does
+not yet match YJIT's throughput on this workload. Rigor's deferred-JIT design
+(`Rigor::Runtime::Jit`, enable YJIT after a 5 s deadline) already picks the
+right JIT and the right moment — this measurement confirms it against the new
+option rather than changing it.
+
+## Caveats / re-evaluation triggers
+
+- **Defaults only.** ZJIT (like YJIT) has tuning knobs
+  (`--zjit-call-threshold`, …); this compares out-of-the-box behaviour — what
+  a user actually gets. Aggressive tuning could shift ZJIT's crossover but is
+  not what ships.
+- **Warm runs unmeasured.** A warm `rigor check` is ~0.2–1.5 s (IO / require
+  bound, not JIT-able); both JITs would lose there, and Rigor never enables a
+  JIT on a run that short.
+- **Re-evaluate ZJIT** when a future Ruby's ZJIT closes the steady-state gap
+  to YJIT on a large-cold `rigor check` (re-run this matrix), or if ZJIT
+  becomes the upstream default JIT. Until then YJIT stands.

--- a/skills/rigor-project-init/SKILL.md
+++ b/skills/rigor-project-init/SKILL.md
@@ -126,6 +126,7 @@ committed `sig/` directory.
 | 2 | [`references/02-configure.md`](references/02-configure.md) | **Phase 4.** Severity-profile choice tied to the mode. The `.rigor.dist.yml` template and every key it uses. The `.rigor.dist.yml` vs `.rigor.yml` convention. |
 | 3 | [`references/04-sig-uplift.md`](references/04-sig-uplift.md) | **Phase 5.** `rigor sig-gen --write` baseline. `rigor sig-gen --params=observed --write` attr_reader precision uplift. Handling residual `untyped` methods. Committing `sig/`. |
 | 4 | [`references/03-baseline-and-bugs.md`](references/03-baseline-and-bugs.md) | **Phases 6–8.** `rigor triage` as the diagnosis layer. Phase 6a pre-baseline cleanup loop (`pre_eval:` for monkey-patch hints, `rbs collection install`). `rigor baseline generate` + wiring `baseline:`. Surfacing likely real bugs; sig quality FP recognition (Struct `call.wrong-arity`, `-> bot` return-type-mismatch, regex-capture `$1` FPs). The two escalation paths — write a project plugin, or open a Rigor issue. |
+| — (optional) | [`references/05-jit-performance.md`](references/05-jit-performance.md) | **Operational, not a phase.** Run speed via a Ruby JIT: Rigor auto-enables YJIT for long runs (~5 s break-even), how to detect JIT support in your install, the override env vars, and why YJIT beats ZJIT for Rigor on Ruby 4.0. Read only when a large project's `rigor check` wall time matters. |
 
 ## Escalation paths (Phase 7 preview)
 

--- a/skills/rigor-project-init/references/05-jit-performance.md
+++ b/skills/rigor-project-init/references/05-jit-performance.md
@@ -1,0 +1,117 @@
+# Reference 05 — JIT and run speed (YJIT / ZJIT)
+
+Operational, not part of onboarding proper: how Rigor uses a Ruby JIT to
+speed up analysis, how to tell whether it is active in your install, and the
+trade-off (and break-even point) if you want to override the default. Read
+this when a project is large enough that `rigor check` wall time matters —
+Rails monorepos especially. On a small project you can ignore it entirely:
+Rigor already does the right thing with no configuration.
+
+## TL;DR
+
+- **You usually do nothing.** Rigor enables YJIT automatically once a run has
+  been going long enough to be worth it, and leaves it off for short runs
+  where it would only add warm-up cost. This is on by default.
+- **Break-even is ~5 seconds.** A JIT pays for its warm-up only on longer
+  runs; below it, JIT-on is *slower*. Rigor's 5-second deadline is set at
+  that crossover.
+- **YJIT, not ZJIT.** Ruby 4.0 ships both JITs, but YJIT is faster for Rigor's
+  workload — measurably so on every run large enough for a JIT to help. Rigor
+  uses YJIT; there is no reason to force ZJIT.
+
+## How Rigor uses a JIT
+
+`rigor check` and `rigor coverage` arm a background timer at the start of a
+run. If the run is still going after ~5 seconds, YJIT is switched on for the
+remainder; a run that finishes first never pays any JIT cost. So:
+
+- A quick check (a small project, or a warm cache hit) runs on the plain
+  interpreter — no warm-up penalty.
+- A long cold analysis of a large project gets YJIT for its dominant tail,
+  where the speed-up more than repays the warm-up.
+
+Diagnostics and their counts are identical whether or not the JIT engages —
+a JIT changes wall time only, never results.
+
+The long-running servers `rigor lsp` and `rigor mcp` turn YJIT on at start
+instead, since they always run long.
+
+## Is a JIT available in my install?
+
+The deferred-YJIT feature only helps if the Ruby your `rigor` runs on was
+built with YJIT support. Rigor is installed standalone (see
+[Installing Rigor](../../../docs/manual/01-installation.md)), so this is a
+property of *that* Ruby, which may differ from your project's Ruby.
+
+Check the Ruby that runs `rigor`:
+
+```sh
+ruby --yjit -e 'require "rbconfig"; puts "YJIT: #{RbConfig::CONFIG["YJIT_SUPPORT"]}"; puts "ZJIT: #{RbConfig::CONFIG["ZJIT_SUPPORT"]}"'
+# YJIT: yes   → the deferred-YJIT engages automatically on long runs
+# YJIT: no    → the feature is a silent no-op; runs use the interpreter
+```
+
+- Most prebuilt CRuby 3.3+ (mise / rbenv / asdf, the recommended install
+  channels) ship with YJIT built in.
+- The Nix flake package of Rigor bundles a Ruby with **both** YJIT and ZJIT.
+- A YJIT-less Ruby is not an error — Rigor just runs interpreted, correctly.
+
+## Overriding the default
+
+Three environment variables, documented in the
+[CLI reference § Environment variables](../../../docs/manual/02-cli-reference.md#environment-variables):
+
+| Want | Do |
+| --- | --- |
+| Force YJIT on for the **whole** run (including the first 5 s) | `RUBYOPT="--yjit" rigor check …` |
+| Turn Rigor's JIT off entirely | `RIGOR_DISABLE_YJIT=1 rigor check …` |
+| Change the deadline (advanced) | `RIGOR_YJIT_DEADLINE=<seconds> rigor check …` |
+
+When would you override?
+
+- **Force-on** helps only if *every* run you care about is long (a big
+  monorepo in CI where even the fast path is > 5 s). On mixed workloads the
+  default deadline is better — it protects your quick local re-checks.
+- **Off** is the escape hatch if a JIT ever misbehaves on your platform, or to
+  get a clean interpreter baseline when measuring.
+
+## Why the ~5-second break-even (the trade-off)
+
+A JIT compiles hot code to machine code, which costs time up front and repays
+it over the rest of the run. On a short run the compilation never amortizes,
+so JIT-on loses. Measured cold `rigor check`, by project size:
+
+| run size | interpreter | YJIT | effect |
+| --- | --- | --- | --- |
+| ~1.6 s (small lib) | baseline | **+67 %** | JIT-on loses badly |
+| ~4 s (medium lib) | baseline | ~break-even | a wash |
+| ~8 s | baseline | **−13 %** | JIT-on wins |
+| ~19 s (Rails monorepo) | baseline | **−20 %** | wins more |
+| ~17 s (large Rails app) | baseline | **−28 %** | biggest win |
+
+The deadline parks the enable point just past the loss zone: runs that finish
+before ~5 s never pay warm-up; longer runs collect the win on their tail.
+
+## YJIT vs ZJIT (Ruby 4.0)
+
+Ruby 4.0 ships a second JIT, **ZJIT** (a newer method-based JIT;
+[upstream docs](https://docs.ruby-lang.org/en/master/jit/zjit_md.html)). It
+is real and correctness-safe on Rigor (identical diagnostics), but **slower
+than YJIT for Rigor's workload** at Ruby 4.0. Measured cold, on the runs where
+a JIT helps at all:
+
+| target | YJIT vs interpreter | ZJIT vs interpreter | ZJIT vs YJIT |
+| --- | --- | --- | --- |
+| ~8 s | −13 % | −4 % | +10 % |
+| ~19 s (monorepo) | −20 % | −13 % | +10 % |
+| ~17 s (large app) | −28 % | −14 % | +21 % |
+
+YJIT wins on every workload large enough to warrant a JIT; ZJIT's peak
+speed-up is roughly half. ZJIT only edges YJIT on tiny runs — the zone where
+you want no JIT at all. **Do not force ZJIT** (`RUBYOPT="--zjit"`) for Rigor;
+the automatic YJIT is faster. Full measurement + methodology:
+[`docs/notes/20260714-jit-evaluation-yjit-zjit-ruby40.md`](../../../docs/notes/20260714-jit-evaluation-yjit-zjit-ruby40.md).
+
+This verdict is Ruby-4.0-specific; ZJIT is younger than YJIT and improving, so
+it may close the gap in a later Ruby. Until then YJIT is the right default —
+which is what Rigor already does.


### PR DESCRIPTION
Two docs deliverables from measuring Rigor under Ruby 4.0's two JITs.

## `docs/notes/20260714-jit-evaluation-yjit-zjit-ruby40.md`
A cold `rigor check` sweep (interpreter / YJIT / ZJIT) across the size spectrum — kramdown, mail, rigor lib, gitlab `app/models`, mastodon `app+lib` — interleaved 3-pass median, `RIGOR_DISABLE_YJIT=1` on every arm so only the arm's process-start JIT is active. **Diagnostics byte-identical across all three arms on every target** (both JITs correctness-safe). Result: a JIT only pays off past ~5 s (below it, both lose to the interpreter); on the runs that matter YJIT wins **−13 % to −28 %** vs interpreter and beats ZJIT by **10–21 %** everywhere both help; ZJIT edges YJIT only on the tiny run where both lose anyway. **Verdict: keep YJIT; do not adopt ZJIT at Ruby 4.0** — which is what Rigor's deferred-YJIT (`Rigor::Runtime::Jit`, 5 s deadline) already does. Re-eval triggers recorded. No flake change needed: the flake Ruby already ships both JITs (`YJIT_SUPPORT=yes` / `ZJIT_SUPPORT=yes`).

## `skills/rigor-project-init/references/05-jit-performance.md`
User-facing operational reference (linked as an optional module in `SKILL.md`): Rigor auto-enables YJIT for long runs so you usually do nothing; how to detect JIT support in your standalone install; the ~5 s break-even and its measured curve; the override env vars (`RUBYOPT=--yjit` force-on, `RIGOR_DISABLE_YJIT=1`, `RIGOR_YJIT_DEADLINE`); and the YJIT-over-ZJIT verdict with the don't-force-ZJIT guidance. Cross-links the note and the CLI-reference env-var table.

`make docs-check` green (237 examples, link-integrity gate); all cross-tree links resolve; `git diff --check` clean; master untouched (explicit-refspec push).