### PR TITLE
Report each loaded plugin's resolved file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
   - It is a warning, never an error — your exit code does not change. The finding also appears in `--format=json` under `config_warnings` with `"kind": "unknown_key"`, so CI can assert on it.
   - Top-level keys only. A typo *inside* a group (`cache: { pth: … }`) is caught by the [JSON schema](schemas/rigor-config.schema.json) as you type instead.
 
+- **[plugins]** `rigor plugins` now reports the resolved file each loaded plugin loaded from — a `path:` line in the text report and a `"path"` key in `--format=json` — and the `plugin_loader.load-error` diagnostic names it when a plugin was loaded but then failed to configure. A stale installed `rigortype` gem silently shadowing a newer checkout's bundled plugin copy is now visible at a glance instead of taking a bisection to pin down.
+
 ### Fixed
 
 - **[cli]** The type probes — `rigor type-of`, `type-scan`, `trace`, and `annotate` — now build the same plugin-aware environment `rigor check` analyses with, so a type synthesized from an inline rbs-inline annotation (or any other plugin) is reported instead of a plugin-free `Dynamic[top]`, and a probe no longer disagrees with the check it is meant to explain. A project with no plugins, or with broken plugin setup, degrades to the previous behaviour rather than failing.

--- a/docs/internal-spec/plugin.md
+++ b/docs/internal-spec/plugin.md
@@ -526,10 +526,13 @@ runner uses before plugins load.
 
 Public exception raised inside the loader when a plugin entry
 cannot be resolved. Carries `plugin_ref` (the offending gem name
-or plugin id) and `cause_class` (the underlying exception class,
-when applicable). The runner converts each one into a
-`Rigor::Analysis::Diagnostic` with `source_family: :plugin_loader`
-and `rule: "load-error"`.
+or plugin id), `cause_class` (the underlying exception class,
+when applicable), and `resolved_path` (the file the plugin gem
+loaded from, stamped by the loader when the `require` succeeded
+but a later configuration / instantiation step failed; nil for a
+`require` that failed outright). The runner converts each one into
+a `Rigor::Analysis::Diagnostic` with `source_family:
+:plugin_loader` and `rule: "load-error"`.
 
 ## Internal surfaces (NOT public)
 
@@ -578,7 +581,11 @@ entry does not abort the others. Each failure is collected as a
 - `rule`: `"load-error"`
 - `message`: the `LoadError`'s message (gem path / registration /
   config-schema / `#init` exception, depending on the failure
-  kind).
+  kind), suffixed with ` (loaded from <path>)` when the `require`
+  succeeded but a later step failed — so a config/init failure
+  names the exact plugin copy it loaded from; a `require` that
+  failed outright has no resolved path and the message is
+  unchanged.
 
 `rigor check` continues with the analysis; plugins that loaded
 successfully still participate in later v0.1.0 slices.

--- a/docs/manual/02-cli-reference.md
+++ b/docs/manual/02-cli-reference.md
@@ -411,6 +411,11 @@ Report the activation status of every plugin configured in
 `.rigor.yml` — loaded, load-error (with reason), and each
 plugin's declared extension surfaces. See [Plugins](07-plugins.md).
 
+Each loaded plugin's row also reports the resolved file it
+loaded from (a `path:` line in text, a `"path"` key in JSON), so
+if a stale installed gem is shadowing a newer checkout's bundled
+plugin copy the mismatch is visible at a glance.
+
 ```sh
 rigor plugins [--format=text|json] [--strict] [--capabilities] [--config=PATH]
 ```

--- a/lib/rigor/analysis/runner/diagnostic_aggregator.rb
+++ b/lib/rigor/analysis/runner/diagnostic_aggregator.rb
@@ -123,12 +123,22 @@ module Rigor
               path: ".rigor.yml",
               line: 1,
               column: 1,
-              message: error.message,
+              message: plugin_load_error_message(error),
               severity: :error,
               rule: "load-error",
               source_family: :plugin_loader
             )
           end
