### PR TITLE
Give the type probes the plugin-aware environment check uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[cli]** The type probes — `rigor type-of`, `type-scan`, `trace`, and `annotate` — now build the same plugin-aware environment `rigor check` analyses with, so a type synthesized from an inline rbs-inline annotation (or any other plugin) is reported instead of a plugin-free `Dynamic[top]`, and a probe no longer disagrees with the check it is meant to explain. A project with no plugins, or with broken plugin setup, degrades to the previous behaviour rather than failing.
+
 - **[type inference]** A `str =~ RE` match where the pattern is a constant (`RE = /.../` or `Regexp.new(...)`) now narrows the match globals just like a literal `str =~ /.../`, so `$1`, `$~`, and the rest read as their matched types after a successful match instead of staying nilable — removing spurious possible-nil warnings on the common "compile the regex once as a constant" idiom.
 
 - **[type inference]** `$+` (the last matched group) is no longer assumed non-nil after a successful match whose groups are all optional or absent (`"b" =~ /(a)?b/` matches yet leaves `$+` nil); it now narrows to `String` only when at least one capture group is guaranteed to participate, matching how an optional `$1` is already treated.

--- a/lib/rigor/cli/annotate_command.rb
+++ b/lib/rigor/cli/annotate_command.rb
@@ -15,6 +15,7 @@ require_relative "../inference/scope_indexer"
 require_relative "../inference/statement_evaluator"
 require_relative "prism_colorizer"
 require_relative "command"
+require_relative "probe_environment"
 
 module Rigor
   class CLI
@@ -106,7 +107,7 @@ module Rigor
         # bindings, so a loop-body line annotates the joined widened type (`Integer`) rather than a stale
         # first-iterations constant (`1 | 2`).
         scope_index = Inference::ScopeIndexer.index(
-          parse_result.value, default_scope: base_scope(configuration),
+          parse_result.value, default_scope: base_scope(configuration, file),
                               converged_loop_recording: true
         )
         line_types = LineTypeCollector.new(scope_index).collect(parse_result.value)
@@ -129,12 +130,12 @@ module Rigor
         @out.puts(JSON.generate({ "annotations" => annotations }))
       end
 
-      def base_scope(configuration)
+      # The plugin-aware environment for the annotated file, so a `#=> <type>` matches what `rigor check`
+      # infers on that line — including types synthesized from the file's own inline RBS annotations (the file
+      # is threaded as the synthesizer's `source_files:`; see {ProbeEnvironment}).
+      def base_scope(configuration, file)
         Scope.empty(
-          environment: Environment.for_project(
-            libraries: configuration.libraries,
-            signature_paths: configuration.signature_paths
-          )
+          environment: ProbeEnvironment.build(configuration: configuration, source_files: [file])
         )
       end
 

