### PR TITLE
Fix rigor annotate noise on multi-line literal interior lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ v0.2.9 sharpens Rigor on large Rails applications, with GitLab-scale projects as
 
 ### Fixed
 
+- **[rigor annotate]** Interior lines of a multi-line Hash literal (and of a multi-line keyword-argument list) no longer carry a noise `#=> Dynamic[top]` annotation; the literal's type now appears once, on the line the enclosing statement closes.
 - **[cli]** `rigor check --format <name>` for a format listed as supported but not wired now fails loudly instead of printing nothing, so a drift between the supported-format list and the dispatch cannot pass silently.
 - **[engine]** A guard like `if login.present?` / `return if content.blank?` now narrows a nilable receiver, so the guarded call no longer reads as `possible nil receiver`.
   - When a predicate's signature declares it always returns `false` for `nil` (as ActiveSupport's `NilClass#present?` does), a truthy answer proves the receiver was not nil and the nil arm is dropped on that edge, mirrored on the falsey edge for `blank?`. Only value-pinned `nil` / `true` / `false` arms participate, and a safe-navigation guard (`x&.blank?`) is deliberately left alone. Removes four false positives on Redmine and sixteen on GitLab, none introduced anywhere.

--- a/lib/rigor/cli/annotate_command.rb
+++ b/lib/rigor/cli/annotate_command.rb
@@ -253,9 +253,13 @@ module Rigor
       end
 
       # For a line no statement closes (the `if` / block header lines), fall back to the widest expression ending there.
+      # A hash-pair node (`1 => 2,` inside a multi-line literal / keyword-argument list) is not an expression — typing
+      # it only echoes the `Dynamic[top]` fallback — so those interior lines stay bare and the literal's type appears
+      # once, on the line the enclosing statement closes.
       def fill_uncovered_lines(program, by_line)
         widest_per_line(program).each do |line, node|
           next if by_line.key?(line)
+          next if node.is_a?(Prism::AssocNode) || node.is_a?(Prism::AssocSplatNode)
 
           type = node.is_a?(Prism::BlockParametersNode) ? block_params_type(node) : type_of(node)
           by_line[line] = type unless type.nil?

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -1624,6 +1624,34 @@ RSpec.describe Rigor::CLI do
       expect(out.lines[0]).to include("#=> :else | :then")
     end
 
+    it "annotates a multi-line hash literal once, on its closing line, leaving pair lines bare" do
+      source = <<~RUBY
+        h = {
+          1 => 1,
+          1 => 2,
+          1.0 => 3,
+          1.00 => 4,
+        }
+        p h
+      RUBY
+      path = write_fixture("a.rb", source)
+
+      status, out, err = run_cli("annotate", "--no-color", path)
+
+      expect(err).to eq("")
+      expect(status).to eq(0)
+      lines = out.lines
+      # Interior pair lines are not expressions — no `Dynamic[top]` fill noise.
+      (1..4).each { |i| expect(lines[i]).not_to include("#=>") }
+      expect(lines[5]).to start_with("}").and include("#=> Hash[1 | 1.0, 1 | 2 | 3 | 4]")
+      expect(lines[6]).to include("p h").and include("#=>")
+
+      # Re-annotating the annotated output is stable (the multi-line-literal shape included).
+      second_path = write_fixture("b.rb", out)
+      _status, second, _err = run_cli("annotate", "--no-color", second_path)
+      expect(second).to eq(out)
+    end
+
     it "annotates `while`-loop body lines with the converged post-fixpoint types" do
       source = <<~RUBY
         def factorial(n)


### PR DESCRIPTION
## Summary

\`rigor annotate\` filled uncovered interior lines of a multi-line Hash literal by typing the widest expression ending on each line — but an \`AssocNode\` / \`AssocSplatNode\` is not an expression, so every interior pair line got a spurious \`#=> Dynamic[top]\` annotation:

```ruby
h = {
  1 => 1,    #=> Dynamic[top]   <- noise (before)
  1 => 2,    #=> Dynamic[top]   <- noise (before)
}            #=> Hash[...]
```

\`fill_uncovered_lines\` now skips assoc nodes, so a multi-line literal annotates exactly once, at its end line. Idempotent re-annotation verified (annotate∘annotate == annotate).

Found while validating the acceptance example from the 2026-07-15 PHPStan-survey follow-up work; composes with #102, after which the example annotates as \`{ 1 => 2, 1.0 => 4 }\`.

## Gates

- New spec asserting the acceptance shape + idempotency; all 28 annotate specs green
- \`make verify\` green (test / lint / self-check / check-plugins), \`make docs-check\` 237/237