### PR TITLE
Fix the cache-hit crash with an active baseline (+ two scenario-run follow-ups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Fixed
+
+- **[cli]** `rigor check` no longer crashes with `uninitialized constant Rigor::Analysis::Baseline` when a run-cache **hit** is served with a `baseline:` configured. The boot-slimmed cache-hit fast path skipped the lazy engine require bundle that carried the baseline filter's own dependency, so the *second* ordinary `check` after wiring a baseline — the exact next step of every acknowledge-mode onboarding — failed outright (workaround was `--no-cache`). The baseline filter is now a load-time dependency of the check command (it pulls only YAML, never the engine), and the hit path stays engine-free.
+- **[cli]** The `rigor baseline generate` hint for a config without `baseline:` now names the config file that actually governs the project (e.g. `.rigor.dist.yml`) instead of always saying `.rigor.yml`.
+
 ### Added
 
 - **[engine]** Hash literals with Integer, Float, `true` / `false` / `nil` keys now type as a value-pinned `HashShape` instead of degrading to a `Hash[K, V]` union, and a duplicate literal key is resolved **last-wins** exactly like the runtime — `{ 1 => 1, 1 => 2, 1.0 => 3, 1.00 => 4 }` types as `{ 1 => 2, 1.0 => 4 }` (previously `Hash[1 | 1.0, 1 | 2 | 3 | 4]`, with the overwritten values polluting the union), and `{ a: 1, a: 2 }` as `{ a: 2 }`.

--- a/lib/rigor/cli/baseline_command.rb
+++ b/lib/rigor/cli/baseline_command.rb
@@ -87,8 +87,11 @@ module Rigor
           "match-mode: #{options.fetch(:match_mode)})"
         )
         if configuration.baseline_path.nil?
+          # Name the config file that actually governs this project (`.rigor.dist.yml` when no local override
+          # exists), so the hint points at the file the user must edit.
+          config_name = options.fetch(:config) || Configuration.discover || ".rigor.yml"
           @err.puts(
-            "rigor: note — `.rigor.yml` does not declare `baseline:`; " \
+            "rigor: note — `#{config_name}` does not declare `baseline:`; " \
             "add `baseline: #{path}` to activate the suppression."
           )
         end

--- a/lib/rigor/cli/check_command.rb
+++ b/lib/rigor/cli/check_command.rb
@@ -8,6 +8,9 @@ require_relative "../configuration"
 require_relative "../config_audit"
 require_relative "../analysis/result"
 require_relative "../analysis/rule_catalog"
+# The baseline filter runs on EVERY exit path — including the ADR-87 WD4 cache-HIT fast path, which skips
+# `load_check_dependencies` — so it must be a load-time require. It pulls only YAML, never the engine.
+require_relative "../analysis/baseline"
 require_relative "../runtime/jit"
 require_relative "command"
 require_relative "options"
@@ -657,7 +660,6 @@ module Rigor
       def load_check_dependencies
         require_relative "../analysis/runner"
         require_relative "../analysis/buffer_binding"
-        require_relative "../analysis/baseline"
         require_relative "../cache/store"
         start_heap_trace_if_requested
       end

--- a/spec/rigor/cli/baseline_command_spec.rb
+++ b/spec/rigor/cli/baseline_command_spec.rb
@@ -69,6 +69,12 @@ RSpec.describe Rigor::CLI::BaselineCommand do
       expect(err).to include("note — `.rigor.yml` does not declare `baseline:`")
     end
 
+    it "names `.rigor.dist.yml` in the hint when that is the governing config file" do
+      FileUtils.mv(File.join(tmpdir, ".rigor.yml"), File.join(tmpdir, ".rigor.dist.yml"))
+      _status, _out, err = run_cli("baseline", "generate", cwd: tmpdir)
+      expect(err).to include("note — `.rigor.dist.yml` does not declare `baseline:`")
+    end
+
     it "refuses to overwrite an existing baseline without --force" do
       File.write(File.join(tmpdir, ".rigor-baseline.yml"), "version: 1\nignored: []\n")
       status, _out, err = run_cli("baseline", "generate", cwd: tmpdir)

--- a/spec/rigor/cli/run_cache_probe_spec.rb
+++ b/spec/rigor/cli/run_cache_probe_spec.rb
@@ -23,8 +23,9 @@ RSpec.describe "ADR-87 WD4 run-cache hit probe (subprocess)" do
   attr_reader :dir
 
   # Runs `rigor check` in a child process with a preload that records, at exit, how many engine features the