--- a/lib/rigor/cli/probe_environment.rb
+++ b/lib/rigor/cli/probe_environment.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require_relative "../environment"
+require_relative "../plugin"
+require_relative "../plugin/loader"
+require_relative "../plugin/services"
+require_relative "../reflection"
+require_relative "../type/combinator"
+
+module Rigor
+  class CLI
+    # Shared construction of the analysis-observing environment for the single-shot probe commands
+    # (`type-of`, `type-scan`, `trace`, `annotate`). Each of these answers "what does the engine infer here?"
+    # for a hand-picked file or position, so the environment they type against MUST match the one `rigor check`
+    # analyses with — otherwise a probe reports a type the real run never computes.
+    #
+    # The gap this closes: the probes historically built their environment with
+    # `Environment.for_project(libraries:, signature_paths:)` only — no plugin registry, no `source_files:`. The
+    # `source_rbs_synthesizer` plugin hook (ADR-32 / ADR-93's auto-wired `rigor-rbs-inline`) therefore never
+    # ran there, so a class whose only signature comes from an inline `#: () -> void` annotation typed as
+    # `Dynamic[top]` under a probe while `check` resolved it through the synthesized RBS. That divergence
+    # misattributed a dispatch tier during the #162 transitive-void design pass (see the 2026-07-19 addendum in
+    # docs/adr/100-static-diagnostic-family-and-void-origins.md).
+    #
+    # This threads the two things that were missing — the plugin registry built by the plugin loader, and the
+    # `source_files:` the synthesizers run over — matching `rigor check`'s `Environment.for_project` call
+    # (built in `Analysis::Runner::PoolCoordinator#build_runner_environment`). A probe legitimately simplifies
+    # relative to check: no synthesis-failure reporter (a probe has no diagnostic pipeline) and no synthesis
+    # cache store (a single-position probe recomputes cheaply). Plugin loading itself matches check — same
+    # `.rigor.yml` `plugins:` config, same ADR-93 auto-wire (already applied by `Configuration.load`), same
+    # `enabled:` / `require_magic_comment` semantics via `Plugin::Loader.load`.
+    #
+    # Fail-soft is the invariant: a project with no plugins, an unresolvable plugin gem, or any error during the
+    # plugin-aware build degrades to the bare environment the probes used before — never a crash. `Plugin::Loader`
+    # already isolates per-entry load failures onto the registry; the `rescue` here is the belt-and-suspenders
+    # around anything the loader or the plugin-aware env build itself might raise.
+    module ProbeEnvironment
+      module_function
+
+      # Builds the plugin-aware {Rigor::Environment} a probe types against.
+      #
+      # @param configuration [Rigor::Configuration] the loaded project configuration (already carries the
+      #   ADR-93 auto-wired `rigor-rbs-inline` entry when the library is resolvable).
+      # @param source_files [Array<String>] the file(s) the probe inspects. Threaded so each loaded plugin's
+      #   `source_rbs_synthesizer` runs over them at env-build time; an empty list contributes no synthesized RBS.
+      # @return [Rigor::Environment]
+      def build(configuration:, source_files:)
+        Environment.for_project(
+          libraries: configuration.libraries,
+          signature_paths: configuration.signature_paths,
+          plugin_registry: load_plugin_registry(configuration),
+          source_files: source_files
+        )
+      rescue StandardError
+        bare(configuration)
+      end
+
+      # Loads the project's configured plugins the same way the plugin-inspection commands (`rigor plugins`,
+      # `rigor doctor`) do: a `Plugin::Services` with no cache store (the probe recomputes) driving
+      # `Plugin::Loader.load`. Returns `nil` — so `Environment.for_project` skips the plugin tier entirely —
+      # when the project declares no plugins.
+      def load_plugin_registry(configuration)
+        return nil if configuration.plugins.empty?
+
+        services = Plugin::Services.new(
+          reflection: Reflection,
+          type: Type::Combinator,
+          configuration: configuration,
+          cache_store: nil
+        )
+        Plugin::Loader.load(configuration: configuration, services: services)
+      end
+
+      # The pre-fix environment: RBS + project signatures only, no plugin tier and no synthesized RBS. The
+      # fail-soft floor — a probe on a project with broken or absent plugin setup lands here and behaves exactly
+      # as it did before this parity fix.
+      def bare(configuration)
+        Environment.for_project(
+          libraries: configuration.libraries,
+          signature_paths: configuration.signature_paths
+        )
+      end
+    end
+  end
+end

--- a/lib/rigor/cli/trace_command.rb
+++ b/lib/rigor/cli/trace_command.rb
@@ -12,6 +12,7 @@ require_relative "../inference/flow_tracer"
 require_relative "../inference/scope_indexer"
 require_relative "command"
 require_relative "trace_renderer"
+require_relative "probe_environment"
 
 module Rigor
   class CLI
@@ -90,13 +91,11 @@ module Rigor
         0
       end
 
-      # Mirrors the single-file path `rigor type-of` takes: a project-aware environment, an empty seed scope, one
-      # statement-level evaluation of the whole program — but recorded under the FlowTracer.
+      # Mirrors the single-file path `rigor type-of` takes: the plugin-aware environment (so a trace replays the
+      # same dispatch `rigor check` would, including plugin-synthesized RBS — see {ProbeEnvironment}), an empty
+      # seed scope, one statement-level evaluation of the whole program — but recorded under the FlowTracer.
       def record_events(root, file, configuration)
-        environment = Environment.for_project(
-          libraries: configuration.libraries,
-          signature_paths: configuration.signature_paths
-        )
+        environment = ProbeEnvironment.build(configuration: configuration, source_files: [file])
         scope = Scope.empty(environment: environment, source_path: file)
         Inference::FlowTracer.record { scope.evaluate(root) }
       end

--- a/lib/rigor/cli/type_of_command.rb
+++ b/lib/rigor/cli/type_of_command.rb
@@ -13,6 +13,7 @@ require_relative "../inference/scope_indexer"
 require_relative "type_of_renderer"
 require_relative "command"
 require_relative "options"
+require_relative "probe_environment"
 
 module Rigor
   class CLI
@@ -92,14 +93,14 @@ module Rigor
         0
       end
 
