### PR TITLE
Stop discarding the return type of a `(?)` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[type inference]** A method whose RBS declares an untyped parameter list — `def call: (?) -> String` — now contributes its return type instead of silently reading as untyped.
+  - Rigor discarded the whole signature for these methods, so `(?) -> String` typed as `untyped` and nothing downstream of the call was checked. This affected stock projects with no `sig/` of their own: core RBS ships the form on `Proc#call`, `Method#call`, `Ractor.select` and `IO.for_fd`.
+  - `(?)` still constrains nothing about arity or argument types, which is what it means — you will not see new argument diagnostics at these call sites. Where such a method is one arm of an overload set, a genuinely typed arm still wins.
+
 - **[rigor init]** Fixed the generated config's editor-schema link, which pointed at a URL that did not exist — so **every project started with `rigor init` had no schema validation at all**: no autocomplete, no hover docs, no structural checking.
   - An unreachable schema looks exactly like a schema with no complaints, which is why this went unnoticed. If you ran `rigor init` before this release, re-run it or repoint the `# yaml-language-server: $schema=…` line at [the schema](schemas/rigor-config.schema.json).
   - The generated file also referred you to an internal contributor document for the key reference; it now links the [configuration manual](docs/manual/03-configuration.md), also available offline via `rigor docs configuration`.

--- a/docs/adr/94-rbs-inline-reader-and-the-rbs-3x-floor.md
+++ b/docs/adr/94-rbs-inline-reader-and-the-rbs-3x-floor.md
@@ -1,11 +1,13 @@
 # ADR-94 — The inline-RBS reader: `RBS::InlineParser` and the rbs 3.x floor
 
-Status: **Accepted, 2026-07-16.** rbs 4.0 absorbed the inline implementation, which dissolves
-the premise [ADR-32](32-rbs-inline-comment-ingestion.md) chose its plugin boundary on.
-Migrating there is the right direction and is **deferred**: it costs the rbs 3.x floor, and
-dropping that floor is not planned for v0.3.0 or the versions near it. The
-`rigor-rbs-inline` plugin stays the reader. One measured blocker, the `UntypedFunction`
-crash (WD2), is a live bug independent of the migration and lands on its own.
+Status: **Accepted, 2026-07-16; WD2 corrected and closed 2026-07-17.** rbs 4.0 absorbed the
+inline implementation, which dissolves the premise
+[ADR-32](32-rbs-inline-comment-ingestion.md) chose its plugin boundary on. Migrating there is
+the right direction and is **deferred**: it costs the rbs 3.x floor, and dropping that floor
+is not planned for v0.3.0 or the versions near it. The `rigor-rbs-inline` plugin stays the
+reader. WD2's `UntypedFunction` defect was real and independent of the migration, as recorded
+— but this ADR misidentified its site and its symptom, and re-adjudication found it wider
+than a hand-written `.rbs`. It is fixed; see WD2 for what was actually true.
 
 Grounding: [`docs/notes/20260716-dspec-formal-spec-substrate-evaluation.md`](../notes/20260716-dspec-formal-spec-substrate-evaluation.md)
 § "ADR-93 WD1 の実装" and the measurements below.
@@ -59,13 +61,34 @@ that to delete ~40 lines of plugin code inverts the trade.
 WD1. The annotation-presence gate and the RDoc neutralization stay; both would be deleted at
 migration, and neither is load-bearing enough to force one.
 
