### PR TITLE
Recalibrate the perf baseline after the v0.3.0 performance arc

### DIFF
--- a/bench/baseline.json
+++ b/bench/baseline.json
@@ -1,13 +1,13 @@
 {
   "calibrated": true,
-  "calibrated_at": "2026-07-11T00:00:00Z",
-  "calibrated_on": "ubuntu-latest (GitHub Actions), release/0.2.9 @ run 29152992231",
-  "note": "Linux CI measurements. wall_s is wider than local macOS (runner noise); allocations is the tight signal. Refresh by triggering release-gate.yml, downloading the bench-baseline-* artifact, and committing its targets here. Recalibrated for the v0.2.9 cut: allocations grew ~+5.6% since the v0.2.8 baseline (27.78M -> 29.33M) — individually-reviewed feature cost from this cycle's engine additions (the ADR-57 WD3 module-singleton discovery seed widens the seed pass, plus the ADR-82 external-gem provenance and the structure.sql schema-source paths), each measured perf-neutral A/B against the prior state, with the OSS-corpus (Mastodon) sweep staying green (no new false positives) — so the increase is blessed feature cost, not a regression. peak_rss_kb and wall_s refreshed to the same run's values. The allocations_pct band stays tight at 5%.",
+  "calibrated_at": "2026-07-14T00:00:00Z",
+  "calibrated_on": "ubuntu-latest (GitHub Actions), master @ run 29358704822",
+  "note": "Linux CI measurements. wall_s is wider than local macOS (runner noise); allocations is the tight signal. Refresh by triggering release-gate.yml, downloading the bench-baseline-* artifact, and committing its targets here. Recalibrated after the v0.3.0 performance arc (PRs #74-#82: deadline-armed YJIT, rigor_each_child, plugin-prepare cache, lazy pre-pass, run-scoped return memo, seed bundles). Allocations fell ~24% (29.33M -> 22.24M) and wall ~35% (21.2s -> 13.8s); the allocation target is tightened to the new value so the 5% band keeps its teeth. peak_rss_kb ROSE ~15% (260.2 MB -> 299.4 MB), which is YJIT: it arms after the 5s deadline and this run lasts ~13.8s, so the JIT's code + metadata are resident for most of it. A/B measured on the dev host, same in-process check: 336 MB with YJIT vs 292 MB with RIGOR_DISABLE_YJIT=1 (+14.9%), matching the CI delta almost exactly — so the increase is the memory price of the 1.7x wall win in PR #75, not a leak. The OSS-corpus (Mastodon) sweep stayed green on the same run (no new false positives).",
   "targets": {
     "lib": {
-      "wall_s": 21.243,
-      "allocations": 29330383,
-      "peak_rss_kb": 260228,
+      "wall_s": 13.808,
+      "allocations": 22239139,
+      "peak_rss_kb": 299364,
       "diagnostics": 1
     }
   }


### PR DESCRIPTION
`bench/baseline.json` still described the v0.2.9 cut, so **master fails its own release gate** ([run 29358704822](https://github.com/rigortype/rigor/actions/runs/29358704822)):

```
FAIL lib peak_rss_kb: 299364 > 286251 (+15.0% vs baseline 260228, band +10%)
OK   lib wall_s:      13.808  ≤ 25       (baseline 21.243)
OK   lib allocations: 22239139 ≤ 30796902 (baseline 29330383)
```

## Adjudication

Two of the three signals improved sharply — allocations **−24%** (29.33M → 22.24M) and wall **−35%** (21.2s → 13.8s), the measured payoff of the perf arc (PRs #74–#82). The allocation target is tightened to the new value: leaving it at 29.33M would leave 24% of slack for a future regression to hide in, which defeats the point of the tightest band.

The one red signal is peak RSS, and it is **YJIT**, not a leak. PR #75's deadline-armed YJIT enables the JIT after 5s; this run lasts ~13.8s, so JIT code + metadata are resident for most of it. A/B on the dev host, same in-process `check --no-cache lib`:

| | peak RSS |
| --- | ---: |
| default (YJIT arms) | 336 MB |
| `RIGOR_DISABLE_YJIT=1` | 292 MB |

**+14.9%** — the CI delta (260.2 → 299.4 MB, +15.0%) almost exactly. So the RSS is the memory price of the 1.7× wall win, and it is blessed as feature cost rather than banded around. The Mastodon OSS sweep on the same run stayed green (advisory job succeeded), so no false positive rides in with the recalibration.

Bands in `bench/thresholds.yml` are unchanged.

## Verification

`make bench-perf` passes locally against the new baseline. Re-dispatching `release-gate.yml` on this branch to confirm green on the Linux runner.