-      # Builds a project-aware environment relative to the probed file. Project-RBS auto-detection roots at CWD today;
-      # future work will walk parent directories to find the enclosing `Gemfile`/`*.gemspec` so probes against files
-      # outside the current process's CWD still see the right `sig/` tree.
-      def project_environment(_file, configuration)
-        Environment.for_project(
-          libraries: configuration.libraries,
-          signature_paths: configuration.signature_paths
-        )
+      # Builds the plugin-aware environment relative to the probed file, so the reported type matches what `rigor
+      # check` computes for the same position — including types synthesized from inline RBS annotations by the
+      # ADR-93 auto-wired `rigor-rbs-inline` plugin (see {ProbeEnvironment} for the #162 misattribution this
+      # closes). The probed file is threaded as the synthesizer's `source_files:`. Project-RBS auto-detection
+      # roots at CWD today; future work will walk parent directories to find the enclosing `Gemfile`/`*.gemspec`
+      # so probes against files outside the current process's CWD still see the right `sig/` tree.
+      def project_environment(file, configuration)
+        ProbeEnvironment.build(configuration: configuration, source_files: [file])
       end
 
       def file_exists?(file)

--- a/lib/rigor/cli/type_scan_command.rb
+++ b/lib/rigor/cli/type_scan_command.rb
@@ -11,6 +11,7 @@ require_relative "../scope"
 require_relative "type_scan_renderer"
 require_relative "type_scan_report"
 require_relative "command"
+require_relative "probe_environment"
 
 module Rigor
   class CLI
@@ -69,20 +70,19 @@ module Rigor
 
       def scan_paths(paths, options)
         configuration = Configuration.load(options.fetch(:config))
-        scope = Scope.empty(environment: project_environment(configuration))
+        scope = Scope.empty(environment: project_environment(configuration, paths))
         scanner = Inference::CoverageScanner.new(scope: scope)
         accumulator = ScanAccumulator.new
         paths.each { |path| scan_one(path, scanner, accumulator, configuration) }
         accumulator.to_report(paths, options)
       end
 
-      # Builds a project-aware environment that auto-detects `<cwd>/sig` by default and honours the configuration's
-      # `libraries:` / `signature_paths:` keys when present.
-      def project_environment(configuration)
-        Environment.for_project(
-          libraries: configuration.libraries,
-          signature_paths: configuration.signature_paths
-        )
+      # Builds the plugin-aware environment that auto-detects `<cwd>/sig` by default and honours the
+      # configuration's `libraries:` / `signature_paths:` keys when present. The scanned `paths` are threaded as
+      # the plugin `source_rbs_synthesizer` inputs so coverage reflects the same synthesized RBS `rigor check`
+      # sees (see {ProbeEnvironment}).
+      def project_environment(configuration, source_files)
+        ProbeEnvironment.build(configuration: configuration, source_files: source_files)
       end
 
       def scan_one(path, scanner, accumulator, configuration)

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -193,6 +193,86 @@ RSpec.describe Rigor::CLI do
       expect(err).to include("file not found")
     end
 