+        end
+
+        # #194 slice 1 — when the require SUCCEEDED but configuration / instantiation then failed, the loader
+        # stamps the resolved file on the error; naming it here turns an engine↔plugin version skew (a stale
+        # installed `rigortype` gem shadowing a checkout's bundled plugin) into a one-line diagnosis. A
+        # require that failed outright carries no resolved path and keeps its original message.
+        def plugin_load_error_message(error)
+          return error.message if error.resolved_path.nil?
+
+          "#{error.message} (loaded from #{error.resolved_path})"
         end
 
         # ADR-10 § "Diagnostic prefix family" — surfaces gems listed in `dependencies.source_inference`

--- a/lib/rigor/cli/plugins_command.rb
+++ b/lib/rigor/cli/plugins_command.rb
@@ -170,7 +170,10 @@ module Rigor
         end
 
         if plugin
-          loaded_row(plugin, gem_name, config)
+          # #194 slice 1 — a loaded plugin's resolved file rides on the registry keyed by gem name (the
+          # frozen plugin instance can't carry it). nil when the gem's entry-file basename differs from its
+          # name, or the resolver couldn't pin it.
+          loaded_row(plugin, gem_name, config, registry.resolved_gem_paths[gem_name])
         else
           # Find the load error whose plugin_ref names this entry (the ref is set by Loader to the gem name on require
           # failures and to the manifest id on later failures).
@@ -190,9 +193,10 @@ module Rigor
         [derived_id, gem_name].include?(plugin.manifest.id)
       end
 
-      def loaded_row(plugin, gem_name, config)
+      def loaded_row(plugin, gem_name, config, resolved_path)
         manifest = plugin.manifest
         identity_fields(gem_name, manifest, config)
+          .merge(path: resolved_path)
           .merge(extension_fields(plugin, manifest))
           .merge(narrow_protocol_fields(plugin))
           .merge(load_error: nil)
@@ -252,6 +256,9 @@ module Rigor
           id: entry_id,
           version: nil,
           description: nil,
+          # #194 slice 1 — set only when the require SUCCEEDED but a later step failed (the loader stamps the
+          # file on the error); a require that failed outright has no resolvable file, so this stays nil.
+          path: error&.resolved_path,
           config: config,
           signature_paths: [],
           open_receivers: [],
@@ -332,6 +339,7 @@ module Rigor
             id: nil,
             version: nil,
             description: nil,
+            path: error.resolved_path,
             config: {},
             signature_paths: [],
             open_receivers: [], owns_receivers: [], produces: [], consumes: [],

--- a/lib/rigor/cli/plugins_renderer.rb
+++ b/lib/rigor/cli/plugins_renderer.rb
@@ -156,6 +156,10 @@ module Rigor
                end
         lines = [head]
         lines << "        #{row[:description]}" if row[:description]
+        # #194 slice 1 — the file the plugin gem loaded from, so an engine↔plugin version skew (a stale
+        # installed `rigortype` shadowing a checkout's bundled plugin) is a glance, not a bisect. Shown for
+        # loaded rows and for a require-succeeded-then-failed error row; omitted when unresolvable.
+        lines << "        path: #{row[:path]}" if row[:path]
 
         if row[:status] == :load_error
           lines << "        load error: #{row[:load_error]}"
@@ -238,6 +242,9 @@ module Rigor
           "id" => row[:id],
           "version" => row[:version],
           "description" => row[:description],
+          # #194 slice 1 — additive per-row provenance; null when the resolver could not pin the file (a
+          # require failure, or an entry-file basename differing from the gem name).
+          "path" => row[:path],
           "config" => row[:config],
           "signature_paths" => row[:signature_paths].map do |sp|
             { "path" => sp[:path], "exists" => sp[:exists], "rbs_files" => sp[:rbs_files] }

