### PR TITLE
Fix the annotate hash-literal test merged red against scalar-key HashShape typing

### DIFF
--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -1643,7 +1643,9 @@ RSpec.describe Rigor::CLI do
       lines = out.lines
       # Interior pair lines are not expressions — no `Dynamic[top]` fill noise.
       (1..4).each { |i| expect(lines[i]).not_to include("#=>") }
-      expect(lines[5]).to start_with("}").and include("#=> Hash[1 | 1.0, 1 | 2 | 3 | 4]")
+      # The scalar-key HashShape folds the literal to a value-pinned shape with last-wins on duplicate keys
+      # (`1 => 1, 1 => 2` → `1 => 2`; `1.0 => 3, 1.00 => 4` share the float key `1.0` → `1.0 => 4`).
+      expect(lines[5]).to start_with("}").and include("#=> { 1 => 2, 1.0 => 4 }")
       expect(lines[6]).to include("p h").and include("#=>")
 
       # Re-annotating the annotated output is stable (the multi-line-literal shape included).


### PR DESCRIPTION
## Background
CI run [29418871430](https://github.com/rigortype/rigor/actions/runs/29418871430/job/87363890287?pr=105) merged to `master` with the annotate test at `spec/rigor/cli_spec.rb:1627` failing.

## Cause (merge-order interaction)
- The annotate feature (PR #103, `feature/annotate-command`) forked from `master` **before** the scalar-key HashShape typing (PR #102, `uplift/hash-shape-and-kernel-typing`) landed.
- Its expectation still asserted the pre-shape union rendering `Hash[1 | 1.0, 1 | 2 | 3 | 4]`.
- Once both branches merged, the hash literal folds to a value-pinned shape with last-wins on duplicate keys, so the actual output became `{ 1 => 2, 1.0 => 4 }` (`1 => 1, 1 => 2` → `1 => 2`; `1.0 => 3, 1.00 => 4` share the float key `1.0` → `1.0 => 4`).
- The test never re-ran against the composed state, so it was merged red.

The output itself is correct — it is PR #102's intended behavior, the same fold the `kernel_functions` snapshot already pins. Only the test expectation was stale.

## Change
- Update the stale expectation `Hash[1 | 1.0, 1 | 2 | 3 | 4]` to the current correct output `{ 1 => 2, 1.0 => 4 }`.
- Add a comment explaining the last-wins fold.
- No production behavior changes — spec-only.

## Testing
- [x] `bundle exec rspec spec/rigor/cli_spec.rb -e "annotates a multi-line hash literal once"` — green.
- [x] `rg "Hash\[1 \| 1.0"` — no other stale references.
- [x] `make verify` (test-binpacker 7849 examples / lint 890 files / `check` lib / `check-plugins`) — all 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)