### PR TITLE
Let a cache producer declare its own generation cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Changed
+
+- **[plugin API]** `Plugin::Base.producer` accepts a `generation_cap:` declaring how many generations of a producer's cache entries survive a compaction pass; it defaults to the previous behaviour (unbounded, reaped only by the `cache.max_bytes` LRU pass), so a whole-project producer that orphans its previous entry on every run can now keep its own cache slice from growing ([#151](https://github.com/rigortype/rigor/issues/151)).
+- **[plugin API]** *(breaking, unpinned surface)* `Cache::Store#fetch_or_compute` and `#fetch_or_validate` now require a `generation_cap:` argument. A plugin that reaches for the store directly rather than through `Plugin::Base.producer` must pass one — `:unbounded` reproduces the previous behaviour exactly. There is deliberately no default: a cache slice that silently grows without bound is the failure this argument exists to make unrepresentable, and no single default is right for both whole-project and per-file producers ([#151](https://github.com/rigortype/rigor/issues/151)).
+
 ### Performance
 
 - **[perf]** `rigor check` no longer re-traverses each file for the `static.value-use.void` rule — its value-position scan now rides the shared per-node walk with the other built-in rules, removing one full AST traversal per file whether or not the rule is enabled. Diagnostics are unchanged ([#207](https://github.com/rigortype/rigor/issues/207)).

--- a/docs/adr/54-cache-slimming.md
+++ b/docs/adr/54-cache-slimming.md
@@ -109,15 +109,23 @@ small repos never trigger it — an audit of a real repository's
 (~1.77 MB each, ~16 MB cache total) that the byte cap had no reason to
 touch. The byte cap alone leaves orphan generations of a content-keyed
 whole-project producer sitting below the cap indefinitely. `Store#evict!`
-now runs a generation cap as a second, orthogonal compaction axis: a small
-hardcoded allow-list of whole-project producer ids keeps only their most
-recent N generations (2 for the RBS producers, 16 for
-`analysis.run-diagnostics`), independent of `max_bytes:` — it runs even
+now runs a generation cap as a second, orthogonal compaction axis: only the
+most recent N generations of a whole-project producer survive a compaction
+pass (2 for the RBS producers, 16 for `analysis.run-diagnostics`),
+independent of `max_bytes:` — it runs even
 when the store is unbounded (`max_bytes: nil`), since it reclaims
 provably-dead bytes rather than enforcing a size budget. See
 `docs/internal-spec/cache.md` § "Compaction (`#evict!`)" for the full
 mechanics, including the co-landed stale temp-file sweep and the
 `Rigor::VERSION`-carrying marker (payload ABI boundary on upgrade).
+
+*Addendum ([#151](https://github.com/rigortype/rigor/issues/151)):* the cap
+started as a hardcoded id→cap table inside `Cache::Store`, which meant a
+whole-project producer added later was uncapped until a maintainer
+remembered the table. Each producer now declares its own budget and every
+fetch call carries it (`generation_cap:`, required), so the omission is not
+expressible; the Store maps the id strings it is handed to the declarations
+it received.
 
 **WD4 (minor) — memoise `RbsDescriptor.build` per loader.** It runs once per
 producer fetch (7×/run, identical result). Measured 1.3 ms × 7 today —

--- a/docs/internal-spec/cache.md
+++ b/docs/internal-spec/cache.md
@@ -201,7 +201,7 @@ and a writable store whose cache root cannot be read/repaired
 (permission error, disk full, deleted root, read-only mount) — neither
 of which may ever break an analysis run.
 
-### `store.fetch_or_compute(producer_id:, params:, descriptor:, serialize: nil, deserialize: nil) { ... } -> Object`
+### `store.fetch_or_compute(producer_id:, params:, descriptor:, generation_cap:, serialize: nil, deserialize: nil) { ... } -> Object`
 
 The compute-keyed producer entry point; `fetch_or_validate` below is
 the record-and-validate variant, and `peek_validated` its read-only
@@ -216,6 +216,10 @@ probe half.
   derive cache keys themselves.
 - `descriptor` ([`Rigor::Cache::Descriptor`](#rigorcachedescriptor-v008-slice-1))
   — the invalidation descriptor for the cached value.
+- `generation_cap` (Integer or `:unbounded`, **required**) — the
+  producer's own compaction budget, per § "Compaction (`#evict!`)"
+  below. Not optional: a producer that reaches disk has stated how
+  many of its generations may accumulate.
 - `serialize` (callable, optional) — turns the producer's return
   value into a binary `String`. Defaults to `Marshal.dump(value).b`.
   Producers whose return values are not `Marshal`-clean (RBS-
@@ -235,7 +239,7 @@ probe half.
 Returns the cached value (loaded from disk on hit; produced by
 the block on miss).
 
-### `store.fetch_or_validate(producer_id:, key_descriptor:, params: {}, serialize: nil, deserialize: nil) { ... } -> Object`
+### `store.fetch_or_validate(producer_id:, key_descriptor:, generation_cap:, params: {}, serialize: nil, deserialize: nil) { ... } -> Object`
 
 The record-and-validate variant ([ADR-45](../adr/45-unchanged-project-fast-path.md)).
 Unlike `fetch_or_compute` — which keys the entry on the descriptor of
@@ -420,23 +424,37 @@ passes, in order:
    never leaves one behind (see "Atomicity and locking" above); this
    is a backstop for a process that died between the temp-file
    write and the rename.
-2. **Whole-project generation cap.** Some producers are
+2. **Producer-declared generation cap.** Some producers are
    content-keyed (the cache key is a function of the value's
    dependencies, not a stable per-project key), so re-running with
    different inputs writes a new entry and leaves the old one
-   unreachable — but still on disk. A small hardcoded allow-list of
-   whole-project producer ids
-   (`rbs.environment`, `rbs.class_ancestor_table`,
-   `rbs.class_type_param_names`, `rbs.constant_type_table`,
-   `rbs.known_class_names`, `analysis.run-diagnostics`) caps how many
-   generations of each survive a compaction pass; beyond the cap the
-   oldest-by-mtime generations are unlinked first. Per-file and
-   per-plugin producers are deliberately absent from this table —
-   many current entries under one such producer id can be live at
-   once, so a generation count is not a meaningful proxy for
-   staleness there. The cap is presently a maintained constant, not
-   producer-declared metadata; a new whole-project producer must be
-   added to the list by hand to benefit.
+   unreachable — but still on disk. Every fetch call
+   (`#fetch_or_compute`, `#fetch_or_validate`) MUST carry a
+   `generation_cap:`, which is either a positive `Integer` (how many
+   generations of that producer survive a compaction pass) or
+   `Cache::Store::UNBOUNDED_GENERATIONS` (`:unbounded` — the producer
+   keeps many entries live at once, so a generation count is not a
+   staleness proxy and only pass 3 bounds it). Beyond the cap the
+   oldest-by-mtime generations are unlinked first. The keyword is
+   REQUIRED: omitting it is an `ArgumentError`, so a whole-project
+   producer added later cannot be silently uncapped — the failure the
+   pre-#151 hardcoded allow-list of producer ids invited.
+
+   The value is the producer's own declaration, not a call-site
+   judgement: `RbsCacheProducer.generation_cap` (2, inherited by every
+   `rbs.*` subclass), `Analysis::RunCacheKey::GENERATION_CAP` (16 for
+   `analysis.run-diagnostics`, one live generation per analyzed-path
+   SET), and `Plugin::Base.producer generation_cap:` (defaulting to
+   `:unbounded`) for plugin-side producers. The per-file
+   `plugin.source_rbs_synthesizer` producer declares `:unbounded`.
+
+   The Store records each declaration against the producer id as the
+   fetch calls arrive, and the compaction pass reads that record. A
+   producer id this Store instance never saw declared is therefore left
+   alone rather than compacted on a guess. That is the safe direction:
+   a producer not consulted during the run also wrote no new
+   generation, so the pass can only skip entries that were already
+   there, never evict a live one.
 3. **Size-based LRU pass.** Unchanged from prior releases: walks
    every remaining `.entry` file, sorts by mtime ascending, and
    unlinks from the oldest until the total is at or below
@@ -542,7 +560,7 @@ backstop for the whole mechanism.
 
 Every bundled RBS-derived producer documented below (`RbsConstantTable`, `RbsKnownClassNames`, `RbsClassAncestorTable`, `RbsClassTypeParamNames`, `RbsEnvironment`) satisfies one shape — a class object responding to `fetch(loader:, store:)` and returning the cached or freshly computed value. This is codified as the structural interface `_CacheProducer` in [`sig/rigor/cache.rbs`](../../sig/rigor/cache.rbs): a structural interface (the RBS/Go sense), not an ADR-28 protocol contract, and distinct from the plugin-side producer surface in [`plugin-cache-producers.md`](plugin-cache-producers.md).
 
-The `fetch` body is identical across producers: read the shared RBS descriptor (`loader.rbs_cache_descriptor`, the per-loader memo around `RbsDescriptor.build`), then call `store.fetch_or_compute(producer_id:, params: {}, descriptor:)` yielding to the producer's `compute(loader)`. Only the `PRODUCER_ID` constant and the `compute` body differ. That shared wiring lives on the `Rigor::Cache::RbsCacheProducer` base; a producer MUST subclass it and declare its own `PRODUCER_ID` and a (private) `self.compute(loader)`. The base reads `self::PRODUCER_ID` so the constant resolves on the concrete subclass. The per-producer sections below specify each producer's `PRODUCER_ID`, `compute` output type, and the `cache_store` consumer that reads it.
+The `fetch` body is identical across producers: read the shared RBS descriptor (`loader.rbs_cache_descriptor`, the per-loader memo around `RbsDescriptor.build`), then call `store.fetch_or_compute(producer_id:, params: {}, descriptor:, generation_cap:)` yielding to the producer's `compute(loader)`. Only the `PRODUCER_ID` constant and the `compute` body differ. That shared wiring lives on the `Rigor::Cache::RbsCacheProducer` base; a producer MUST subclass it and declare its own `PRODUCER_ID` and a (private) `self.compute(loader)`. The base also declares `self.generation_cap` (2 — see § "Compaction"), which a subclass inherits and may override; no `rbs.*` producer can therefore be added without a compaction budget. The base reads `self::PRODUCER_ID` so the constant resolves on the concrete subclass. The per-producer sections below specify each producer's `PRODUCER_ID`, `compute` output type, and the `cache_store` consumer that reads it.
 
 ## `Rigor::Cache::RbsConstantTable` (v0.0.8 slice 3)
 

--- a/docs/internal-spec/plugin-cache-producers.md
+++ b/docs/internal-spec/plugin-cache-producers.md
@@ -38,7 +38,7 @@ ADR-7 § "Slice 6" pins three implementation choices:
 
 ## Public surface (drift-pinned)
 
-### `Rigor::Plugin::Base.producer(id, watch: nil, serialize: nil, deserialize: nil, &block)`
+### `Rigor::Plugin::Base.producer(id, watch: nil, serialize: nil, deserialize: nil, generation_cap: :unbounded, &block)`
 
 Class-level DSL that registers a producer. The block is the
 producer body; it runs through `instance_exec` so `self`
@@ -62,6 +62,18 @@ config) returning that Array. Each evaluated `(root, pattern)`
 becomes a `Cache::Descriptor::GlobEntry` row in the producer's
 dependency descriptor — one entry digests the whole glob, so a
 content change, an addition, or a removal all invalidate.
+
+`generation_cap:` declares how many generations of this
+producer's entries survive `Cache::Store#evict!`'s compaction
+pass (see [`cache.md`](cache.md) § "Compaction"). The default,
+`Cache::Store::UNBOUNDED_GENERATIONS`, suits the usual plugin
+producer — keyed per file or per discovered unit, with many
+entries live at once — and leaves it to the size-based LRU pass
+alone. A producer whose entries are whole-project and
+content-keyed (each run orphans the previous entry) declares a
+small positive `Integer` instead. Any other value raises
+`ArgumentError` at class-definition time, so a whole-project
+plugin producer cannot end up silently uncapped.
 
 `serialize:` / `deserialize:` apply to the producer's return
 **value** (the cache layer wraps them around the stored

--- a/lib/rigor/analysis/run_cache_key.rb
+++ b/lib/rigor/analysis/run_cache_key.rb
@@ -36,6 +36,16 @@ module Rigor
 
       RUN_DIAGNOSTICS_PRODUCER_ID = "analysis.run-diagnostics"
 
+      # The run-result producer's declared compaction budget (`Cache::Store#evict!` pass 2). Whole-project,
+      # but unlike the `rbs.*` producers several generations can be live at once: the `paths` key slot means
+      # one entry per analyzed-path SET, so `rigor check` over the whole project, over `lib`, and over a
+      # single file are three separate live generations. 16 is a judgement call sized for that churn; it is
+      # a cap on GENERATIONS, not on correctness — over-evicting here costs a recompute, never a wrong
+      # answer. Measured 2026-07-25 against a real project's `.rigor/cache`: the cap does bind (60 distinct
+      # path-set generations observed, differing in the `paths` slot alone), with no evidence yet on how
+      # often an evicted generation is asked for again — see issue #151.
+      GENERATION_CAP = 16
+
       # @param rbs_config_entries [Array<Cache::Descriptor::ConfigEntry>] the RBS-derived config slots
       #   (`rbs.libraries` [+ `rbs.virtual_rbs`]). nil on any failure so a malformed key disables the cache.
       def descriptor(configuration:, files:, explain:, rbs_config_entries:)

--- a/lib/rigor/analysis/runner.rb
+++ b/lib/rigor/analysis/runner.rb
@@ -454,7 +454,8 @@ module Rigor
 
         computed = false
         diagnostics = @cache_store.fetch_or_validate(
-          producer_id: RunCacheKey::RUN_DIAGNOSTICS_PRODUCER_ID, key_descriptor: key_descriptor
+          producer_id: RunCacheKey::RUN_DIAGNOSTICS_PRODUCER_ID, key_descriptor: key_descriptor,
+          generation_cap: RunCacheKey::GENERATION_CAP
         ) do
           computed = true
           diags = assemble_run_diagnostics(expansion, environment: environment)

--- a/lib/rigor/cache/rbs_cache_producer.rb
+++ b/lib/rigor/cache/rbs_cache_producer.rb
@@ -15,12 +15,22 @@ module Rigor
     # `self::PRODUCER_ID` resolves the constant on the concrete subclass, and `compute(loader)` dispatches to
     # its private class method. See the `_CacheProducer` RBS interface for the structural contract.
     class RbsCacheProducer
+      # Every RBS producer is whole-project and content-keyed: one entry is live and any older generation is
+      # unreachable, so `Cache::Store#evict!` keeps a small number of them (one spare for the still-warm
+      # previous signature state — the RBS environment blob alone runs to ~1.8 MB, ADR-54 WD3). Declared on
+      # the base, so a producer added by subclassing inherits a cap instead of being silently uncapped; a
+      # subclass with different economics overrides this method.
+      def self.generation_cap
+        2
+      end
+
       def self.fetch(loader:, store:)
         # ADR-54 WD4 — the descriptor is identical for every producer consulting the same loader (same sig
         # files, same libraries), so the loader memoises one build per process instead of re-digesting every
         # .rbs file once per producer.
         descriptor = loader.rbs_cache_descriptor
-        store.fetch_or_compute(producer_id: self::PRODUCER_ID, params: {}, descriptor: descriptor) do
+        store.fetch_or_compute(producer_id: self::PRODUCER_ID, params: {}, descriptor: descriptor,
+                               generation_cap: generation_cap) do
           compute(loader)
         end
       end

--- a/lib/rigor/cache/store.rb
+++ b/lib/rigor/cache/store.rb
@@ -37,18 +37,10 @@ module Rigor
       # blob whose class layout still happens to unmarshal.
       PAYLOAD_ABI_VERSION = Rigor::VERSION
 
-      # Whole-project producers are content-keyed, so dependency / signature churn writes a new entry and leaves
-      # the old generation unreachable. The global 256 MB cap is intentionally generous and often never fires on
-      # one project, so these producers get a small generation cap as a second compaction axis. Per-file / plugin
-      # producers are deliberately absent from this table: many current entries under one producer id can be live.
-      GENERATION_CAP_BY_PRODUCER = {
-        "analysis.run-diagnostics" => 16,
-        "rbs.class_ancestor_table" => 2,
-        "rbs.class_type_param_names" => 2,
-        "rbs.constant_type_table" => 2,
-        "rbs.environment" => 2,
-        "rbs.known_class_names" => 2
-      }.freeze
+      # The `generation_cap:` value declaring that a producer keeps MANY live entries under one id at once
+      # (per-file and per-plugin producers): a generation count is not a staleness proxy there, so the
+      # compaction pass in {#evict!} leaves the producer alone and only the size-based LRU pass can touch it.
+      UNBOUNDED_GENERATIONS = :unbounded
 
       STALE_TEMP_FILE_AGE_SECONDS = 60 * 60
 
@@ -76,6 +68,14 @@ module Rigor
         @misses = 0
         @writes = 0
         @by_producer = Hash.new { |h, k| h[k] = { hits: 0, misses: 0, writes: 0 } }
+        # `producer_id => generation cap`, populated from the `generation_cap:` every fetch call declares (see
+        # {#declare_generation_cap}). This is the bridge between the id STRINGS the fetch API takes and the
+        # directory names {#evict!} walks: a producer id the Store never saw declared stays uncapped, which
+        # errs toward under-evicting. Per-instance rather than process-global on purpose — a global mutable
+        # registry would be a `Ractor` shareability hazard for pool mode, and the Store instance that wrote a
+        # generation is the one whose `evict!` compacts it (`CLI::CheckCommand` calls
+        # `runner.cache_store&.evict!`).
+        @generation_caps = {}
         # Process-level in-memory layer keyed by `(producer_id, cache_key)`. Avoids the disk read +
         # `Marshal.load` cost (the dominant share of repeated cache-hit calls per stackprof) when many
         # short-lived `Analysis::Runner` instances share one `Store` — the spec process, the LSP daemon's
@@ -161,6 +161,12 @@ module Rigor
       private_class_method :collect_producers
 
       # @param producer_id [String] stable cache namespace; only `[a-z][a-z0-9._-]*` is accepted.
+      # @param generation_cap [Integer, Symbol] how many generations of this producer survive a compaction
+      #   pass — a positive `Integer` for a whole-project producer (one live entry, older ones unreachable),
+      #   or {UNBOUNDED_GENERATIONS} for a producer with many simultaneously-live entries. REQUIRED, and
+      #   sourced from the producer's own declaration (`RbsCacheProducer.generation_cap`,
+      #   `RunCacheKey::GENERATION_CAP`, `Plugin::Base.producer generation_cap:`) rather than invented at the
+      #   call site. See {#evict!}.
       # @param params [Hash] producer inputs; mixed into the cache key via {Descriptor#cache_key_for}.
       # @param descriptor [Rigor::Cache::Descriptor] the invalidation descriptor for the value being cached.
       # @param serialize [#call, nil] optional callable that turns the producer's return value into a binary
@@ -175,9 +181,10 @@ module Rigor
       #   path.
       # @yieldreturn the value to cache.
       # @return the cached value (loaded from disk on hit; produced by the block on miss).
-      def fetch_or_compute(producer_id:, params:, descriptor:,
+      def fetch_or_compute(producer_id:, params:, descriptor:, generation_cap:,
                            serialize: nil, deserialize: nil, &block)
         validate_producer_id!(producer_id)
+        declare_generation_cap(producer_id, generation_cap)
         disk = ensure_schema_version!
 
         key = descriptor.cache_key_for(producer_id: producer_id, params: params)
@@ -217,8 +224,12 @@ module Rigor
       #
       # The block MUST return `[value, dependency_descriptor]`. Disk reads are not in-process-memoised —
       # validation always re-checks the filesystem — but a single run only looks up once.
-      def fetch_or_validate(producer_id:, key_descriptor:, params: {}, serialize: nil, deserialize: nil)
+      #
+      # `generation_cap:` carries the same producer-declared compaction budget as {#fetch_or_compute}.
+      def fetch_or_validate(producer_id:, key_descriptor:, generation_cap:, params: {},
+                            serialize: nil, deserialize: nil)
         validate_producer_id!(producer_id)
+        declare_generation_cap(producer_id, generation_cap)
         disk = ensure_schema_version!
 
         key = key_descriptor.cache_key_for(producer_id: producer_id, params: params)
@@ -243,6 +254,9 @@ module Rigor
       # to serve a run's diagnostics WITHOUT loading the inference engine — it never runs a producer block, so
       # there is nothing to write. Records a hit (for `--cache-stats` parity) but never a miss (a probe miss
       # hands off to the full path, which records its own).
+      #
+      # Takes no `generation_cap:`: a pure read creates no generation, so a run that only ever peeks has
+      # nothing to compact. The write path for the same producer declares the cap.
       def peek_validated(producer_id:, key_descriptor:, params: {}, deserialize: nil)
         validate_producer_id!(producer_id)
         return nil unless ensure_schema_version!
@@ -256,8 +270,15 @@ module Rigor
         validated[0]
       end
 
-      # ADR-6 § "Eviction" — compaction pass over the on-disk cache. No-op when the store is read-only. Stale
-      # temp file cleanup and the whole-project generation cap run regardless of `max_bytes:` — they reclaim
+      # ADR-6 § "Eviction" — compaction pass over the on-disk cache. No-op when the store is read-only.
+      #
+      # The generation cap of pass 2 comes from what the producers themselves declared through this Store's
+      # fetch calls (`generation_cap:`), NOT from a maintained table of producer ids: a producer id this
+      # Store never saw is left alone. That is deliberately the safe direction — a producer that was not
+      # consulted this run also wrote no new generation, so the only entries this can skip are ones that were
+      # already sitting there.
+      #
+      # Stale temp file cleanup and the generation cap run regardless of `max_bytes:` — they reclaim
       # provably-dead bytes (leaked temp files, unreachable content-keyed generations) rather than enforcing a
       # size budget, so an explicitly unbounded store (`max_bytes: nil`) still benefits from them. The
       # size-based LRU pass below stays gated on `max_bytes:` being configured: it walks all remaining
@@ -318,6 +339,37 @@ module Rigor
 
         raise ArgumentError,
               "producer_id must match #{VALID_PRODUCER_ID.inspect}, got #{producer_id.inspect}"
+      end
+
+      # Records the producer's declared compaction budget for {#evict!}. Every fetch call carries it, so a
+      # producer cannot reach disk without stating one — the failure mode the previous hardcoded id table
+      # had (a new whole-project producer silently uncapped) is not expressible.
+      #
+      # Two DIFFERENT caps for one producer id in one process is a producer bug, not a policy: whichever the
+      # compaction pass picked would be arbitrary. It raises, consistent with the serializer-contract
+      # violations {#try_write_entry} deliberately lets through.
+      def declare_generation_cap(producer_id, generation_cap)
+        validate_generation_cap!(producer_id, generation_cap)
+        @monitor.synchronize do
+          previous = @generation_caps[producer_id]
+          if !previous.nil? && previous != generation_cap
+            raise ArgumentError,
+                  "producer #{producer_id.inspect} declared generation_cap #{generation_cap.inspect} after " \
+                  "#{previous.inspect}; one producer id must declare one cap"
+          end
+
+          @generation_caps[producer_id] = generation_cap
+        end
+      end
+
+      def validate_generation_cap!(producer_id, generation_cap)
+        return if generation_cap == UNBOUNDED_GENERATIONS
+        return if generation_cap.is_a?(Integer) && generation_cap.positive?
+
+        raise ArgumentError,
+              "producer #{producer_id.inspect} must declare generation_cap as a positive Integer (a " \
+              "whole-project producer: how many generations survive compaction) or " \
+              "#{UNBOUNDED_GENERATIONS.inspect} (many entries live at once), got #{generation_cap.inspect}"
       end
 
       def entry_path(producer_id, key)
@@ -550,9 +602,11 @@ module Rigor
       end
 
       def evict_excess_generations(entries)
+        caps = @monitor.synchronize { @generation_caps.dup }
         removed = {}
         entries.group_by { |entry| entry[:producer] }.each do |producer, producer_entries|
-          cap = GENERATION_CAP_BY_PRODUCER[producer]
+          cap = caps[producer]
+          cap = nil if cap == UNBOUNDED_GENERATIONS
           next if cap.nil? || producer_entries.size <= cap
 
           producer_entries.sort_by { |entry| [entry[:mtime], entry[:path]] }

--- a/lib/rigor/environment.rb
+++ b/lib/rigor/environment.rb
@@ -394,7 +394,8 @@ module Rigor
         cache_store.fetch_or_compute(
           producer_id: SYNTHESIZER_CACHE_PRODUCER_ID,
           params: {},
-          descriptor: descriptor
+          descriptor: descriptor,
+          generation_cap: synthesizer_generation_cap
         ) { invoke_synthesizer_safely(callable, path) || "" }
       end
 
@@ -419,6 +420,14 @@ module Rigor
 
       SYNTHESIZER_CACHE_PRODUCER_ID = "plugin.source_rbs_synthesizer"
       private_constant :SYNTHESIZER_CACHE_PRODUCER_ID
+
+      # One entry per (plugin, source file), all of them live for as long as the file is in the project — a
+      # generation count says nothing about staleness here, so this producer declares itself out of
+      # `Cache::Store#evict!`'s compaction pass and is bounded only by the size-based LRU pass. A method
+      # rather than a constant: `Cache::Store` is not loaded yet when this class body runs.
+      def synthesizer_generation_cap
+        Cache::Store::UNBOUNDED_GENERATIONS
+      end
 
       def build_synthesizer_cache_descriptor(plugin, path)
         Cache::Descriptor.new(

--- a/lib/rigor/plugin/base.rb
+++ b/lib/rigor/plugin/base.rb
@@ -8,6 +8,9 @@ require "prism"
 require_relative "manifest"
 require_relative "node_context"
 require_relative "../analysis/diagnostic"
+# `producer generation_cap:` defaults to (and validates against) `Cache::Store::UNBOUNDED_GENERATIONS`, and a
+# plugin class body can be evaluated before anything else pulled the cache layer in.
+require_relative "../cache/store"
 require_relative "../source/node_walker"
 
 module Rigor
@@ -86,16 +89,39 @@ module Rigor
         #
         # Producer ids are auto-prefixed `plugin.<manifest.id>.` at the cache layer (slice 6-C) so plugin-side
         # ids cannot collide with built-in producers.
-        def producer(id, watch: nil, serialize: nil, deserialize: nil, &block)
+        #
+        # `generation_cap:` declares how many generations of this producer's entries survive
+        # `Cache::Store#evict!`'s compaction pass. The default —
+        # `Cache::Store::UNBOUNDED_GENERATIONS` — suits the usual plugin producer, which keys per file or per
+        # discovered unit and keeps many entries live at once; only the size-based LRU pass bounds it. A
+        # producer whose entries are WHOLE-PROJECT and content-keyed (each run's inputs produce a fresh key
+        # and orphan the previous one) should declare a small positive Integer instead, so the orphans are
+        # reclaimed rather than accumulating under the global byte cap.
+        def producer(id, watch: nil, serialize: nil, deserialize: nil,
+                     generation_cap: Cache::Store::UNBOUNDED_GENERATIONS, &block)
           raise ArgumentError, "Plugin::Base.producer requires a block body" if block.nil?
 
           validate_producer_watch!(watch)
+          validate_producer_generation_cap!(id, generation_cap)
           @producers ||= {}
           @producers[id.to_sym] = {
-            block: block, watch: watch, serialize: serialize, deserialize: deserialize
+            block: block, watch: watch, serialize: serialize, deserialize: deserialize,
+            generation_cap: generation_cap
           }.freeze
           id.to_sym
         end
+
+        # A bad `generation_cap:` is caught at class-definition time (plugin load) rather than at the first
+        # `cache_for` round-trip, so the plugin author sees it before any caching happens.
+        def validate_producer_generation_cap!(id, generation_cap)
+          return if generation_cap == Cache::Store::UNBOUNDED_GENERATIONS
+          return if generation_cap.is_a?(Integer) && generation_cap.positive?
+
+          raise ArgumentError,
+                "Plugin::Base.producer #{id.inspect} generation_cap: must be a positive Integer or " \
+                "#{Cache::Store::UNBOUNDED_GENERATIONS.inspect}, got #{generation_cap.inspect}"
+        end
+        private :validate_producer_generation_cap!
 
         # ADR-60 WD3 — `watch:` is nil (no glob coverage), a static tuple Array, or a Proc evaluated per
         # `cache_for` call.
@@ -728,6 +754,7 @@ module Rigor
           store.fetch_or_validate(
             producer_id: prefixed_id,
             key_descriptor: key_descriptor,
+            generation_cap: producer[:generation_cap],
             params: params,
             serialize: pair_serializer(producer[:serialize]),
             deserialize: pair_deserializer(producer[:deserialize])

--- a/sig/rigor/cache.rbs
+++ b/sig/rigor/cache.rbs
@@ -14,6 +14,12 @@ module Rigor
     # PRODUCER_ID constant and a private `self.compute(loader)`.
     class RbsCacheProducer
       def self.fetch: (loader: untyped, store: untyped) -> untyped
+
+      # The generation cap this producer declares to `Cache::Store#evict!`
+      # (issue #151). `rigor sig-gen` infers the literal `2` from the base
+      # body; the contract is the wider `Integer`, since a subclass may
+      # override it.
+      def self.generation_cap: () -> Integer
     end
   end
 end

--- a/sig/rigor/plugin/base.rbs
+++ b/sig/rigor/plugin/base.rbs
@@ -14,7 +14,7 @@ class Rigor::Plugin::Base
   # the no-arg `manifest` reads the cached value back.
   def self.manifest: (**untyped fields) -> Rigor::Plugin::Manifest
 
-  def self.producer: (untyped id, ?watch: untyped, ?serialize: untyped, ?deserialize: untyped) { (untyped params) -> untyped } -> Symbol
+  def self.producer: (untyped id, ?watch: untyped, ?serialize: untyped, ?deserialize: untyped, ?generation_cap: untyped) { (untyped params) -> untyped } -> Symbol
   def self.producers: () -> Hash[Symbol, untyped]
 
   def self.node_rule: (untyped node_type) { (*untyped) -> untyped } -> untyped

--- a/spec/rigor/cache/store_spec.rb
+++ b/spec/rigor/cache/store_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe Rigor::Cache::Store do
   describe "#fetch_or_compute" do
     it "runs the block on cache miss and returns its value" do
       called = 0
-      result = store.fetch_or_compute(producer_id: "test.producer", params: { x: 1 }, descriptor: descriptor) do
+      result = store.fetch_or_compute(
+        producer_id: "test.producer", generation_cap: :unbounded, params: { x: 1 }, descriptor: descriptor
+      ) do
         called += 1
         { value: 42 }
       end
@@ -25,12 +27,16 @@ RSpec.describe Rigor::Cache::Store do
     end
 
     it "skips the block on cache hit and returns the stored value" do
-      store.fetch_or_compute(producer_id: "test.producer", params: { x: 1 }, descriptor: descriptor) do
+      store.fetch_or_compute(
+        producer_id: "test.producer", generation_cap: :unbounded, params: { x: 1 }, descriptor: descriptor
+      ) do
         { value: 42 }
       end
 
       called = 0
-      result = store.fetch_or_compute(producer_id: "test.producer", params: { x: 1 }, descriptor: descriptor) do
+      result = store.fetch_or_compute(
+        producer_id: "test.producer", generation_cap: :unbounded, params: { x: 1 }, descriptor: descriptor
+      ) do
         called += 1
         { value: 0 }
       end
@@ -39,8 +45,12 @@ RSpec.describe Rigor::Cache::Store do
     end
 
     it "treats different params as different cache entries" do
-      a = store.fetch_or_compute(producer_id: "p", params: { x: 1 }, descriptor: descriptor) { :a }
-      b = store.fetch_or_compute(producer_id: "p", params: { x: 2 }, descriptor: descriptor) { :b }
+      a = store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: { x: 1 }, descriptor: descriptor
+      ) { :a }
+      b = store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: { x: 2 }, descriptor: descriptor
+      ) { :b }
       expect(a).to eq(:a)
       expect(b).to eq(:b)
     end
@@ -50,29 +60,39 @@ RSpec.describe Rigor::Cache::Store do
       d2 = Rigor::Cache::Descriptor.new(
         files: [Rigor::Cache::Descriptor::FileEntry.new(path: "a.rb", comparator: :digest, value: "abc")]
       )
-      a = store.fetch_or_compute(producer_id: "p", params: {}, descriptor: d1) { :a }
-      b = store.fetch_or_compute(producer_id: "p", params: {}, descriptor: d2) { :b }
+      a = store.fetch_or_compute(producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: d1) { :a }
+      b = store.fetch_or_compute(producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: d2) { :b }
       expect(a).to eq(:a)
       expect(b).to eq(:b)
     end
 
     it "treats different producer_ids as different cache entries" do
-      a = store.fetch_or_compute(producer_id: "p1", params: {}, descriptor: descriptor) { :a }
-      b = store.fetch_or_compute(producer_id: "p2", params: {}, descriptor: descriptor) { :b }
+      a = store.fetch_or_compute(
+        producer_id: "p1", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) { :a }
+      b = store.fetch_or_compute(
+        producer_id: "p2", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) { :b }
       expect(a).to eq(:a)
       expect(b).to eq(:b)
     end
 
     it "round-trips Marshal-serialisable values" do
       payload = { strings: %w[a b], symbols: %i[x y], nested: { n: 1 } }
-      store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { payload }
-      result = store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :should_not_run }
+      store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) { payload }
+      result = store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) { :should_not_run }
       expect(result).to eq(payload)
     end
 
     it "rejects an invalid producer_id (only [a-z0-9._-] allowed)" do
       expect do
-        store.fetch_or_compute(producer_id: "Bad/Producer", params: {}, descriptor: descriptor) { :v }
+        store.fetch_or_compute(
+          producer_id: "Bad/Producer", generation_cap: :unbounded, params: {}, descriptor: descriptor
+        ) { :v }
       end.to raise_error(ArgumentError, /producer_id/)
     end
   end
@@ -80,20 +100,22 @@ RSpec.describe Rigor::Cache::Store do
   describe "on-disk layout" do
     it "writes a sharded path .rigor/cache/<producer-id>/<2-prefix>/<62-suffix>.entry" do
       key = descriptor.cache_key_for(producer_id: "p", params: { x: 1 })
-      store.fetch_or_compute(producer_id: "p", params: { x: 1 }, descriptor: descriptor) { :v }
+      store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: { x: 1 }, descriptor: descriptor
+      ) { :v }
 
       expected = File.join(cache_root, "p", key[0, 2], "#{key[2..]}.entry")
       expect(File.exist?(expected)).to be true
     end
 
     it "writes a schema_version.txt marker at the cache root" do
-      store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :v }
+      store.fetch_or_compute(producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor) { :v }
       marker = File.join(cache_root, "schema_version.txt")
       expect(File.read(marker).strip).to eq(described_class.schema_marker_value)
     end
 
     it "leaves no .tmp files behind on a successful write" do
-      store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :v }
+      store.fetch_or_compute(producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor) { :v }
       stragglers = Dir.glob(File.join(cache_root, "**", "*.tmp.*"))
       expect(stragglers).to be_empty
     end
@@ -108,7 +130,9 @@ RSpec.describe Rigor::Cache::Store do
 
   describe "schema-version mismatch" do
     it "drops the cache directory when the marker disagrees with SCHEMA_VERSION" do
-      store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :first }
+      store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) { :first }
       File.write(File.join(cache_root, "schema_version.txt"), "999")
 
       # The disk-level schema-mismatch recovery applies on the disk-read path. A fresh `Store` (process restart / new
@@ -116,7 +140,9 @@ RSpec.describe Rigor::Cache::Store do
       # entirely.
       fresh_store = described_class.new(root: cache_root)
       called = 0
-      result = fresh_store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) do
+      result = fresh_store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) do
         called += 1
         :second
       end