--- a/lib/rigor/plugin/load_error.rb
+++ b/lib/rigor/plugin/load_error.rb
@@ -11,6 +11,14 @@ module Rigor
     class LoadError < StandardError
       attr_reader :plugin_ref, :cause_class, :reason
 
+      # #194 slice 1 — the file `require` resolved the plugin gem to, when the require SUCCEEDED but the
+      # later configuration / instantiation step then failed. The loader stamps it in a rescue after a
+      # successful require (a require that failed outright never resolves a file and leaves this nil), so a
+      # config/init failure names the exact plugin copy it loaded from — the engine↔plugin version skew that
+      # made #194 a multi-round diagnosis. Consumed by the `plugin_loader.load-error` diagnostic message and
+      # the `rigor plugins` load-error row.
+      attr_accessor :resolved_path
+
       # ADR-9 slice 5 introduces two new reason codes alongside the implicit "load failure" used for require /
       # configuration / init failures:
       #
@@ -19,11 +27,12 @@ module Rigor
       #   - `:dependency-cycle` — the consumes graph forms a cycle.
       #
       # Older callers omit `reason:` and the field defaults to nil (the legacy "load failure" envelope).
-      def initialize(message, plugin_ref:, cause: nil, reason: nil)
+      def initialize(message, plugin_ref:, cause: nil, reason: nil, resolved_path: nil)
         super(message)
         @plugin_ref = plugin_ref
         @cause_class = cause&.class
         @reason = reason&.to_sym
+        @resolved_path = resolved_path
       end
     end
   end

--- a/lib/rigor/plugin/loader.rb
+++ b/lib/rigor/plugin/loader.rb
@@ -23,18 +23,33 @@ module Rigor
     # entries that resolve to the same gem. Failures do not abort the run; the loader collects them on the
     # {Registry} so the runner can convert each one into a `:plugin_loader` diagnostic.
     class Loader # rubocop:disable Metrics/ClassLength
-      attr_reader :services, :requirer
+      attr_reader :services, :requirer, :feature_resolver
+
+      # #194 slice 1 — resolve the file that satisfied `require <gem>` by scanning `$LOADED_FEATURES` for the
+      # entry ending in `/<gem>.rb`, LAST match preferred. Provenance-agnostic: it pins the actual file for a
+      # Bundler path gem, an installed gem, and a `-I`-injected checkout alike, and — because the feature is
+      # already present from the first load — it still resolves when `require` no-ops on a repeat in-process
+      # load (ADR-88 WD4b). Returns nil, never raises, in the degenerate cases: a gem whose entry-file
+      # basename differs from the gem name, and a spec's fake requirer that never populated `$LOADED_FEATURES`.
+      FEATURE_RESOLVER = lambda do |gem_name|
+        suffix = "/#{gem_name}.rb"
+        $LOADED_FEATURES.rfind { |feature| feature.end_with?(suffix) }
+      end
 
       # @param services [Rigor::Plugin::Services]
       # @param requirer [#call] takes a gem name and returns truthy on successful require. Defaulted to
       #   `Kernel.require` via a lambda; the spec injects a fake to avoid touching the real load path.
-      def initialize(services:, requirer: ->(name) { require name })
+      # @param feature_resolver [#call] takes a gem name and returns the absolute path `require` resolved it
+      #   to (or nil). Defaulted to {FEATURE_RESOLVER}; the spec injects a fake so it never has to mutate the
+      #   real `$LOADED_FEATURES` global.
+      def initialize(services:, requirer: ->(name) { require name }, feature_resolver: FEATURE_RESOLVER)
         @services = services
         @requirer = requirer
+        @feature_resolver = feature_resolver
       end
 
-      def self.load(configuration:, services:, requirer: ->(name) { require name })
-        new(services: services, requirer: requirer).load(configuration.plugins)
+      def self.load(configuration:, services:, requirer: ->(name) { require name }, feature_resolver: FEATURE_RESOLVER)
+        new(services: services, requirer: requirer, feature_resolver: feature_resolver).load(configuration.plugins)
       end
 
       # @param entries [Array<String, Hash>] the raw `plugins:` list from the configuration.
