### PR TITLE
Anchor bundled-plugin resolution to the engine (#194 slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[plugins]** Bundled plugins now always load from the engine's own copy. A `plugins:` entry naming a plugin Rigor ships — including the auto-wired `rigor-rbs-inline` — was required by gem name, so an older `rigortype` gem installed alongside a git checkout or a newer engine could silently shadow the engine's copy with a mismatched version and produce wrong diagnostics. Rigor now requires each bundled plugin by its path inside the engine, which is versioned together with it; a trimmed or single-binary install that ships no bundled copy falls back to gem-name resolution exactly as before.
+
 - **[cli]** The type probes — `rigor type-of`, `type-scan`, `trace`, and `annotate` — now build the same plugin-aware environment `rigor check` analyses with, so a type synthesized from an inline rbs-inline annotation (or any other plugin) is reported instead of a plugin-free `Dynamic[top]`, and a probe no longer disagrees with the check it is meant to explain. A project with no plugins, or with broken plugin setup, degrades to the previous behaviour rather than failing.
 
 - **[type inference]** A `str =~ RE` match where the pattern is a constant (`RE = /.../` or `Regexp.new(...)`) now narrows the match globals just like a literal `str =~ /.../`, so `$1`, `$~`, and the rest read as their matched types after a successful match instead of staying nilable — removing spurious possible-nil warnings on the common "compile the regex once as a constant" idiom.

--- a/docs/internal-spec/plugin.md
+++ b/docs/internal-spec/plugin.md
@@ -567,6 +567,31 @@ explicit `id:` field disambiguates; without it the loader emits a
 `LoadError` rather than guessing. Duplicate ids across entries are
 an error, not a silent dedupe.
 
+## Bundled-plugin resolution ([ADR-93](../adr/93-default-rbs-inline-ingestion.md) WD5)
+
+An entry whose `gem` names a plugin the engine itself bundles —
+`<engine root>/plugins/<gem>/lib/<gem>.rb` exists, the engine root
+anchored from the loader's own location — is `require`d **by that
+absolute path**, not by gem name. The engine and its bundled
+plugins are versioned together, so name resolution against
+whichever installation's `require_paths` happens to win is
+skew-prone by definition: a stale installed `rigortype` gem could
+otherwise displace the engine's own copy silently (the [#194][i194]
+hazard). Anchoring loads the engine's own vendored file instead.
+When the anchored file does **not** exist — a trimmed packaging,
+the [ADR-27](../adr/27-tool-distribution-model.md) single-binary
+target — the loader falls back to the bare gem-name `require`, so no
+install mode regresses. The rule is uniform across the auto-wired
+`rigor-rbs-inline` default and every user-listed entry. There is no
+name-level escape hatch back to gem resolution; an external copy
+would earn an explicit per-entry `path:` key
+([ADR-99](../adr/99-config-schema-authority.md)), not a silent name
+race. `rigor doctor` flags any bundled plugin that still resolved
+outside the engine tree — the guard for the fallback path and
+genuinely mixed installations that anchoring cannot see.
+
+[i194]: https://github.com/rigortype/rigor/issues/194
+
 ## Failure isolation (per ADR-2 § "Plugin Trust and I/O Policy")
 
 Loading runs every plugin entry independently; a failure on one

--- a/lib/rigor/plugin/loader.rb
+++ b/lib/rigor/plugin/loader.rb
@@ -36,9 +36,18 @@ module Rigor
         $LOADED_FEATURES.rfind { |feature| feature.end_with?(suffix) }
       end
 
+      # #194 slice 2 (ADR-93 WD5) — the engine's own root, anchored from THIS file's location: the loader
+      # lives at `<root>/lib/rigor/plugin/loader.rb`, so three levels up is the engine root. It resolves
+      # identically in a git checkout and inside an installed `rigortype` gem, because the gem packages the
+      # `plugins/` tree at the same relative path — which is exactly what makes it a trustworthy anchor for
+      # the engine's own bundled plugin copies.
+      ENGINE_ROOT = File.expand_path("../../..", __dir__)
+
       # @param services [Rigor::Plugin::Services]