@@ -138,7 +164,9 @@ RSpec.describe Rigor::Cache::Store do
                  "#{Rigor::Cache::Descriptor::SCHEMA_VERSION}\n")
 
       described_class.new(root: cache_root)
-                     .fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :fresh }
+                     .fetch_or_compute(
+                       producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+                     ) { :fresh }
 
       expect(File.exist?(stale_entry)).to be(false)
       expect(File.read(File.join(cache_root, "schema_version.txt")).strip)
@@ -152,12 +180,12 @@ RSpec.describe Rigor::Cache::Store do
 
     it "round-trips through the supplied callables" do
       store.fetch_or_compute(
-        producer_id: "demo", params: {}, descriptor: descriptor,
+        producer_id: "demo", generation_cap: :unbounded, params: {}, descriptor: descriptor,
         serialize: upcase_serialize, deserialize: downcase_deserialize
       ) { "hello" }
 
       result = store.fetch_or_compute(
-        producer_id: "demo", params: {}, descriptor: descriptor,
+        producer_id: "demo", generation_cap: :unbounded, params: {}, descriptor: descriptor,
         serialize: upcase_serialize, deserialize: downcase_deserialize
       ) { :should_not_run }
 
@@ -173,7 +201,7 @@ RSpec.describe Rigor::Cache::Store do
         JSON.parse(bytes)
       }
       store.fetch_or_compute(
-        producer_id: "demo", params: {}, descriptor: descriptor,
+        producer_id: "demo", generation_cap: :unbounded, params: {}, descriptor: descriptor,
         serialize: json_serialize, deserialize: json_deserialize
       ) { { "name" => "Alice", "age" => 30 } }
 
