### PR TITLE
Flip the rbs-inline default to annotation-gated (ADR-93 WD1)

### DIFF
--- a/plugins/rigor-rbs-inline/lib/rigor/plugin/rbs_inline.rb
+++ b/plugins/rigor-rbs-inline/lib/rigor/plugin/rbs_inline.rb
@@ -155,11 +155,16 @@ module Rigor
       # override (returned by `#manifest`, which `Plugin::Registry#source_rbs_synthesizers` consults via
       # `plugin.manifest.source_rbs_synthesizer`).
       #
-      # ADR-32 WD10 — `require_magic_comment` defaults to `true`. Setting it to `false` in `.rigor.yml`
-      # flips the synthesizer into "process every file" mode.
+      # ADR-93 WD1 — `require_magic_comment` defaults to `false`: annotations are official type sources
+      # "always parsed whenever present" per the binding spec (overview.md § Compatibility hierarchy), so
+      # a file is processed when it actually carries an annotation, with the magic comment not required.
+      # The magic-comment-free mode is annotation-presence-gated (see {Synthesizer#annotated?}), so an
+      # unannotated file contributes nothing and the flip cannot regress it. Set `require_magic_comment:
+      # true` in `.rigor.yml` to restore the ADR-32 opt-in behaviour; `# rbs_inline: disabled` remains the
+      # per-file opt-out either way (honoured by upstream unconditionally).
       def initialize(services:, config: {})
         super
-        @require_magic_comment = config.fetch("require_magic_comment", true) ? true : false
+        @require_magic_comment = config.fetch("require_magic_comment", false) ? true : false
         @synthesizer = Synthesizer.new(require_magic_comment: @require_magic_comment)
         # Build the per-instance manifest eagerly (before `freeze`) so the registry's repeated reads
         # return the same object and we don't need to mutate a frozen instance later.

--- a/spec/integration/plugins/rbs_inline_plugin_spec.rb
+++ b/spec/integration/plugins/rbs_inline_plugin_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "plugins/rigor-rbs-inline" do
     expect(instance.manifest.source_rbs_synthesizer).to respond_to(:call)
   end
 
-  describe "default mode (require_magic_comment: true, ADR-32 WD2)" do
+  describe "default mode (require_magic_comment: false, ADR-93 WD1)" do
     it "flags an argument-type mismatch on a class-wrapped # @rbs param annotation" do
       source = <<~RUBY
         # rbs_inline: enabled
@@ -59,9 +59,9 @@ RSpec.describe "plugins/rigor-rbs-inline" do
       expect(mismatches.first.message).to include(":bad")
     end
 
-    it "contributes nothing for a file without the magic comment" do
+    it "processes an annotated file even without the magic comment (the ADR-93 flip)" do
       source = <<~RUBY
-        # NOTE: no `# rbs_inline: enabled` magic comment here.
+        # NOTE: no `# rbs_inline: enabled` magic comment — the default no longer requires it.
         class AscDesc
           # @rbs asc_or_desc: :asc | :desc
           def ascdesc(asc_or_desc)
@@ -72,6 +72,29 @@ RSpec.describe "plugins/rigor-rbs-inline" do
         AscDesc.new.ascdesc(:bad)
       RUBY
       result = run_plugin(source: source)
+      mismatches = result.diagnostics.select { |d| d.qualified_rule == "call.argument-type-mismatch" }
+      expect(mismatches).not_to be_empty
+    end
+
+    it "restores the ADR-32 opt-in when require_magic_comment: true is set explicitly" do
+      source = <<~RUBY
+        # NOTE: annotated, but no `# rbs_inline: enabled` magic comment.
+        class AscDesc
+          # @rbs asc_or_desc: :asc | :desc
+          def ascdesc(asc_or_desc)
+            asc_or_desc
+          end
+        end
+
+        AscDesc.new.ascdesc(:bad)
+      RUBY
+      result = run_plugin(
+        source: source,
+        plugin_entry: {
+          "gem" => "rigor-rbs-inline",
+          "config" => { "require_magic_comment" => true }
+        }
+      )
       mismatches = result.diagnostics.select { |d| d.qualified_rule == "call.argument-type-mismatch" }
       expect(mismatches).to be_empty
     end


### PR DESCRIPTION
Advances #173 — slice 1 of 5. The default flip only; WD2 auto-wiring, the `enabled: false` opt-out schema, the WD3 standalone hint, and accepting ADR-93 follow in a separate PR.

## What changes

`require_magic_comment` now defaults to **`false`**: an annotated file is processed without the `# rbs_inline: enabled` magic comment, per the binding spec's "always parsed whenever present" (`overview.md` § Compatibility hierarchy — the divergence ADR-92 marked). The flip is regression-free by construction: the annotation-presence gate (landed with ADR-93's WD4 measurement) means an unannotated file still contributes nothing.

- `require_magic_comment: true` in the plugin config restores the ADR-32 opt-in.
- `# rbs_inline: disabled` remains the per-file opt-out (honoured by upstream unconditionally).
- **Only affects projects that already load the plugin** — auto-wiring for plugin-less projects is WD2, deliberately not in this PR.

## Verification

- Plugin integration spec updated: the stale "default requires the magic comment" assertion now asserts the ADR-93 behaviour, plus new coverage that explicit `require_magic_comment: true` restores the opt-in. 18 examples green.
- `make verify` exit 0 on the branch (full suite; no other spec depends on the old default).
- The ADR-57 root-fix prerequisite for this flip (#172, `Regexp.last_match` narrowing) merged in PR #181; herb's 4 possible-nil FPs are fixed at root.