### PR TITLE
Fold join on an all-literal string array to a precise Constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Added
 
+- **[type inference]** `Array#join` on an array of string literals now infers the exact resulting string. `["a", "b"].join("-")` types as `"a-b"` rather than a generic `String`, matching the precision already given to `[1, 2, 3].join` and to non-string arrays. The gain flows through any downstream use of the joined value.
+
 - **[rigor check]** A top-level key in `.rigor.yml` that Rigor does not recognise is now reported instead of silently ignored, with the nearest real key suggested.
   - Previously a typo'd `exclude:` loaded in silence, so the exclusion never applied and the run reported errors from the very files you meant to skip. Nothing said the key had done nothing.
   - It is a warning, never an error — your exit code does not change. The finding also appears in `--format=json` under `config_warnings` with `"kind": "unknown_key"`, so CI can assert on it.

--- a/docs/notes/20260522-type-method-coverage.md
+++ b/docs/notes/20260522-type-method-coverage.md
@@ -2,6 +2,21 @@
 
 2026-05-22 生成。Ruby 4.0 の `"".methods - Object.new.methods` 等から型ごとに固有メソッドを抽出し、現在の精度カバレッジを分類する。
 
+> **2026-07-18 監査パス（#121 P3 スライス）。** 本表の多くの 🔲 は 2026-05-22 以降に実装済み
+> （`String#[]`/`slice`、`Tuple#drop`/`rotate`/`flatten`/`join`、CGI/URI/Regexp/Math シングルトン
+> フォールド等）。空きの主因は「フォールドが存在しないこと」ではなく、**先行ティアによる遮蔽**だった。
+> 本スライスで閉じたのは `Array#join`：全要素が `Constant[String]`（セパレータが Constant/省略）の
+> ときだけ、`ShapeDispatch.tuple_join` の精密 `Constant[String]` を `LiteralStringFolding` が
+> 汎用 `literal-string` で覆い隠していた（整数・混在要素の tuple は既に精密フォールド済み）。
+>
+> **本スライスで対象外と判断した項目（P0 側／FP リスク）:**
+> - `String#to_r` / `Integer#to_r` / `Float#to_r` / `#to_c` の一部 — `Rational`/`Complex` の同値・
+>   算術は演算子 `==` がオペランド `==` に委譲し得るため、フォールドの一部が **ユーザ再定義可能な経路**
+>   を通る（本表 `RATIONAL_BINARY`/`COMPLEX_BINARY` が `==` を除外している理由と同じ）。単純な `to_r`
+>   自体は純粋だが、下流の同値比較で新規診断（`flow.*`）を誘発し得るため、別途評価とする。
+> - `String#%` の Hash 形式（`"%{k}" % {…}`）— HashShape 経由の精密化は可能だが、フォーマット文字列の
+>   検証で新規診断を生む可能性があり、P3 の「新規診断ゼロ」制約に抵触し得る。
+
 ---
 
 ## 凡例
@@ -375,7 +390,7 @@ IntegerRange 向け専用ハンドラ群は別途 `shape_dispatch.rb` に存在�
 | `index` / `find_index` | ✅ | `PER_ELEMENT_TUPLE_METHODS` → `Constant[Integer\|nil]`。 |
 | `insert` | 🚫 | 破壊的変更。 |
 | `intersection` | 🔲 | 集合交差。低優先度。 |
-| `join` | 🔲 | Tuple 要素を String に連結。中優先度（すべて Constant のとき `Constant[String]`）。 |
+| `join` | ✅ | `tuple_join` — すべて Constant のとき `Constant[String]`。全要素が `Constant[String]` かつセパレータが Constant/省略の場合は `LiteralStringFolding` が精密フォールドに道を譲る（2026-07-18）。 |
 | `keep_if` | 🚫 | 破壊的変更。 |
 | `last` | ✅ | `tuple_last` → 末尾 n 要素。 |
 | `length` / `size` | ✅ | `tuple_size` → `Constant[Integer]`。 |