@@ -188,7 +216,7 @@ RSpec.describe Rigor::Cache::Store do
       # transparent at the contract layer). A fresh Store forces the disk read.
       fresh = described_class.new(root: cache_root)
       result = fresh.fetch_or_compute(
-        producer_id: "demo", params: {}, descriptor: descriptor,
+        producer_id: "demo", generation_cap: :unbounded, params: {}, descriptor: descriptor,
         serialize: json_serialize, deserialize: json_deserialize
       ) { :should_not_run }
       expect(seen_bytes).to eq('{"name":"Alice","age":30}')
@@ -196,7 +224,9 @@ RSpec.describe Rigor::Cache::Store do
     end
 
     it "treats a pre-compression (format v1) entry as a cache miss" do
-      store.fetch_or_compute(producer_id: "demo", params: {}, descriptor: descriptor) { :v2_value }
+      store.fetch_or_compute(
+        producer_id: "demo", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) { :v2_value }
       key = descriptor.cache_key_for(producer_id: "demo", params: {})
       entry_path = File.join(cache_root, "demo", key[0, 2], "#{key[2..]}.entry")
       bytes = File.binread(entry_path).dup
@@ -206,7 +236,7 @@ RSpec.describe Rigor::Cache::Store do
 
       called = 0
       result = described_class.new(root: cache_root).fetch_or_compute(
-        producer_id: "demo", params: {}, descriptor: descriptor
+        producer_id: "demo", generation_cap: :unbounded, params: {}, descriptor: descriptor
       ) do
         called += 1
         :recomputed