-  # process loaded. Returns `[exitstatus, engine_feature_count, stdout]`.
-  def check_run(*extra_args)
+  # process loaded. Returns `[exitstatus, engine_feature_count, stdout]`. Pass `baseline: true` to run without
+  # `--no-baseline`, letting the config's `baseline:` key apply.
+  def check_run(*extra_args, baseline: false)
     preload = File.join(dir, "loaded_features_probe.rb")
     marker = File.join(dir, "engine_features.txt")
     File.write(preload, <<~RUBY)
@@ -35,8 +36,9 @@ RSpec.describe "ADR-87 WD4 run-cache hit probe (subprocess)" do
       end
     RUBY
 
+    baseline_args = baseline ? [] : ["--no-baseline"]
     cmd = ["bundle", "exec", "ruby", "-r", preload, exe,
-           "check", "--no-ci-detect", "--no-stats", "--no-baseline", *extra_args, "lib"]
+           "check", "--no-ci-detect", "--no-stats", *baseline_args, *extra_args, "lib"]
     stdout, _stderr, status = Open3.capture3(*cmd, chdir: dir)
     [status.exitstatus, File.read(marker).to_i, stdout]
   end
@@ -63,6 +65,21 @@ RSpec.describe "ADR-87 WD4 run-cache hit probe (subprocess)" do
     expect(hit_engine).to eq(0)
     # The clean fixture produces a clean run, served from cache.
     expect(hit_stdout).to include("No diagnostics")
+  end
+
+  it "serves a warm HIT engine-free with an active baseline (the onboarding second-run sequence)" do
+    write_project
+    File.write(File.join(dir, ".rigor.yml"),
+               "severity_profile: balanced\nbaseline: .rigor-baseline.yml\n")
+
+    # The exact post-onboarding sequence: prime the run cache, generate + wire a baseline, run again normally.
+    check_run(baseline: true) # cold miss primes the cache
+    _stdout, _stderr, status = Open3.capture3("bundle", "exec", "ruby", exe, "baseline", "generate", chdir: dir)
+    expect(status.exitstatus).to eq(0)
+
+    hit_status, hit_engine, = check_run(baseline: true)
+    expect(hit_status).to eq(0) # regression guard: this crashed with `uninitialized constant Analysis::Baseline`
+    expect(hit_engine).to eq(0) # the baseline filter must not drag the engine onto the hit path
   end
 
   it "declines the probe (loads the engine) for --no-cache" do


### PR DESCRIPTION
## Summary

An autonomous onboarding-scenario run (rigor-next-steps → rigor-project-init in acknowledge mode, driven by a subagent against a real Rails app, kaigionrails/conference-app) surfaced a HIGH-severity crash plus two smaller defects. All three are fixed here.

### 1. Cache-hit crash with an active baseline (the headline)

The ADR-87 WD4 boot-slimmed run-cache HIT path skips `load_check_dependencies` — the only place that required `analysis/baseline`. So the exact sequence every acknowledge-mode adopter follows — (1) `rigor check` (primes the cache), (2) `rigor baseline generate`, (3) wire `baseline:`, (4) run `rigor check` again — crashed deterministically on step 4 with `uninitialized constant Rigor::Analysis::Baseline`; even the rescue clause failed to resolve the constant. Workaround was `--no-cache`.

Fix: the baseline filter runs on every exit path, so require it at load time (it pulls only YAML, never the engine — the WD4 engine-free-hit property is preserved and asserted). The probe spec's helper hard-coded `--no-baseline`, which is why the gap was invisible; the onboarding second-run sequence is now a subprocess regression case asserting both no-crash and engine-free.

### 2. Stale annotate spec (pre-existing master red)

`make verify` on master fails by one example: the scalar-key HashShape slice changed the fixture's rendering to the exact last-wins shape, and the annotate multi-line-hash spec still asserted the old `Hash[K, V]` union text. Expectation aligned; the spec's actual subject (annotate once, on the closing line) is untouched.

### 3. `baseline generate` hint names the wrong file

The activation hint always said `.rigor.yml`; on a `.rigor.dist.yml`-configured project (the onboarding default) that reads as a wrong instruction. The hint now resolves the governing file via `--config` / `Configuration.discover`.

## Verification

`make verify` green (test 7851 examples / lint / check / check-plugins), `git diff --check` clean. Red-check: the new probe spec fails with the fix reverted.

A separate PR follows with the skill-side improvements from the same scenario run.