@@ -420,10 +435,12 @@ IntegerRange 向け専用ハンドラ群は別途 `shape_dispatch.rb` に存在�
 [x] take(n)             → TUPLE_HANDLERS → 先頭 n 要素 Tuple
 
 中優先度:
-[ ] drop(n)   → TUPLE_HANDLERS → n 以降の部分 Tuple
-[ ] rotate(n) → TUPLE_HANDLERS → 回転後 Tuple
-[ ] flatten   → TUPLE_HANDLERS → 1 段ネスト展開（depth=1 限定で実用十分）
-[ ] join      → TUPLE_HANDLERS → すべて Constant のとき Constant[String]
+[x] drop(n)   → TUPLE_HANDLERS → n 以降の部分 Tuple
+[x] rotate(n) → TUPLE_HANDLERS → 回転後 Tuple
+[x] flatten   → TUPLE_HANDLERS → 1 段ネスト展開（depth=1 限定で実用十分）
+[x] join      → TUPLE_HANDLERS `tuple_join`（すべて Constant のとき Constant[String]）。
+    2026-07-18: 全要素 Constant[String] のケースを `LiteralStringFolding` が
+    `literal-string` で覆い隠していたのを解消（精密フォールドに委譲）。
 [x] slice     → TUPLE_HANDLERS → `[]` の別名（整数 / Range / start-length 形式）
 
 低優先度:

--- a/lib/rigor/inference/method_dispatcher/literal_string_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/literal_string_folding.rb
@@ -139,8 +139,27 @@ module Rigor
           return nil unless receiver.elements.all? { |el| Type::Combinator.literal_string_compatible?(el) }
           return nil unless args.size <= 1
           return nil if args.size == 1 && !Type::Combinator.literal_string_compatible?(args.first)
+          # Defer to {ShapeDispatch}'s `tuple_join` when the precise `Constant<String>` fold is reachable —
+          # every element is a `Constant` and the separator is absent or a `Constant<String>`. This tier runs
+          # AHEAD of ShapeDispatch, so returning the generic `literal-string` here would shadow that strictly
+          # more precise result (`["a", "b"].join("-")` → `Constant<"a-b">` rather than `literal-string`).
+          # Mixed tuples that carry a non-`Constant` `literal-string` element keep folding to `literal-string`
+          # here, because no exact value is knowable for them.
+          return nil if constant_join_reachable?(receiver, args)
 
           Type::Combinator.literal_string
+        end
+
+        # True when every tuple element is a `Constant` and the separator is absent or a `Constant<String>` —
+        # exactly the inputs for which `ShapeDispatch.tuple_join` materialises a precise `Constant<String>`.
+        # An empty tuple qualifies (`[].join` → `Constant<"">`). Callers have already verified every element
+        # is literal-string-compatible, so a `Constant` element is necessarily a `Constant<String>`.
+        def constant_join_reachable?(receiver, args)
+          return false unless receiver.elements.all?(Type::Constant)
+          return true if args.empty?
+
+          arg = args.first
+          arg.is_a?(Type::Constant) && arg.value.is_a?(String)
         end
 
         # `"foo %s" % "x"` / `"foo %s" % ["x", "y"]` — receiver is the template (already verified
@@ -203,6 +222,7 @@ module Rigor
         end
 
         private_class_method :fold_no_arg, :fold_concat, :fold_repeat, :fold_array_join,
+                             :constant_join_reachable?,
                              :fold_string_percent, :fold_width_pad,
                              :non_empty_literal_result, :literal_or_constant?,
                              :integer_typed?, :known_negative_integer?,