+    # ADR-93 / #162 — type-of must build the same plugin-aware environment `rigor check` analyses with, so a
+    # type synthesized from an inline RBS annotation by the auto-wired `rigor-rbs-inline` plugin is observed by
+    # the probe instead of the plugin-free `Dynamic[top]`. See `Rigor::CLI::ProbeEnvironment`.
+    describe "plugin-synthesized RBS (rbs-inline auto-wire parity)" do
+      # `foo`'s ONLY signature is the inline `#: () -> void`; `bar` / `baz` are un-annotated. Lines match the
+      # #162 design-session repro: `a = foo` is line 14, `b = bar` is line 19.
+      let(:void_source) do
+        <<~RUBY
+          class VoidRepro
+            #: () -> void
+            def foo; end
+
+            def bar
+              foo
+            end
+
+            def baz
+              bar
+            end
+
+            def use_foo
+              a = foo
+              a
+            end
+
+            def use_bar
+              b = bar
+              b
+            end
+
+            def use_baz
+              c = baz
+              c
+            end
+          end
+        RUBY
+      end
+
+      # The suite pins the auto-wire probe off and pervasively empties the plugin registry (see spec_helper), so
+      # an auto-wire spec lifts the pin with `:rbs_inline_autowire` and re-registers the plugin class (whose
+      # top-level `register` is a require-no-op after another spec's `unregister!`).
+      context "with the rbs-inline plugin auto-wired", :rbs_inline_autowire do
+        before do
+          allow(Rigor::Configuration).to receive(:rbs_inline_library_resolvable?).and_return(true)
+          require "rigor-rbs-inline"
+          Rigor::Plugin.register(Rigor::Plugin::RbsInline) unless Rigor::Plugin.registered_for("rbs-inline")
+        end
+
+        it "resolves an inline-annotated method through the synthesized RBS under type-of" do
+          path = write_fixture("void_repro.rb", void_source)
+          config = write_fixture(".rigor.yml", %(target_ruby: "4.0"\n))
+
+          _s, foo_out, _e = run_cli("type-of", "--format=json", "--config", config, "#{path}:14:8")
+          _s, bar_out, _e = run_cli("type-of", "--format=json", "--config", config, "#{path}:19:8")
+
+          # `a = foo`: foo's synthesized `-> void` recovers to `top` (was `Dynamic[top]` under the plugin-free env).
+          expect(JSON.parse(foo_out)["type"]).to eq("top")
+          # `b = bar`: bar is un-annotated, so its synthesized skeleton is `() -> untyped` and it stays Dynamic —
+          # proving the flip at 14 is the annotation's synthesis, not an unrelated change.
+          expect(JSON.parse(bar_out)["type"]).to eq("Dynamic[top]")
+        end
+      end
+
+      it "degrades to the plugin-free type when the synthesizer is disabled (fail-soft)" do
+        path = write_fixture("void_repro.rb", void_source)
+        config = write_fixture(".rigor.yml", <<~YAML)
+          plugins:
+            - gem: rigor-rbs-inline
+              enabled: false
+        YAML
+
+        status, out, err = run_cli("type-of", "--format=json", "--config", config, "#{path}:14:8")
+
+        expect(err).to eq("")
+        expect(status).to eq(0)
+        # No synthesizer contributes, so `foo` reads exactly as it did before this parity fix — never a crash.
+        expect(JSON.parse(out)["type"]).to eq("Dynamic[top]")
+      end
+    end
+
     describe "editor mode (--tmp-file / --instead-of)" do
       it "rejects --tmp-file alone" do
         status, _out, err = run_cli("type-of", "--tmp-file=/nonexistent", "lib/foo.rb:1:1")


### PR DESCRIPTION
## Problem

`rigor type-of`, `type-scan`, `trace`, and `annotate` built their environment with `Environment.for_project(libraries:, signature_paths:)` only — no plugin registry, no `source_files:`. The plugin `source_rbs_synthesizer` hook (the ADR-93 auto-wired `rigor-rbs-inline`) therefore never ran under a probe, so a value typed through an inline `#: () -> void` annotation read as `Dynamic[top]` while `rigor check` resolved it through the synthesized RBS. **A probe silently disagreed with the check it exists to explain.**

That divergence misattributed a dispatch tier during the #162 transitive-void design pass — a `type-of` reading taken as ground truth pointed at the wrong origin (see the 2026-07-19 addendum in `docs/adr/100-static-diagnostic-family-and-void-origins.md`).

## Fix

Extract `Rigor::CLI::ProbeEnvironment`, which loads the project's plugins the way `rigor plugins` / `rigor doctor` do and threads the probed file(s) as `source_files:`, and route all four probes through it. Plugin loading matches `check` — same `.rigor.yml` config, same ADR-93 auto-wire (already applied by `Configuration.load`), same `enabled:` / `require_magic_comment` semantics.

A probe legitimately simplifies relative to `check`: no synthesis cache store (a single position recomputes cheaply) and no synthesis-failure reporter (a probe has no diagnostic pipeline). It **fails soft** — a project with no plugins, an unresolvable plugin gem, or any error during the plugin-aware build degrades to the previous bare environment rather than crashing.

## Acceptance repro (flips)

On a class whose only signature for `foo` is an inline `#: () -> void`:

| position | before | after |
| --- | --- | --- |
| `14:8` (`a = foo`) | `Dynamic[top]` | `top` (synthesized `-> void`) |
| `19:8` (`b = bar`) | `Dynamic[top]` | `Dynamic[top]` (un-annotated → `() -> untyped` skeleton) |

`19` staying `Dynamic[top]` proves the flip at `14` is the annotation's synthesis, not an unrelated change. Both are pinned as specs (`spec/rigor/cli_spec.rb`), alongside a fail-soft spec (disabled synthesizer → the previous plugin-free type).

## Audit — every `Environment.for_project` caller in `lib/rigor/cli/`

| caller | disposition |
| --- | --- |
| `type_of_command.rb` | fixed |
| `type_scan_command.rb` | fixed |
| `trace_command.rb` | fixed |
| `annotate_command.rb` | fixed (same gap) |
| `coverage_scan.rb` | deliberately left — precision-measurement surface shared with `check --coverage`, not a point probe; its plugin-awareness is a separate concern the `--protection` path already handles via `ProjectContext` |

`make verify`, `make docs-check`, `git diff --check` all clean.