-      # @param requirer [#call] takes a gem name and returns truthy on successful require. Defaulted to
-      #   `Kernel.require` via a lambda; the spec injects a fake to avoid touching the real load path.
+      # @param requirer [#call] takes a gem name OR an absolute file path (#194 slice 2 — a bundled plugin is
+      #   required by its {.bundled_plugin_path}) and returns truthy on successful require. Defaulted to
+      #   `Kernel.require` via a lambda, which accepts both forms; the spec injects a fake to avoid touching
+      #   the real load path.
       # @param feature_resolver [#call] takes a gem name and returns the absolute path `require` resolved it
       #   to (or nil). Defaulted to {FEATURE_RESOLVER}; the spec injects a fake so it never has to mutate the
       #   real `$LOADED_FEATURES` global.
@@ -50,6 +59,21 @@ module Rigor
 
       def self.load(configuration:, services:, requirer: ->(name) { require name }, feature_resolver: FEATURE_RESOLVER)
         new(services: services, requirer: requirer, feature_resolver: feature_resolver).load(configuration.plugins)
+      end
+
+      # #194 slice 2 (ADR-93 WD5) — the absolute path of the engine's OWN bundled copy of a plugin gem
+      # (`<ENGINE_ROOT>/plugins/<gem>/lib/<gem>.rb`), or nil when the engine does not bundle it. A bundled
+      # plugin is required by this path rather than by gem name, so a stale installed `rigortype` gem can
+      # never displace the engine's own versioned copy through RubyGems name resolution — the engine and its
+      # bundled plugins are versioned together. Returns nil for a third-party / project-bundle plugin and for
+      # a trimmed packaging (the ADR-27 single-binary target that ships no `plugins/` tree), where the caller
+      # falls back to today's gem-name require so no install mode regresses. The rule is uniform across the
+      # auto-wired `rigor-rbs-inline` default and every user-listed entry, because the skew mechanism is
+      # identical for both. Also read by `rigor doctor`'s skew check (#194 slice 3) to decide which loaded
+      # plugins the engine bundles.
+      def self.bundled_plugin_path(gem_name)
+        path = File.join(ENGINE_ROOT, "plugins", gem_name, "lib", "#{gem_name}.rb")
+        File.file?(path) ? path : nil
       end
 
       # @param entries [Array<String, Hash>] the raw `plugins:` list from the configuration.
@@ -190,8 +214,13 @@ module Rigor
         end
       end
 
+      # #194 slice 2 (ADR-93 WD5) — a bundled plugin is required by its engine-anchored absolute path; every
+      # other gem keeps today's bare-name require. The injectable `requirer` seam therefore widens from gem
+      # names to name-or-absolute-path (both are valid arguments to `Kernel.require`). The slice-1
+      # `feature_resolver` is unaffected: an absolute-path require's `$LOADED_FEATURES` entry still ends in
+      # `/<gem>.rb`, the suffix {FEATURE_RESOLVER} matches.
       def require_gem!(entry)