@@ -218,7 +248,9 @@ RSpec.describe Rigor::Cache::Store do
     it "raises TypeError when serialize returns a non-String" do
       bad = ->(_) { 42 }
       expect do
-        store.fetch_or_compute(producer_id: "demo", params: {}, descriptor: descriptor, serialize: bad) { "x" }
+        store.fetch_or_compute(
+          producer_id: "demo", generation_cap: :unbounded, params: {}, descriptor: descriptor, serialize: bad
+        ) { "x" }
       end.to raise_error(TypeError, /serialize must return a String/)
     end
 
@@ -226,26 +258,30 @@ RSpec.describe Rigor::Cache::Store do
       identity = ->(v) { v }
       raising = ->(_) { raise "boom" }
       store.fetch_or_compute(
-        producer_id: "demo", params: {}, descriptor: descriptor,
+        producer_id: "demo", generation_cap: :unbounded, params: {}, descriptor: descriptor,
         serialize: identity, deserialize: identity
       ) { "first" }
       # `Store#fetch_or_compute` memoises the produced value in-process; the disk-read deserialise path is exercised by
       # a fresh `Store` ("process restart" scenario).
       fresh_store = described_class.new(root: cache_root)
       result = fresh_store.fetch_or_compute(
-        producer_id: "demo", params: {}, descriptor: descriptor,
+        producer_id: "demo", generation_cap: :unbounded, params: {}, descriptor: descriptor,
         serialize: identity, deserialize: raising
       ) { "second" }
       expect(result).to eq("second")
     end
 
     it "keeps the default Marshal path unchanged when serialize/deserialize are omitted" do
