### PR TITLE
Warn on unknown top-level config keys (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,18 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Added
+
+- **[rigor check]** `rigor check` now warns when `.rigor.yml` carries a top-level key Rigor does not recognise, naming the nearest real key: `` rigor: `excludee` is not a recognized configuration key; it has no effect. Did you mean `exclude`? ``
+  - Previously the loader dropped the key in silence, so a typo'd `exclude:` never applied and the run reported errors from the very files you meant to skip, with nothing saying why. This is the same class of mistake the existing config warnings cover — a value that silently resolves to nothing — and whole keys were the one instance of it going unwarned.
+  - It is a warning, never an error: your exit code does not change. The finding also appears in `--format=json` under `config_warnings` with `"kind": "unknown_key"`, so CI can assert on it.
+  - Top-level keys only. A typo *inside* a group (`cache: { pth: … }`) is caught by the [JSON schema](schemas/rigor-config.schema.json) as you type instead.
+
 ### Fixed
+
+- **[rigor init]** The generated config's editor-schema link now resolves. `rigor init` wrote a `# yaml-language-server: $schema=…` comment pointing at a GitHub org this project does not use, so the URL 404'd and **every project started with `rigor init` had no schema validation at all** — no autocomplete, no hover docs, no structural checking. An unreachable schema is indistinguishable from a schema with no complaints, which is why it went unnoticed. The URL and the schema's own `$id` now come from one constant and are pinned equal by a spec. The generated file also pointed readers at an internal contributor document; it now links the [configuration manual](docs/manual/03-configuration.md) and `rigor docs configuration`.
+
+- **[rigor check]** `.rigor.yml`'s `cache.max_bytes` and `cache.validation` are no longer rejected by the [JSON schema](schemas/rigor-config.schema.json). Both are real, documented keys, but the schema declared only `cache.path` and closed the object — so an editor loading the schema told you your valid config was invalid. The schema's parity spec only checked top-level keys, which is how the nested surface drifted; it now walks every level. ([ADR-99](docs/adr/99-config-schema-authority.md))
 
 - **[docs]** The plugin documentation no longer tells you to add `gem "rigor-rails"` to your `Gemfile` — an impossible action, in five places including the **shipped** [plugin chapter](docs/manual/07-plugins.md) served by `rigor docs`. [ADR-12](docs/adr/12-dry-rb-packaging.md) designed `rigor-rails` as a *Gemfile-convenience* meta-gem for a world where each plugin was its own gem; commit `9769f5fa` dropped the per-plugin gemspecs and [ADR-31](docs/adr/31-contribution-and-supply-chain-policy.md) settled distribution on the single bundled `rigortype` gem. The premise died, the language did not: there is no `rigor-rails` gem (404 on RubyGems), and `plugins: [rigor-rails]` is rejected by the loader. The meta-gem is now described as what it is — **unwired**, with no supported use — and kept deliberately rather than removed ([ADR-96](docs/adr/96-plugin-target-gems.md) WD5, applying [ADR-92](docs/adr/92-normative-status-fidelity.md)'s rule that a marker is always cheaper than a lie). Also corrected: `Plugin::Loader`'s worked example for the `{gem:, id:}` config form used `{gem: "rigor-rails", id: "rails"}`, and **no plugin has the id `rails`**.
 

--- a/docs/CURRENT_WORK.md
+++ b/docs/CURRENT_WORK.md
@@ -5,9 +5,10 @@ The session handoff (ADR-98). It answers ONE question: what should the next sess
   Anything that would outlive two sessions does not belong here: backlog → a GitHub issue
   (docs/agents/issue-tracker.md), operational pitfalls → the workflow's skill, decisions → an ADR,
   measurements → docs/notes/, shipped → CHANGELOG.md.
-- Verify a claim before carrying it forward. Two items died of this in one week: the 2026-07-17 #1
-  item ("a live bug, do this first") was refuted by its own repro — guarded since 2026-05-01 — and
-  an "open" AR-lambda item had been fixed since 2026-05-28 (`fde760a2`).
+- Verify a claim before carrying it forward. Three items have died of this in one week: the
+  2026-07-17 #1 item ("a live bug, do this first") was refuted by its own repro — guarded since
+  2026-05-01 — an "open" AR-lambda item had been fixed since 2026-05-28 (`fde760a2`), and roughly
+  40% of the ROADMAP backlog turned out to have shipped.
 -->
 
 # Current Work — Session Handoff
@@ -21,42 +22,52 @@ the one that is wrong.
 - **v0.2.9 published 2026-07-11.** master accumulates toward **v0.3.0**; its two mandatory pieces
   (deprecation clearance [#94](https://github.com/rigortype/rigor/pull/94), perf recalibration
   [#95](https://github.com/rigortype/rigor/pull/95)) are done — the rest of the cut is whatever
-  issues get the `v0.3.0` milestone.
+  issues carry the `v0.3.0` milestone.
 - The line is **evaluation** (ADR-50): outside feedback + completing the feature set toward the
   v1.0.0 freeze. The protection ceiling is a measured floor (ADR-67 WD2 spiked and deferred — do not
   re-recommend it); the next direction is the line's purpose, not another engine-precision feature.
-- `make verify` and `make docs-check` clean. PR [#119](https://github.com/rigortype/rigor/pull/119)
-  (docs-economy + ADR-97/98 flow re-org) is open and awaiting the user's review.
+- **The docs/flow re-org is done** (ADR-97, ADR-98, [#119](https://github.com/rigortype/rigor/pull/119)):
+  the backlog is GitHub Issues, `docs/ROADMAP.md` is deleted and gated against recreation, `CLAUDE.md`
+  is an `@AGENTS.md` shell, and this file is capped at 120 lines.
+- **The config surface is done** (ADR-99, [#170](https://github.com/rigortype/rigor/pull/170)): the
+  JSON schema is a named source of truth, `rigor_rs:` is reserved for the Rust port, and the nested /
+  reserved / URL axes are gated.
+- `make verify` and `make docs-check` clean.
 
 ## Next session
 
-1. **`Regexp.last_match` match-success narrowing (ADR-93 WD1a).** herb gains 4
-   `call.possible-nil-receiver` under `--treat-all-as-inline-rbs`: the receiver is
-   `Regexp.last_match(1)` after a successful `=~` whose group always participates
-   (`/\n([ \t]+)\z/`), so nil is unreachable. A pre-existing imprecision masked by herb's
-   `-> untyped` sigs; FP-reducing on its own, and per the ADR-57 protocol it must land **before**
-   item 2, which surfaces it.
-2. **ADR-93's `require_magic_comment:` default flip + the WD2 default-wiring decision — after 1.**
-   The WD1 gate is landed and the mode is corpus-safe; note ADR-94: if the rbs 3.x floor ever moves,
-   the reader migrates to `RBS::InlineParser` and WD2/WD3 evaporate — do not over-invest.
-3. **Correct ADR-94 WD2 — its `UntypedFunction` "live bug" does not reproduce.** The WD2 claim
-   ("a `(?)` method type crashes `rigor check` today") is refuted: `CheckRules#arity_eligible?` and
-   `#argument_check_eligible?` guard the form (landed 2026-05-01, `fc1da90e` / `ef0dd777`), and the
-   ADR's own repro plus six variant shapes run clean (probed 2026-07-17). Adjudicate whether any
-   reproducing shape exists, then fix the ADR text — a normative record asserting a bug that is not
-   there is ADR-92's disease in the opposite direction.
+The `v0.3.0` config arc is closed; pick from the milestone. The two open items there:
 
-Adjacent open issues, if a session wants them instead:
-[#161](https://github.com/rigortype/rigor/issues/161) (env-quarantine warning → diagnostic; needs a
-severity decision — new rule ids freeze at v1.0),
-[#162](https://github.com/rigortype/rigor/issues/162) (`static.*` + `void_origins`),
-[#163](https://github.com/rigortype/rigor/issues/163) (internal-spec status-fidelity sweep).
+1. **[#120](https://github.com/rigortype/rigor/issues/120) — mature `--incremental` (ADR-46) toward a
+   default-capable check path.** `ready-for-human`: it needs a judgment call on what "default-capable"
+   requires before implementation. The `--verify-incremental` gate (incremental == full `--no-cache`,
+   byte-identical) is the acceptance bar and is already wired into CI.
+2. Whatever else earns the milestone. The unmilestoned backlog is
+   [the open issues](https://github.com/rigortype/rigor/issues); `ready-for-agent` ones are specified
+   enough to start with no human context.
+
+Carried over from the rbs-inline arc, still open and not milestoned:
+
+- **`Regexp.last_match` match-success narrowing (ADR-93 WD1a).** herb gains 4
+  `call.possible-nil-receiver` under `--treat-all-as-inline-rbs`: the receiver is
+  `Regexp.last_match(1)` after a successful `=~` whose group always participates
+  (`/\n([ \t]+)\z/`), so nil is unreachable. A pre-existing imprecision masked by herb's
+  `-> untyped` sigs; FP-reducing on its own, and per the ADR-57 protocol it must land **before**
+  ADR-93's default flip, which surfaces it.
+- **ADR-93's `require_magic_comment:` default flip + the WD2 default-wiring decision.** Note ADR-94:
+  if the rbs 3.x floor ever moves, the reader migrates to `RBS::InlineParser` and WD2/WD3 evaporate.
+- **Correct ADR-94 WD2 — its `UntypedFunction` "live bug" does not reproduce.** `CheckRules`
+  guards the form via `arity_eligible?` / `argument_check_eligible?` (both landed 2026-05-01,
+  `fc1da90e` / `ef0dd777`); the ADR's own repro plus six variant shapes run clean (probed
+  2026-07-17). Adjudicate whether any reproducing shape exists, then fix the ADR text.
 
 ## Waiting on the user
 
 - **Publish the staged `ruby/rbs` upstream fix** — branch `widen-strscan-resolv-stdlib-sigs` in
   `references/rbs` (widens `StringScanner#[]`, `Resolv#initialize`); push + upstream PR are the
   user's action. Tracked as [#159](https://github.com/rigortype/rigor/issues/159).
-- **Merge or amend PR [#119](https://github.com/rigortype/rigor/pull/119).**
 - The upstream `rbs-inline` RDoc fix ([soutaro/rbs-inline#249](https://github.com/soutaro/rbs-inline/pull/249))
   is open under the user's fork; nothing to do repo-side until upstream responds.
+- **rigor-rs side:** the reserve pipeline (ADR-99) now has its first reservation. `rigor_rs.ruby` is
+  declared in our schema, so the port can implement against it and its vendored copy stops rejecting
+  its own key on the next submodule bump.

--- a/docs/internal-spec/config.md
+++ b/docs/internal-spec/config.md
@@ -42,9 +42,23 @@ design, not an implementation detail** — a key may sit in one tier, or all thr
 
 Tier 2 is for a value the loader cannot proceed on (a malformed `dependencies.source_inference[]`
 entry, an out-of-range `budget_per_gem`). Tier 3 is for a value that is well-formed but **silently
-resolves to nothing** — a missing signature path, an unknown library name, an inert suppression;
-the class of mistake whose only symptom is confusing and downstream. Tier 3 warns and never errors,
-because a partial or forward-looking config is a valid setup, and it never fires on an unset default.
+resolves to nothing** — a missing signature path, an unknown library name, an inert suppression, an
+unrecognised top-level key; the class of mistake whose only symptom is confusing and downstream.
+Tier 3 warns and never errors, because a partial or forward-looking config is a valid setup, and it
+never fires on an unset default.
+
+Tiers 1 and 3 overlap on unrecognised **top-level** keys, and both are needed: tier 1 catches the
+mistake as it is typed but only for a user whose editor loads the schema, while tier 3 always runs.
+`Configuration::KNOWN_KEYS` is the complete set a conforming file may carry (the `DEFAULTS` keys +
+`includes:` + the reserved namespaces); anything else is recorded on `Configuration#unknown_keys` —
+the loader fetches each key it owns and never enumerates the rest, so without that record the keys
+are gone before the audit sees a Configuration.
+
+**Tier 3 covers top-level keys only.** A nested check would need each group's known key set, and
+`DEFAULTS` cannot supply it: `DEFAULTS["dependencies"]` omits `budget_overrun_strategy`, which is
+real, documented, and schema-declared — a `DEFAULTS`-keyed nested check would flag a working config.
+`severity_overrides:` is an open map of rule ids besides. Nested unknown keys are tier 1's job: every
+nested object in the schema is `additionalProperties: false`, and the gate below keeps it complete.
 
 ## Reserved namespaces
 

--- a/docs/manual/03-configuration.md
+++ b/docs/manual/03-configuration.md
@@ -83,6 +83,7 @@ types it was meant to describe into a high-confidence
 of real type errors. The audit covers:
 
 ```
+rigor: `excludee` is not a recognized configuration key; it has no effect. Did you mean `exclude`?
 rigor: signature_paths: "/path/to/sig" does not exist (no signatures loaded from it)
 rigor: signature_paths: "/path/to/sig" matched 0 signature files
 rigor: libraries: "csb" is not an available RBS library (no signatures loaded from it)
@@ -90,6 +91,11 @@ rigor: disable: "call.undefined-methdo" is not a recognized rule id; the suppres
 rigor: severity_overrides: "flow.bogus" is not a recognized rule id; the override has no effect
 rigor: bundler.lockfile: "./missing/Gemfile.lock" does not exist
 ```
+
+The unrecognised-key check covers **top-level** keys, and skips
+the namespaces reserved for other implementations (see below).
+A typo *inside* a group — `cache: { pth: … }` — is caught by
+the JSON schema as you type rather than at check time.
 
 These are warnings, not errors — partial or optional bundles and
 forward-looking config are valid setups. The audit only fires on explicit,

--- a/lib/rigor/config_audit.rb
+++ b/lib/rigor/config_audit.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "did_you_mean"
+
 require_relative "signature_path_audit"
 # ADR-87 WD4 — only the pure rule-id table (`ALL_RULES` / `RULE_FAMILIES`) is needed, so require the light
 # `rule_ids.rb` rather than the engine-pulling `check_rules.rb`; keeps `config_audit` (loaded by every check)
@@ -39,11 +41,52 @@ module Rigor
     #   paths resolve against (the CLI's CWD), used only by the explicit-path checks.
     # @return [Array<Warning>]
     def self.warnings(configuration, project_root: Dir.pwd)
-      signature_path_warnings(configuration) +
+      unknown_key_warnings(configuration) +
+        signature_path_warnings(configuration) +
         library_warnings(configuration) +
         rule_token_warnings(configuration) +
         explicit_path_warnings(configuration, project_root)
     end
+
+    # Top-level keys the loader does not own. The archetypal case is a typo — `excludee:` for
+    # `exclude:` — which the loader drops in silence, so the exclusion never applies and the run
+    # reports errors from the very files the user meant to skip, with nothing anywhere saying the key
+    # did nothing. That is exactly this module's class of mistake, and it was the one whole-key
+    # instance of it going unwarned.
+    #
+    # A reserved namespace ({Configuration::RESERVED_NAMESPACES}) is unknown *on purpose* — another
+    # implementation reads it from the same file — so it is exempt. {Configuration#unknown_keys}
+    # already applies that exemption; warning here would push users to delete the key their other
+    # tool needs.
+    #
+    # **Top level only, and deliberately.** A nested check would have to name each group's known keys,
+    # and DEFAULTS cannot supply them: `DEFAULTS["dependencies"]` carries `source_inference` and
+    # `budget_per_gem` but not `budget_overrun_strategy`, which is real (`Configuration::Dependencies`
+    # reads it), documented, and schema-declared — so a DEFAULTS-keyed nested check would flag a
+    # working config. `severity_overrides:` is an open map of rule ids besides. Nested unknown keys are
+    # the schema tier's job: every nested object in `schemas/rigor-config.schema.json` is
+    # `additionalProperties: false`, and `config_schema_spec` keeps it complete
+    # ([ADR-99](../../docs/adr/99-config-schema-authority.md), `docs/internal-spec/config.md`).
+    def self.unknown_key_warnings(configuration)
+      configuration.unknown_keys.map do |key|
+        suggestion = suggest_config_key(key)
+        hint = suggestion ? " Did you mean `#{suggestion}`?" : ""
+        Warning.new(
+          kind: :unknown_key,
+          message: "`#{key}` is not a recognized configuration key; it has no effect.#{hint}",
+          fields: { "key" => key, "suggestion" => suggestion }
+        )
+      end
+    end
+
+    # Nearest known key, or nil. Uses `DidYouMean::SpellChecker` — the engine behind Ruby's own
+    # `NoMethodError` hints, and the one `Plugin::Base.suggest` wraps. Called directly rather than
+    # through that helper because `plugin/base.rb` pulls Prism and the diagnostic model in, and
+    # ADR-87 WD4 keeps this file (loaded by every check) off that path; `did_you_mean` is stdlib.
+    def self.suggest_config_key(key)
+      DidYouMean::SpellChecker.new(dictionary: Configuration::KNOWN_KEYS).correct(key.to_s).first
+    end
+    private_class_method :suggest_config_key
 
     # `signature_paths:` entries that resolve to nothing — delegated to {SignaturePathAudit},
     # which mirrors the loader's `directory?` + recursive `**/*.rbs` acceptance test.

--- a/lib/rigor/configuration.rb
+++ b/lib/rigor/configuration.rb
@@ -164,6 +164,27 @@ module Rigor
     # from DEFAULTS, so the DEFAULTS-driven schema gate can never see it.
     RESERVED_NAMESPACES = %w[rigor_rs].freeze
 
+    # Every top-level key a conforming `.rigor.yml` may carry: the keys this implementation owns, plus
+    # `includes:`, plus the namespaces reserved for another implementation. Anything else is recorded in
+    # {#unknown_keys} and warned about by {ConfigAudit}, and is also the did-you-mean dictionary for a
+    # near-miss.
+    #
+    # `includes:` is a load-time directive — {load_with_includes} `delete`s it while merging, so it never
+    # reaches `#initialize` and could not be seen as unknown regardless. It is listed because a user
+    # legitimately writes it, so a typo like `include:` must be able to suggest it.
+    KNOWN_KEYS = (DEFAULTS.keys + %w[includes] + RESERVED_NAMESPACES).freeze
+
+    # Top-level keys the loaded config carried that this implementation does not own — neither a
+    # {DEFAULTS} key, nor `includes:`, nor a reserved namespace. Recorded rather than acted on: an
+    # unknown key stays as inert at run time as it has always been, and {ConfigAudit} turns the record
+    # into a warning. Empty for every conforming config.
+    #
+    # This exists because `#initialize` fetches each key it owns and never enumerates the rest, so by
+    # the time anything holds a Configuration the unknown keys are gone. The audit reads a
+    # Configuration, so without this the class of mistake it exists to catch — a value that silently
+    # resolves to nothing — was structurally invisible to it for whole keys.
+    attr_reader :unknown_keys
+
     attr_reader :target_ruby, :paths, :exclude_patterns, :plugins, :cache_path, :cache_max_bytes,
                 :cache_validation, :disabled_rules,
                 :libraries, :signature_paths, :fold_platform_specific_paths,
@@ -301,6 +322,10 @@ module Rigor
 
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     def initialize(data = DEFAULTS)
+      # Record before the per-key fetches below discard the evidence. Top level only, deliberately —
+      # see {ConfigAudit.unknown_key_warnings} for why a nested check cannot key on DEFAULTS.
+      @unknown_keys = (data.keys.map(&:to_s) - KNOWN_KEYS).sort.freeze
+
       cache = DEFAULTS.fetch("cache").merge(data.fetch("cache", {}))
       plugins_io = DEFAULTS.fetch("plugins_io").merge(data.fetch("plugins_io", {}))
 

--- a/spec/rigor/config_audit_spec.rb
+++ b/spec/rigor/config_audit_spec.rb
@@ -15,6 +15,45 @@ RSpec.describe Rigor::ConfigAudit do
     described_class.warnings(Rigor::Configuration.new(config_hash), project_root: project_root)
   end
 
+  describe "unknown top-level keys" do
+    it "flags a typo'd key and suggests the near miss" do
+      warnings = audit("excludee" => ["generated/**"])
+
+      unknown = warnings.find { |w| w.kind == :unknown_key }
+      expect(unknown).not_to be_nil
+      expect(unknown.message).to include("`excludee` is not a recognized configuration key")
+      expect(unknown.message).to include("Did you mean `exclude`?")
+      expect(unknown.to_h).to include("kind" => "unknown_key", "key" => "excludee", "suggestion" => "exclude")
+    end
+
+    it "flags a key with no near miss, without a suggestion" do
+      warnings = audit("wibble" => 1)
+
+      unknown = warnings.find { |w| w.kind == :unknown_key }
+      expect(unknown.message).to eq("`wibble` is not a recognized configuration key; it has no effect.")
+      expect(unknown.to_h).to include("suggestion" => nil)
+    end
+
+    it "stays silent on a reserved namespace" do
+      # Unknown on purpose: another implementation reads it from the same file. Warning here would push
+      # users to delete the key their other tool needs (ADR-99).
+      expect(audit("rigor_rs" => { "ruby" => "auto" })).to all(satisfy { |w| w.kind != :unknown_key })
+    end
+
+    it "stays silent on a nested key DEFAULTS does not carry" do
+      # `budget_overrun_strategy` is real, documented, and schema-declared, but absent from
+      # DEFAULTS["dependencies"] — so a DEFAULTS-keyed nested check would flag a working config. Nested
+      # unknowns are the schema tier's job; this axis is top-level only (ADR-99, docs/internal-spec/config.md).
+      warnings = audit("dependencies" => { "budget_overrun_strategy" => "walker_cap" })
+
+      expect(warnings).to all(satisfy { |w| w.kind != :unknown_key })
+    end
+
+    it "stays silent on a conforming config" do
+      expect(audit("target_ruby" => "4.0", "paths" => ["lib"])).to all(satisfy { |w| w.kind != :unknown_key })
+    end
+  end
+
   describe "signature_paths" do
     it "flags a missing path with kind :signature_path" do
       warnings = audit("signature_paths" => ["/no/such/path/sig"])

--- a/spec/rigor/configuration_spec.rb
+++ b/spec/rigor/configuration_spec.rb
@@ -558,6 +558,42 @@ RSpec.describe Rigor::Configuration do
     end
   end
 
+  describe "#unknown_keys" do
+    it "records a top-level key the loader does not own" do
+      configuration = described_class.new(described_class::DEFAULTS.merge("excludee" => ["x/**"]))
+
+      expect(configuration.unknown_keys).to eq(["excludee"])
+    end
+
+    it "does not record a reserved namespace" do
+      configuration = described_class.new(described_class::DEFAULTS.merge("rigor_rs" => { "ruby" => "auto" }))
+
+      expect(configuration.unknown_keys).to be_empty
+    end
+
+    it "is empty for a conforming config" do
+      expect(described_class.new(described_class::DEFAULTS).unknown_keys).to be_empty
+    end
+
+    it "does not record `includes:`, which the include merge consumes before this point" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "base.yml"), "libraries: [csv]\n")
+        path = File.join(dir, ".rigor.yml")
+        File.write(path, "includes:\n  - base.yml\n")
+
+        expect(described_class.load(path).unknown_keys).to be_empty
+      end
+    end
+  end
+
+  describe "KNOWN_KEYS" do
+    it "is the DEFAULTS keys plus `includes:` plus the reserved namespaces" do
+      expect(described_class::KNOWN_KEYS.to_set).to eq(
+        (described_class::DEFAULTS.keys + %w[includes] + described_class::RESERVED_NAMESPACES).to_set
+      )
+    end
+  end
+
   describe ".load with `includes:`" do
     it "merges an explicit included file under the current file's keys" do
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
Closes #166. The last piece of the config arc, deliberately split out of #170 because a new warning is BC-bearing.

## The gap

`rigor check` warns when a configured value silently resolves to nothing — a missing signature path, an unknown library, an inert suppression — because that mistake is invisible where it is made and confusing downstream. **Whole keys were the one instance of the class going unwarned:**

```
rigor: `excludee` is not a recognized configuration key; it has no effect. Did you mean `exclude`?
```

Before: the typo loaded in silence, the exclusion never applied, and the run reported errors from the very files the user meant to skip.

## Two things that had to be decided, not coded

**The audit could not see unknown keys at all.** It reads a `Configuration`, and `#initialize` fetches each key it owns and never enumerates the rest — so by the time anything holds one, the evidence is gone. The issue said "extend the config audit"; that was not possible as written. Keys are now recorded on `#unknown_keys` where they still exist, against a single `Configuration::KNOWN_KEYS` (DEFAULTS + `includes:` + reserved namespaces) that doubles as the did-you-mean dictionary.

**Top-level only — because a nested check would fire on working configs.** `DEFAULTS["dependencies"]` omits `budget_overrun_strategy`, which is real (`Configuration::Dependencies` reads it), documented, and schema-declared. A `DEFAULTS`-keyed nested check would flag it. `severity_overrides:` is an open map of rule ids besides. Nested unknowns are already tier 1's job — every nested object is `additionalProperties: false`, kept complete by the gate #170 added.

The two tiers overlap on top-level keys **on purpose**: tier 1 catches the typo as you type, but only if your editor loads the schema; tier 3 always runs.

## Behaviour

| Input | Result |
| --- | --- |
| `excludee:` | warns, suggests `exclude` |
| `wibble:` (no near miss) | warns, no suggestion |
| `rigor_rs:` (reserved) | **silent** — unknown on purpose; warning would push users to delete the key their other implementation needs (ADR-99) |
| `dependencies.budget_overrun_strategy` | **silent** — nested, and real |
| clean code + unknown key | **exit 0** — warn, never error |

`--format=json` carries it under `config_warnings` with `"kind": "unknown_key"`, `key`, and `suggestion`, so CI can assert on it. The kind name is v1.0-frozen vocabulary (ADR-50 WD1) and was chosen deliberately.

The suggestion uses `DidYouMean::SpellChecker` directly rather than through `Plugin::Base.suggest`, which wraps the same engine — `base.rb` pulls Prism and the diagnostic model in, and ADR-87 WD4 keeps `config_audit` (loaded by every check) off that path. `did_you_mean` is stdlib.

## Also here

Two CHANGELOG entries **#170 should have carried and I did not file**: its `rigor init` schema-URL fix and the `cache.max_bytes` / `cache.validation` schema fix are both user-observable. The handoff is refreshed — it still said PR #119 was awaiting review, two merges ago.

## Verification

- `make verify` exit 0; 13 suites green; rubocop clean on 894 files; `make docs-check` 267 green; `git diff --check` clean.
- **All 35 config files in the tree stay warning-free** (the repo's own, every fixture, every demo).
- Teeth: unwiring `unknown_key_warnings` from `warnings` fails the suite (19 examples, 2 failures).
- Exit code checked independently on an otherwise-clean run: 0.