### PR TITLE
Classify IO / File line iteration as non-escaping (fix always-falsey FP)

### DIFF
--- a/lib/rigor/inference/closure_escape_analyzer.rb
+++ b/lib/rigor/inference/closure_escape_analyzer.rb
@@ -144,6 +144,16 @@ module Rigor
       RANGE_EXTRA = %i[step].freeze
       INTEGER_EXTRA = %i[times upto downto].freeze
 
+      # IO / File / StringIO line- and byte-iteration methods invoke the block immediately, once per line /
+      # byte / char, and never retain it — the same immediate-invocation contract as `Array#each`. Both the
+      # singleton `File.foreach` / `IO.foreach` (receiver `singleton(File)` → class name "File") and the
+      # instance `io.each_line` / `each_char` … forms resolve through the same class-name key. Without these,
+      # `File.foreach(path) { case … when … then flag = true when … then return true if flag end }` classifies
+      # `:unknown` and misses the loop-body re-narrowing, so a local written in one `when` arm reads its
+      # pre-loop value in a sibling arm and a guarding condition folds to a spurious constant.
+      IO_ITERATION = %i[each_line each each_byte each_char each_codepoint].freeze
+      IO_SINGLETON_ITERATION = %i[foreach].freeze
+
       NON_ESCAPING = {
         "Array" => (ENUMERABLE_NON_ESCAPING + ARRAY_EXTRA).freeze,
         "Hash" => (ENUMERABLE_NON_ESCAPING + HASH_EXTRA).freeze,
@@ -151,7 +161,10 @@ module Rigor
         "Set" => ENUMERABLE_NON_ESCAPING,
         "Integer" => INTEGER_EXTRA,
         "Enumerator" => ENUMERABLE_NON_ESCAPING,
-        "Enumerator::Lazy" => ENUMERABLE_NON_ESCAPING
+        "Enumerator::Lazy" => ENUMERABLE_NON_ESCAPING,
+        "IO" => (IO_ITERATION + IO_SINGLETON_ITERATION).freeze,
+        "File" => (IO_ITERATION + IO_SINGLETON_ITERATION).freeze,
+        "StringIO" => IO_ITERATION
       }.freeze
 
       # Methods that are documented to **retain** the block past the call. The block is stored or scheduled,

--- a/spec/rigor/analysis/runner_spec.rb
+++ b/spec/rigor/analysis/runner_spec.rb
@@ -500,6 +500,45 @@ RSpec.describe Rigor::Analysis::Runner do
       end
     end
 
+    # Regression: File.foreach / IO iteration blocks must get the same loop-body re-narrowing as Array#each,
+    # so a local written in one `when` arm is visible in a sibling arm across iterations. Without it,
+    # `flag` reads its pre-loop `false` at the `return true if flag` site, the guard folds to a constant, the
+    # block-level `return` is dropped from the method's return summary, and the caller's guard on the method
+    # false-fires `flow.always-truthy-condition` (polarity "falsey").
+    it "does not false-fire always-falsey on a File.foreach block-carried local" do # rubocop:disable RSpec/ExampleLength
+      Dir.mktmpdir("rigor-foreach-fixpoint-") do |tmpdir|
+        FileUtils.mkdir_p(File.join(tmpdir, "lib"))
+        File.write(File.join(tmpdir, "lib", "scan.rb"), <<~RUBY)
+          # frozen_string_literal: true
+          class Scan
+            def hit?(path)
+              flag = false
+              File.foreach(path) do |line|
+                case line
+                when /a/ then flag = true
+                when /b/ then return true if flag
+                end
+              end
+              false
+            end
+
+            def guard(path)
+              return [] unless hit?(path)
+              [1]
+            end
+          end
+        RUBY
+
+        Dir.chdir(tmpdir) do
+          configuration = Rigor::Configuration.new("paths" => ["lib"])
+          result = described_class.new(configuration: configuration, cache_store: nil).run
+          falsey = result.diagnostics.select { |d| d.rule == "flow.always-truthy-condition" }
+
+          expect(falsey).to be_empty
+        end
+      end
+    end
+
     # ADR-72 — Gemfile.lock-gated bundled RBS overlays.
     def write_duration_project(tmpdir, lock_gem:)
       File.write(File.join(tmpdir, "Gemfile.lock"), <<~LOCK)