-      result = store.fetch_or_compute(producer_id: "demo", params: {}, descriptor: descriptor) do
+      result = store.fetch_or_compute(
+        producer_id: "demo", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) do
         { complex: [1, "two", :three] }
       end
       expect(result).to eq(complex: [1, "two", :three])
 
-      hit = store.fetch_or_compute(producer_id: "demo", params: {}, descriptor: descriptor) { :should_not_run }
+      hit = store.fetch_or_compute(
+        producer_id: "demo", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) { :should_not_run }
       expect(hit).to eq(complex: [1, "two", :three])
     end
   end
@@ -260,7 +296,9 @@ RSpec.describe Rigor::Cache::Store do
 
     it "misses, runs the block, writes, and returns the produced value" do
       called = 0
-      result = store.fetch_or_validate(producer_id: "p", key_descriptor: descriptor, params: { x: 1 }) do
+      result = store.fetch_or_validate(
+        producer_id: "p", generation_cap: :unbounded, key_descriptor: descriptor, params: { x: 1 }
+      ) do
         called += 1
         [{ v: 42 }, Rigor::Cache::Descriptor.new]
       end
@@ -280,14 +318,14 @@ RSpec.describe Rigor::Cache::Store do
       end
 
       first = described_class.new(root: cache_root).fetch_or_validate(
-        producer_id: "p", key_descriptor: Rigor::Cache::Descriptor.new, params: {}, &produce
+        producer_id: "p", generation_cap: :unbounded, key_descriptor: Rigor::Cache::Descriptor.new, params: {}, &produce
       )
       expect(first).to eq("v1")
 
       called = 0
       second_store = described_class.new(root: cache_root)
       second = second_store.fetch_or_validate(
-        producer_id: "p", key_descriptor: Rigor::Cache::Descriptor.new, params: {}
+        producer_id: "p", generation_cap: :unbounded, key_descriptor: Rigor::Cache::Descriptor.new, params: {}
       ) do
         called += 1
         ["should-not-run", Rigor::Cache::Descriptor.new]
@@ -302,7 +340,9 @@ RSpec.describe Rigor::Cache::Store do
       File.write(file, "v1")
 
       run = lambda do |s|
-        s.fetch_or_validate(producer_id: "p", key_descriptor: Rigor::Cache::Descriptor.new, params: {}) do
+        s.fetch_or_validate(
+          producer_id: "p", generation_cap: :unbounded, key_descriptor: Rigor::Cache::Descriptor.new, params: {}
+        ) do
           content = File.read(file)
           [content, fresh_descriptor(file, content)]
         end
@@ -313,7 +353,7 @@ RSpec.describe Rigor::Cache::Store do
       File.write(file, "v2")
       called = 0
       result = described_class.new(root: cache_root).fetch_or_validate(
-        producer_id: "p", key_descriptor: Rigor::Cache::Descriptor.new, params: {}
+        producer_id: "p", generation_cap: :unbounded, key_descriptor: Rigor::Cache::Descriptor.new, params: {}
       ) do
         called += 1
         content = File.read(file)
@@ -326,13 +366,13 @@ RSpec.describe Rigor::Cache::Store do
     it "increments misses (and writes on success) on every miss, hits on a fresh re-read" do
       3.times do |i|
         described_class.new(root: cache_root).fetch_or_validate(
-          producer_id: "demo", key_descriptor: descriptor, params: { i: i }
+          producer_id: "demo", generation_cap: :unbounded, key_descriptor: descriptor, params: { i: i }
         ) { [i, Rigor::Cache::Descriptor.new] }
       end
       hit_store = described_class.new(root: cache_root)
       2.times do
         hit_store.fetch_or_validate(
-          producer_id: "demo", key_descriptor: descriptor, params: { i: 0 }
+          producer_id: "demo", generation_cap: :unbounded, key_descriptor: descriptor, params: { i: 0 }
         ) { [:unused, Rigor::Cache::Descriptor.new] }
       end
 
