### PR TITLE
Use strict cache validation in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,14 @@ jobs:
       fail-fast: false
       matrix:
         cache: [warm, cold]
+    # A CI checkout regenerates every stat tuple (mtime/ctime/inode), so the
+    # stat tier of cache validation (ADR-87) never short-circuits here and any
+    # glob-watched slot would read as stale on every run.  Strict mode
+    # validates by content digest — deterministic across checkouts — which is
+    # the same work the digest fallback already does in CI for file slots, and
+    # keeps the warm restore effective for every slot kind.
+    env:
+      RIGOR_STRICT_VALIDATION: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/oss-sweep.yml
+++ b/.github/workflows/oss-sweep.yml
@@ -38,6 +38,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    # A CI checkout regenerates every stat tuple (mtime/ctime/inode), so the
+    # default stat-tier cache validation (ADR-87) reads restored plugin
+    # `watch:`-glob slots as stale on every run and recomputes the producers
+    # even when no watched file changed.  Strict mode validates by content
+    # digest — deterministic across checkouts — so the restored cache's
+    # producer slots actually hit.  CI is exactly the "stat tuples cannot be
+    # trusted" filesystem the strict escape hatch exists for.
+    env:
+      RIGOR_STRICT_VALIDATION: "1"
+
     steps:
       - name: Checkout Rigor
         uses: actions/checkout@v7

--- a/docs/manual/11-ci.md
+++ b/docs/manual/11-ci.md
@@ -246,6 +246,57 @@ updates:
 extra files — but Dependabot does not see a version inside a `run:`
 step, so updates to the pin are manual.
 
+## Persisting the analysis cache across runs
+
+By default each CI run starts cold and re-analyses everything. The
+templates leave it that way on purpose — cold runs are simple,
+deterministic, and fast enough for most projects. When the Rigor
+job's runtime starts to matter (a large codebase, many plugins),
+persist [the analysis cache](12-caching.md) between runs.
+
+Two things make this work:
+
+1. **Restore and save the cache directory** with your CI's cache
+   facility, keyed on anything that changes the analysis wholesale
+   (the Rigor version / lockfile).
+2. **Set `RIGOR_STRICT_VALIDATION=1`.** A fresh checkout
+   regenerates every file's timestamps and inode, so Rigor's
+   default stat-based freshness check can never short-circuit in CI,
+   and plugin watch-glob entries — which are validated by stat
+   signature alone — would be recomputed on every run. Strict mode
+   validates by content hash, which is identical across checkouts.
+   (Details: [How a file is checked for changes](12-caching.md#how-a-file-is-checked-for-changes).)
+
+GitHub Actions:
+
+```yaml
+      - uses: actions/cache@v4
+        with:
+          path: .rigor/cache
+          key: rigor-cache-${{ runner.os }}-${{ hashFiles('.github/rigor/Gemfile.lock') }}-${{ github.sha }}
+          restore-keys: rigor-cache-${{ runner.os }}-${{ hashFiles('.github/rigor/Gemfile.lock') }}-
+      - run: bundle exec rigor check
+        env:
+          RIGOR_STRICT_VALIDATION: "1"
+```
+
+GitLab CI:
+
+```yaml
+rigor:
+  variables:
+    RIGOR_STRICT_VALIDATION: "1"
+  cache:
+    key: rigor-cache
+    paths:
+      - .rigor/cache
+```
+
+The cache is content-keyed and self-invalidating — a stale or
+corrupt restore degrades to a recompute, never a wrong result. If
+you would rather guarantee every run is independent, pass
+`--no-cache` instead and skip this section.
+
 ## Container image
 
 A standalone image is published to GHCR with Ruby 4.0 and Rigor

--- a/docs/manual/12-caching.md
+++ b/docs/manual/12-caching.md
@@ -66,6 +66,16 @@ cache:
 or, for a single run, set `RIGOR_STRICT_VALIDATION=1` (which
 wins over the config key).
 
+CI is the common case of untrustworthy stat metadata: a fresh
+checkout regenerates every timestamp and inode, so a cache
+restored across CI runs (for example with `actions/cache`) never
+passes the stat check. Most entries still validate through the
+content-hash fallback, but plugin watch-glob entries are
+stat-signature only and would recompute on every run. When you
+restore Rigor's cache in CI, set `RIGOR_STRICT_VALIDATION=1` (or
+`cache.validation: digest`) so validation is deterministic
+across checkouts.
+
 ## Controlling the cache
 
 | Flag | Effect |

--- a/skills/rigor-ci-setup/SKILL.md
+++ b/skills/rigor-ci-setup/SKILL.md
@@ -141,6 +141,13 @@ The exact recipe (the `BUNDLE_GEMFILE` wiring, the Dependabot entry) is in
   role.
 - **Determinism.** Add `--no-cache` in CI if you want each run independent
   of any persisted `.rigor/cache`.
+- **Cache persistence (opposite trade).** When the Rigor job's runtime
+  matters, persist `.rigor/cache` with the CI's cache facility **and set
+  `RIGOR_STRICT_VALIDATION=1` on the job** — a fresh checkout regenerates
+  every stat tuple, and without strict mode the plugin watch-glob cache
+  slots read as stale on every run. Never persist the cache without the
+  env var. Snippets: `rigor docs ci` § "Persisting the analysis cache
+  across runs".
 
 ## Verify
 


### PR DESCRIPTION
## Why

A CI checkout regenerates every stat tuple (mtime, ctime, inode), so ADR-87's default stat-tier cache validation never short-circuits in CI:

- **File entries** fall back to the content digest — the restored cache still hits, at re-hash cost. Fine.
- **Plugin `watch:`-glob entries** (ADR-87 WD2) are a stat-tuple aggregate signature with **no content fallback** — a restored cache's producer slots read as stale on every CI run, and the producers recompute even when no watched file changed.

`RIGOR_STRICT_VALIDATION=1` switches glob rows to content hashes, which are deterministic across checkouts. CI is exactly the "stat tuples cannot be trusted" filesystem the strict escape hatch was built for.

## Evidence

Reproduced on the `rigor-rails-i18n` demo (warm cache → fresh-stat copy of the tree at the same path → unrelated source edit so the ADR-45 whole-run fast path misses and producers are actually consulted), observing which `.entry` files get rewritten:

| Mode | Entries rewritten after the fresh-stat run |
| --- | --- |
| default (`stat`) | `analysis.run-diagnostics` (expected) **+ `plugin.rails-i18n.locale_index`** (no locale file changed) |
| strict (`digest`) | `analysis.run-diagnostics` only |

Note the whole-run ADR-45 fast path masks this when *nothing* changed — but a typical CI run has changes, misses the run slot, and then pays the per-producer recompute.

## Changes

- `ci.yml` self-check matrix and `oss-sweep.yml` sweep job get job-level `RIGOR_STRICT_VALIDATION: "1"`. The oss-sweep (Mastodon, many watch-glob plugins) is the measurable win; the self-check gets consistency at identical cost (its stat tier never hits in CI anyway).
- `docs/manual/12-caching.md`: document the CI recommendation for users restoring Rigor's cache in their own pipelines.

First run after merge re-records the cache under strict signatures (a one-time glob miss, same as every run today); subsequent runs hit.

Prompted by moznion/cccc#63 (mtime-validated results cache) and the observation that mtime-keyed caches are ineffective under GitHub Actions' fresh checkouts.