@@ -43,6 +58,10 @@ module Rigor
         plugins = []
         load_errors = []
         seen_ids = {}
+        # #194 slice 1 — `gem name => resolved file path` for every gem the loader successfully required.
+        # A frozen plugin instance (e.g. `rigor-rbs-inline` self-freezes per ADR-32) can't carry the path,
+        # so it rides on the Registry keyed by gem name; the `rigor plugins` loaded row reads it back.
+        @resolved_gem_paths = {}
 
         Array(entries).each_with_index do |raw, index|
           entry = normalise_entry(raw, index)
@@ -70,7 +89,8 @@ module Rigor
         load_errors.concat(sort_errors)
 
         blueprints = plugins.map { |plugin| Blueprint.new(klass_name: plugin.class.name, config: plugin.config) }
-        Registry.new(plugins: plugins, blueprints: blueprints, load_errors: load_errors)
+        Registry.new(plugins: plugins, blueprints: blueprints, load_errors: load_errors,
+                     resolved_gem_paths: @resolved_gem_paths)
       end
 
       private
@@ -110,6 +130,9 @@ module Rigor
       def resolve_and_instantiate(entry, seen_ids) # rubocop:disable Metrics/AbcSize
         before = Plugin.registered.keys.to_set
         require_gem!(entry)
+        # The require SUCCEEDED — pin the file it resolved to (nil when the resolver can't, never a raise).
+        # Recorded before the fallible steps below so a config/init failure can still name the loaded copy.
+        @resolved_gem_paths[entry[:gem]] = @feature_resolver.call(entry[:gem])
         after = Plugin.registered.keys.to_set
         newly_registered = (after - before).to_a
 
@@ -141,6 +164,13 @@ module Rigor
         plugin = instantiate(plugin_class, entry[:config])
         validate_signature_paths!(plugin)
         plugin
+      rescue LoadError => e
+        # #194 slice 1 — annotate a POST-require failure (bad config, a raising `#init`, a missing signature
+        # dir, a duplicate id, no/many registrations) with the file the gem loaded from, so the surfaced
+        # diagnostic names the exact plugin copy. A require that failed outright never populated the map for
+        # this gem, so the lookup is nil and the message is left unchanged.
+        e.resolved_path ||= @resolved_gem_paths[entry[:gem]]
+        raise
       end
 
       # ADR-25 — a plugin's manifest-declared `signature_paths:` are resolved (by

--- a/lib/rigor/plugin/registry.rb
+++ b/lib/rigor/plugin/registry.rb
@@ -215,7 +215,7 @@ module Rigor
     # Ractor. The eventual Phase 4 pool ships `blueprints` across the boundary and calls {.materialize}
     # per-Ractor; the live `plugins` carriage on the coordinator registry stays unchanged.
     class Registry
-      attr_reader :plugins, :load_errors, :blueprints, :contribution_index
+      attr_reader :plugins, :load_errors, :blueprints, :contribution_index, :resolved_gem_paths
 
       # @param plugins [Array<Rigor::Plugin::Base>] instantiated plugin instances in deterministic order.
       # @param load_errors [Array<Rigor::Plugin::LoadError>] failures surfaced during loading. Each error is
@@ -223,20 +223,17 @@ module Rigor
       # @param blueprints [Array<Rigor::Plugin::Blueprint>] frozen, Ractor-shareable replay descriptors
       #   aligned 1:1 with `plugins`. The loader fills this in; callers that construct Registry manually MAY
       #   pass `[]` and accept that {.materialize} cannot replay the set.