-**WD2 — the `UntypedFunction` crash is a separate bug and lands independently.** A `(?)`
-method type in a hand-written `.rbs` crashes `rigor check` today:
-`NoMethodError: undefined method 'required_positionals' for an instance of
-RBS::Types::UntypedFunction`. `Inference::MethodDispatcher::RbsDispatch` guards the form for
-blocks; the arity path in `Analysis::CheckRules` does not. This is reachable without any
-migration (a user writes `(?)`, or rbs 4.x core RBS adopts it), and it is a prerequisite of
-the migration rather than part of it.
+**WD2 — the `UntypedFunction` defect is a separate bug and lands independently. Correct as
+written; wrong on every particular. Fixed 2026-07-17.** The call this working decision made —
+that the defect is independent of the migration, reachable without it, and lands on its own —
+held. Re-adjudication (2026-07-17, prompted by the claim not reproducing) confirmed the bug
+and corrected three things about it:
+
+- **Not a crash.** `rigor check` never died. The `NoMethodError` was raised and then swallowed
+  by one of the dispatcher's broad `rescue StandardError` clauses, so the dispatch degraded to
+  `Dynamic[top]` and the method's **declared return type was silently discarded**. A `(?) ->
+  String` method typed as untyped. Silent precision loss is the symptom, which is why the
+  original probe read as a crash that would not reproduce.
+- **Not `Analysis::CheckRules`.** That path was already guarded, and had been since before this
+  ADR was written: `arity_eligible?` and `argument_check_eligible?` both bail via
+  `respond_to?(:required_keywords)`, each documenting the untyped-function case as the reason.
+  The unguarded site was `MethodDispatcher::ReceiverAffinity`'s pre-sort, which reached for
+  `required_positionals` while reordering overloads by receiver affinity — upstream of the
+  selector, which is why no selector-level guard could have caught it. `OverloadSelector`'s own
+  arity path was unguarded too, but latent: the pre-sort raised first.
+- **Not confined to hand-written `.rbs`.** This ADR guessed the trigger was a user writing `(?)`
+  "or rbs 4.x core RBS adopting it". Core RBS ships it **already**, on `Proc#call`,
+  `Method#call`, `Ractor.select` and `IO.for_fd` — so the defect fired on a stock `rigor check`
+  against a project with no `sig/` at all. `Proc#call` and `Method#call` return `untyped`
+  regardless, which is very likely why the loss stayed invisible for so long.
+
+The fix guards each site with the bail the form implies: no affinity to compare, no arity to
+enforce, no declared params to zip — and, load-bearing for false positives, `(?)` must never
+win the selector's strict pass over a genuinely typed sibling overload, since a param list of
+nothing otherwise satisfies "every param is strict" vacuously.
 
 **WD3 — the decision under review is the floor, not the reader.** Re-open this ADR when the
 rbs 3.x floor moves for its own reasons, not to make the migration possible. The reader

--- a/lib/rigor/inference/method_dispatcher/overload_selector.rb
+++ b/lib/rigor/inference/method_dispatcher/overload_selector.rb
@@ -241,6 +241,9 @@ module Rigor
           # would beat strictly-typed alternatives in pass 2 of the selector.
           def strictly_typed_params?(method_type, actual_count)
             fun = method_type.type
+            # A `(?)` method type declares no params at all: it is the gradual case by construction, so it
+            # must never win the strict pass over a genuinely typed sibling overload.
+            return false unless fun.respond_to?(:required_positionals)
             return false unless arity_compatible?(fun, actual_count)
 
             params = positional_params_for(fun, actual_count)
@@ -299,7 +302,11 @@ module Rigor
             !fun.required_keywords.empty?
           end
 
+          # `RBS::Types::UntypedFunction` (`(?)`) declares no arity to enforce, so every call site is
+          # arity-compatible with it.
           def arity_compatible?(fun, actual_count)
+            return true unless fun.respond_to?(:required_positionals)
+
             min_arity = fun.required_positionals.size + fun.trailing_positionals.size
             return false if actual_count < min_arity
 
@@ -314,6 +321,10 @@ module Rigor
           # Rest_positionals consumes the remainder; we repeat its single declaration for each absorbed
           # argument.
           def positional_params_for(fun, actual_count)
+            # `(?)` declares no positional params; the caller zips this against the actual args, so an empty
+            # list is what "accepts anything, constrains nothing" looks like here.
+            return [] unless fun.respond_to?(:required_positionals)
+
             required = fun.required_positionals
             optional = fun.optional_positionals
             rest = fun.rest_positionals

--- a/lib/rigor/inference/method_dispatcher/receiver_affinity.rb
+++ b/lib/rigor/inference/method_dispatcher/receiver_affinity.rb
@@ -41,8 +41,13 @@ module Rigor
             end
           end
 
+          # `RBS::Types::UntypedFunction` (a `(?)` method type, e.g. core's `Proc#call`) declares no
+          # parameters and exposes none of the per-arity accessors. It has no param classes to compare
+          # against the receiver, so it carries no affinity either way.
           def overload_param_classes_in_ancestry?(method_type, self_class_name, environment)
             fun = method_type.type
+            return false unless fun.respond_to?(:required_positionals)
+
             params = fun.required_positionals + fun.optional_positionals + fun.trailing_positionals
             return false if params.empty?
 