-        @requirer.call(entry[:gem])
+        @requirer.call(self.class.bundled_plugin_path(entry[:gem]) || entry[:gem])
       rescue ::LoadError => e
         raise LoadError.new(
           "could not load plugin gem #{entry[:gem].inspect}: #{e.message}",

--- a/spec/integration/plugins/actionpack_plugin_spec.rb
+++ b/spec/integration/plugins/actionpack_plugin_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "plugins/rigor-actionpack" do
           configuration: configuration,
           cache_store: nil,
           plugin_requirer: lambda do |name|
-            case name
+            case File.basename(name, ".rb")
             when "rigor-rails-routes" then Rigor::Plugin.register(Rigor::Plugin::RailsRoutes)
             when "rigor-actionpack" then Rigor::Plugin.register(Rigor::Plugin::Actionpack)
             end
@@ -302,7 +302,7 @@ RSpec.describe "plugins/rigor-actionpack" do
             configuration: configuration,
             cache_store: nil,
             plugin_requirer: lambda do |name|
-              case name
+              case File.basename(name, ".rb")
               when "rigor-rails-routes" then Rigor::Plugin.register(Rigor::Plugin::RailsRoutes)
               when "rigor-actionpack" then Rigor::Plugin.register(Rigor::Plugin::Actionpack)
               end
@@ -340,7 +340,7 @@ RSpec.describe "plugins/rigor-actionpack" do
           runner = Rigor::Analysis::Runner.new(
             configuration: configuration, cache_store: nil,
             plugin_requirer: lambda { |name|
-              case name
+              case File.basename(name, ".rb")
               when "rigor-rails-routes" then Rigor::Plugin.register(Rigor::Plugin::RailsRoutes)
               when "rigor-actionpack" then Rigor::Plugin.register(Rigor::Plugin::Actionpack)
               end
@@ -632,7 +632,7 @@ RSpec.describe "plugins/rigor-actionpack" do
           runner = Rigor::Analysis::Runner.new(
             configuration: configuration, cache_store: nil,
             plugin_requirer: lambda { |name|
-              case name
+              case File.basename(name, ".rb")
               when "rigor-rails-routes" then Rigor::Plugin.register(Rigor::Plugin::RailsRoutes)
               when "rigor-actionpack" then Rigor::Plugin.register(Rigor::Plugin::Actionpack)
               end
@@ -740,7 +740,7 @@ RSpec.describe "plugins/rigor-actionpack" do
           runner = Rigor::Analysis::Runner.new(
             configuration: configuration, cache_store: nil,
             plugin_requirer: lambda { |name|
-              case name
+              case File.basename(name, ".rb")
               when "rigor-rails-routes" then Rigor::Plugin.register(Rigor::Plugin::RailsRoutes)
               when "rigor-activerecord" then Rigor::Plugin.register(Rigor::Plugin::Activerecord)
               when "rigor-actionpack" then Rigor::Plugin.register(Rigor::Plugin::Actionpack)
@@ -869,7 +869,7 @@ RSpec.describe "plugins/rigor-actionpack" do
       Rigor::Analysis::Runner.new(
         configuration: configuration, cache_store: nil,
         plugin_requirer: lambda { |name|
-          case name
+          case File.basename(name, ".rb")
           when "rigor-rails-routes" then Rigor::Plugin.register(Rigor::Plugin::RailsRoutes)
           when "rigor-actionpack" then Rigor::Plugin.register(Rigor::Plugin::Actionpack)
           end
@@ -941,7 +941,7 @@ RSpec.describe "plugins/rigor-actionpack" do
             configuration: configuration,
             cache_store: nil,
             plugin_requirer: lambda do |name|
-              Rigor::Plugin.register(Rigor::Plugin::Actionpack) if name == "rigor-actionpack"
+              Rigor::Plugin.register(Rigor::Plugin::Actionpack) if File.basename(name, ".rb") == "rigor-actionpack"
               true
             end
           )

--- a/spec/integration/plugins/activerecord_plugin_spec.rb
+++ b/spec/integration/plugins/activerecord_plugin_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "plugins/rigor-activerecord" do
           runner = Rigor::Analysis::Runner.new(
             configuration: configuration, cache_store: nil,
             plugin_requirer: lambda { |name|
-              Rigor::Plugin.register(plugin_class) if name == "rigor-activerecord"
+              Rigor::Plugin.register(plugin_class) if File.basename(name, ".rb") == "rigor-activerecord"
               true
             }
           )
@@ -175,7 +175,7 @@ RSpec.describe "plugins/rigor-activerecord" do
           runner = Rigor::Analysis::Runner.new(
             configuration: configuration, cache_store: nil,
             plugin_requirer: lambda { |name|
-              Rigor::Plugin.register(plugin_class) if name == "rigor-activerecord"
+              Rigor::Plugin.register(plugin_class) if File.basename(name, ".rb") == "rigor-activerecord"
               true
             }
           )
@@ -1031,7 +1031,10 @@ RSpec.describe "plugins/rigor-activerecord" do
           runner = Rigor::Analysis::Runner.new(
             configuration: configuration, cache_store: nil,
             plugin_requirer: lambda { |name|
-              case name
+              # #194 slice 2 — a bundled plugin now arrives as its engine-anchored absolute path; basename
+              # recovers the gem name (a bare name, e.g. the non-bundled `rigor-model-consumer`, passes
+              # through unchanged).
+              case File.basename(name, ".rb")
               when "rigor-activerecord" then Rigor::Plugin.register(Rigor::Plugin::Activerecord)
               when "rigor-model-consumer" then Rigor::Plugin.register(consumer_plugin)
               end

--- a/spec/integration/plugins/dry_schema_plugin_spec.rb
+++ b/spec/integration/plugins/dry_schema_plugin_spec.rb
@@ -224,7 +224,9 @@ RSpec.describe "rigor-dry-schema integration" do
       Rigor::Analysis::Runner.new(
         configuration: configuration, cache_store: nil,
         plugin_requirer: lambda do |name|
-          case name
+          # #194 slice 2 — a bundled plugin now arrives as its engine-anchored absolute path; basename
+          # recovers the gem name (a bare name passes through unchanged).
+          case File.basename(name, ".rb")
           when "rigor-dry-types" then Rigor::Plugin.register(Rigor::Plugin::DryTypes)
           when "rigor-dry-schema" then Rigor::Plugin.register(Rigor::Plugin::DrySchema)
           end

--- a/spec/integration/plugins/dry_struct_plugin_spec.rb
+++ b/spec/integration/plugins/dry_struct_plugin_spec.rb
@@ -143,7 +143,9 @@ RSpec.describe "rigor-dry-struct integration" do
             configuration: configuration,
             cache_store: nil,
             plugin_requirer: lambda do |name|
-              case name
+              # #194 slice 2 — a bundled plugin now arrives as its engine-anchored absolute path; basename
+              # recovers the gem name (a bare name passes through unchanged).
+              case File.basename(name, ".rb")
               when "rigor-dry-types" then Rigor::Plugin.register(dry_types_plugin)
               when "rigor-dry-struct" then Rigor::Plugin.register(plugin_class)
               end

--- a/spec/integration/plugins/factorybot_plugin_spec.rb
+++ b/spec/integration/plugins/factorybot_plugin_spec.rb
@@ -206,7 +206,9 @@ RSpec.describe "plugins/rigor-factorybot" do
           runner = Rigor::Analysis::Runner.new(
             configuration: configuration, cache_store: nil,
             plugin_requirer: lambda { |name|
-              case name
+              # #194 slice 2 — a bundled plugin now arrives as its engine-anchored absolute path; basename
+              # recovers the gem name (a bare name passes through unchanged).
+              case File.basename(name, ".rb")
               when "rigor-activerecord" then Rigor::Plugin.register(Rigor::Plugin::Activerecord)
               when "rigor-factorybot" then Rigor::Plugin.register(Rigor::Plugin::Factorybot)
               end

--- a/spec/rigor/plugin/loader_spec.rb
+++ b/spec/rigor/plugin/loader_spec.rb
@@ -310,8 +310,12 @@ RSpec.describe Rigor::Plugin::Loader do
     let(:plugins) { %w[rigor-actionpack rigor-activerecord] }
 
     def consumer_first_requirer
-      lambda { |name|
-        case name
+      # #194 slice 2 — `rigor-actionpack` / `rigor-activerecord` are both bundled plugins, so the loader now
+      # hands the requirer their engine-anchored absolute paths, not the bare gem names. `File.basename(…,
+      # ".rb")` recovers the gem name from either form (a bare name is returned unchanged), modelling
+      # `Kernel.require`, which accepts name-or-path alike.
+      lambda { |arg|
+        case File.basename(arg, ".rb")
         when "rigor-actionpack" then Rigor::Plugin.register(consumer_class)
         when "rigor-activerecord" then Rigor::Plugin.register(producer_class)
         end
@@ -531,6 +535,109 @@ RSpec.describe Rigor::Plugin::Loader do
       expect(error.message).to include('could not load plugin gem "rigor-alpha"')
       expect(error.resolved_path).to be_nil
       expect(registry.resolved_gem_paths).to be_empty
+    end
+  end
+
+  # #194 slice 2 (ADR-93 WD5) — a `plugins:` entry naming a plugin the engine itself bundles is required BY
+  # ITS ENGINE-ANCHORED ABSOLUTE PATH, never by gem name, so a stale installed `rigortype` gem can never
+  # displace the engine's own versioned copy through RubyGems name resolution. Every other gem keeps today's
+  # bare-name require. WD5 records the spec-level requirer-argument proof as the acceptance: reproducing the
+  # real stale-gem skew is out of proportion and no-ops under Bundler (`Gem.paths` manipulation is inert).
+  describe ".bundled_plugin_path" do
+    # `rigor-rbs-inline` is the WD5-central bundled plugin (the ADR-93 auto-wire default); any bundled gem
+    # would do. The expected path is derived the same way the loader derives it, so the assertion holds
+    # wherever the checkout lives.
+    let(:bundled_gem) { "rigor-rbs-inline" }
+    let(:anchored) { File.join(described_class::ENGINE_ROOT, "plugins", bundled_gem, "lib", "#{bundled_gem}.rb") }
+
+    it "returns the engine-anchored absolute path of a plugin the engine bundles" do
+      expect(described_class.bundled_plugin_path(bundled_gem)).to eq(anchored)
+      expect(File.file?(described_class.bundled_plugin_path(bundled_gem))).to be(true)
+    end
+
+    it "returns nil for a gem the engine does not bundle (a third-party / project-bundle plugin)" do
+      expect(described_class.bundled_plugin_path("rigor-nonexistent-xyz")).to be_nil
+    end
+  end
+
+  describe "engine-anchored bundled-plugin resolution (#194 slice 2)" do
+    let(:bundled_gem) { "rigor-rbs-inline" }
+    let(:anchored) { File.join(described_class::ENGINE_ROOT, "plugins", bundled_gem, "lib", "#{bundled_gem}.rb") }
+
+    def config_for(plugins)
+      Rigor::Configuration.new(Rigor::Configuration::DEFAULTS.merge("plugins" => plugins))
+    end
+
+    def services_for(configuration)
+      Rigor::Plugin::Services.new(
+        reflection: Rigor::Reflection, type: Rigor::Type::Combinator, configuration: configuration
+      )
+    end
+
+    def capturing_requirer(sink)
+      lambda { |arg|
+        sink << arg
+        Rigor::Plugin.register(plugin_class_a)
+        true
+      }
+    end
+
+    # (a) A bundled-name entry hands the requirer the anchored ABSOLUTE PATH, not the gem name.
+    it "requires a bundled plugin by its engine-anchored absolute path" do
+      received = []
+      configuration = config_for([bundled_gem])
+
+      registry = described_class.load(
+        configuration: configuration, services: services_for(configuration),
+        requirer: capturing_requirer(received)
+      )
+
+      expect(received).to eq([anchored])
+      expect(registry.load_errors).to be_empty
+    end
+
+    # (b) A gem the engine does not bundle keeps today's bare-name require, unchanged.
+    it "requires a non-bundled gem by its bare name" do
+      received = []
+      configuration = config_for(["rigor-alpha"])
+      expect(described_class.bundled_plugin_path("rigor-alpha")).to be_nil
+
+      described_class.load(
+        configuration: configuration, services: services_for(configuration),
+        requirer: capturing_requirer(received)
+      )
+
+      expect(received).to eq(["rigor-alpha"])
+    end
+
+    # (c) When the engine's bundled copy is absent (a trimmed ADR-27 packaging), the loader falls back to the
+    #     bare gem name so no install mode regresses — even for a gem the engine normally bundles.
+    it "falls back to the bare gem name when the anchored file is absent" do
+      allow(File).to receive(:file?).and_call_original
+      allow(File).to receive(:file?).with(anchored).and_return(false)
+      received = []
+      configuration = config_for([bundled_gem])
+
+      described_class.load(
+        configuration: configuration, services: services_for(configuration),
+        requirer: capturing_requirer(received)
+      )
+
+      expect(received).to eq([bundled_gem])
+    end
+
+    # (d) Slice-1 interplay: an absolute-path require's `$LOADED_FEATURES` entry still ends in `/<gem>.rb`,
+    #     the suffix FEATURE_RESOLVER matches — so anchoring does not break slice 1's resolved-path capture.
+    it "anchors to a path the slice-1 feature resolver still pins" do
+      expect(anchored).to end_with("/#{bundled_gem}.rb")
+
+      # Probe the real FEATURE_RESOLVER against an absolute-path entry, with a synthetic gem name so the real
+      # `$LOADED_FEATURES` is never left mutated for a plugin the suite might genuinely have loaded.
+      probe_path = "/fake/gems/rigor-anchor-probe/lib/rigor-anchor-probe.rb"
+      $LOADED_FEATURES.push(probe_path)
+      expect(described_class::FEATURE_RESOLVER.call("rigor-anchor-probe")).to eq(probe_path)
+    ensure
+      $LOADED_FEATURES.delete(probe_path)
     end
   end
 end


### PR DESCRIPTION
## #194 slice 2 — anchor bundled-plugin resolution to the engine

Implements [ADR-93](docs/adr/93-default-rbs-inline-ingestion.md) **WD5**. Stacked on top of #197 (slice 1).

**Stack order: do not merge before #197.** Base branch is `194-plugin-resolved-path`; this PR's diff is only slice 2's commit.

### The hazard (WD5)

WD2's auto-wire `require`s the bundled `rigor-rbs-inline` plugin **by gem name** on every run, and a gem-name require resolves against whichever installation's `require_paths` win. Under the checkout's own bundle the checkout copy wins, but an engine loaded without its gemspec activation (`ruby -I lib`, an embedding, a future packaging) falls through to RubyGems, which activates the newest *installed* `rigortype` and serves **that** gem's plugin copy. In #194 this loaded a v0.2.4-era `rigor-rbs-inline` predating the WD1 `annotated?` gate — the engine ran with a load-bearing false-positive gate silently missing.

### The fix

A `plugins:` entry whose `gem` names a plugin the engine itself bundles (`<engine root>/plugins/<gem>/lib/<gem>.rb` exists, root anchored from the loader's own `__dir__`) is required **by that absolute path**, not by gem name. Absent (a trimmed packaging, the ADR-27 single-binary target) → falls back to today's gem-name require, so no install mode regresses. Uniform across the auto-wired default and user-listed entries.

Requirer-argument before/after for a bundled entry (`rigor-rbs-inline`):

| | require argument |
| --- | --- |
| before | `"rigor-rbs-inline"` (gem name → RubyGems picks the installation) |
| after | `"<engine root>/plugins/rigor-rbs-inline/lib/rigor-rbs-inline.rb"` (the engine's own copy) |

**Audit — other by-name requires of bundled plugins:** none. `rg` over `lib/` finds no direct `require "rigor-<plugin>"`; both the WD2 auto-wire (`configuration.rb`) and `--treat-all-as-inline-rbs` (`check_command.rb`) build `plugins:` entries that route through the loader's single `require_gem!` site, which this PR anchors. So anchoring that one site covers every path.

### Why no environment repro

Reproducing the real stale-gem skew is out of proportion and no-ops under Bundler (`Gem.paths` manipulation is inert), so — as WD5 records — the acceptance is the **spec-level requirer-argument proof**: anchored-hit, fallback-on-absence, non-bundled bare name, and the slice-1 interplay (`spec/rigor/plugin/loader_spec.rb`). The slice-1 `feature_resolver` is unaffected: an absolute-path require's `$LOADED_FEATURES` entry still ends in `/<gem>.rb`.

### User-visible surface unchanged in a healthy checkout

`bundle exec exe/rigor plugins` still shows the rbs-inline row engine-anchored (slice 1's line):

```
  [OK ] rbs-inline  v0.1.0  (rigor-rbs-inline)
        path: /Users/.../rigor/plugins/rigor-rbs-inline/lib/rigor-rbs-inline.rb
        config: {"require_magic_comment" => false}
```

Anchoring only changes *which identical-version file* loads in a skewed install; a healthy checkout is byte-identical.

### Binding docs

`docs/internal-spec/plugin.md` gains a normative **"Bundled-plugin resolution (ADR-93 WD5)"** subsection describing the anchoring and the fallback, in the same commit (spec-binds rule).

### Verification (inside the Flake)

- `make verify` — green: 8126 examples across 12 workers, Ractor pool 8/8, rubocop 902 files clean, `make check` + `make check-plugins` clean.
- `make docs-check` — 270 examples, 0 failures.
- `git diff --check` — clean.

Integration-spec requirer fakes that discriminate on a bundled gem name were updated to normalize with `File.basename(name, ".rb")` now that they receive the anchored path (the widened requirer seam).