@@ -341,14 +381,18 @@ RSpec.describe Rigor::Cache::Store do
     end
 
     it "treats a missing block as [nil, Descriptor.new] and does not raise" do
-      result = store.fetch_or_validate(producer_id: "p", key_descriptor: descriptor, params: {})
+      result = store.fetch_or_validate(
+        producer_id: "p", generation_cap: :unbounded, key_descriptor: descriptor, params: {}
+      )
       expect(result).to be_nil
     end
 
     it "does not write to disk and does not raise when read_only" do
       ro = described_class.new(root: cache_root, read_only: true)
       called = 0
-      result = ro.fetch_or_validate(producer_id: "p", key_descriptor: descriptor, params: {}) do
+      result = ro.fetch_or_validate(
+        producer_id: "p", generation_cap: :unbounded, key_descriptor: descriptor, params: {}
+      ) do
         called += 1
         [:v, Rigor::Cache::Descriptor.new]
       end
@@ -363,7 +407,9 @@ RSpec.describe Rigor::Cache::Store do
     it "raises TypeError when serialize returns a non-String (write-contract errors stay visible)" do
       bad = ->(_) { 42 }
       expect do
-        store.fetch_or_validate(producer_id: "p", key_descriptor: descriptor, params: {}, serialize: bad) do
+        store.fetch_or_validate(
+          producer_id: "p", generation_cap: :unbounded, key_descriptor: descriptor, params: {}, serialize: bad
+        ) do
           ["v", Rigor::Cache::Descriptor.new]
         end
       end.to raise_error(TypeError, /serialize must return a String/)
@@ -378,10 +424,16 @@ RSpec.describe Rigor::Cache::Store do
 
     it "increments misses and writes on a cache miss, hits on subsequent reads" do
       3.times do |i|
-        store.fetch_or_compute(producer_id: "demo", params: { i: i }, descriptor: descriptor) { i }
+        store.fetch_or_compute(
+          producer_id: "demo", generation_cap: :unbounded, params: { i: i }, descriptor: descriptor
+        ) { i }
       end
-      store.fetch_or_compute(producer_id: "demo", params: { i: 0 }, descriptor: descriptor) { :unused }
-      store.fetch_or_compute(producer_id: "demo", params: { i: 0 }, descriptor: descriptor) { :unused }
+      store.fetch_or_compute(
+        producer_id: "demo", generation_cap: :unbounded, params: { i: 0 }, descriptor: descriptor
+      ) { :unused }
+      store.fetch_or_compute(
+        producer_id: "demo", generation_cap: :unbounded, params: { i: 0 }, descriptor: descriptor
+      ) { :unused }
 
       stats = store.stats
       expect(stats).to include(misses: 3, writes: 3, hits: 2)
@@ -389,9 +441,13 @@ RSpec.describe Rigor::Cache::Store do
     end
 
     it "tracks counters separately per producer" do
-      store.fetch_or_compute(producer_id: "alpha", params: {}, descriptor: descriptor) { :a }
-      store.fetch_or_compute(producer_id: "beta", params: {}, descriptor: descriptor) { :b }
-      store.fetch_or_compute(producer_id: "alpha", params: {}, descriptor: descriptor) { :unused }
+      store.fetch_or_compute(
+        producer_id: "alpha", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) { :a }
+      store.fetch_or_compute(producer_id: "beta", generation_cap: :unbounded, params: {}, descriptor: descriptor) { :b }
+      store.fetch_or_compute(
+        producer_id: "alpha", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) { :unused }
 
       by_producer = store.stats.fetch(:by_producer)
       expect(by_producer.fetch("alpha")).to eq(hits: 1, misses: 1, writes: 1)
@@ -399,7 +455,7 @@ RSpec.describe Rigor::Cache::Store do
     end
 
     it "returns a frozen snapshot so callers cannot mutate the live counters" do
-      store.fetch_or_compute(producer_id: "demo", params: {}, descriptor: descriptor) { :v }
+      store.fetch_or_compute(producer_id: "demo", generation_cap: :unbounded, params: {}, descriptor: descriptor) { :v }
       snapshot = store.stats
       expect(snapshot).to be_frozen
       expect(snapshot.fetch(:by_producer)).to be_frozen
@@ -416,9 +472,13 @@ RSpec.describe Rigor::Cache::Store do
     end
 
     it "reports per-producer entry counts after writes" do
-      store.fetch_or_compute(producer_id: "alpha", params: { x: 1 }, descriptor: descriptor) { :a }
-      store.fetch_or_compute(producer_id: "alpha", params: { x: 2 }, descriptor: descriptor) { :b }
-      store.fetch_or_compute(producer_id: "beta", params: {}, descriptor: descriptor) { :c }
+      store.fetch_or_compute(
+        producer_id: "alpha", generation_cap: :unbounded, params: { x: 1 }, descriptor: descriptor
+      ) { :a }
+      store.fetch_or_compute(
+        producer_id: "alpha", generation_cap: :unbounded, params: { x: 2 }, descriptor: descriptor
+      ) { :b }
+      store.fetch_or_compute(producer_id: "beta", generation_cap: :unbounded, params: {}, descriptor: descriptor) { :c }
 
       inv = described_class.disk_inventory(root: cache_root)
       expect(inv[:schema_version]).to eq(described_class.schema_marker_value)
@@ -437,7 +497,9 @@ RSpec.describe Rigor::Cache::Store do
     let(:entry_path) { File.join(cache_root, "p", key[0, 2], "#{key[2..]}.entry") }
 
     before do
-      store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :first }
+      store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) { :first }
     end
 
     # The corruption-tolerance cases simulate the disk being mutated externally (e.g. by a buggy editor or a crash
@@ -454,7 +516,7 @@ RSpec.describe Rigor::Cache::Store do
 
       called = 0
       result = fresh_store_after_corruption.fetch_or_compute(
-        producer_id: "p", params: {}, descriptor: descriptor
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
       ) do
         called += 1
         :second
@@ -468,7 +530,7 @@ RSpec.describe Rigor::Cache::Store do
 
       called = 0
       result = fresh_store_after_corruption.fetch_or_compute(
-        producer_id: "p", params: {}, descriptor: descriptor
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
       ) do
         called += 1
         :second
@@ -484,7 +546,7 @@ RSpec.describe Rigor::Cache::Store do
 
       called = 0
       result = fresh_store_after_corruption.fetch_or_compute(
-        producer_id: "p", params: {}, descriptor: descriptor
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
       ) do
         called += 1
         :second
@@ -496,7 +558,9 @@ RSpec.describe Rigor::Cache::Store do
 
   describe "atomic write (#write_entry / #atomically_replace)" do
     it "round-trips the exact written value and leaves no .tmp file behind" do
-      store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { "the-value" }
+      store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) { "the-value" }
       key = descriptor.cache_key_for(producer_id: "p", params: {})
       entry_path = File.join(cache_root, "p", key[0, 2], "#{key[2..]}.entry")
 
@@ -504,13 +568,15 @@ RSpec.describe Rigor::Cache::Store do
       expect(Dir.glob("#{entry_path}.tmp.*")).to be_empty
 
       fresh = described_class.new(root: cache_root)
-      result = fresh.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :should_not_run }
+      result = fresh.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) { :should_not_run }
       expect(result).to eq("the-value")
     end
 
     it "derives the temp filename's random suffix from SecureRandom.hex(4) (16 hex chars)" do
       allow(SecureRandom).to receive(:hex).and_call_original
-      store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :v }
+      store.fetch_or_compute(producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor) { :v }
       expect(SecureRandom).to have_received(:hex).with(4)
     end
 
@@ -518,7 +584,7 @@ RSpec.describe Rigor::Cache::Store do
       allow(File).to receive(:rename).and_raise(Errno::ENOSPC)
 
       expect do
-        store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { "v" }
+        store.fetch_or_compute(producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor) { "v" }
       end.not_to raise_error
 
       expect(Dir.glob(File.join(cache_root, "**", "*.tmp.*"))).to be_empty
@@ -531,7 +597,7 @@ RSpec.describe Rigor::Cache::Store do
       threads = Array.new(16) do |i|
         Thread.new do
           described_class.new(root: cache_root).fetch_or_compute(
-            producer_id: "p", params: {}, descriptor: descriptor
+            producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
           ) { "value-#{i}" }
         end
       end
@@ -542,7 +608,7 @@ RSpec.describe Rigor::Cache::Store do
       # in-flight temp file.
       expect(Dir.glob("#{entry_path}.tmp.*")).to be_empty
       final = described_class.new(root: cache_root).fetch_or_compute(
-        producer_id: "p", params: {}, descriptor: descriptor
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
       ) { :should_not_run }
       expect(final).to match(/\Avalue-\d+\z/)
     end
@@ -559,7 +625,7 @@ RSpec.describe Rigor::Cache::Store do
   describe "#evict! (ADR-6 LRU eviction)" do
     def write_entry(store, producer_id, key, value)
       store.fetch_or_compute(
-        producer_id: producer_id, params: { k: key },
+        producer_id: producer_id, generation_cap: :unbounded, params: { k: key },
         descriptor: Rigor::Cache::Descriptor.new
       ) { value }
     end
