### PR TITLE
Host the void-value-use collector on the shared RuleWalk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Performance
+
+- **[perf]** `rigor check` no longer re-traverses each file for the `static.value-use.void` rule — its value-position scan now rides the shared per-node walk with the other built-in rules, removing one full AST traversal per file whether or not the rule is enabled. Diagnostics are unchanged ([#207](https://github.com/rigortype/rigor/issues/207)).
+
 ## [0.3.0] - 2026-07-19
 
 This release is dominated by a performance arc that makes repeat and incremental analysis of large Rails apps several times faster: an engine-free warm-hit "null build" floor, semantic propagation gates and per-file seed bundles for `--incremental`, a deadline-armed YJIT, and a broad allocation reduction ([ADR-87](docs/adr/87-null-build-floor.md), [ADR-85](docs/adr/85-seed-bundles-and-lazy-def-node-handles.md), [ADR-89](docs/adr/89-semantic-propagation-gates.md)). Inline rbs-inline annotations now work out of the box, with no `plugins:` entry and no magic comment ([ADR-93](docs/adr/93-default-rbs-inline-ingestion.md)). Several new diagnostics land — five PHPStan-derived checks, use-of-`void`, duplicate hash keys, and more — alongside sharper Hash / Struct / `Data` / Kernel value typing and opt-in call-site parameter inference. It also removes the deprecated `type_specifier` plugin hook and the verb-form `docs` / `skill` subcommands (both breaking).

--- a/lib/rigor/analysis/check_rules.rb
+++ b/lib/rigor/analysis/check_rules.rb
@@ -97,7 +97,6 @@ module Rigor
         collectors = node_collectors || run_node_collectors(path, root, scope_index)
         diagnostics = collectors[:main_pass].results.dup
         diagnostics.concat(self_undefined_method_diagnostics(path, self_call_misses, root, scope_index))
-        diagnostics.concat(void_value_use_diagnostics(path, root, scope_index))
         COLLECTOR_DIAGNOSTIC_BUILDERS.each do |role, builder|
           diagnostics.concat(send(builder, path, collectors[role].results))
         end
@@ -109,10 +108,13 @@ module Rigor
       end
 
       # The per-collector diagnostic builders {.diagnose} folds over, in the historical emission order
-      # (always-truthy → unreachable-clause → shadowed-rescue → ivar-write → dead-assignment →
-      # duplicate-hash-key → return-in-ensure). Keys match {.build_node_collectors}' roles; each value is a
-      # `(path, results)` module_function on this module.
+      # (value-use-void → always-truthy → unreachable-clause → shadowed-rescue → ivar-write →
+      # dead-assignment → duplicate-hash-key → return-in-ensure). Keys match {.build_node_collectors}'
+      # roles; each value is a `(path, results)` module_function on this module. `void_value_use` leads
+      # because its standalone walk used to run before this fold, and the emission order is byte-identical
+      # output, not an implementation detail.
       COLLECTOR_DIAGNOSTIC_BUILDERS = {
+        void_value_use: :void_value_use_diagnostics,
         always_truthy: :always_truthy_condition_diagnostics,
         unreachable_clauses: :unreachable_clause_diagnostics,
         shadowed_rescues: :shadowed_rescue_diagnostics,
@@ -155,6 +157,7 @@ module Rigor
       def build_node_collectors(path, scope_index)
         {
           main_pass: MainPassCollector.new(->(node) { main_pass_node_diagnostics(path, node, scope_index) }),
+          void_value_use: VoidValueUseCollector.new(scope_index),
           always_truthy: AlwaysTruthyConditionCollector.new(scope_index),
           unreachable_clauses: UnreachableClauseCollector.new(scope_index),
           shadowed_rescues: ShadowedRescueCollector.new(scope_index),
@@ -354,12 +357,11 @@ module Rigor
         end
       end
 
-      # ADR-100 WD2 — `static.value-use.void`. Runs a standalone walk (like `self_undefined_method_diagnostics`)
-      # over `root`, so its value-context slot inspection stays independent of the shared per-node
-      # {RuleWalk}. Each result is a value-context use of a call whose author-declared `-> void` return the
-      # engine recovered to `top`.
-      def void_value_use_diagnostics(path, root, scope_index)
-        VoidValueUseCollector.new(scope_index).collect(root).map do |result|
+      # ADR-100 WD2 — `static.value-use.void`. Its value-context slot inspection rides the shared per-node
+      # {RuleWalk} like the other collectors, so the file is not re-traversed for it. Each result is a
+      # value-context use of a call whose author-declared `-> void` return the engine recovered to `top`.
+      def void_value_use_diagnostics(path, results)
+        results.map do |result|
           build_void_value_use_diagnostic(path, result)
         end
       end

--- a/lib/rigor/analysis/check_rules/void_value_use_collector.rb
+++ b/lib/rigor/analysis/check_rules/void_value_use_collector.rb
@@ -36,6 +36,12 @@ module Rigor
           Prism::ConstantWriteNode, Prism::ConstantPathWriteNode
         ].freeze
 
+        # ADR-53 Track B — the node classes the shared {RuleWalk} dispatches to this collector: the consumer
+        # nodes whose slots are value positions. Prism node classes are leaves, so class-equality dispatch
+        # matches the legacy walk's `case`. No context gate — a value-context void use is a use wherever the
+        # DFS reaches it, loops and blocks included.
+        NODE_CLASSES = [Prism::CallNode, *WRITE_NODE_CLASSES].freeze
+
         Result = Data.define(:void_node, :origin)
 
         def initialize(scope_index)
@@ -43,11 +49,24 @@ module Rigor
           @results = []
         end
 
-        # Walk the whole subtree once, checking each consumer node's value slots. Returns one {Result} per
-        # value-context use of a recovered-`void` call.
+        # Legacy single-collector walk — kept as the oracle the ADR-53 Track B equivalence harness compares
+        # {RuleWalk} against. Walks the whole subtree once, checking each consumer node's value slots.
+        # Returns one {Result} per value-context use of a recovered-`void` call.
         # @return [Array<Result>]
         def collect(root)
           walk(root)
+          @results.freeze
+        end
+
+        # {RuleWalk} entry point: the legacy walk's per-node slot inspection, invoked at every consumer node
+        # under the shared traversal contract. The `context` is unused — every consumer node is inspected.
+        def visit(node, _context = nil)
+          inspect_consumer(node)
+        end
+
+        # The accumulated result, frozen the same way `#collect` returns it — used by {RuleWalk}-driven
+        # callers after the walk completes.
+        def results
           @results.freeze
         end
 

--- a/spec/rigor/analysis/check_rules/rule_walk_equivalence_spec.rb
+++ b/spec/rigor/analysis/check_rules/rule_walk_equivalence_spec.rb
@@ -242,6 +242,21 @@ module RuleWalkEquivalenceCases # rubocop:disable Metrics/ModuleLength -- curate
         end
       end
     RUBY
+    "recovered void value in each value slot (assignment, receiver, argument)" => <<~RUBY,
+      class VoidUses
+        CONST_SLOT = logger.void_call
+
+        def slots
+          local = logger.void_call
+          @ivar = logger.void_call
+          $global = logger.void_call
+          logger.void_call.inspect
+          store(logger.void_call)
+          logger.void_call
+          [1, 2].each { store(logger.void_call) }
+        end
+      end
+    RUBY
     "shadowed rescue chain via a namespaced project subclass (prefix-dependent)" => <<~RUBY
       module M
         class E < StandardError; end
@@ -259,6 +274,7 @@ module RuleWalkEquivalenceCases # rubocop:disable Metrics/ModuleLength -- curate
   # Every {RuleWalk}-hosted collector, in the order it is added to the shared walk. Each keeps its legacy `#collect`
   # walk as the oracle.
   HOSTED_COLLECTOR_CLASSES = [
+    Rigor::Analysis::CheckRules::VoidValueUseCollector,
     Rigor::Analysis::CheckRules::AlwaysTruthyConditionCollector,
     Rigor::Analysis::CheckRules::UnreachableClauseCollector,
     Rigor::Analysis::CheckRules::ShadowedRescueCollector,
@@ -275,7 +291,29 @@ RSpec.describe Rigor::Analysis::CheckRules::RuleWalk do
     return nil if parsed.errors.any?
 
     root = parsed.value
-    [root, Rigor::Inference::ScopeIndexer.index(root, default_scope: Rigor::Scope.empty)]
+    scope_index = Rigor::Inference::ScopeIndexer.index(root, default_scope: Rigor::Scope.empty)
+    seed_void_origins(root, scope_index)
+    [root, scope_index]
+  end
+
+  # {VoidValueUseCollector} reads `Scope#void_origins`, which only the return-typing tier populates during
+  # inference — a parse + `ScopeIndexer` harness can never fill it, so the collector would ride these cases
+  # vacuously. Seed the table the tier would have written for every call spelled `void_call`, which is what
+  # the curated "recovered void value in each value slot" case uses.
+  def seed_void_origins(root, scope_index)
+    origin = Rigor::Inference::VoidOrigin.new(class_name: "Logger", method_name: :log, kind: :instance)
+    each_node(root) do |node|
+      next unless node.is_a?(Prism::CallNode) && node.name == :void_call
+
+      scope_index[node]&.record_void_origin(node, origin)
+    end
+  end
+
+  def each_node(node, &block)
+    return unless node.is_a?(Prism::Node)
+
+    block.call(node)
+    node.compact_child_nodes.each { |child| each_node(child, &block) }
   end
 
   def legacy_results(root, scope_index)


### PR DESCRIPTION
Partial work on #207 — and a correction to that issue's premise.

## The issue's premise is stale

#207 says the five #101 rules "run as **standalone AST walks**, each re-traversing the tree". They do not: `flow.duplicate-hash-key`, `flow.return-in-ensure`, and `flow.shadowed-rescue-clause` were born as `RuleWalk`-hosted collectors on 2026-07-15 (`a722dfca`, `0103e888`, `57404d26`), `call.raise-non-exception` lives in the main pass, and `suppression.*` reads comments, not the AST. Nothing there to fold.

The one built-in rule that *was* still walking the tree on its own is `static.value-use.void` (ADR-100 WD2, 2026-07-18): `diagnose` built a fresh `VoidValueUseCollector` and re-walked `root` after `RuleWalk` had already visited every node — unconditionally, even though every shipped profile resolves the rule to `:off`. This PR folds that one in.

## What this buys

`lib` self-check allocations **32,499,303 → 32,340,885** (−158k, −0.49%). That is the whole recoverable amount from traversal sharing; the v0.3.0 +45.7% drift is therefore **not** duplicate traversals — it is the rule and typing logic itself (#101 rule bodies, #102 Hash/Kernel typing). `bench/baseline.json` is left alone: 0.5% is inside the noise the threshold already absorbs, and recalibrating for it is churn. Whether to keep chasing the drift at its real source is a fresh call — see the issue comment.

## Equivalence

- Byte-identical diagnostics over `lib spec plugins examples` (~6500 diagnostics; the only diff is line shifts inside the spec file this PR edits).
- `RIGOR_SHADOW_RULE_WALK=1 rigor check lib` clean — the collector's legacy `#collect` walk stays as the oracle.
- `rule_walk_equivalence_spec` now covers it. It could not have, as it stood: `void_origins` is written by the return-typing tier during inference, which a parse + `ScopeIndexer` harness never reaches, so the collector would have ridden every curated case vacuously and the non-vacuity guard would have caught it (it did). The spec seeds the table the tier would have written and adds a curated case exercising each value slot.
- `make verify` green.