-      def initialize(plugins: [], load_errors: [], blueprints: [])
+      # @param resolved_gem_paths [Hash{String=>String,nil}] #194 slice 1 — `gem name => resolved file path`
+      #   for each successfully required plugin gem, so `rigor plugins` can print where a loaded (and
+      #   possibly frozen) plugin actually loaded from. Defaults to empty; a worker registry built by
+      #   {.materialize} carries none (the provenance surface runs only on the coordinator).
+      def initialize(plugins: [], load_errors: [], blueprints: [], resolved_gem_paths: {})
         @plugins = plugins.dup.freeze
         @load_errors = load_errors.dup.freeze
         @blueprints = blueprints.dup.freeze
+        @resolved_gem_paths = resolved_gem_paths.dup.freeze
         @contribution_index = ContributionIndex.new(@plugins)
-        # ADR-52 WD1 — aggregate queries the engine issues per def / per diagnostic candidate / per path are
-        # compiled once here (the registry is frozen, so the flat_map-on-every-call versions re-derived an
-        # invariant). `@contracts_by_path` is a mutable per-path memo inside the frozen registry — safe
-        # because the contract set and the glob semantics are fixed for the lifetime of the run.
-        @additional_initializers = @plugins.flat_map { |p| safe_manifest(p)&.additional_initializers || [] }.freeze
-        @open_receivers = @plugins.flat_map { |p| (safe_manifest(p)&.open_receivers || []).map(&:to_s) }.uniq.freeze
-        @open_receivers_set = @open_receivers.to_set.freeze
-        @protocol_contracts = @plugins.flat_map { |p| safe_protocol_contracts(p) }.freeze
-        @contracts_by_path = {}
+        compile_aggregates
         # ADR-52 WD4 — the single engine-owned node-rule walk, compiled once per run from the node-rule
         # plugin subset (registry order). The runner reuses it for every file; it builds fresh per-file
         # state internally, so it is safe to freeze and share.
@@ -371,6 +368,18 @@ module Rigor
       private_constant :FNMATCH_FLAGS
 
       private
+
+      # ADR-52 WD1 — aggregate queries the engine issues per def / per diagnostic candidate / per path are
+      # compiled once at construction (the registry is frozen, so the flat_map-on-every-call versions
+      # re-derived an invariant). `@contracts_by_path` is a mutable per-path memo inside the frozen registry
+      # — safe because the contract set and the glob semantics are fixed for the lifetime of the run.
+      def compile_aggregates
+        @additional_initializers = @plugins.flat_map { |p| safe_manifest(p)&.additional_initializers || [] }.freeze
+        @open_receivers = @plugins.flat_map { |p| (safe_manifest(p)&.open_receivers || []).map(&:to_s) }.uniq.freeze
+        @open_receivers_set = @open_receivers.to_set.freeze
+        @protocol_contracts = @plugins.flat_map { |p| safe_protocol_contracts(p) }.freeze
+        @contracts_by_path = {}
+      end
 
       def path_matches_glob?(glob, path)
         File.fnmatch?(glob, path, FNMATCH_FLAGS) ||

