### PR TITLE
Gate spec sentences that promise an already-released version (ADR-92 WD6)

### DIFF
--- a/docs/adr/92-normative-status-fidelity.md
+++ b/docs/adr/92-normative-status-fidelity.md
@@ -1,7 +1,7 @@
 # ADR-92 — Normative status fidelity: the founding-era stratum and the declare-or-mark gate
 
-Status: **Accepted — implemented 2026-07-16 (WD1–WD5); WD2's `void` verdict resolved to
-option (b), landed.** WD2 verdicts + WD3 markers landed
+Status: **Accepted — implemented 2026-07-16 (WD1–WD5) and 2026-07-25 (WD6, the corpus sweep and its
+gate); WD2's `void` verdict resolved to option (b), landed.** WD2 verdicts + WD3 markers landed
 in `special-types.md` (§ `void`, § `top`), `diagnostic-policy.md` (four family rows + the
 guidelines preamble), and `internal-type-api.md` (a document-level status block narrowing
 the method surface to what ships). WD4's gate is axis 5 of
@@ -23,6 +23,60 @@ table already used it), and admits both statuses.
 
 Grounding: [`docs/notes/20260716-dspec-formal-spec-substrate-evaluation.md`](../notes/20260716-dspec-formal-spec-substrate-evaluation.md)
 § P1 / § (b) / § 段 0 — the three findings and the probes that produced them.