@@ -617,7 +683,7 @@ RSpec.describe Rigor::Cache::Store do
       sleep(0.05)
       fresh = described_class.new(root: cache_root, max_bytes: 10 * 1024 * 1024)
       fresh.fetch_or_compute(
-        producer_id: "evict.test", params: { k: "a" },
+        producer_id: "evict.test", generation_cap: :unbounded, params: { k: "a" },
         descriptor: Rigor::Cache::Descriptor.new
       ) { raise "should not be called" }
 
@@ -635,7 +701,9 @@ RSpec.describe Rigor::Cache::Store do
 
     it "runs the producer block on miss and returns its value without writing to disk" do
       called = 0
-      result = ro_store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) do
+      result = ro_store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) do
         called += 1
         :produced
       end
@@ -647,17 +715,19 @@ RSpec.describe Rigor::Cache::Store do
     end
 
     it "does not write the schema_version.txt marker even on a fresh root" do
-      ro_store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :v }
+      ro_store.fetch_or_compute(producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor) { :v }
 
       expect(File.exist?(File.join(cache_root, "schema_version.txt"))).to be(false)
     end
 
     it "still serves hits from disk when an existing entry is present" do
       # Warm the cache with a write-enabled store.
-      store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :warm }
+      store.fetch_or_compute(producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor) { :warm }
 
       called = 0
-      result = ro_store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) do
+      result = ro_store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) do
         called += 1
         :should_not_run
       end
@@ -667,8 +737,10 @@ RSpec.describe Rigor::Cache::Store do
     end
 
     it "leaves the writes counter at zero (misses still recorded so callers can detect cold runs)" do
-      ro_store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :v }
-      ro_store.fetch_or_compute(producer_id: "p", params: { other: 1 }, descriptor: descriptor) { :w }
+      ro_store.fetch_or_compute(producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor) { :v }
+      ro_store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: { other: 1 }, descriptor: descriptor
+      ) { :w }
 
       stats = ro_store.stats
       expect(stats[:writes]).to eq(0)
@@ -678,7 +750,7 @@ RSpec.describe Rigor::Cache::Store do
     it "memoises within the same instance so repeated lookups skip the producer" do
       called = 0
       2.times do
-        ro_store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) do
+        ro_store.fetch_or_compute(producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor) do
           called += 1
           :v
         end
@@ -690,12 +762,12 @@ RSpec.describe Rigor::Cache::Store do
 
   describe "read-only marker gate (ABI safety)" do
     it "treats a stale marker as unavailable: no disk hit, no recompute writeback" do
-      store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) { :warm }
+      store.fetch_or_compute(producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor) { :warm }
       File.write(File.join(cache_root, "schema_version.txt"), "stale-marker\n")
 
       ro = described_class.new(root: cache_root, read_only: true)
       called = 0
-      result = ro.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) do
+      result = ro.fetch_or_compute(producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor) do
         called += 1
         :recomputed
       end
@@ -711,7 +783,7 @@ RSpec.describe Rigor::Cache::Store do
 
       ro = described_class.new(root: cache_root, read_only: true)
       called = 0
-      result = ro.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) do
+      result = ro.fetch_or_compute(producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor) do
         called += 1
         :produced
       end
@@ -727,7 +799,9 @@ RSpec.describe Rigor::Cache::Store do
       allow(FileUtils).to receive(:mkdir_p).and_raise(Errno::EACCES)
 
       called = 0
-      result = store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) do
+      result = store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) do
         called += 1
         :produced
       end
@@ -736,7 +810,9 @@ RSpec.describe Rigor::Cache::Store do
 
       # Same instance, same lookup: served from the in-process memo, never re-attempts disk.
       called_again = 0
-      result_again = store.fetch_or_compute(producer_id: "p", params: {}, descriptor: descriptor) do
+      result_again = store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) do
         called_again += 1
         :ignored
       end
@@ -745,40 +821,118 @@ RSpec.describe Rigor::Cache::Store do
     end
   end
 
-  describe "#evict! (generation cap for whole-project producers, ADR-54 follow-up)" do
+  describe "#evict! (producer-declared generation cap, issue #151)" do
     def cache_key_path(producer_id, params)
       key = Rigor::Cache::Descriptor.new.cache_key_for(producer_id: producer_id, params: params)
       File.join(cache_root, producer_id, key[0, 2], "#{key[2..]}.entry")
     end
 