--- a/spec/rigor/analysis/runner/diagnostic_aggregator_spec.rb
+++ b/spec/rigor/analysis/runner/diagnostic_aggregator_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# #194 slice 1 — the `plugin_loader.load-error` diagnostic names the file a plugin loaded from when the
+# require SUCCEEDED but a later step (config / instantiation) failed, so an engine↔plugin version skew is a
+# one-line diagnosis; a require that failed outright keeps its original message. That message composition
+# lives in the aggregator, so it is exercised here directly against a hand-built registry — no real load
+# path, no `$LOADED_FEATURES`.
+RSpec.describe Rigor::Analysis::Runner::DiagnosticAggregator do
+  # `plugin_load_diagnostics` reads only the plugin registry, so every other collaborator is an inert stub.
+  def build_aggregator(registry)
+    described_class.new(
+      configuration: Rigor::Configuration.new(Rigor::Configuration::DEFAULTS),
+      rbs_extended_reporter: nil,
+      boundary_cross_reporter: nil,
+      source_rbs_synthesis_reporter: nil,
+      plugin_registry: -> { registry },
+      dependency_source_index: -> {},
+      pool_mode: -> { false },
+      cached_plugin_prepare_diagnostics: -> { [] },
+      pre_eval_diagnostics_from_scanner: -> { [] },
+      synthesized_namespaces_snapshot: -> {},
+      quarantined_signatures_snapshot: -> { [] },
+      env_build_failure_snapshot: -> {},
+      conformance_results_snapshot: -> {}
+    )
+  end
+
+  def load_error(message, resolved_path: nil)
+    error = Rigor::Plugin::LoadError.new(message, plugin_ref: "x")
+    error.resolved_path = resolved_path
+    error
+  end
+
+  it "appends the resolved file to a post-require failure so it names the loaded plugin copy" do
+    registry = Rigor::Plugin::Registry.new(
+      load_errors: [
+        load_error('plugin "x" raised during init: RuntimeError: boom',
+                   resolved_path: "/checkout/plugins/rigor-x/lib/rigor-x.rb")
+      ]
+    )
+
+    diagnostic = build_aggregator(registry).plugin_load_diagnostics.first
+
+    expect(diagnostic.rule).to eq("load-error")
+    expect(diagnostic.source_family).to eq(:plugin_loader)
+    expect(diagnostic.message).to eq(
+      'plugin "x" raised during init: RuntimeError: boom ' \
+      "(loaded from /checkout/plugins/rigor-x/lib/rigor-x.rb)"
+    )
+  end
+
+  it "leaves a require-failure message unchanged when no file was resolved" do
+    registry = Rigor::Plugin::Registry.new(
+      load_errors: [load_error('could not load plugin gem "rigor-y": cannot load such file')]
+    )
+
+    diagnostic = build_aggregator(registry).plugin_load_diagnostics.first
+
+    expect(diagnostic.message).to eq('could not load plugin gem "rigor-y": cannot load such file')
+    expect(diagnostic.message).not_to include("loaded from")
+  end
+end

--- a/spec/rigor/cli/plugins_command_spec.rb
+++ b/spec/rigor/cli/plugins_command_spec.rb
@@ -108,6 +108,13 @@ RSpec.describe Rigor::CLI::PluginsCommand do
       expect(out).to match(%r{rigor-activesupport-core-ext/sig.*\.rbs file})
     end
 
+    # #194 slice 1 — the resolved file makes an engine↔plugin version skew visible; the plugin is really
+    # required by the before-hook here, so the real `$LOADED_FEATURES` scan pins its entry file.
+    it "prints the resolved plugin file path in text" do
+      _, out, = run([])
+      expect(out).to match(%r{path: /.*rigor-activesupport-core-ext\.rb$})
+    end
+
     it "exposes the manifest fields in JSON" do
       status, out, = run(["--format", "json"])
       expect(status).to eq(0)
@@ -116,6 +123,7 @@ RSpec.describe Rigor::CLI::PluginsCommand do
       expect(plugin["status"]).to eq("loaded")
       expect(plugin["id"]).to eq("activesupport-core-ext")
       expect(plugin["signature_paths"].first).to include("rbs_files" => be > 0)
+      expect(plugin["path"]).to end_with("rigor-activesupport-core-ext.rb")
     end
   end
 
@@ -190,6 +198,15 @@ RSpec.describe Rigor::CLI::PluginsCommand do
       plugin = parsed["plugins"].first
       expect(plugin["status"]).to eq("load_error")
       expect(plugin["load_error"]).to include("rigor-this-plugin-does-not-exist")
+    end
+
+    # #194 slice 1 — a require that failed outright has no resolvable file, so the additive `path` key is
+    # present but null (never fabricated, and no $LOAD_PATH dump).
+    it "carries a null path in JSON when the require failed outright" do
+      _, out, = run(["--format", "json"])
+      plugin = JSON.parse(out)["plugins"].first
+      expect(plugin).to have_key("path")
+      expect(plugin["path"]).to be_nil
     end
   end
 