--- a/spec/rigor/inference/closure_escape_analyzer_spec.rb
+++ b/spec/rigor/inference/closure_escape_analyzer_spec.rb
@@ -37,6 +37,19 @@ RSpec.describe Rigor::Inference::ClosureEscapeAnalyzer do
         %i[times upto downto].each { |m| expect(classify(integer_nominal, m)).to eq(:non_escaping) }
       end
 
+      it "recognises IO / File line iteration, singleton foreach and instance each_line/each_char" do
+        # File.foreach's receiver is singleton(File); io.each_line's is a File / IO instance. Both must be
+        # non_escaping so the loop-body re-narrowing applies (a local written in one `when` arm is visible in
+        # a sibling arm across iterations) — otherwise a guarding condition folds to a spurious constant and a
+        # block-level `return` is dropped from the method's return summary.
+        expect(classify(Rigor::Type::Combinator.singleton_of("File"), :foreach)).to eq(:non_escaping)
+        expect(classify(Rigor::Type::Combinator.singleton_of("IO"), :foreach)).to eq(:non_escaping)
+        %i[each_line each each_byte each_char each_codepoint].each do |m|
+          expect(classify(Rigor::Type::Combinator.nominal_of("File"), m)).to eq(:non_escaping)
+          expect(classify(Rigor::Type::Combinator.nominal_of("IO"), m)).to eq(:non_escaping)
+        end
+      end
+
       it "recognises Object#tap / then / yield_self on any receiver" do
         %i[tap then yield_self].each do |m|
           expect(classify(string_nominal, m)).to eq(:non_escaping)


### PR DESCRIPTION
## The bug

`make check` (Rigor's self-check over `lib/`) emitted a false positive:

```
lib/rigor/cli/doctor_command.rb:279:26: warning: condition is always falsey (the surrounding flow proves it folds to a constant)
```

Line 279 is `return [] unless rubygems_sourced_rigortype?(lock)`, and `rubygems_sourced_rigortype?` genuinely can return `true` (a `return true` inside a `File.foreach` block). Pre-existing on `master` (`make check` exits 0, so warnings never failed the gate — which is why it went unnoticed).

## Root cause

`ClosureEscapeAnalyzer`'s `NON_ESCAPING` catalogue listed `Array`/`Hash`/`Range`/`Integer`/… iteration but **not** `File.foreach` / `IO.foreach` or the instance line/byte/char iterators. So a `File.foreach` block classified `:unknown` and missed the loop-body re-narrowing that `Array#each` gets. Inside the block, a local written in one `case`/`when` arm read its **pre-loop** value in a sibling arm:

- `section == "GEM" && in_specs` folded to constant `false`
- → `return true if <false>` dropped the block-level `return` from the method's return summary
- → the method inferred a constant `false` return
- → the caller's guard false-fired `flow.always-truthy-condition` (polarity "falsey").

Confirmed by a minimal `File.foreach` vs `Array#each` repro (identical body): only `File.foreach` false-fired. With the fix, the block-carried `section` correctly infers `String?` instead of `nil`.

## The fix

Add the documented immediate-invocation, non-retaining IO iterators to `NON_ESCAPING`:
- singleton `File.foreach` / `IO.foreach`
- instance `each_line`, `each`, `each_byte`, `each_char`, `each_codepoint` (IO / File / StringIO)

This meets the catalogue's bar (immediate invocation is part of the documented contract). It only adds loop-body re-narrowing — sound, never a new fact.

## Verification (in the Flake)

- `make check` now **clean** (the doctor_command.rb:279 warning is gone).
- `make verify` green (0 failures, lint clean).
- New coverage: a `ClosureEscapeAnalyzer` unit test (File/IO `foreach` + instance iterators → `:non_escaping`) and a runner regression test (a `File.foreach` loop-carried local no longer false-fires always-falsey).