-    it "keeps only the cap for a listed producer, removing the oldest generations first, " \
-       "even when max_bytes is nil" do
-      st = described_class.new(root: cache_root, max_bytes: nil)
-      paths = Array.new(4) do |i|
-        st.fetch_or_compute(
-          producer_id: "rbs.environment", params: { i: i }, descriptor: Rigor::Cache::Descriptor.new
+    # Writes `count` generations of `producer_id` under `target`, forcing a deterministic write-order mtime
+    # (same-millisecond writes would otherwise tie), and returns the entry paths oldest-first.
+    def write_generations(target, producer_id, count, generation_cap:)
+      Array.new(count) do |i|
+        target.fetch_or_compute(
+          producer_id: producer_id, generation_cap: generation_cap,
+          params: { i: i }, descriptor: Rigor::Cache::Descriptor.new
         ) { i }
-        path = cache_key_path("rbs.environment", { i: i })
-        # Force a deterministic write-order mtime; same-millisecond writes would otherwise tie.
-        stamp = Time.now - (10 - i)
+        path = cache_key_path(producer_id, { i: i })
+        stamp = Time.now - (60 - i)
         File.utime(stamp, stamp, path)
         path
       end
+    end
+
+    it "keeps only the cap a producer declared, removing the oldest generations first, " \
+       "even when max_bytes is nil" do
+      st = described_class.new(root: cache_root, max_bytes: nil)
+      paths = write_generations(st, "whole.project", 4, generation_cap: 2)
 
       st.evict!
 
-      remaining = Dir.glob(File.join(cache_root, "rbs.environment", "**", "*.entry"))
+      remaining = Dir.glob(File.join(cache_root, "whole.project", "**", "*.entry"))
       expect(remaining.size).to eq(2)
       expect(remaining).to contain_exactly(paths[2], paths[3])
     end
 
-    it "does not cap a producer absent from the allow-list" do
+    it "leaves a producer that declared :unbounded alone (many entries live at once)" do
       st = described_class.new(root: cache_root, max_bytes: nil)
-      5.times { |i| st.fetch_or_compute(producer_id: "custom.thing", params: { i: i }, descriptor: descriptor) { i } }
+      write_generations(st, "custom.thing", 5, generation_cap: :unbounded)
 
       st.evict!
 
       expect(Dir.glob(File.join(cache_root, "custom.thing", "**", "*.entry")).size).to eq(5)
+    end
+
+    it "leaves a producer this Store never saw declared alone (errs toward under-evicting)" do
+      described_class.new(root: cache_root, max_bytes: nil)
+                     .then do |st|
+        write_generations(st, "whole.project", 4,
+                          generation_cap: 2)
+      end
+
+      # A second Store over the same root: nothing declared `whole.project` to IT, so its compaction pass
+      # has no cap to apply — the entries survive rather than being evicted on a guess.
+      described_class.new(root: cache_root, max_bytes: nil).evict!
+
+      expect(Dir.glob(File.join(cache_root, "whole.project", "**", "*.entry")).size).to eq(4)
+    end
+
+    it "rejects a fetch that declares no generation_cap at all" do
+      expect do
+        store.fetch_or_compute(producer_id: "whole.project", params: {}, descriptor: descriptor) { :v }
+      end.to raise_error(ArgumentError, /missing keyword: :generation_cap/)
+
+      expect do
+        store.fetch_or_validate(producer_id: "whole.project", key_descriptor: descriptor) { [:v, descriptor] }
+      end.to raise_error(ArgumentError, /missing keyword: :generation_cap/)
+    end
+
+    it "rejects a generation_cap that is neither a positive Integer nor :unbounded" do
+      [nil, 0, -1, "2", :whatever].each do |bad|
+        expect do
+          store.fetch_or_compute(
+            producer_id: "whole.project", generation_cap: bad, params: {}, descriptor: descriptor
+          ) { :v }
+        end.to raise_error(ArgumentError, /must declare generation_cap as a positive Integer/)
+      end
+    end
+
+    it "rejects two different caps for one producer id in one Store" do
+      store.fetch_or_compute(producer_id: "whole.project", generation_cap: 2, params: {}, descriptor: descriptor) { :v }
+
+      expect do
+        store.fetch_or_compute(
+          producer_id: "whole.project", generation_cap: 4, params: { other: 1 }, descriptor: descriptor
+        ) { :v }
+      end.to raise_error(ArgumentError, /must declare one cap/)
+    end
+
+    describe "the caps the bundled producers declare (pre-#151 parity)" do
+      it "matches the values the removed GENERATION_CAP_BY_PRODUCER allow-list carried" do
+        rbs_producers = [
+          Rigor::Cache::RbsEnvironment, Rigor::Cache::RbsKnownClassNames, Rigor::Cache::RbsConstantTable,
+          Rigor::Cache::RbsClassTypeParamNames, Rigor::Cache::RbsClassAncestorTable
+        ]
+        expect(rbs_producers.map { |p| [p::PRODUCER_ID, p.generation_cap] }).to contain_exactly(
+          ["rbs.environment", 2], ["rbs.known_class_names", 2], ["rbs.constant_type_table", 2],
+          ["rbs.class_type_param_names", 2], ["rbs.class_ancestor_table", 2]
+        )
+        expect(Rigor::Analysis::RunCacheKey::RUN_DIAGNOSTICS_PRODUCER_ID).to eq("analysis.run-diagnostics")
+        expect(Rigor::Analysis::RunCacheKey::GENERATION_CAP).to eq(16)
+      end
+
+      it "caps a producer whose declared cap is inherited from RbsCacheProducer" do
+        st = described_class.new(root: cache_root, max_bytes: nil)
+        # A whole-project producer added later: it declares nothing of its own, and inherits the base's cap
+        # rather than silently escaping compaction.
+        cap = Class.new(Rigor::Cache::RbsCacheProducer).generation_cap
+        paths = write_generations(st, "rbs.environment", 4, generation_cap: cap)
+
+        st.evict!
+
+        expect(Dir.glob(File.join(cache_root, "rbs.environment", "**", "*.entry")))
+          .to contain_exactly(paths[2], paths[3])
+      end
     end
   end
 

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -461,7 +461,9 @@ RSpec.describe Rigor::CLI do
         cache_root = File.join(tmpdir, ".rigor", "cache")
         store = Rigor::Cache::Store.new(root: cache_root)
         descriptor = Rigor::Cache::Descriptor.new
-        store.fetch_or_compute(producer_id: "demo", params: {}, descriptor: descriptor) { :seed }
+        store.fetch_or_compute(
+          producer_id: "demo", generation_cap: :unbounded, params: {}, descriptor: descriptor
+        ) { :seed }
 
         status, out, _err = run_cli("check", "--cache-stats", "a.rb")
         expect(status).to eq(0)

--- a/spec/rigor/plugin/cache_producer_spec.rb
+++ b/spec/rigor/plugin/cache_producer_spec.rb
@@ -249,6 +249,51 @@ RSpec.describe Rigor::Plugin::Base, # rubocop:disable RSpec/SpecFilePathFormat
     end
   end
 
+  # Issue #151 — the producer, not a table inside `Cache::Store`, states how many of its generations survive
+  # a compaction pass. A plugin producer keeps many entries live at once, so the default opts out.
+  describe ".producer generation_cap: (issue #151)" do
+    it "defaults to :unbounded and accepts a positive Integer" do
+      klass = Class.new(described_class) do
+        manifest(id: "alpha", version: "0.1.0")
+        producer(:many) { |_p| 1 }
+        producer(:whole_project, generation_cap: 2) { |_p| 2 }
+      end
+
+      expect(klass.producers[:many][:generation_cap]).to eq(Rigor::Cache::Store::UNBOUNDED_GENERATIONS)
+      expect(klass.producers[:whole_project][:generation_cap]).to eq(2)
+    end
+
+    it "rejects a non-positive / non-symbolic generation_cap at class-definition time" do
+      expect do
+        Class.new(described_class) do
+          manifest(id: "alpha", version: "0.1.0")
+          producer(:bad, generation_cap: 0) { |_p| 1 }
+        end
+      end.to raise_error(ArgumentError, /generation_cap: must be a positive Integer/)
+    end
+
+    it "threads the declared cap through cache_for into the Store" do
+      store = Rigor::Cache::Store.new(root: File.join(tmpdir, ".rigor", "cache"))
+      declared = []
+      allow(store).to receive(:fetch_or_validate).and_wrap_original do |original, **kwargs, &block|
+        declared << [kwargs[:producer_id], kwargs[:generation_cap]]
+        original.call(**kwargs, &block)
+      end
+      plugin_services = Rigor::Plugin::Services.new(
+        reflection: Rigor::Reflection, type: Rigor::Type::Combinator,
+        configuration: configuration, cache_store: store, trust_policy: trust_policy
+      )
+      klass = Class.new(described_class) do
+        manifest(id: "alpha", version: "0.1.0")
+        producer(:whole_project, generation_cap: 3) { |_p| :value }
+      end
+
+      klass.new(services: plugin_services).cache_for(:whole_project, params: {}).call
+
+      expect(declared).to eq([["plugin.alpha.whole_project", 3]])
+    end
+  end
+
   # ADR-60 WD3 — `cache_for` rides `Cache::Store#fetch_or_validate`: the entry is keyed on the stable identity inputs,
   # and the dependency descriptor (boundary reads + `watch:` globs) is recorded AFTER the producer block runs. Each
   # "session" below uses a FRESH `Cache::Store` (empty in-process memo) and a fresh plugin instance — the faithful

--- a/spec/rigor/public_api_drift_spec.rb
+++ b/spec/rigor/public_api_drift_spec.rb
@@ -212,7 +212,7 @@ module PublicApiDriftSnapshots # rubocop:disable Metrics/ModuleLength
     node_file_context_block()
     node_rule(req:node_type,block:block)
     node_rules()
-    producer(req:id,key:watch,key:serialize,key:deserialize,block:block)
+    producer(req:id,key:watch,key:serialize,key:deserialize,key:generation_cap,block:block)
     producers()
     suggest(req:name,req:candidates)
   ].freeze


### PR DESCRIPTION
Closes #151.

`GENERATION_CAP_BY_PRODUCER` was a hardcoded allow-list of six producer ids. A new whole-project producer was capped only if a maintainer remembered to edit a table in `Store` — and forgetting was **silent**, which is the failure mode worth designing away rather than documenting.

## The design, and the one break it costs

The cap now lives with the producer (`RbsCacheProducer.generation_cap` = 2, inherited by every `rbs.*` subclass; `RunCacheKey::GENERATION_CAP` = 16; `Plugin::Base.producer generation_cap:`) and rides every fetch call as a **required** keyword. Omitting it is an `ArgumentError` on the first fetch; a nonsense value raises naming the producer. There is no "no cap" state left to fall into, so an uncapped whole-project producer is not representable. `:unbounded` remains available but is now a positive declaration rather than an absence.

**Requiring the keyword rather than defaulting it is the load-bearing choice, and it is breaking**: a plugin reaching for the store directly instead of through `Plugin::Base.producer` must now pass one. `Rigor::Cache::*` sits in [`public-api.md`](docs/internal-spec/public-api.md)'s explicitly *not-locked* list, and no bundled plugin or example calls the store directly, so the blast radius is external callers only. It is recorded in the CHANGELOG as breaking, with `:unbounded` named as the exact previous behaviour.

A default was rejected because no single value is right for both whole-project and per-file producers: too low over-evicts and buys silent recomputes, too high reproduces the bug. A process-global producer registry was the other candidate and is worse for the same reason the table was — registering is exactly as forgettable as tabulating, and a global mutable map is a shareability hazard for the pool.

## The empirical half of the issue

The issue also asked whether `analysis.run-diagnostics => 16` holds up in real usage. **It was measured, not assumed.** Across 29 project caches on this machine it binds in exactly one — the rigor-rs differential-testing workspace:

- 16 live entries against **57 shard directories, 44 of them empty** — the fossils of entries `evict!` unlinked. The cache totals 2.3 MB against the 256 MB `max_bytes` default, so the LRU pass cannot have done it.
- Decoding the 16 survivors' descriptors shows the churn is **entirely path-set variation**: `configuration`, `engine`, `rbs.libraries` and `gem:rbs` are byte-identical across all 16. Exactly the multi-invocation-path hypothesis the issue raised.

So the cap demonstrably fires. But nothing on disk can show whether an evicted generation was later *wanted* again, so **the value stays at 16** and the finding is recorded beside it. Proving 16 too small needs a miss-after-evict counter, not more archaeology.

## Which way each decision errs

- **Undeclared producer id ⇒ uncapped (under-evict).** The only behavioural difference from the old table. Safe by construction: a producer not consulted this run also wrote no new generation, so growth and compaction are triggered by the same call.
- **`:unbounded` for per-file and plugin producers ⇒ under-evict**, identical to their pre-#151 absence from the table.
- **The six existing caps ⇒ unchanged**, pinned by a parity example.
- **Conflicting redeclaration of one id ⇒ raise.** The one place loud was chosen over lenient: two different caps for one producer in one process is a producer bug, and whichever cap compaction picked would be arbitrary.

## Verification

`make verify` green — 8,192 examples across 12 workers, `make check` + `make check-plugins` clean. `spec/rigor/cache/` 196 examples, `make docs-check` 311, `make lint` clean, `git diff --check` clean. `cache.md`, `plugin-cache-producers.md` and ADR-54's allow-list wording are updated in the same change.

## Incidental, worth its own issue

`evict_excess_generations` unlinks entries but leaves the empty shard directories behind forever — 44 of them in that one producer. Harmless and inode-only, but it is why the eviction archaeology above was possible at all.