--- a/spec/rigor/plugin/loader_spec.rb
+++ b/spec/rigor/plugin/loader_spec.rb
@@ -451,4 +451,86 @@ RSpec.describe Rigor::Plugin::Loader do
       expect(registry.load_errors.map(&:message)).to include(/signature path .* not a directory/)
     end
   end
+
+  # #194 slice 1 — the loader pins the file each successfully-required gem loaded from (via the injectable
+  # `feature_resolver` seam, so these specs never touch the real `$LOADED_FEATURES`) and threads it onto the
+  # registry / the surfaced LoadError, so an engine↔plugin version skew is diagnosable at a glance.
+  describe "resolved plugin file paths (#194 slice 1)" do
+    let(:plugins) { ["rigor-alpha"] }
+
+    def register_alpha_requirer
+      lambda { |_name|
+        Rigor::Plugin.register(plugin_class_a)
+        true
+      }
+    end
+
+    it "records the file the gem require resolved to, keyed by gem name" do
+      resolver = ->(gem) { "/fake/gems/#{gem}/lib/#{gem}.rb" }
+
+      registry = described_class.load(
+        configuration: configuration, services: services,
+        requirer: register_alpha_requirer, feature_resolver: resolver
+      )
+
+      expect(registry.ids).to eq(["alpha"])
+      expect(registry.resolved_gem_paths).to eq("rigor-alpha" => "/fake/gems/rigor-alpha/lib/rigor-alpha.rb")
+    end
+
+    it "degrades to a nil path when the resolver cannot pin the file, without failing the load" do
+      resolver = ->(_gem) {}
+
+      registry = described_class.load(
+        configuration: configuration, services: services,
+        requirer: register_alpha_requirer, feature_resolver: resolver
+      )
+
+      expect(registry.ids).to eq(["alpha"])
+      expect(registry.load_errors).to be_empty
+      expect(registry.resolved_gem_paths).to have_key("rigor-alpha")
+      expect(registry.resolved_gem_paths.fetch("rigor-alpha")).to be_nil
+    end
+
+    it "stamps the resolved path on a post-require failure so the diagnostic can name the loaded copy" do
+      bomb_class = Class.new(Rigor::Plugin::Base) do
+        manifest(id: "bomb", version: "0.1.0")
+      end
+      bomb_class.define_method(:init) { |_| raise "kaboom" }
+      stub_const("FakeBombPathPlugin", bomb_class)
+      requirer = lambda { |_name|
+        Rigor::Plugin.register(bomb_class)
+        true
+      }
+      resolver = ->(gem) { "/checkout/plugins/#{gem}/lib/#{gem}.rb" }
+      configuration = Rigor::Configuration.new(
+        Rigor::Configuration::DEFAULTS.merge("plugins" => ["rigor-bomb"])
+      )
+      services = Rigor::Plugin::Services.new(
+        reflection: Rigor::Reflection, type: Rigor::Type::Combinator, configuration: configuration
+      )
+
+      registry = described_class.load(
+        configuration: configuration, services: services, requirer: requirer, feature_resolver: resolver
+      )
+
+      error = registry.load_errors.first
+      expect(error.message).to include("raised during init")
+      expect(error.resolved_path).to eq("/checkout/plugins/rigor-bomb/lib/rigor-bomb.rb")
+    end
+
+    it "leaves resolved_path nil on a require that failed outright — there is no file to name" do
+      requirer = ->(_name) { raise LoadError, "cannot load such file -- rigor-alpha" }
+      # A resolver that WOULD hand back a path is never consulted, because the require never succeeded.
+      resolver = ->(gem) { "/should/not/be/used/#{gem}.rb" }
+
+      registry = described_class.load(
+        configuration: configuration, services: services, requirer: requirer, feature_resolver: resolver
+      )
+
+      error = registry.load_errors.first
+      expect(error.message).to include('could not load plugin gem "rigor-alpha"')
+      expect(error.resolved_path).to be_nil
+      expect(registry.resolved_gem_paths).to be_empty
+    end
+  end
 end

