### PR TITLE
Compare override signatures at the instantiated generic type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Added
 
+- **[type inference]** The override-signature checks (`def.override-return-widened`, `def.override-param-narrowed`) now compare a generic parent contract at the type its subclass instantiates: when `class Sub < Parent[Integer]`, an inherited `-> T` is checked as `-> Integer` instead of being waved through. A subclass that leaves the type parameter open still reports nothing, so no correct override is newly flagged.
+
 - **[type inference]** `Struct` and `Data.define` value objects now infer precise member types through a setter and through a block-defined class, in two more cases.
   - After a straight-line `s.x = 5`, reading `s.x` back now infers the assigned value (and a sibling `s.y` keeps its own value) — where before the whole struct went untyped the moment you wrote to any member. A read is left untyped, exactly as before, when the struct is aliased, passed to another method, or mutated inside a loop or block, so a later write you can't see never makes an earlier read wrong.
   - A `Data.define(:x) do … end` assigned to a plain local variable now folds its member reads too, matching the constant form — unless the block redefines a member's reader (`def x`), in which case the read stays untyped because it would run your method, not return the member.

--- a/docs/adr/35-override-signature-compatibility.md
+++ b/docs/adr/35-override-signature-compatibility.md
@@ -1,6 +1,7 @@
 # ADR-35 — Override signature compatibility (Liskov signature rule)
 
-Status: **Accepted, 2026-05-29 (slices 1–4 done; slice 5 deferred).**
+Status: **Accepted, 2026-05-29 (slices 1–4 done; WD9 tier 1 landed
+2026-07-18; slice 5 deferred).**
 
 Records the decision to add a new family of diagnostics that check a
 method override against the contract it inherits — the **Liskov Substitution Principle (LSP)
@@ -375,6 +376,22 @@ still catch a genuine violation inside a generic context
 The param/return slices ship FP-safely without it; substitution is a
 follow-on precision uplift.
 
+**Tier-1 landed (2026-07-18).** The return (slice 2) and parameter
+(slice 3) comparisons now build a substitution map from the RBS
+instance-ancestor `.args` the overriding subclass applies to the
+generic ancestor (`class Sub < Parent[Concrete]` / `include
+_Iface[Concrete]`) and translate the parent signature under it, so a
+parent `-> T` is compared at `-> Integer` instead of `Dynamic[Top]`.
+The map is built only when arities agree and every instantiation
+argument translates; otherwise it is empty and the type variable
+keeps degrading to `Dynamic[Top]` (the pre-WD9 silence). A subclass
+that *propagates* rather than binds the variable (`class Open[T] <
+Parent[T]`) translates the forwarded `T` to `Dynamic[Top]` under the
+empty caller map, so it too stays silent — the FP-safety proof. Scope
+is unchanged: user-source ancestors + instance methods only; the
+RBS-only-ancestor reach and singleton (`def self.`) coverage remain
+deferred follow-ons.
+
 **Tier 2 — The body-narrowing dual layer (the everyday case).** Most
 "I want a narrower type here" situations need no escape hatch at all.
 Keep the *declared* parameter at the parent's wide type (LSP-safe)
@@ -407,11 +424,14 @@ synergistic: a user who has authored both signatures is already in
 bounded generic (tier 1) is a natural, in-language move rather than
 a foreign imposition.
 
-**How to apply:** tier 1 requires the WD3 / WD6 comparison to
-substitute ancestor `type_args` into the parent signature before
-`accepts`; unbound / unresolved type parameters degrade to `:maybe`
-(silent per WD7), never a false `:no`. Tiers 2–3 need no new
-mechanism. A structured RBS::Extended opt-out annotation
+**How to apply:** tier 1 (landed 2026-07-18) has the WD3 / WD6
+comparison substitute the subclass's instantiation args
+(`RBS::Definition#ancestors` `.args`, zipped against the parent's
+declared type-parameter names — the same ADR-4 Phase 2d `type_vars`
+threading the dispatcher uses) into the parent signature before
+`accepts`; unbound / unresolved type parameters keep degrading to
+`Dynamic[Top]` (silent per WD7), never a false `:no`. Tiers 2–3 need
+no new mechanism. A structured RBS::Extended opt-out annotation
 (`%a{rigor:v1:override-exempt}`-shape) as a middle ground between
 tier 1 and tier 3 is deferred — see Open Questions.
 