--- a/spec/rigor/inference/method_dispatcher/untyped_function_overload_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/untyped_function_overload_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# `RBS::Types::UntypedFunction` is the `(?)` method type -- core RBS ships it on `Proc#call`,
+# `Method#call`, `Ractor.select` and `IO.for_fd`, and a project may hand-write it. It exposes none of
+# the per-arity accessors (`required_positionals` and friends), so every dispatcher site that reaches
+# for them must bail rather than raise. Before these guards landed, `ReceiverAffinity.reorder` raised
+# `NoMethodError` on the form; a broad `rescue StandardError` in the dispatcher swallowed it and the
+# whole dispatch degraded to `Dynamic[top]`, silently discarding the declared return type.
+RSpec.describe "(?) method types (RBS::Types::UntypedFunction)", type: :runner do
+  let(:sig) do
+    {
+      "widget.rbs" => <<~RBS
+        class Widget
+          def untyped_fn: (?) -> String
+          def normal: (Integer) -> String
+          def overloaded: (?) -> String
+                        | (Integer) -> Integer
+        end
+      RBS
+    }
+  end
+
+  def undefined_method_diagnostics(result)
+    result.diagnostics.select { |d| d.rule == "call.undefined-method" }
+  end
+
+  it "adopts the declared return type of a `(?)` method" do
+    result = analyze(<<~RUBY, sig: sig)
+      w = Widget.new
+      w.untyped_fn.bogus_method
+    RUBY
+
+    diagnostic = undefined_method_diagnostics(result).first
+    expect(diagnostic).not_to be_nil
+    expect(diagnostic.message).to include("bogus_method")
+    expect(diagnostic.message).to include("String")
+  end
+
+  it "constrains no arity or argument type at a `(?)` call site" do
+    result = analyze(<<~RUBY, sig: sig)
+      w = Widget.new
+      w.untyped_fn
+      w.untyped_fn(1)
+      w.untyped_fn(1, 2, 3)
+      w.untyped_fn("a", key: 2)
+    RUBY
+
+    expect(result.diagnostics).to be_empty
+  end
+
+  it "never lets a leading `(?)` overload beat a strictly-typed sibling" do
+    result = analyze(<<~RUBY, sig: sig)
+      w = Widget.new
+      w.overloaded(1).bogus_method
+    RUBY
+
+    # `(Integer) -> Integer` must win over the `(?) -> String` arm that precedes it in the overload
+    # list: `(?)` declares no params, so it would otherwise match vacuously in the strict pass.
+    diagnostic = undefined_method_diagnostics(result).first
+    expect(diagnostic).not_to be_nil
+    expect(diagnostic.message).to include("Integer")
+  end
+
+  it "leaves a strictly-typed method's diagnostics unchanged" do
+    result = analyze(<<~RUBY, sig: sig)
+      w = Widget.new
+      w.normal(1).bogus_method
+      w.normal("wrong")
+      w.normal(1, 2)
+    RUBY
+
+    rules = result.diagnostics.map(&:rule)
+    expect(rules).to include("call.undefined-method")
+    expect(rules).to include("call.argument-type-mismatch")
+    expect(rules).to include("call.wrong-arity")
+  end
+end


### PR DESCRIPTION
Closes #174.

#174 asked whether ADR-94 WD2's `UntypedFunction` "live bug" reproduces. It does — but the ADR was wrong about the site, the symptom, and the trigger, so the honest outcome was the issue's option (b): fix the guard at root and narrow WD2 to what actually reproduces.

## What was happening

`ReceiverAffinity`'s pre-sort reached for `required_positionals` while ordering overloads by receiver affinity. `RBS::Types::UntypedFunction` (`(?)`) exposes none of the per-arity accessors, so it raised `NoMethodError` — and one of the dispatcher's broad `rescue StandardError` clauses swallowed it. The dispatch degraded to `Dynamic[top]` and the **declared return type was silently discarded**.

Not a crash, which is why the ADR's repro read as "does not reproduce". And not confined to hand-written sigs: core RBS ships `(?)` on `Proc#call`, `Method#call`, `Ractor.select` and `IO.for_fd`, so it fired on a stock `rigor check` against a project with no `sig/` at all. `Proc#call` and `Method#call` return `untyped` regardless — the likeliest reason this stayed invisible.

## Where the ADR was wrong

It named `Analysis::CheckRules` as the unguarded arity path. That path has been guarded since before the ADR was written (`arity_eligible?` / `argument_check_eligible?`, both bailing via `respond_to?`, each documenting the untyped-function case). The unguarded site was upstream of the selector entirely, which is why no selector-level guard could have caught it. `OverloadSelector`'s own arity path was unguarded too, but latent — the pre-sort raised first.

WD2's actual *call* — that the defect is independent of the rbs 4.x migration, reachable without it, and lands on its own — held exactly. The ADR text is corrected rather than deleted, per ADR-92's rubric.

## The FP-sensitive part

`(?)` must never win the selector's strict pass over a genuinely typed sibling overload: a param list of nothing satisfies "every param is strict" **vacuously**. Without that guard, `def f: (?) -> String | (Integer) -> Integer` would type `f(1)` as `String`. The spec pins this arm.

`(?)` still constrains nothing about arity or argument types — no new argument diagnostics at these call sites.

## Verification

- `make verify` and `make docs-check` green; `git diff --check` clean.
- `make check` output byte-identical to master (A/B'd — the one pre-existing `doctor_command.rb` warning is unchanged and predates this branch).
- The specs have teeth: **2 of the 4 fail without the lib change**.
- Adjudication probes covered 0/1/3 args, keywords, blocks, singleton form, typed return, and `(?)` in either overload position, with `--no-cache` (the run-result cache silently served an unanalyzed result on the first attempt — worth knowing).