--- a/spec/rigor/public_api_drift_spec.rb
+++ b/spec/rigor/public_api_drift_spec.rb
@@ -274,6 +274,7 @@ module PublicApiDriftSnapshots # rubocop:disable Metrics/ModuleLength
     open_receivers()
     plugins()
     protocol_contracts()
+    resolved_gem_paths()
     signature_paths()
     source_rbs_synthesizers()
     type_node_resolvers()


### PR DESCRIPTION
#194 slice 1 — suggestion (1) from the triage thread: print each loaded plugin's **resolved file path** in `rigor plugins` and in the `plugin_loader.load-error` diagnostic, so an engine↔plugin version skew through the ADR-93 auto-wire (a stale installed `rigortype` gem silently shadowing a newer checkout's bundled plugin copy) is a one-minute diagnosis instead of a multi-round bisection. Suggestions (2) (auto-wire resolution order) and (3) (`doctor` flag) are intentionally **not** in this PR; the issue stays open for those slices.

## Before / after (`bundle exec exe/rigor plugins` in this repo)

Before:

```
  [OK ] rbs-inline  v0.1.0  (rigor-rbs-inline)
        Ingests rbs-inline-shaped comments (`# @rbs name: T`, `#: () -> T`, …) as RBS contributions.
        source_rbs_synthesizer: yes
        config: {"require_magic_comment" => false}
```

After:

```
  [OK ] rbs-inline  v0.1.0  (rigor-rbs-inline)
        Ingests rbs-inline-shaped comments (`# @rbs name: T`, `#: () -> T`, …) as RBS contributions.
        path: /Users/megurine/repo/ruby/rigor/plugins/rigor-rbs-inline/lib/rigor-rbs-inline.rb
        source_rbs_synthesizer: yes
        config: {"require_magic_comment" => false}
```

`--format=json` gains an additive per-row `"path"` key (`null` when unresolvable — e.g. a require that failed outright). The ADR-37 `--capabilities` output is untouched.

## How it works

- `Plugin::Loader::FEATURE_RESOLVER` scans `$LOADED_FEATURES` for the **last** entry ending in `/<gem>.rb` after a successful require — provenance-agnostic (Bundler path gems, installed gems, `-I` injection) and stable when `require` no-ops on an in-process repeat load (ADR-88 WD4b). Unresolvable degrades to nil, never raises.
- The seam is injectable (`feature_resolver:` kwarg, mirroring `requirer:`), so specs stub it and never mutate the real global.
- The path rides on the `Registry` keyed by gem name (a plugin instance may self-freeze in `initialize` — `rigor-rbs-inline` does), and is stamped onto `Plugin::LoadError#resolved_path` for post-require failures.
- `plugin_loader.load-error` message: `… raised during init: … (loaded from /path/to/rigor-x.rb)` when the require succeeded but config/instantiation failed; a require that failed outright keeps its current message (no fabricated path, no `$LOAD_PATH` dump).

## Verification

- `make verify` green inside the Flake (binpacker suite 8120 examples / ractor-pool 8 / RuboCop 902 files no offenses / `make check` / `make check-plugins` all clean); `git diff --check` clean.
- `make docs-check` green (270 examples) — updated `docs/manual/02-cli-reference.md`, and the normative `docs/internal-spec/plugin.md` rows for `LoadError` and the load-error diagnostic message in the same commit.
- Public-API drift snapshot updated for the new `Registry#resolved_gem_paths` reader (a deliberate additive surface change).
- New/extended specs: loader (path recorded; nil degrade; stamped on post-require failure; nil on require failure), `rigor plugins` (text `path:` line, JSON key presence incl. null case), and a new focused `DiagnosticAggregator` spec for the message with/without a resolvable path.