--- a/spec/integration/fold_runtime_parity_spec.rb
+++ b/spec/integration/fold_runtime_parity_spec.rb
@@ -76,7 +76,8 @@ FOLD_PARITY_CASES = {
     "[1, 2, 3].length", "[1, 2, 3].count", "[1, 2, 2].include?(2)",
     "[1, 2, 3].empty?", "[].empty?", "[1, nil, 2].compact", "[1, 2, 3].take(2)",
     "[1, 2] + [3, 4]", "[10, 20, 30][1]",
-    '[1, 2, 3].join("-")', "[1, 2, 3].join"
+    '[1, 2, 3].join("-")', "[1, 2, 3].join",
+    '["a", "b"].join("-")', '["a", "b"].join', "[].join"
   ],
   "Hash — ShapeDispatch" => [
     "{ a: 1 }.merge(b: 2)", "{ a: 1, b: 2 }.keys", "{ a: 1, b: 2 }.values",

--- a/spec/rigor/inference/method_dispatcher/literal_string_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/literal_string_folding_spec.rb
@@ -108,8 +108,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::LiteralStringFolding do
 
   describe "Array#join (Tuple receiver lift)" do
     let(:tuple_of_literals) { Rigor::Type::Combinator.tuple_of(literal_string, string_const) }
+    let(:tuple_of_constants) { Rigor::Type::Combinator.tuple_of(string_const, string_const) }
     let(:tuple_with_nominal) { Rigor::Type::Combinator.tuple_of(literal_string, nominal_string) }
-    let(:empty_tuple) { Rigor::Type::Combinator.tuple_of }
 
     it "lifts Tuple[literal, Constant<String>].join to literal-string (no separator)" do
       result = described_class.try_dispatch(cc(receiver: tuple_of_literals, method_name: :join, args: []))
@@ -123,8 +123,33 @@ RSpec.describe Rigor::Inference::MethodDispatcher::LiteralStringFolding do
       expect(result).to eq(literal_string)
     end
 
-    it "lifts Tuple[].join (empty tuple) to literal-string" do
+    # An all-`Constant` tuple with an absent or `Constant<String>` separator is exactly what
+    # `ShapeDispatch.tuple_join` folds to a precise `Constant<String>`. This tier runs ahead of
+    # ShapeDispatch, so it MUST decline (return nil) rather than shadow that with `literal-string`.
+    it "declines Tuple[Constant<String>, Constant<String>].join so ShapeDispatch folds the precise Constant" do
+      result = described_class.try_dispatch(cc(receiver: tuple_of_constants, method_name: :join, args: []))
+      expect(result).to be_nil
+    end
+
+    it "declines an all-Constant tuple join with a Constant<String> separator" do
+      result = described_class.try_dispatch(cc(
+                                              receiver: tuple_of_constants, method_name: :join, args: [string_const]
+                                            ))
+      expect(result).to be_nil
+    end
+
+    it "declines Tuple[].join (empty tuple) so ShapeDispatch folds Constant<\"\">" do
+      empty_tuple = Rigor::Type::Combinator.tuple_of
       result = described_class.try_dispatch(cc(receiver: empty_tuple, method_name: :join, args: []))
+      expect(result).to be_nil
+    end
+
+    it "still lifts an all-Constant tuple join to literal-string when the separator is non-Constant" do
+      # A `literal-string` separator has no knowable value, so the precise Constant fold is unreachable and
+      # this tier keeps producing `literal-string`.
+      result = described_class.try_dispatch(cc(
+                                              receiver: tuple_of_constants, method_name: :join, args: [literal_string]
+                                            ))
       expect(result).to eq(literal_string)
     end
 

--- a/spec/rigor/inference/method_dispatcher/shape_dispatch_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/shape_dispatch_spec.rb
@@ -181,6 +181,17 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ShapeDispatch do
           .to eq(constant("1-2-3"))
       end
 
+      it "folds join across all-String Constant elements to a precise Constant" do
+        string_t = tuple(constant("a"), constant("b"))
+        expect(dispatch(receiver: string_t, method_name: :join)).to eq(constant("ab"))
+        expect(dispatch(receiver: string_t, method_name: :join, args: [constant("-")]))
+          .to eq(constant("a-b"))
+      end
+
+      it "folds join on the empty tuple to Constant<\"\">" do
+        expect(dispatch(receiver: tuple, method_name: :join)).to eq(constant(""))
+      end
+
       it "declines join with a non-Constant-String separator" do
         expect(dispatch(receiver: numeric_t, method_name: :join, args: [constant(0)])).to be_nil
       end


### PR DESCRIPTION
Advances #121 (FP-safe deterministic builtin/stdlib precision folds, P3). This is one slice of an ongoing backlog category, so the issue stays open.

## The gap

`ShapeDispatch.tuple_join` already folds a Tuple of `Constant` elements to the exact joined string — `[1, 2, 3].join("-")` → `Constant<"1-2-3">`. But the **all-`Constant<String>`** case was shadowed: `LiteralStringFolding` runs ahead of `ShapeDispatch`, and its `fold_array_join` claimed every literal-bearing Tuple, returning the generic `literal-string` carrier. So the string sibling widened to `String` while the integer one stayed exact — an inconsistency, not a missing fold.

`Array#join` on constant string arrays (path building, message/CSV/SQL assembly) is extremely common, and the precise fold already existed and merely needed un-shadowing — which is why this was the highest-value gap in the audit.

## The fix

`fold_array_join` now declines exactly when the precise fold is reachable (every element a `Constant`, separator absent or a `Constant<String>`), deferring to `ShapeDispatch.tuple_join`. Mixed Tuples carrying a non-`Constant` `literal-string` element keep folding to `literal-string` (no exact value is knowable). The empty Tuple folds to `Constant<"">`.

### type-of, before → after (`--no-cache`)

| expression | before | after |
|---|---|---|
| `["a", "b"].join` | `String` | `Constant<"ab">` |
| `["a", "b"].join("-")` | `String` | `Constant<"a-b">` |
| `["a", "b".upcase].join` | `String` | `Constant<"aB">` |
| `[].join` | `literal-string` | `Constant<"">` |
| `[1, 2, 3].join("-")` (control) | `Constant<"1-2-3">` | unchanged |
| `[1, "b"].join` (control) | `Constant<"1b">` | unchanged |

## No new diagnostic (the P3 defining constraint)

- **Self-check byte-identical**: `rigor check lib --no-cache` diffs to nothing but wall-time/RSS between the fixed and reverted tree.
- **Corpus spot-check**: `rigor check` over kramdown / haml / liquid `lib/` (fixed vs reverted) — diagnostic lines **identical, zero new firings**.
- The fold is deterministic and routes through no user-overridable `coerce`: `join` calls `to_s` on `Constant` scalar elements whose `to_s` is fixed. The change only narrows (`literal-string` → a specific `Constant`).

## Tests

- `literal_string_folding_spec.rb`: 3 new decline tests (all-Constant no-sep, all-Constant + Constant sep, empty tuple) + 1 guard that a non-Constant separator still lifts to `literal-string`. **Teeth confirmed**: reverting the lib change fails exactly these 3 decline tests.
- `shape_dispatch_spec.rb`: string-Constant join + empty-tuple join fold assertions.
- `fold_runtime_parity_spec.rb`: `["a", "b"].join(...)` / `[].join` added to the runtime-parity table.
- `make verify` clean (7999 examples, 0 offenses); `git diff --check` clean.

## Audit findings (for the next slice)

The 2026-05-22 coverage docs are largely stale — most `🔲` are now implemented (`String#[]`/`slice`, `Tuple#drop`/`rotate`/`flatten`/`join`, CGI/URI/Regexp/Math singleton folders all exist). The dominant remaining cause of lost precision is **tier shadowing**, not absent folds; this slice closed one such case. Recorded in `docs/notes/20260522-type-method-coverage.md` (2026-07-18 audit note).

**Declined as out-of-scope (P0 / FP risk), reported not built:**
- `String#to_r` / `Integer#to_r` / `#to_c` family — the value conversions are pure, but downstream `Rational`/`Complex` `==` delegates to operand `==` (user-redefinable; the reason `RATIONAL_BINARY`/`COMPLEX_BINARY` already exclude `==`), so folding them risks a new `flow.*` diagnostic on a later comparison.
- `String#%` Hash form (`"%{k}" % {…}`) — HashShape-based precision is feasible but format-string validation could surface a new diagnostic.