@@ -445,7 +465,9 @@ Recommended order; each slice independently shippable.
    `Dynamic[Top]` and stay silent (FP-safe per WD9 finding). Scoped
    to **user-source ancestors** + **instance methods** in this slice;
    RBS-only ancestors and singleton (`def self.`) methods are
-   follow-ons.
+   follow-ons. **WD9 tier 1 (landed 2026-07-18)** now translates the
+   parent return at its instantiated type when the subclass binds the
+   generic ancestor (`class Sub < Parent[Concrete]`).
 3. **Parameter contravariance. — LANDED (v0.1.x, 2026-05-29).**
    `def.override-param-narrowed` — per-position type comparison in
    the corrected parameter direction `override_param.accepts(parent_param)
@@ -460,10 +482,12 @@ Recommended order; each slice independently shippable.
    silent on it (FP-safe per WD7). Reach is therefore over core /
    stdlib / loadable-gem hierarchies; firing on app-only hierarchies
    would need a project-RBS-ancestor-aware subtype path (follow-on).
-   WD9 tier 1 (generic-instantiation-aware comparison) is the
-   *precision* follow-on noted in WD9 — it is **not** required for
-   FP-safety here, since unbound generics already degrade to
-   `Dynamic[Top]`.
+   WD9 tier 1 (generic-instantiation-aware comparison) — the
+   *precision* follow-on noted in WD9 — **landed 2026-07-18**: a
+   parameter is compared at the ancestor's instantiated type when the
+   subclass binds it (`class Sub < Parent[Concrete]`). It was never
+   required for FP-safety here, since an unbound / propagated generic
+   still degrades to `Dynamic[Top]`.
 4. **Mastodon-corpus FP verification. — DONE (v0.1.x, 2026-05-29).**
    Ran all three against the full Mastodon `app` + `lib` (1219 files)
    under a forced `strict` profile. Findings (full write-up:
@@ -631,3 +655,12 @@ for an inherited contract.
   must never false-fire. A structured `%a{rigor:v1:override-exempt}`
   annotation is floated as an open question and provisionally
   declined.
+- 2026-07-18 — WD9 tier 1 (generic-instantiation-aware comparison)
+  landed for the return + parameter checks. The parent signature is
+  now translated under the subclass's instantiation args before the
+  `accepts` comparison, so a `-> T` inherited from `Parent[Integer]`
+  is compared at `-> Integer`. Reframed as a *precision* uplift, not a
+  correctness requirement (an unbound / propagated generic already
+  degrades to `Dynamic[Top]` and stays silent, so it adds no
+  false-positive risk). RBS-only-ancestor reach and singleton (`def
+  self.`) coverage stay deferred.

--- a/lib/rigor/analysis/check_rules.rb
+++ b/lib/rigor/analysis/check_rules.rb
@@ -2504,11 +2504,16 @@ module Rigor
           declared_return_union(method_def, scope.environment)
         end
 
-        def declared_return_union(method_def, _environment)
+        # `type_vars:` — ADR-35 WD9 tier 1. When the caller supplies a generic-instantiation
+        # substitution map (parent-side, keyed by the parent class's declared type-parameter names),
+        # a `-> T` return is translated at its instantiated type (`-> Integer`) rather than degrading
+        # to `Dynamic[Top]`. The default empty map is the pre-WD9 behaviour, under which any type
+        # variable degrades to `Dynamic[Top]` and the rule stays silent.
+        def declared_return_union(method_def, _environment, type_vars: {})
           translated = method_def.method_types.filter_map do |mt|
             Inference::RbsTypeTranslator.translate(
               mt.type.return_type,
-              self_type: nil, instance_type: nil, type_vars: {}
+              self_type: nil, instance_type: nil, type_vars: type_vars
             )
           rescue StandardError
             nil
@@ -2736,8 +2741,9 @@ module Rigor
           return nil if resolved.nil?
 
           scope, override_method, parent_class, parent_method = resolved
+          parent_type_vars = ancestor_instantiation_type_vars(scope, parent_class)
           override_return = declared_return_union(override_method, scope.environment)
-          parent_return = declared_return_union(parent_method, scope.environment)
+          parent_return = declared_return_union(parent_method, scope.environment, type_vars: parent_type_vars)
           return nil if override_return.nil? || parent_return.nil?
           return nil if dynamic_top?(parent_return) # untyped / unbound-generic parent contract
 
@@ -2776,6 +2782,56 @@ module Rigor
           name.to_s.delete_prefix("::")
         end
 
+        # ADR-35 WD9 tier 1 — generic-instantiation-aware comparison. Builds the substitution map
+        # `{ parent_type_param_name => instantiated Rigor::Type }` for the parent contract as the
+        # overriding subclass instantiates it (RBS `class Sub < Parent[Concrete]` / `include
+        # _Iface[Concrete]`). Mirrors the ADR-4 Phase 2d dispatcher zip (`build_type_vars`): the
+        # parent's declared type-parameter names zipped against the subclass-side instantiation args.
+        #
+        # Returns `{}` — restoring the pre-WD9 behaviour under which any parent type variable degrades
+        # to `Dynamic[Top]` and the rule stays silent — whenever the subclass does not instantiate the
+        # ancestor generically, the RBS definition cannot be built, arities disagree, or an argument
+        # fails to translate. This is the FP-safety contract: substitution only ever *adds* precision
+        # (a `-> T` compared at `-> Integer`); an unbound / unresolved generic keeps degrading to
+        # silence, never a false `:no`.
+        def ancestor_instantiation_type_vars(scope, parent_class)
+          self_type = scope.self_type
+          return {} unless self_type.respond_to?(:class_name)
+
+          args = ancestor_instantiation_args(scope, self_type.class_name.to_s, parent_class)
+          return {} if args.nil? || args.empty?
+
+          param_names = Reflection.class_type_param_names(parent_class, scope: scope)
+          return {} if param_names.empty? || param_names.size != args.size
+
+          translated = args.map do |arg|
+            Inference::RbsTypeTranslator.translate(arg, self_type: nil, instance_type: nil, type_vars: {})
+          rescue StandardError
+            nil
+          end
+          return {} if translated.any?(&:nil?)
+
+          param_names.zip(translated).to_h
+        end
+
+        # The RBS type arguments the subclass applies to `parent_class` in its ancestry, or nil when
+        # the subclass has no RBS definition or does not name that ancestor. Reads the resolved
+        # instance-ancestor list (`RBS::Definition#ancestors`), whose `Ancestor::Instance` entries carry
+        # the instantiation `.args` for each superclass / included module. Fail-soft: any RBS build
+        # error yields nil, which the caller treats as "no instantiation" and degrades to silence.
+        def ancestor_instantiation_args(scope, subclass_name, parent_class)
+          definition = Reflection.instance_definition(subclass_name, scope: scope)
+          return nil if definition.nil?
+
+          target = normalize_class_name(parent_class)
+          ancestor = definition.ancestors.ancestors.find do |anc|
+            anc.respond_to?(:args) && normalize_class_name(anc.name.to_s) == target
+          end
+          ancestor&.args
+        rescue ::RBS::BaseError, StandardError
+          nil
+        end
+
         def build_override_return_widened_diagnostic(path, def_node, parent_class, parent_return, override_return)
           Diagnostic.from_name_loc(
             def_node,
@@ -2804,9 +2860,10 @@ module Rigor
           resolved = resolve_authored_override(def_node, scope_index)
           return nil if resolved.nil?
 
-          _scope, override_method, parent_class, parent_method = resolved
+          scope, override_method, parent_class, parent_method = resolved
+          parent_type_vars = ancestor_instantiation_type_vars(scope, parent_class)
           override_params = positional_param_types(override_method)
-          parent_params = positional_param_types(parent_method)
+          parent_params = positional_param_types(parent_method, type_vars: parent_type_vars)
           return nil if override_params.nil? || parent_params.nil?
 
           index = first_narrowed_param_index(override_params, parent_params)
@@ -2822,7 +2879,11 @@ module Rigor
         # parameter list is not introspectable. Per-position translation failures yield `nil` at that slot
         # (skipped by the comparison). `self`/`instance` translate with `self_type: nil` (→
         # `Dynamic[Top]`), matching the return-side handling.
-        def positional_param_types(method_def)
+        # `type_vars:` — ADR-35 WD9 tier 1, parent side only. Substitutes the generic-instantiation
+        # map (parent class's type params → the subclass's instantiation) so a parent `(T)` parameter
+        # is compared at its instantiated type. Empty (the default, and the override side) keeps the
+        # pre-WD9 degrade-to-`Dynamic[Top]` behaviour.
+        def positional_param_types(method_def, type_vars: {})
           method_types = method_def.method_types
           return nil unless method_types.size == 1
 
@@ -2831,7 +2892,7 @@ module Rigor
 
           (func.required_positionals + func.optional_positionals).map do |param|
             Inference::RbsTypeTranslator.translate(
-              param.type, self_type: nil, instance_type: nil, type_vars: {}
+              param.type, self_type: nil, instance_type: nil, type_vars: type_vars
             )
           rescue StandardError
             nil

--- a/spec/rigor/analysis/runner_spec.rb
+++ b/spec/rigor/analysis/runner_spec.rb
@@ -3505,6 +3505,161 @@ RSpec.describe Rigor::Analysis::Runner do
       end
     end
 
+    # ADR-35 WD9 tier 1 — generic-instantiation-aware comparison. When the overriding subclass binds a
+    # generic ancestor's type parameters (RBS `class Sub < Parent[Concrete]`), the parent signature is
+    # compared at the *instantiated* type instead of degrading its type variable to `Dynamic[Top]`. An
+    # unbound / propagated type variable keeps degrading to `Dynamic[Top]` and stays silent (FP-safe).
+    describe "override rules — generic-instantiation-aware comparison (ADR-35 WD9 tier 1)" do
+      def override_return_diags(result)
+        result.diagnostics.select { |d| d.rule == "def.override-return-widened" }
+      end
+
+      def override_param_diags(result)
+        result.diagnostics.select { |d| d.rule == "def.override-param-narrowed" }
+      end
+
+      it "flags a return widened relative to the instantiated generic parent contract" do
+        result = analyze(<<~RUBY, sig: { "demo.rbs" => <<~RBS })
+          class Container
+            def fetch
+              1
+            end
+          end
+
+          class IntContainer < Container
+            def fetch
+              Object.new
+            end
+          end
+        RUBY
+          class Container[T]
+            def fetch: () -> T
+          end
+
+          class IntContainer < Container[Integer]
+            def fetch: () -> Object
+          end
+        RBS
+        # Parent `-> T` instantiated at `T = Integer` is `-> Integer`; the override widens to `-> Object`.
+        # Before WD9 the bare `T` degraded to `Dynamic[Top]` and this stayed silent.
+        diag = override_return_diags(result).first
+        expect(diag).not_to be_nil
+        expect(diag.severity).to eq(:warning)
+        expect(diag.message).to include("`fetch'")
+        expect(diag.message).to include("Container")
+      end
+
+      it "stays silent when the subclass propagates (does not bind) the ancestor type variable" do
+        result = analyze(<<~RUBY, sig: { "demo.rbs" => <<~RBS })
+          class Container
+            def fetch
+              1
+            end
+          end
+
+          class OpenContainer < Container
+            def fetch
+              Object.new
+            end
+          end
+        RUBY
+          class Container[T]
+            def fetch: () -> T
+          end
+
+          class OpenContainer[T] < Container[T]
+            def fetch: () -> Object
+          end
+        RBS
+        # The subclass forwards its own unbound `T` to the ancestor, so the parent return degrades to
+        # `Dynamic[Top]`, which accepts everything. This is the load-bearing FP-safety case.
+        expect(override_return_diags(result)).to be_empty
+      end
+
+      it "does not fire when the override narrows relative to the instantiated parent (covariant-safe)" do
+        result = analyze(<<~RUBY, sig: { "demo.rbs" => <<~RBS })
+          class Container
+            def fetch
+              1
+            end
+          end
+
+          class NumContainer < Container
+            def fetch
+              1
+            end
+          end
+        RUBY
+          class Container[T]
+            def fetch: () -> T
+          end
+
+          class NumContainer < Container[Numeric]
+            def fetch: () -> Integer
+          end
+        RBS
+        # Parent instantiated at `Numeric`; override returns the narrower `Integer` — allowed.
+        expect(override_return_diags(result)).to be_empty
+      end
+
+      it "flags a parameter narrowed relative to the instantiated generic parent contract" do
+        result = analyze(<<~RUBY, sig: { "demo.rbs" => <<~RBS })
+          class Sink
+            def accept(value)
+              value
+            end
+          end
+
+          class NumSink < Sink
+            def accept(value)
+              value
+            end
+          end
+        RUBY
+          class Sink[T]
+            def accept: (T) -> void
+          end
+
+          class NumSink < Sink[Numeric]
+            def accept: (Integer) -> void
+          end
+        RBS
+        # Parent `(T)` instantiated at `Numeric` is `(Numeric)`; the override narrows to `(Integer)`,
+        # which cannot accept the wider parent argument. Before WD9 the bare `T` degraded to
+        # `Dynamic[Top]` and this stayed silent.
+        diag = override_param_diags(result).first
+        expect(diag).not_to be_nil
+        expect(diag.severity).to eq(:warning)
+        expect(diag.message).to include("`accept'")
+      end
+
+      it "stays silent on a narrowed parameter when the subclass propagates the type variable" do
+        result = analyze(<<~RUBY, sig: { "demo.rbs" => <<~RBS })
+          class Sink
+            def accept(value)
+              value
+            end
+          end
+
+          class OpenSink < Sink
+            def accept(value)
+              value
+            end
+          end
+        RUBY
+          class Sink[T]
+            def accept: (T) -> void
+          end
+
+          class OpenSink[T] < Sink[T]
+            def accept: (Integer) -> void
+          end
+        RBS
+        # The unbound ancestor `T` degrades to `Dynamic[Top]`, which is skipped by the comparison.
+        expect(override_param_diags(result)).to be_empty
+      end
+    end
+
     # ADR-35 slice 3 — Liskov signature rule for parameters (contravariance). Uses real (loadable) classes
     # Numeric/Integer so the nominal subtype check resolves to :no rather than the FP-safe :maybe it returns for
     # unloadable user-only class hierarchies.


### PR DESCRIPTION
## Summary

Lands **ADR-35 WD9 tier 1** — generic-instantiation-aware comparison — in the `def.override-return-widened` and `def.override-param-narrowed` checks.

Today those checks translate a generic parent contract with its type variables **unbound**, so an inherited `-> T` degrades to `Dynamic[Top]` and accepts any override return/param. That is FP-safe but imprecise: when a subclass binds the generic ancestor (`class Sub < Parent[Integer]`), the *instantiated* contract `-> Integer` would catch a genuine widening that the unbound `T` waves through.

This change builds a substitution map from the subclass's RBS instance-ancestor `.args` (the same ADR-4 Phase 2d `type_vars` threading the dispatcher already uses) and translates the **parent** signature under it before the `accepts` comparison, so `-> T` inherited from `Parent[Integer]` is compared as `-> Integer`.

## Why it carries no new false-positive risk

The map is built only when arities agree and every instantiation argument translates; otherwise it stays empty and the type variable keeps degrading to `Dynamic[Top]` — the pre-WD9 silence. A subclass that *propagates* rather than binds the variable (`class Open[T] < Parent[T]`) forwards an unbound `T` that itself translates to `Dynamic[Top]` under the empty map, so it too stays silent. Substitution therefore only ever **adds precision**; it never turns a silent-and-correct override into a firing.

## Scope

Scoped to the already-covered **user-source-ancestor + instance-method** surface. This is a *precision* uplift, not a soundness requirement.

**Not in this PR (deferred, remain tracked on #130):**
- **RBS-only-ancestor reach** — extending past user-source ancestors to RBS-known ancestors would fire on legitimate overrides of library methods; needs a corpus-measured FP-acceptance decision first.
- **`def self.` singleton coverage** — rides with the RBS-only-ancestor decision.
- **Slice 5** (parent-authored + child-*inferred* covariance) stays blocked by #156.

Uses **Advances #130** rather than **Closes** deliberately: the two deferred follow-ons stay tracked on the issue for a later cut, so #130 must remain open after merge.

## Verification

- New specs in `runner_spec.rb` (5) pin both directions: return + param firing on a bound generic (`Parent[Integer]`), and staying silent on a propagated/unbound variable (`Open[T] < Parent[T]`) — the load-bearing FP-safety proof — plus the covariant-safe narrowing case.
- **Spec teeth:** reverting the lib change makes exactly the two *firing* specs fail (the three silent specs correctly pass both ways).
- **Corpus before/after** (faraday, liquid, mail, net-ssh, kramdown, oj, erubi; HEAD vs change, same working bundle, `--no-cache`): **zero new `def.override-*` firings**. kramdown exercises the family (5 `override-return-widened` on both HEAD and change — unchanged), so the result is non-vacuous.
- `make verify` + `make check` + `make check-plugins` clean; `git diff --check` clean.

## Docs

ADR-35 § WD9 / slices 2–3 / changelog updated to record tier-1 landing; `## [Unreleased]` CHANGELOG entry under `**[type inference]**`.

Advances #130
