### PR TITLE
Skip receiver typing for unresolvable calls in the parameter pre-pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 - **[plugins]** `rigor plugins` now reports the resolved file each loaded plugin loaded from — a `path:` line in the text report and a `"path"` key in `--format=json` — and the `plugin_loader.load-error` diagnostic names it when a plugin was loaded but then failed to configure. A stale installed `rigortype` gem silently shadowing a newer checkout's bundled plugin copy is now visible at a glance instead of taking a bisection to pin down.
 
+### Performance
+
+- **[perf]** The opt-in `parameter_inference:` pre-pass is cheaper: it now skips typing the receiver of any call whose name no user-defined method declares (~73 % of call sites in a Rails app, which can never resolve to a `def` it infers from), cutting the pre-pass cost on a cold `rigor check` with an inferred-parameter table that is byte-identical.
+
 ### Fixed
 
 - **[plugins]** Bundled plugins now always load from the engine's own copy. A `plugins:` entry naming a plugin Rigor ships — including the auto-wired `rigor-rbs-inline` — was required by gem name, so an older `rigortype` gem installed alongside a git checkout or a newer engine could silently shadow the engine's copy with a mismatched version and produce wrong diagnostics. Rigor now requires each bundled plugin by its path inside the engine, which is versioned together with it; a trimmed or single-binary install that ships no bundled copy falls back to gem-name resolution exactly as before.

--- a/docs/adr/67-parameter-type-inference.md
+++ b/docs/adr/67-parameter-type-inference.md
@@ -286,11 +286,17 @@ no longer fires `possible-nil-receiver`, because the inferred element type prove
 lift (`coverage --protection`, collector off vs on, cache cleared between A/B): mastodon `app/models`
 0.3044 → 0.3122 (+46 protected sites), redmine `app` 0.3161 → 0.3219 (+110 sites). Perf (mastodon
 `app/models`, cold, 3 runs): gate off ≈ 2.2 s / 161 MB, unchanged from master (≈ 2.5 s, within noise —
-the gate-off guards are O(1) no-ops on an empty mark set); gate on ≈ 3.1 s / 191 MB — the one-round
-collector pre-pass is ≈ 0.9 s (+40 % wall, +19 % RSS), well over the 5 % band. Per the addendum the
+the gate-off guards are O(1) no-ops on an empty mark set); gate on ≈ 3.0 s / 191 MB — the one-round
+collector pre-pass is ≈ 0.8 s (+37 % wall, +19 % RSS), well over the 5 % band. Per the addendum the
 pre-pass is the *price* of the opt-in and is reported separately; the check walk itself is unchanged
 (the byte-identical gate-off run proves it), so the cost is entirely the whole-project re-type the WD3
-collector performs. This cost is exactly why the gate stays off by default and default-on is deferred.
+collector performs. Profiling that re-type (mastodon `app/models`) found ~98 % of it is the per-file
+scope-index build (`ScopeIndexer.index` — the flow-sensitive typing pass the collector needs to read
+each argument type), unshareable with the check walk because the two build their per-file index under
+different seeds; the call-site walk that resolves callees and unions argument types is only ~2 %. A
+call-name pre-filter (skip any call whose name no discovered `def` declares — ~73 % of call sites in a
+Rails app — before typing its receiver) trimmed the residual and cut allocations ~8 %, table-identical.
+This cost is exactly why the gate stays off by default and default-on is deferred.
 
 ## Consequences
 

--- a/lib/rigor/inference/parameter_inference_collector.rb
+++ b/lib/rigor/inference/parameter_inference_collector.rb
@@ -150,6 +150,11 @@ module Rigor
         # sequential path.
         @environment.rbs_loader&.prewarm if ForkMap.parallel?([@workers, parsed.size].min)
         discovery = discovery_seed_tables
+        # The union of every method name any discovered `def` declares. A call whose name is absent cannot
+        # bind in `resolve_callee`, so {#record_call} short-circuits it before typing its receiver (an
+        # on-demand dispatch for an otherwise-unresolved call). ~73% of call sites in a Rails app name a
+        # method no user def declares; a pure negative filter, so the resolved table is byte-identical.
+        @user_method_names = user_method_names(discovery)
         table = EMPTY
         @max_rounds.times do
           rounded = run_round(parsed, discovery, table)
@@ -264,7 +269,17 @@ module Rigor
       }.freeze
       private_constant :DISCOVERY_FIELD
 
+      # Built once over the whole project and inherited by the fork workers via copy-on-write; a frozen Set
+      # for O(1) membership in the {#record_call} hot loop.
+      def user_method_names(discovery)
+        tables = [discovery[:discovered_def_nodes], discovery[:discovered_singleton_def_nodes]].compact
+        tables.flat_map { |table| table.values.flat_map(&:keys) }.to_set.freeze
+      end
+
       def record_call(call_node, index)
+        # See {#collect}: a name no discovered def declares cannot resolve, so skip without typing anything.
+        return unless @user_method_names.include?(call_node.name)
+
         args = positional_args(call_node)
         return if args.nil?
 


### PR DESCRIPTION
## What

Cuts the cold-run cost of the opt-in `parameter_inference:` check-walk pre-pass ([ADR-67](docs/adr/67-parameter-type-inference.md) WD6, landed in #202) without changing the inferred parameter table.

## Profile

On mastodon `app/models` (248 files), the collector's per-round re-type is **≈98% `ScopeIndexer.index`** — the flow-sensitive per-file typing pass needed to read each argument's type, and unshareable with the check walk (the two seed their per-file index differently). The call-site walk that resolves callees and unions argument types is only **~2%**. Within that walk, resolving a call with a receiver types the receiver, which for a call that will not resolve triggers an on-demand dispatch purely to be discarded.

## Fix

`resolve_callee` can only bind a def whose `(class, name)` pair is in the discovered def tables, so a call whose name **no** discovered def declares cannot resolve regardless of receiver type. Build the union of all discovered method names once (inherited by fork workers via COW) and short-circuit `record_call` on any call outside it before typing anything. On mastodon `app/models` **~73%** of call sites name a method no user def declares.

## Table-preserving

The filter only removes calls `lookup_def` would reject anyway. Verified:
- Full `[class, method, kind] => {param => Type}` table (types via `Type#describe`) dumped before/after on mastodon `app/models` — **identical** (21 entries).
- Gate-on diagnostic parity before/after on **kramdown** and **redmine** — identical.

## Numbers (mastodon `app/models`, cold `--no-cache`, ≥3 runs)

| | wall | RSS |
|---|---|---|
| gate off | 3.33s | 253 MB |
| gate on (before) | 4.56s | 273 MB |
| gate on (after) | 4.41s | 272 MB |

Opt-in price ≈1.17s (+35%) → ≈1.08s (+32%); allocations −8%. The residual is the irreducible whole-project scope-index rebuild.

## Gates

`make verify` (exit 0), `make check`, `make check-plugins`, `make docs-check` all clean. ADR-67 WD6 measured-price sentence + CHANGELOG updated in the same commit.