+
+**Amendment (2026-07-25) — a second class, found by finishing the sweep (WD6).** The carry-over
+above ("`internal-spec`'s other documents were not swept") was worked through
+([#163](https://github.com/rigortype/rigor/issues/163); ledger:
+[`docs/notes/20260725-internal-spec-status-fidelity-sweep.md`](../notes/20260725-internal-spec-status-fidelity-sweep.md)).
+The *claimed-but-never-implemented* class recurred exactly once —
+[`implementation-expectations.md`](../internal-spec/implementation-expectations.md) § Engine surface,
+where the incomplete-inference result carrier and the *inference* half of capability roles both name
+surfaces absent from all of `lib/`. Three of the five findings were a class this ADR did not
+anticipate:
+
+> **A version-anchored future tense that the release then outran.**
+
+"The merger lands in v0.1.0" (`flow-contribution.md`, written at v0.0.9 and still there at v0.3.0,
+four sections above the note that it shipped); "the substrate the v0.1.0 plugin API will be designed
+against" plus three extensions it never got (`reflection.md`); "nothing consumes it yet"
+(`plugin-trust.md`, false since the run-result cache started folding plugin boundary reads into the
+run dependency descriptor). **Each was true the day it was written.** That is what separates this
+class from the founding-era stratum: no one misstated anything, and no author error is available to
+correct. The corpus simply has no mechanism that expires such a sentence, so the release date
+silently converts an accurate plan into a false claim — and WD4's gate cannot see it, because that
+gate reads the diagnostic-family table and WD1 leaves the prose body ungated.
+
+The inverse direction belongs to the same class: `plugin-trust.md` *under*-claimed what ships. WD4
+already names this ("the marker expires"); this amendment records that an unmarked deferral rots the
+same way a marker does.
+
+**WD6 — the gate: `manual_drift_spec.rb` axis 6.** Over `docs/type-specification/` +
+`docs/internal-spec/`, no sentence may pair a pending marker (`will` / `lands` / `introduces` /
+`adds` / …) with a **pinned** version literal at or below `Rigor::VERSION`. Three properties make
+this gateable where the general prose body is not:
+
+- **The comparison is decidable** — a version literal against `Rigor::VERSION`, never a judgement
+  about whether a clause is satisfied. That is the WD1 line, not an exception to it.
+- **A release line cannot expire.** `v0.4.x` / `v1` name a line, not a release, so a sentence about
+  one stays true as the line grows. The corpus already uses that spelling for open work
+  (`plugin-cache-producers.md`), and the gate's remediation is to adopt it.
+- **Past tense is never matched.** `landed` / `added` / `shipped` are how a corrected sentence
+  reads; matching them would fight the fix.
+
+The detector carries its own non-vacuity examples — the three real sentences above, plus the shapes
+it must not fire on. Without them the axis is silence-shaped: a corpus that is clean passes forever,
+including when the detector has quietly stopped detecting.
+
+Precision on the live corpus: two false positives, both instructive. One was a marker in one bullet
+pairing with a version literal in the next (fixed by splitting list items before joining lines); the
+other was a sentence naming an old version for *history* while promising something else entirely
+(fixed by requiring the version to sit within a short window of the marker — the promise must
+*govern* the version, not merely share a sentence with it).
+
+The gate is a floor, not a ceiling. `public-api.md` carried three stale sentences that axis 6 does
+not match ("until v0.1.0 ratifies them", "as the v0.1.0 plugin observability story finalises"); they
+were found by reading and fixed in the same pass. Per WD1 the manual probe remains the instrument
+for the prose body.
 
 ## Context
 
@@ -225,7 +279,10 @@ skip, which is the discipline this ADR exists to install.
   transitive case (`def bar; foo; end; a = bar` — `bar` declares nothing, so a call-site rule
   reading `bar`'s RBS cannot see the `void` that reached it through the body). (2) The prose-clause body stays ungated (WD1) — the P1-class probe remains a
   manual instrument. (3) `internal-spec`'s other documents were not swept; only
-  `internal-type-api.md` was probed.
+  `internal-type-api.md` was probed — **resolved 2026-07-25**, see the WD6 amendment above: the sweep
+  found one more instance of this ADR's class and three of a second one, now gated by axis 6. The
+  three largest documents (`inference-engine.md`, `plugin.md`, `cache.md`) got the enumerated-surface
+  pass rather than a line-by-line read, which is what keeps #163 open.
 
 ## Relationship to other ADRs
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -105,7 +105,7 @@ This directory contains the Architecture Decision Records (ADRs) for Rigor. Each
 | ADR-89 | [Semantic propagation gates: declaration-shape and observed-key return summaries](89-semantic-propagation-gates.md) | Accepted (WD1 declaration-shape gate + WD2 return-summary gate implemented, PR #90; gitlab 341→1) |
 | ADR-90 | [Target-library resolution from the analyzed project's bundle](90-target-library-resolution-from-project-bundle.md) | Accepted (implemented 2026-07-16; WD1-WD3 landed) |
 | ADR-91 | [Kernel intrinsic fold ownership gate + spelling-parity invariant](91-kernel-intrinsic-fold-ownership-gate.md) | Accepted (implemented 2026-07-16, WD1-WD4; corpus gate byte-identical) |
-| ADR-92 | [Normative status fidelity: the founding-era stratum and the declare-or-mark gate](92-normative-status-fidelity.md) | Accepted (implemented 2026-07-16, WD1-WD5; void verdict resolved to option b) |
+| ADR-92 | [Normative status fidelity: the founding-era stratum and the declare-or-mark gate](92-normative-status-fidelity.md) | Accepted (implemented 2026-07-16 WD1-WD5, 2026-07-25 WD6; void verdict resolved to option b) |
 | ADR-93 | [Default rbs-inline ingestion: reconciling ADR-32's opt-in with the always-parse spec](93-default-rbs-inline-ingestion.md) | Accepted (WD5 engine-anchored bundled-plugin resolution added 2026-07-19, slice queued) |
 | ADR-94 | [The inline-RBS reader: `RBS::InlineParser` and the rbs 3.x floor](94-rbs-inline-reader-and-the-rbs-3x-floor.md) | Accepted (migration deferred; rigor-rbs-inline stays the reader) |
 | ADR-95 | [Homebrew distribution: deferred behind the single binary](95-homebrew-tap-deferral.md) | Proposed (deferred, trigger-gated; nothing implemented) |

--- a/docs/internal-spec/public-api.md
+++ b/docs/internal-spec/public-api.md
@@ -1,18 +1,19 @@
 # Public API Stability Boundary
 
-Status: **Active (v0.1.0 contract shipped; stabilising toward v0.2.0).**
+Status: **Active — the enumerated surface is under the `v0.2.0` evaluation
+trial** ([`docs/compatibility.md`](../compatibility.md) § the three stages:
+committed-to-as-a-trial from `v0.2.0`, binding at `v1.0.0`).
 Lists the namespaces the plugin contract is designed against and pins
 them in place via the [public-API drift spec](../../spec/rigor/public_api_drift_spec.rb).
-The v0.1.0 plugin contract shipped and the `0.1.x` preview line has
-extended the surface (cross-plugin facts, `signature_paths:`,
-`open_receivers:`, `protocol_contracts:`, `source_rbs_synthesizer:`);
-v0.2.0 is the first line where this surface is stabilised for external
-`rigor-*` gems. (The `rigor <command>` CLI itself — including newer
-subcommands like `mcp`, `triage`, `baseline`, `plugin`, `skill` — stays
-internal plumbing per the exclusion list below; its user-facing
-contract lives in `docs/manual/`.) The drift spec
-catches accidental signature changes so every change stays deliberate
-and reviewable.
+The v0.1.0 plugin contract shipped and the `0.1.x` preview line extended
+the surface (cross-plugin facts, `signature_paths:`, `open_receivers:`,
+`protocol_contracts:`, `source_rbs_synthesizer:`); `v0.2.0` was the first
+line to pledge minor-non-break on it for external `rigor-*` gems. (The
+`rigor <command>` CLI itself — including newer subcommands like `mcp`,
+`triage`, `baseline`, `plugin`, `skill` — stays internal plumbing per
+the exclusion list below; its user-facing contract lives in
+`docs/manual/`.) The drift spec catches accidental signature changes so
+every change stays deliberate and reviewable.
 
 This document is the **plugin-author view** of the pinned namespaces.
 The project-wide compatibility commitment — the full public surface
@@ -110,28 +111,31 @@ Any signature change on these methods has to update the matching
   the bundle shape via the public-API drift spec. Plugin authors
   should consume bundles via the public reader / `to_h` form and
   avoid pinning the per-slot value shapes (`PredicateEffect`,
-  `AssertEffect`, …) directly until v0.1.0 ratifies them.
+  `AssertEffect`, …) directly — v0.1.0 ratified the bundle, not those.
 - **`Rigor::FlowContribution::Element` / `MergeResult` / `Conflict` /
   `Merger`** — slice 3 surface; pinned by the drift spec. The
   flattening + merge policy is normative per
   [`flow-contribution-merger.md`](flow-contribution-merger.md).
 - **`Rigor::Analysis::Diagnostic`** — `source_family` and
-  `qualified_rule` were added in v0.0.8 (`ed9ae0a`) but the
-  per-rule diagnostic identifiers are still in flux as the v0.1.0
-  plugin observability story finalises.
+  `qualified_rule` were added in v0.0.8 (`ed9ae0a`); the per-rule
+  identifiers themselves remain out of the pinned surface and freeze
+  as public vocabulary at `v1.0.0` (ADR-50), which is why
+  `Rigor::Analysis::Diagnostic` stays out of the drift spec.
 - **`Rigor::Cache::*`** — the producer-facing
   `Store#fetch_or_compute(producer_id:, params:, descriptor:,
-  serialize:, deserialize:)` API is the most stable layer and the
-  one plugin-side cache producers will ride. The descriptor schema
-  is fixed by ADR-6 and the slice-taxonomy design doc; plugin
-  authors should add `PluginEntry` rows rather than new slot kinds.
+  serialize:, deserialize:)` API is the most stable layer, and the
+  one plugin-side cache producers ride
+  ([plugin-cache-producers.md](plugin-cache-producers.md)). The
+  descriptor schema is fixed by ADR-6 and the slice-taxonomy design
+  doc; plugin authors should add `PluginEntry` rows rather than new
+  slot kinds.
 - **`Rigor::RbsExtended`** directive parsers — public reader
   methods (`read_predicate_effects`, `read_assert_effects`,
   `read_return_type_override`, `read_param_type_overrides`,
   `read_flow_contribution`) are stable shapes today; the per-effect
   Data carriers (`PredicateEffect`, `AssertEffect`,
-  `ParamOverride`) are subject to the same v0.1.0 refinement as
-  `FlowContribution`.
+  `ParamOverride`) are unpinned for the same reason as
+  `FlowContribution`'s per-slot shapes.
 - **`Rigor::Plugin::*`** — registration / loading surface landed
   in v0.1.0 slice 1. The instance-level `Rigor::Plugin::Base#init`
   hook is stable today; protocol hooks added by slices 3–6 may

--- a/docs/internal-spec/reflection.md
+++ b/docs/internal-spec/reflection.md
@@ -63,10 +63,12 @@ The RBS-consulting methods accept **either** `scope:` **or** `environment:` (the
 
 The provenance side of the API (which source family contributed
 each fact) is explicitly **out of scope for the v0.0.7 first
-pass**. v0.1.0's plugin API adds it as a separate concern, per
-ADR-2 § "Plugin Diagnostic Provenance" and the readiness
-analysis's recommendation to keep the facade narrow until plugin
-authors require provenance for diagnostic explanations.
+pass**, and remains unbuilt — it was to be a separate concern of
+the plugin API, per ADR-2 § "Plugin Diagnostic Provenance" and
+the readiness analysis's recommendation to keep the facade narrow
+until plugin authors require provenance for diagnostic
+explanations. No plugin author has asked, so the facade is still
+narrow; see the marker under § *Future evolution*.
 
 ## Stability
 

--- a/docs/notes/20260725-internal-spec-status-fidelity-sweep.md
+++ b/docs/notes/20260725-internal-spec-status-fidelity-sweep.md
@@ -148,3 +148,20 @@ could: flag any spec sentence naming a released version in the future tense ("la
 be", "v0.1.0 introduces") once `Rigor::VERSION` has passed that version. That is a mechanical,
 low-false-positive check over a corpus this small, and it would have caught three of these five before
 a reader did. Worth its own issue rather than being smuggled into this sweep.
+
+**Built, same day** ([#211](https://github.com/rigortype/rigor/issues/211)) — `manual_drift_spec.rb`
+axis 6, recorded as ADR-92 WD6. Two things it taught while being calibrated against the live corpus,
+both now encoded in the check:
+
+- **Bullets are not sentences.** Joining a hard-wrapped paragraph pairs a marker in one list item
+  with a version literal in the next, and the axis reports a sentence nobody wrote. List items and
+  table rows are split as their own units first.
+- **Sharing a sentence is not being promised.** "Re-attempt the v0.0.9 carry-over … that work is
+  descoped and lands in a separate v0.1.x ticket" names an old version for *history* while promising
+  something else. The version must sit within a short window of the marker — the promise has to
+  *govern* the version.
+
+The gate is a floor, not a ceiling: `public-api.md` carried three stale sentences it does not match
+("until v0.1.0 ratifies them", "still in flux as the v0.1.0 plugin observability story finalises",
+"the one plugin-side cache producers **will** ride" — they do ride it). Found by reading, fixed in
+the same pass. Per ADR-92 WD1 the manual probe stays the instrument for the prose body.

--- a/spec/docs/manual_drift_spec.rb
+++ b/spec/docs/manual_drift_spec.rb
@@ -12,11 +12,15 @@
 #   5. Declared diagnostic families — every family the type spec's identifier taxonomy declares resolves to a
 #      real emitted id, or says in the row that it does not (ADR-92 WD4). Axes 1-4 all run impl -> doc; this
 #      one runs doc -> impl, the direction that let five divergences ship unnoticed.
+#   6. Expired version promises — no binding spec sentence speaks of an ALREADY-RELEASED version in the future
+#      tense (#211). Axis 5's sibling: same doc -> impl direction, different failure mode. Each sentence it
+#      catches was TRUE when written ("the merger lands in v0.1.0"), and nothing else in the corpus expires it.
 #
 # These checks are purely textual — no Rigor analysis needed.
 
 require "spec_helper"
 
+require "rigor/version"
 require "rigor/cli"
 require "rigor/configuration"
 require "rigor/analysis/check_rules"
@@ -51,6 +55,65 @@ MANUAL_DRIFT_EMITTED_FAMILIES = (
     File.read(rb, encoding: "utf-8").scan(/rule: *"([a-z][a-z0-9_-]*(?:\.[a-z0-9_-]+)+)"/).flatten
   end
 ).map { |id| id.split(".").first }.uniq.freeze
+
+# Axis 6: the binding corpus — the two spec trees CLAUDE.md says bind, and the only reader (the rigor-rs port)
+# that cannot fall back on reading lib/ when a sentence misleads.
+MANUAL_DRIFT_SPEC_CORPUS = (
+  Dir[File.join(MANUAL_DRIFT_DOCS_ROOT, "type-specification", "**", "*.md")] +
+  Dir[File.join(MANUAL_DRIFT_DOCS_ROOT, "internal-spec", "**", "*.md")]
+).sort.freeze
+
+# Axis 6: the future / pending markers that turn a version mention into a promise. Deliberately narrow — each
+# can only be read as "this has not happened yet", and every past-tense form is excluded on purpose (`landed`,
+# `added`, `shipped` are how a corrected sentence reads, so matching them would fight the fix). `yet` alone is
+# excluded too: it is common in settled prose ("not yet recognised" describes shipped fail-soft behaviour).
+MANUAL_DRIFT_PENDING_MARKERS = /\b(will|lands?|introduces?|adds?|plans? to|ships? in|is scheduled)\b/i
+
+# Axis 6: only a fully-pinned version can expire. `v0.1.x` / `v1` name a line, not a release, and a sentence
+# about a line stays true as the line grows — the corpus uses that spelling deliberately for open work.
+MANUAL_DRIFT_VERSION_LITERAL = /\bv?(\d+\.\d+\.\d+)\b/
+
+# Axis 6: the version must be GOVERNED by the marker, not merely present in the same sentence. Every real
+# finding reads as one phrase ("the merger lands in v0.1.0", "v0.1.0 will define …", "v0.1.0's plugin API adds
+# it"); a sentence that names an old version for history and a pending marker for something else is not a
+# promise about that version ("the v0.0.9 per-method carry-over … lands in a separate v0.1.x ticket" — the
+# first live false positive this axis produced). A short window in either direction separates the two.
+MANUAL_DRIFT_PROMISE_WINDOW = 40
+
+# Axis 6: the release a promise is measured against.
+MANUAL_DRIFT_CURRENT_VERSION = Gem::Version.new(Rigor::VERSION)
+
+# Axis 6: the versions a sentence promises something about — every pinned version sitting within
+# {MANUAL_DRIFT_PROMISE_WINDOW} characters of a pending marker, in either direction. Empty for a sentence that
+# makes no promise, whatever versions it happens to mention.
+def manual_drift_promised_versions(sentence)
+  markers = sentence.enum_for(:scan, MANUAL_DRIFT_PENDING_MARKERS).map { Regexp.last_match.begin(0) }
+  return [] if markers.empty?
+
+  sentence.enum_for(:scan, MANUAL_DRIFT_VERSION_LITERAL).filter_map do
+    match = Regexp.last_match
+    next unless markers.any? { |m| (match.begin(0) - m).abs <= MANUAL_DRIFT_PROMISE_WINDOW }
+
+    Gem::Version.new(match[1])
+  end
+end
+
+# Axis 6: a document's own sentences, whitespace-normalised. The corpus is hard-wrapped at ~100 columns, so a
+# promise routinely straddles a line break ("the merger lands in\nv0.1.0 will define …") and a line-based scan
+# would miss exactly the sentences this axis exists to catch. Fenced code blocks are dropped: a version string
+# inside an example is data, not a claim.
+#
+# List items and table rows are split as their own units before the join, or a marker in one bullet would pair
+# with a version literal in its neighbour — the axis would then report a sentence nobody wrote. That was the
+# first thing this check got wrong when it was run against the live corpus.
+def manual_drift_sentences(path)
+  body = File.read(path, encoding: "utf-8").gsub(/^```.*?^```/m, "")
+  body.split(/\n[ \t]*\n/).flat_map do |block|
+    block.split(/^(?=[ \t]*(?:[-*+]|\d+\.|\|)\s)/).flat_map do |unit|
+      unit.gsub(/\s+/, " ").strip.split(/(?<=[.:])\s+(?=[A-Z`*\[(])/)
+    end
+  end
+end
 
 RSpec.describe "manual accuracy" do
   # ── 1. CLI subcommand coverage ──────────────────────────────────
@@ -170,6 +233,72 @@ RSpec.describe "manual accuracy" do
                                               "Families still marked in diagnostic-policy.md that now emit " \
                                               "real ids: #{stale.map { |f| f[:prefix] }.inspect}\n" \
                                               "Drop the status marker — the family shipped."
+    end
+  end
+
+  # ── 6. Expired version promises (#211) ──────────────────────────
+  #
+  # The class this catches is not axis 5's. A clause axis 5 catches was never true; a sentence here was true
+  # the day it was written and rotted on release day — "the merger lands in v0.1.0" (written at v0.0.9, still
+  # in the document at v0.3.0 four sections above the note that it shipped). The comparison is decidable, which
+  # is what makes this gateable where ADR-92 WD1 leaves the prose body ungated: a version literal against
+  # `Rigor::VERSION`, not a judgement about whether a clause is satisfied. A sentence naming a version we have
+  # NOT reached is a legitimate plan and passes.
+  describe "expired version promises (spec corpus)" do
+    it "reads a non-trivial corpus (guards against a glob that matches nothing)" do
+      expect(MANUAL_DRIFT_SPEC_CORPUS.size).to be > 20
+    end
+
+    # The axis is silence-shaped: once the corpus is clean it passes forever, including if the detector
+    # silently stops detecting. These pin it against the sentences that motivated it (all real, all from the
+    # #163 sweep) and against the shapes it must NOT fire on.
+    describe "the detector itself" do
+      it "fires on a promise about a released version" do
+        [
+          "The merger that lands in v0.1.0 will define a tagged element form.",
+          "It is the substrate the v0.1.0 plugin API will be designed against.",
+          "v0.1.0's plugin API adds it as a separate concern."
+        ].each do |sentence|
+          expect(manual_drift_promised_versions(sentence).map(&:to_s)).to eq(["0.1.0"]), sentence
+        end
+      end
+
+      it "stays silent on history, on release lines, and on versions we have not reached" do
+        {
+          "past tense" => "The merger landed in v0.1.0 alongside the plugin API.",
+          "release line" => "That work is descoped and lands in a separate v0.1.x ticket.",
+          "distant mention" => "Re-attempt the v0.0.9 per-method Reflection cache carry-over, per ADR-7 " \
+                               "§ Slice 6-D, because that work is descoped and lands in another ticket.",
+          "no version" => "The catalogue will grow as later slices promote more nodes."
+        }.each do |shape, sentence|
+          expect(manual_drift_promised_versions(sentence)).to be_empty, shape
+        end
+      end
+
+      it "lets a genuine plan through (a version we have not released)" do
+        promised = manual_drift_promised_versions("The identifiers will freeze as public vocabulary in v9.0.0.")
+        expect(promised.map(&:to_s)).to eq(["9.0.0"])
+        expect(promised.none? { |v| v <= MANUAL_DRIFT_CURRENT_VERSION }).to be(true)
+      end
+    end
+
+    MANUAL_DRIFT_SPEC_CORPUS.each do |path|
+      it "#{path.sub(MANUAL_DRIFT_DOCS_ROOT.to_s, '').delete_prefix('/')} makes no promise about a released version" do
+        relative = path.sub("#{MANUAL_DRIFT_DOCS_ROOT}/", "")
+        expired = manual_drift_sentences(path).select do |sentence|
+          manual_drift_promised_versions(sentence).any? { |v| v <= MANUAL_DRIFT_CURRENT_VERSION }
+        end
+
+        expect(expired).to be_empty,
+                           "#{relative} speaks of an already-released version " \
+                           "(current: #{Rigor::VERSION}) in " \
+                           "the future tense:\n\n" \
+                           "#{expired.map { |s| "  - #{s}" }.join("\n\n")}\n\n" \
+                           "Each sentence was true when written and is not now. Rewrite it in the past tense " \
+                           "if the work shipped, or — if it did not — say so at the point of declaration " \
+                           "(ADR-92 WD3) and name the release line (`v0.4.x`) rather than a pinned version, " \
+                           "which cannot expire."
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #211. Refs #163, and lands as ADR-92 **WD6**.

## The class

Every instance was **true when it was written** — that is what makes it distinct from ADR-92's founding-era stratum, and why nothing caught it:

- `flow-contribution.md`: "the merger **lands in** v0.1.0", written at v0.0.9, still present at v0.3.0 — four sections above the note that it shipped in v0.1.0.
- `reflection.md`: "the substrate the v0.1.0 plugin API **will be** designed against", plus three extensions it never got.
- `plugin-trust.md`: "nothing consumes it **yet**", false since the runner started folding plugin boundary reads into the run dependency descriptor.

There is no author error to correct. The corpus has no mechanism that expires such a sentence, so the release date converts an accurate plan into a false claim. ADR-92 WD4's gate cannot see it — that axis reads the diagnostic-family table, and WD1 deliberately leaves the prose body ungated.

## The gate — `manual_drift_spec.rb` axis 6

Over `docs/type-specification/` + `docs/internal-spec/`: a pending marker paired with a **pinned** version literal at or below `Rigor::VERSION` fails.

Why this is gateable where the prose body is not — it compares a version literal against a constant and never judges whether a clause is satisfied. Three properties keep it honest:

- **A release line cannot expire.** `v0.4.x` names a line, not a release; the failure message's remediation is to adopt that spelling, which the corpus already uses for open work.
- **Past tense is never matched.** `landed` / `added` / `shipped` are how a corrected sentence reads — matching them would fight the fix.
- **The detector carries its own non-vacuity examples** (the three real sentences, plus the shapes it must not fire on). Without them the axis is silence-shaped: a clean corpus passes forever, including when the detector has quietly stopped detecting.

## Two false positives, both instructive

Calibration against the live corpus, both now encoded in the check:

1. **Bullets are not sentences.** Joining a hard-wrapped paragraph paired a marker in one list item with a version literal in the next — the axis reported a sentence nobody wrote. List items and table rows split as their own units first.
2. **Sharing a sentence is not being promised.** "Re-attempt the v0.0.9 carry-over … that work is descoped and **lands** in a separate v0.1.x ticket" names an old version for *history*. The version must sit within a short window of the marker: the promise has to **govern** the version.

## Also in this PR

The gate is a floor, not a ceiling. `public-api.md` carried three stale sentences axis 6 does **not** match — "until v0.1.0 ratifies them", "still in flux as the v0.1.0 plugin observability story finalises", "the one plugin-side cache producers **will** ride" (they do ride it). Found by reading, fixed here, along with `reflection.md`'s surviving § Provenance sentence. Per ADR-92 WD1 the manual probe stays the instrument for the prose body.

ADR-92 gains the WD6 amendment and its carry-over (3) is resolved; the ADR index row and the sweep ledger are updated.

`make verify` green, `make docs-check` green (311 examples), `git diff --check` clean.