### PR TITLE
Add rigor skill describe --deep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Added
+
+- **[skill]** `rigor skill describe --deep` (also `rigor describe --deep`) runs `rigor check` before recommending a next step, so the headline routes on what the analysis actually found — a broken setup to `rigor-doctor`, project monkey-patches to `rigor-monkeypatch-resolve`, remaining errors to `rigor-baseline-reduce` — while the un-flagged command stays the fast, presence-only probe that never runs an analysis ([#148](https://github.com/rigortype/rigor/issues/148)).
+
 ### Changed
 
 - **[plugin API]** `Plugin::Base.producer` accepts a `generation_cap:` declaring how many generations of a producer's cache entries survive a compaction pass; it defaults to the previous behaviour (unbounded, reaped only by the `cache.max_bytes` LRU pass), so a whole-project producer that orphans its previous entry on every run can now keep its own cache slice from growing ([#151](https://github.com/rigortype/rigor/issues/151)).

--- a/docs/adr/73-skill-driven-user-experience.md
+++ b/docs/adr/73-skill-driven-user-experience.md
@@ -177,9 +177,26 @@ analysis.
   `check` result and route on its error clusters (no new analysis, still
   side-effect-free); (b) a `rigor skill describe --deep` opt-in that runs
   a scoped check first (default stays pure). Criterion if pursued: never
-  make the *default* `describe` run `check`. **Deferred** — the landed
-  agent-prompt routing may suffice; revisit if the headline itself proves
-  to mislead in practice.
+  make the *default* `describe` run `check`.
+  **Settled as shape (b), landed 2026-07-25** ([#148](https://github.com/rigortype/rigor/issues/148)):
+  `rigor skill describe --deep` runs a real `rigor check` — with the
+  configured cache and workers, so it is slow and *does* write
+  `.rigor/cache` — and lets the result pick the headline. WD2 is
+  untouched: the un-flagged command is still presence-only and
+  side-effect-free, enforced by load boundary rather than by discipline
+  (`CLI::SkillDeepProbe` is the only file that runs an analysis, and
+  `CLI::SkillDescribe` requires it only under the flag, so a default
+  `describe` never loads the engine). The prerequisite named above landed
+  first as `CLI::CheckInvocation` — the shared "run check →
+  `Analysis::Result`" entry point `check`, `doctor`, and `describe
+  --deep` now all go through. Routing reuses the agent-prompt vocabulary
+  verbatim (empty RBS env / `configuration-error` → `rigor-doctor`;
+  `project_definition_site`-proven monkey-patches →
+  `rigor-monkeypatch-resolve`; remaining errors →
+  `rigor-baseline-reduce`), and deliberately declines the weaker
+  `Dynamic`-framework-call signal: a check that cannot run, or a signal
+  that is only a guess, degrades to the presence-only recommendation
+  rather than routing someone into the wrong workflow.
 - **`rbs-setup` priority softening.** The trial found the `rbs-setup`
   headline over-recommended. **Landed 2026-06-20:** a configured Rails
   project with no Rails plugins enabled now recommends `rigor-plugin-tune`

--- a/docs/manual/02-cli-reference.md
+++ b/docs/manual/02-cli-reference.md
@@ -479,6 +479,7 @@ so a skill can never be shadowed by a verb.
 
 ```sh
 rigor skill [<name>] [--full <name>] [--path <name>] [--list] [--describe]
+rigor skill describe [--deep]
 ```
 
 | Form | Purpose |
@@ -488,6 +489,33 @@ rigor skill [<name>] [--full <name>] [--path <name>] [--list] [--describe]
 | `--full <name>` | Print the `SKILL.md` body **followed by every `references/*.md` inline** — the complete, version-current procedure in one call. This is what a skill's "First: load the version-current copy" directive points at, so a copy vendored into a project (e.g. via `npx skills add`) re-fetches its current steps from the installed gem instead of following a frozen copy. |
 | `--path <name>` | Print the single-line absolute `SKILL.md` path, suitable as input to a file-reading tool. |
 | `--describe` | Probe the project's state (config / baseline / `sig/` / CI — presence only, never runs `rigor check`) and recommend the next skill to run. Also spelled `describe`; surfaced top-level as [`rigor describe`](#rigor-describe) below. |
+| `describe --deep` | The same report, except it **runs `rigor check` first** and routes the headline recommendation on the result. Opt-in, because it costs a full analysis and writes `.rigor/cache` — the un-flagged form stays presence-only and side-effect-free. |
+
+### `describe --deep`
+
+By default the recommendation comes from a presence-only probe, so it can
+tell that a project *has* a config but not whether the analysis is
+healthy. `--deep` runs the check for you and lets the result pick the
+headline, using the same routing the `## For the agent` section already
+teaches:
+
+| Deep check result | Headline becomes |
+| --- | --- |
+| RBS environment built to 0 classes, or a `configuration-error` diagnostic | `rigor-doctor` — the analysis is hollow until the setup is fixed. |
+| Call sites resolving to the project's own definitions (reopened core / gem classes), as at least a third of the errors | `rigor-monkeypatch-resolve` — list them in `pre_eval:` and they clear wholesale. |
+| Any remaining error diagnostics | `rigor-baseline-reduce`. Proven monkey-patch sites below that share are still reported here, so the finding survives even when the headline stays on the larger problem. |
+| Clean, or the project has no config yet | Unchanged — the presence-only recommendation stands. |
+
+If the check **cannot run at all** (no config, an unloadable plugin, a
+malformed config) `--deep` does not fail and does not pretend the project
+is clean: it reports what went wrong, falls back to the presence-only
+recommendation, and points you at `rigor doctor`. It deliberately does
+*not* route on weaker signals — "framework calls typing as `Dynamic`" is
+still a judgement call left to you and your agent.
+
+```sh
+rigor skill describe --deep   # also: rigor describe --deep
+```
 
 The verb spellings `rigor skill list` / `print <name>` / `path <name>`
 were **removed in v0.3.0** — the positional slot is a skill name, so
@@ -510,6 +538,10 @@ It reports a presence-only project-state probe (does a `.rigor.yml`,
 `.rigor-baseline.yml`, `sig/` directory, or CI integration exist?) and a
 recommended next skill. It is read-only and side-effect-free — it never
 runs `rigor check`. Identical output to `rigor skill describe`.
+
+`rigor describe --deep` forwards to
+[`rigor skill describe --deep`](#rigor-skill), which opts into running the
+check first — slow, and it writes the cache.
 
 ## `rigor docs`
 

--- a/docs/manual/08-skills.md
+++ b/docs/manual/08-skills.md
@@ -106,6 +106,7 @@ source checkout. The `rigor skill` command surfaces them:
 
 ```sh
 rigor skill describe        # probe the project + recommend the next skill (alias: rigor describe)
+rigor skill describe --deep # same, but run `rigor check` first and route on its result
 rigor skill --list          # name + absolute path for each bundled skill
 rigor skill <name>          # print the SKILL.md body (with a references/ header)
 rigor skill --full <name>   # the body + every references/*.md inline (complete procedure)
@@ -113,7 +114,11 @@ rigor skill --path <name>   # one-line absolute SKILL.md path, for a file-readin
 ```
 
 `rigor skill describe` is the recommendation engine driven by
-`rigor-next-steps`; `rigor skill rigor-project-init` is the
+`rigor-next-steps`. It is a presence-only probe by default — cheap and
+side-effect-free; add `--deep` when you want the recommendation to come
+from a real analysis instead
+([CLI reference](02-cli-reference.md#describe---deep)).
+`rigor skill rigor-project-init` is the
 canonical way to hand an agent the onboarding workflow without pointing
 it at the repository. The `list` / `print` / `path` verb spellings are
 deprecated (removed in v0.3.0). See [CLI reference](02-cli-reference.md#rigor-skill).

--- a/lib/rigor/cli/check_command.rb
+++ b/lib/rigor/cli/check_command.rb
@@ -65,11 +65,12 @@ module Rigor
         special = dispatch_special_check_mode(configuration, options, cache_root)
         return special unless special.nil?
 
-        runner = build_check_runner(
+        invocation = invoke_check(
           configuration: configuration, options: options,
           buffer: buffer, cache_root: cache_root
         )
-        raw_result = runner.run(@argv.empty? ? configuration.paths : @argv)
+        runner = invocation.runner
+        raw_result = invocation.result
         result = apply_baseline_filter(raw_result, configuration, options)
 
         coverage = compute_coverage(runner, configuration, options)
@@ -383,11 +384,16 @@ module Rigor
         @err.puts("rigor: #{silenced_count} diagnostic(s) silenced by baseline #{baseline_path}")
       end
 
-      def build_check_runner(configuration:, options:, buffer:, cache_root:)
-        require_relative "check_runner_factory"
-        CheckRunnerFactory.build(
+      # The primary check run, routed through the shared {CheckInvocation} entry point so `rigor doctor` and
+      # `rigor skill describe --deep` reach a result through this exact path rather than re-deriving it (#148).
+      # Required lazily for the reason the old inline `CheckRunnerFactory.build` was: it pulls the inference engine,
+      # and ADR-87 WD4's cache-hit fast path must reach its verdict without it.
+      def invoke_check(configuration:, options:, buffer:, cache_root:)
+        require_relative "check_invocation"
+        CheckInvocation.run(
           configuration: configuration, options: options,
-          buffer: buffer, cache_root: cache_root
+          buffer: buffer, cache_root: cache_root,
+          paths: @argv.empty? ? nil : @argv
         )
       end
 

--- a/lib/rigor/cli/check_invocation.rb
+++ b/lib/rigor/cli/check_invocation.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Rigor
+  class CLI
+    # The one place a CLI command turns a loaded {Configuration} into an {Analysis::Result}.
+    #
+    # {CheckRunnerFactory} builds the runner; this module owns the *invocation* wrapped around it — resolving the
+    # analysed paths, running, and handing back both the runner (`rigor check`'s reporting tail still needs its cache
+    # store and stats) and the raw result. It exists so a non-`check` command — `rigor doctor`, `rigor skill describe
+    # --deep` — reaches a check result through the same code path `rigor check` walks, instead of re-deriving the
+    # plumbing (issue #148; ADR-73 § "Field-trial follow-ups" names the shared helper as the prerequisite).
+    #
+    # Nothing here is required at load time: {CheckRunnerFactory} pulls the inference engine, so both entry points
+    # require it lazily. A command that merely *mentions* this module therefore stays engine-free until it actually
+    # runs an analysis — the property ADR-87 WD4 protects for `rigor check`'s cache-hit fast path, and the property
+    # that keeps an un-flagged `rigor skill describe` from loading the engine at all.
+    module CheckInvocation
+      # A completed analysis. `runner` is exposed because `rigor check`'s tail reads its `cache_store` (eviction,
+      # `--cache-stats`) and feeds it to `--coverage`; `result` is the raw, pre-baseline-filter {Analysis::Result}.
+      Invocation = Data.define(:runner, :result)
+
+      # The outcome of {.attempt} — the best-effort variant. Exactly one of the two is non-nil, so a caller can never
+      # read "the check could not run" as "the check ran clean": `result` is nil precisely when `error` is set.
+      Outcome = Data.define(:result, :error) do
+        # @return [Boolean] true when an analysis actually completed.
+        def ran?
+          !result.nil?
+        end
+      end
+
+      # Options for a caller that wants a check *result* rather than a check *run*: no cache writes, no explain
+      # traces, sequential. `stats: true` because the RBS-environment signal (`stats.rbs_classes_total`) lives there.
+      # This is `rigor doctor`'s preset — a diagnostic command that must not churn the project's cache.
+      READ_ONLY_OPTIONS = { no_cache: true, explain: false, stats: true, workers: 0 }.freeze
+
+      # Options for an opt-in deep probe (`rigor skill describe --deep`). Unlike {READ_ONLY_OPTIONS} this uses the
+      # configured cache and worker count, i.e. it behaves exactly like `rigor check` — fast on a warm cache, and it
+      # WRITES `.rigor/cache`. That side effect is the whole reason the flag is opt-in.
+      DEEP_OPTIONS = { no_cache: false, explain: false, stats: true, workers: nil }.freeze
+
+      module_function
+
+      # Runs the analysis the way `rigor check` does and returns the runner + its raw result.
+      #
+      # @param configuration [Rigor::Configuration]
+      # @param options [Hash] at least `:no_cache`, `:explain`, `:stats`, `:workers` (see {CheckRunnerFactory.build}).
+      # @param paths [Array<String>, nil] analysed paths; nil falls back to the configuration's `paths:`.
+      # @param buffer [Rigor::Analysis::BufferBinding, nil]
+      # @param cache_root [String, nil] nil falls back to the configuration's cache path.
+      # @return [Invocation]
+      def run(configuration:, options:, paths: nil, buffer: nil, cache_root: nil)
+        require_relative "check_runner_factory"
+        runner = CheckRunnerFactory.build(
+          configuration: configuration,
+          options: options,
+          buffer: buffer,
+          cache_root: cache_root || configuration.cache_path
+        )
+        Invocation.new(runner: runner, result: runner.run(paths || configuration.paths))
+      end
+
+      # Best-effort variant for a *routing* caller: one that wants to sharpen a recommendation with check evidence and
+      # has a perfectly good answer when there is none. Loads the configuration itself and converts every way the run
+      # can fail outright — an unreadable / invalid config, an unloadable plugin, an engine error — into an {Outcome}
+      # carrying a short human-readable `error`. It never raises and never fabricates a clean result.
+      #
+      # Deliberately broad: the caller's contract is "degrade to the presence-only answer, whatever went wrong". A
+      # routing hint is outside the false-positive envelope, but a crash in it is not — `describe` must stay a command
+      # an agent can run freely.
+      #
+      # @param config_path [String, nil] path to the config file; nil uses {Configuration.discover}.
+      # @param options [Hash] runner options (defaults to {DEEP_OPTIONS}).
+      # @param paths [Array<String>, nil]
+      # @return [Outcome]
+      def attempt(config_path: nil, options: DEEP_OPTIONS, paths: nil)
+        require_relative "../configuration"
+        configuration = Configuration.load(config_path)
+        Outcome.new(result: run(configuration: configuration, options: options, paths: paths).result, error: nil)
+      rescue StandardError, LoadError => e
+        Outcome.new(result: nil, error: "#{e.class}: #{e.message.to_s.lines.first.to_s.strip}")
+      end
+    end
+  end
+end

--- a/lib/rigor/cli/doctor_command.rb
+++ b/lib/rigor/cli/doctor_command.rb
@@ -12,7 +12,7 @@ require_relative "../plugin/loader"
 require_relative "../plugin/services"
 require_relative "../reflection"
 require_relative "../type/combinator"
-require_relative "check_runner_factory"
+require_relative "check_invocation"
 require_relative "command"
 require_relative "options"
 
@@ -53,14 +53,12 @@ module Rigor
         findings.concat(audit_config(configuration))
 
         # 2. Run a scoped analysis to gather stats + diagnostics for the
-        #    deeper checks.  Use no-cache so the probe doesn't churn disk.
-        runner = CheckRunnerFactory.build(
+        #    deeper checks, through the shared check-invocation entry point (#148).
+        #    `READ_ONLY_OPTIONS` is no-cache so the probe doesn't churn disk.
+        result = CheckInvocation.run(
           configuration: configuration,
-          options: { no_cache: true, explain: false, stats: true, workers: 0 },
-          buffer: nil,
-          cache_root: configuration.cache_path
-        )
-        result = runner.run(configuration.paths)
+          options: CheckInvocation::READ_ONLY_OPTIONS
+        ).result
 
         # 3. RBS environment check.
         findings.concat(check_rbs_environment(result))

--- a/lib/rigor/cli/skill_command.rb
+++ b/lib/rigor/cli/skill_command.rb
@@ -36,6 +36,13 @@ module Rigor
     #                                version-coupled guidance is frozen into
     #                                the SKILL. Also spelled `describe`, and
     #                                surfaced top-level as `rigor describe`.
+    # - `rigor skill describe --deep`
+    #                              — the same report, except it runs `rigor
+    #                                check` first and lets the result pick the
+    #                                headline. Opt-in because that is slow and
+    #                                writes the cache; the un-flagged form keeps
+    #                                WD2's presence-only, side-effect-free
+    #                                contract exactly (issue #148).
     #
     # `describe` is a no-argument action, not a name-slot verb, so it stays first-class alongside `--describe`.
     class SkillCommand < Command
@@ -51,6 +58,10 @@ module Rigor
           rigor skill --path <name>  Print the absolute path of the SKILL.md file for <name>
           rigor skill --list         List bundled skills (name + absolute path)
           rigor skill --describe     Report project state + recommend the next skill to run
+                                     (presence-only probe — never runs `rigor check`)
+          rigor skill describe --deep
+                                     Same, but run `rigor check` first and route the
+                                     recommendation on its result (slow; writes the cache)
 
         Examples:
           rigor skill
@@ -58,6 +69,7 @@ module Rigor
           rigor skill --full rigor-baseline-reduce
           rigor skill --path rigor-baseline-reduce
           rigor skill --describe        (also: rigor describe)
+          rigor skill describe --deep   (also: rigor describe --deep)
       USAGE
 
       # The bundled skills live at `<gem_root>/skills/`. From `lib/rigor/cli/skill_command.rb` that is three directories
@@ -159,10 +171,18 @@ module Rigor
       # probes the current project's state with cheap presence checks (it never runs `rigor check`), recommends the next
       # skill to run, and prints every bundled skill's current frontmatter description, so the `rigor-next-steps` SKILL
       # can route without copying any version-coupled guidance into itself.
+      #
+      # `--deep` is the one opt-in that breaks the "never runs `rigor check`" guarantee — and only for the invocation
+      # that asks for it (issue #148 / ADR-73 § "Field-trial follow-ups"). It runs a real check and lets the result
+      # pick the headline; the un-flagged command is unchanged, down to loading no analysis code at all.
       def run_describe
+        deep = !@argv.delete("--deep").nil?
+        unknown = @argv.first
+        return usage_error("unknown option for `describe`: #{unknown}") unless unknown.nil?
+
         require_relative "skill_describe"
 
-        @out.puts(SkillDescribe.new(skills: discover_skills).render)
+        @out.puts(SkillDescribe.new(skills: discover_skills, deep: deep).render)
         0
       end
 

--- a/lib/rigor/cli/skill_deep_probe.rb
+++ b/lib/rigor/cli/skill_deep_probe.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require_relative "check_invocation"
+
+module Rigor
+  class CLI
+    # `rigor skill describe --deep` — the one part of `describe` that runs an analysis (issue #148; ADR-73
+    # § "Field-trial follow-ups", the "headline check-awareness" open decision, shape (b)).
+    #
+    # **The boundary is this file.** ADR-73 WD2 makes `describe` presence-only and side-effect-free, and that
+    # guardrail binds the *un-flagged* command exactly as before: {SkillDescribe} requires this file only when
+    # `--deep` was passed, so a default `rigor skill describe` never loads the inference engine, never opens a
+    # project source file, and writes nothing. `--deep` is the opt-in that trades that purity away: it runs a real
+    # `rigor check` over the configured paths using the configured cache and worker count, so it is as slow as
+    # `rigor check` on a cold cache and it WRITES `.rigor/cache` just like `rigor check` does.
+    #
+    # The routing vocabulary is deliberately the one `describe`'s "For the agent" section already teaches (errors →
+    # `rigor-baseline-reduce`, a proven monkey-patch cluster → `rigor-monkeypatch-resolve`, an empty RBS environment
+    # or a `configuration-error` → `rigor-doctor`). `--deep` makes the headline compute the call the agent would
+    # otherwise make from the same evidence; it does not introduce a second taxonomy.
+    class SkillDeepProbe
+      # Diagnostics the engine emits when the *setup* is broken rather than the code — the `rigor-doctor` signal.
+      CONFIGURATION_ERROR_RULE = "configuration-error"
+
+      # The share of a run's errors that must be proven monkey-patches before the headline routes to
+      # `rigor-monkeypatch-resolve` rather than `rigor-baseline-reduce`. The agent-prompt vocabulary this reuses says
+      # "a monkey-patch *cluster*", and a cluster is what makes the workflow the right one: `pre_eval:` clears those
+      # sites wholesale, so it is the shortest path only when clearing them materially changes the count. One proven
+      # site beside four hundred unrelated errors is a true finding pointing at the wrong workflow — the report says
+      # so in the reason line either way, so nothing is lost by leaving the headline on the bigger problem.
+      MONKEY_PATCH_CLUSTER_SHARE = Rational(1, 3)
+
+      # What the deep check concluded.
+      #
+      # - `status` — `:skipped` (no config to check), `:error` (the check could not run), `:analyzed` (it ran).
+      # - `detail` — the human line printed under "## Deep check"; on `:error` it says so outright, because a check
+      #   that could not run is NOT a clean check and the report must never let it read as one.
+      # - `route` / `reason` — the headline override, or nil to leave the presence-only recommendation standing.
+      Report = Data.define(:status, :detail, :route, :reason) do
+        # @return [Boolean] true when the check did not complete — the caller must then say so rather than let the
+        #   fallback recommendation read as an all-clear.
+        def failed?
+          status == :error
+        end
+      end
+
+      # @param config [String, nil] the config filename the presence probe found, relative to `root`.
+      # @param root [String] project root (the analysis itself resolves paths against the process cwd, as
+      #   `rigor check` does).
+      def initialize(config:, root: Dir.pwd)
+        @config = config
+        @root = root
+      end
+
+      # @return [Report] never raises — every failure degrades to a `:error`/`:skipped` report whose `route` is nil,
+      #   leaving the presence-only headline in charge.
+      def run
+        if @config.nil?
+          return Report.new(
+            status: :skipped, route: nil, reason: nil,
+            detail: "skipped — this project has no Rigor configuration, so there is nothing to check yet."
+          )
+        end
+
+        outcome = CheckInvocation.attempt(config_path: File.join(@root, @config))
+        return failed(outcome.error) unless outcome.ran?
+
+        classify(outcome.result)
+      end
+
+      private
+
+      # A check that could not run at all. Reported as a failure, not as a clean result, and with the raw error text
+      # so the user can act on it — the un-run check is itself a finding, but not one precise enough to route on.
+      def failed(error)
+        Report.new(
+          status: :error, route: nil, reason: nil,
+          detail: "the check could NOT run: #{error}. This is not a clean result — the recommendation below " \
+                  "falls back to the presence-only probe. Run `rigor check` (or `rigor doctor`) to see what failed."
+        )
+      end
+
+      def classify(result)
+        sites = monkey_patch_diagnostics(result)
+        if broken_environment?(result)
+          doctor_report(result)
+        elsif monkey_patch_cluster?(result, sites)
+          monkeypatch_report(result, sites)
+        elsif result.error_count.positive?
+          baseline_report(result, sites)
+        else
+          Report.new(
+            status: :analyzed, route: nil, reason: nil,
+            detail: "the check ran clean — 0 error diagnostics. The recommendation below is the presence-only one."
+          )
+        end
+      end
+
+      # The `rigor-doctor` signal, read exactly as `rigor doctor` itself reads it: an RBS environment that built to
+      # zero classes (analysis is hollow, so every other count is meaningless), or a `configuration-error` the run
+      # already emitted. Checked first — with a broken setup the remaining diagnostics are not evidence of anything.
+      def broken_environment?(result)
+        result.stats&.rbs_classes_total&.zero? ||
+          result.diagnostics.any? { |diagnostic| diagnostic.rule == CONFIGURATION_ERROR_RULE }
+      end
+
+      # ADR-17 / the `project-monkey-patch-known` triage recogniser: `call.undefined-method` sets
+      # `project_definition_site` when the project itself defines the called method on the receiver class somewhere
+      # in the analysed file set. That is engine-proven evidence, not a spread heuristic, which is why it routes with
+      # no count threshold — and why the *unproven* shapes (a bare `call.unresolved-toplevel` count, "framework calls
+      # typing as Dynamic") are deliberately not routed on here. Guessing a workflow from a weak signal is worse than
+      # leaving the generic recommendation standing.
+      def monkey_patch_diagnostics(result)
+        result.diagnostics.select(&:project_definition_site)
+      end
+
+      # Whether the proven sites dominate the run enough for `pre_eval:` to be the shortest path. Any proven site is
+      # real evidence — `project_definition_site` is engine-proven, not a spread heuristic — but evidence of a *site*
+      # is not evidence that clearing it is the next thing to do. Below the share, `baseline_report` still names the
+      # sites, so the finding survives even when the headline does not follow it.
+      def monkey_patch_cluster?(result, sites)
+        return false if sites.empty?
+        return true unless result.error_count.positive?
+
+        Rational(sites.size, result.error_count) >= MONKEY_PATCH_CLUSTER_SHARE
+      end
+
+      def doctor_report(result)
+        classes = result.stats&.rbs_classes_total
+        cause = if classes&.zero?
+                  "the RBS environment built to 0 classes"
+                else
+                  "the run emitted a `#{CONFIGURATION_ERROR_RULE}` diagnostic"
+                end
+        Report.new(
+          status: :analyzed, route: "rigor-doctor",
+          reason: "a `--deep` check found a broken setup (#{cause}) — the analysis is hollow until that is fixed, " \
+                  "so no other finding is trustworthy yet.",
+          detail: "the check found a broken setup — #{cause}."
+        )
+      end
+
+      def monkeypatch_report(result, sites)
+        files = sites.filter_map { |d| d.project_definition_site&.sub(/:\d+\z/, "") }.uniq.sort
+        Report.new(
+          status: :analyzed, route: "rigor-monkeypatch-resolve",
+          reason: "a `--deep` check found #{sites.size} call site(s) that resolve to the project's own definitions " \
+                  "in #{files.first(3).join(', ')} — reopened classes Rigor does not apply cross-file. Listing " \
+                  "them in `pre_eval:` clears them wholesale.",
+          detail: "the check reported #{result.error_count} error diagnostic(s), #{sites.size} of them proven " \
+                  "project monkey-patches (#{files.size} file(s))."
+        )
+      end
+
+      def baseline_report(result, sites = [])
+        aside = if sites.empty?
+                  ""
+                else
+                  " #{sites.size} of them are proven project monkey-patches — too small a share to make `pre_eval:` " \
+                    "the shortest path, but `rigor-monkeypatch-resolve` clears them if you want them gone first."
+                end
+        Report.new(
+          status: :analyzed, route: "rigor-baseline-reduce",
+          reason: "a `--deep` check reported #{result.error_count} error diagnostic(s) — work them down (or record " \
+                  "them in a baseline) before adding more surface.#{aside}",
+          detail: "the check reported #{result.error_count} error diagnostic(s), " \
+                  "#{sites.empty? ? 'none' : sites.size} of them proven project monkey-patches."
+        )
+      end
+    end
+  end
+end

--- a/lib/rigor/cli/skill_describe.rb
+++ b/lib/rigor/cli/skill_describe.rb
@@ -142,26 +142,42 @@ module Rigor
 
       # @param skills [Array<Hash>] discovered skills, each `{name:, path:}`.
       # @param root [String] project root to probe (defaults to the cwd).
-      def initialize(skills:, root: Dir.pwd)
+      # @param deep [Boolean] opt into `--deep`: run a real `rigor check` and let its result pick the headline. Off by
+      #   default, and off is ADR-73 WD2's contract — see {SkillDeepProbe} for why the whole analysis path lives
+      #   behind this one flag and in its own file.
+      def initialize(skills:, root: Dir.pwd, deep: false)
         @skills = skills
         @root = root
+        @deep = deep
       end
 
       # @return [String] the full describe report.
       def render
         catalog = catalog_skills
         state = ProjectStateProbe.new(@root).to_h
-        recommendation = recommend(state, catalog)
+        deep = deep_report(state)
+        recommendation = recommend(state, catalog, deep)
         [
           title,
           state_section(state),
+          deep_section(deep),
           recommendation_section(recommendation),
           catalog_section(catalog),
-          agent_prompt(recommendation)
-        ].join("\n")
+          agent_prompt(recommendation, deep)
+        ].compact.join("\n")
       end
 
       private
+
+      # The `--deep` analysis, or nil when the flag was not given. `require` sits here rather than at the top of the
+      # file so the default, presence-only path never even loads the check-invocation plumbing — WD2's "runs no
+      # analysis" guarantee is enforced by what gets loaded, not only by what gets called.
+      def deep_report(state)
+        return nil unless @deep
+
+        require_relative "skill_deep_probe"
+        SkillDeepProbe.new(config: state.fetch(:config), root: @root).run
+      end
 
       # The skills offered as "what to do next", in adoption-journey order. The entry-point skill is excluded, and
       # unknown skills sort after the known journey, alphabetically.
@@ -173,8 +189,12 @@ module Rigor
 
       # The decision tree (ADR-73 WD2). Returns `{ skill:, reason: }` for the recommended next step, or nil when no
       # catalogue skill matches.
-      def recommend(state, catalog)
-        name, reason = recommended_name_and_reason(state)
+      #
+      # A `--deep` report overrides the presence-only tree only when it actually routed: a check that was skipped,
+      # could not run, or ran clean leaves the tree's answer standing untouched. So the un-flagged behaviour is
+      # literally the `deep == nil` branch of this one method.
+      def recommend(state, catalog, deep = nil)
+        name, reason = deep&.route ? [deep.route, deep.reason] : recommended_name_and_reason(state)
         skill = catalog.find { |candidate| candidate.fetch(:name) == name }
         skill.nil? ? nil : { skill: skill, reason: reason }
       end
@@ -248,6 +268,18 @@ module Rigor
         STATE
       end
 
+      # Printed only under `--deep`, so the un-flagged report is byte-identical to what it has always been.
+      def deep_section(deep)
+        return nil if deep.nil?
+
+        <<~DEEP
+          ## Deep check (--deep)
+          A real `rigor check` was run for this recommendation — unlike the probe above it
+          is slow and it writes `.rigor/cache`, exactly as `rigor check` does.
+          - Result: #{deep.detail}
+        DEEP
+      end
+
       def recommendation_section(recommendation)
         return "## Recommended next step\n- (no bundled skill matched the current state)\n" if recommendation.nil?
 
@@ -267,7 +299,7 @@ module Rigor
         "## All skills you can run next\n#{lines.join("\n")}\n"
       end
 
-      def agent_prompt(recommendation)
+      def agent_prompt(recommendation, deep = nil)
         opener =
           if recommendation.nil?
             "Ask the user what they would like to do next"
@@ -279,6 +311,33 @@ module Rigor
           #{opener}, then run `rigor skill <name>` for the chosen skill and
           follow its body top to bottom.
 
+          #{check_awareness(deep)}
+
+          Re-run `rigor skill describe` whenever you need the next step — it always
+          reflects the project's current state.
+        PROMPT
+      end
+
+      # The check-aware routing block. Without `--deep` it teaches the agent to make the call itself from a check it
+      # has already run (the 2026-06-20 field-trial fix, unchanged); with `--deep` the headline already made that
+      # call, so the block reports what happened instead of re-teaching it. The routing vocabulary is one taxonomy
+      # shared by both branches and by {SkillDeepProbe}.
+      def check_awareness(deep)
+        return presence_only_check_awareness if deep.nil?
+        return deep_failure_check_awareness if deep.failed?
+
+        <<~DEEP.chomp
+          The recommendation above already factors in the `--deep` check result, using the
+          same routing this command teaches without `--deep`: proven project monkey-patches
+          → rigor-monkeypatch-resolve; `RBS classes available: 0` or a `configuration-error`
+          → rigor-doctor; remaining error diagnostics → rigor-baseline-reduce. It does not
+          route on weaker signals (framework calls typing as Dynamic → rigor-plugin-tune is
+          still yours to judge from the check output).
+        DEEP
+      end
+
+      def presence_only_check_awareness
+        <<~PROMPT.chomp
           The recommendation above is from a presence-only probe — it does not run
           `rigor check`. If you have run (or now run) `rigor check`, let its findings
           refine the choice:
@@ -287,9 +346,16 @@ module Rigor
           - framework calls (ActiveRecord, routes, i18n …) typing as Dynamic with no
             matching plugins enabled → rigor-plugin-tune
           - `RBS classes available: 0` or a `configuration-error` diagnostic → rigor-doctor
+          (`rigor skill describe --deep` runs that check for you and applies this routing
+          to the headline itself — at the cost of a full analysis.)
+        PROMPT
+      end
 
-          Re-run `rigor skill describe` whenever you need the next step — it always
-          reflects the project's current state.
+      def deep_failure_check_awareness
+        <<~PROMPT.chomp
+          The `--deep` check did NOT complete, so the recommendation above is the
+          presence-only one. Do not treat the project as clean: run `rigor doctor`
+          (or `rigor check`) and fix what it reports before trusting any routing.
         PROMPT
       end
 

--- a/spec/rigor/cli/skill_command_spec.rb
+++ b/spec/rigor/cli/skill_command_spec.rb
@@ -4,8 +4,15 @@ require "fileutils"
 require "stringio"
 require "tmpdir"
 
+require "rigor/analysis/diagnostic"
+require "rigor/analysis/result"
+require "rigor/analysis/run_stats"
 require "rigor/cli"
+require "rigor/cli/check_invocation"
 require "rigor/cli/skill_command"
+# `--deep` loads this lazily (that laziness is the WD2 boundary); the spec requires it up front so the routing
+# examples can assert it is NOT reached on the un-flagged path.
+require "rigor/cli/skill_deep_probe"
 
 # `rigor skill` exposes the SKILL.md files Rigor bundles under `skills/` (`rigor-project-init`, `rigor-baseline-reduce`,
 # `rigor-plugin-author`). The integration-style examples here exercise the real on-disk skill directory so the contract
@@ -246,6 +253,182 @@ RSpec.describe Rigor::CLI::SkillCommand do
         flag = Dir.chdir(dir) { run(["--describe"]) }
         expect(flag).to eq(sub)
       end
+    end
+
+    # ADR-73 WD2's guardrail: the UN-flagged command is presence-only and side-effect-free. `--deep` (below) is the
+    # opt-in that trades that away, so these two examples pin the boundary from the default side.
+    it "runs no analysis at all without --deep" do
+      allow(Rigor::CLI::CheckInvocation).to receive(:attempt)
+      allow(Rigor::CLI::SkillDeepProbe).to receive(:new)
+      _status, out, = describe_in({ ".rigor.dist.yml" => "target_ruby: '3.3'\n" })
+      expect(Rigor::CLI::CheckInvocation).not_to have_received(:attempt)
+      expect(Rigor::CLI::SkillDeepProbe).not_to have_received(:new)
+      expect(out).not_to include("## Deep check")
+      expect(out).to include("it does not run\n`rigor check`")
+    end
+
+    it "advertises --deep from the un-flagged report without doing its work" do
+      _status, out, = describe_in({ ".rigor.dist.yml" => "target_ruby: '3.3'\n" })
+      expect(out).to include("`rigor skill describe --deep` runs that check for you")
+    end
+  end
+
+  # `rigor skill describe --deep` (issue #148 / ADR-73 § "Field-trial follow-ups") — the opt-in that runs a real
+  # `rigor check` and lets the result pick the headline. The routing examples stub the shared {CheckInvocation}
+  # entry point so each result shape is exercised deterministically; one end-to-end example below runs the real
+  # analysis so the plumbing itself is covered too.
+  describe "describe --deep" do
+    def describe_in(files, argv = %w[describe --deep])
+      Dir.mktmpdir do |dir|
+        files.each do |relative, contents|
+          path = File.join(dir, relative)
+          FileUtils.mkdir_p(File.dirname(path))
+          File.write(path, contents)
+        end
+        Dir.chdir(dir) { run(argv) }
+      end
+    end
+
+    def diagnostic(rule:, severity: :error, project_definition_site: nil)
+      Rigor::Analysis::Diagnostic.new(
+        path: "lib/a.rb", line: 1, column: 1, message: "boom",
+        severity: severity, rule: rule, project_definition_site: project_definition_site
+      )
+    end
+
+    def stub_check(diagnostics: [], rbs_classes: 400, error: nil)
+      outcome =
+        if error
+          Rigor::CLI::CheckInvocation::Outcome.new(result: nil, error: error)
+        else
+          stats = instance_double(Rigor::Analysis::RunStats, rbs_classes_total: rbs_classes)
+          result = Rigor::Analysis::Result.new(diagnostics: diagnostics, stats: stats)
+          Rigor::CLI::CheckInvocation::Outcome.new(result: result, error: nil)
+        end
+      allow(Rigor::CLI::CheckInvocation).to receive(:attempt).and_return(outcome)
+    end
+
+    let(:configured) { { ".rigor.dist.yml" => "target_ruby: '3.3'\n" } }
+
+    it "runs the check through the shared CheckInvocation helper, pointed at the discovered config" do
+      stub_check
+      describe_in(configured)
+      expect(Rigor::CLI::CheckInvocation).to have_received(:attempt)
+        .with(config_path: a_string_ending_with(".rigor.dist.yml"))
+    end
+
+    it "labels the section and warns that it is slow and writes the cache" do
+      stub_check
+      status, out, = describe_in(configured)
+      expect(status).to eq(0)
+      expect(out).to include("## Deep check (--deep)")
+      expect(out).to include("writes `.rigor/cache`")
+    end
+
+    it "routes error diagnostics to rigor-baseline-reduce" do
+      stub_check(diagnostics: [diagnostic(rule: "call.undefined-method")])
+      _status, out, = describe_in(configured)
+      expect(out).to include("→ rigor-baseline-reduce — a `--deep` check reported 1 error diagnostic(s)")
+    end
+
+    it "routes engine-proven project monkey-patches to rigor-monkeypatch-resolve" do
+      stub_check(
+        diagnostics: [
+          diagnostic(rule: "call.undefined-method", project_definition_site: "lib/core_ext/string.rb:12"),
+          diagnostic(rule: "call.undefined-method")
+        ]
+      )
+      _status, out, = describe_in(configured)
+      expect(out).to include("→ rigor-monkeypatch-resolve —")
+      expect(out).to include("lib/core_ext/string.rb")
+      expect(out).to include("1 of them proven project monkey-patches")
+    end
+
+    # A proven site is real evidence, but evidence of a site is not evidence that clearing it is the next thing to
+    # do: `pre_eval:` is the shortest path only when it materially changes the count. The finding still has to
+    # survive the headline not following it.
+    it "leaves the headline on rigor-baseline-reduce when the proven sites are not a cluster" do
+      stub_check(
+        diagnostics: [
+          diagnostic(rule: "call.undefined-method", project_definition_site: "lib/core_ext/string.rb:12"),
+          *Array.new(5) { diagnostic(rule: "call.undefined-method") }
+        ]
+      )
+      _status, out, = describe_in(configured)
+      expect(out).to include("→ rigor-baseline-reduce —")
+      expect(out).to include("1 of them proven project monkey-patches")
+      expect(out).to include("rigor-monkeypatch-resolve")
+    end
+
+    it "routes an empty RBS environment to rigor-doctor" do
+      stub_check(diagnostics: [diagnostic(rule: "call.undefined-method")], rbs_classes: 0)
+      _status, out, = describe_in(configured)
+      expect(out).to include("→ rigor-doctor —")
+      expect(out).to include("the RBS environment built to 0 classes")
+    end
+
+    it "routes a configuration-error diagnostic to rigor-doctor" do
+      stub_check(diagnostics: [diagnostic(rule: "configuration-error")])
+      _status, out, = describe_in(configured)
+      expect(out).to include("→ rigor-doctor —")
+      expect(out).to include("`configuration-error` diagnostic")
+    end
+
+    it "leaves the presence-only headline standing when the check is clean" do
+      stub_check
+      _status, out, = describe_in(configured)
+      expect(out).to include("the check ran clean — 0 error diagnostics")
+      expect(out).to include("→ rigor-ci-setup —")
+    end
+
+    # The degradation contract: a check that could not run must not crash, must not be reported as clean, and must
+    # not route. Saying less beats routing a user into the wrong workflow on evidence that never arrived.
+    it "degrades to the presence-only recommendation when the check cannot run" do
+      stub_check(error: "Rigor::Configuration::Error: plugin `rigor-nope` failed to load")
+      status, out, = describe_in(configured)
+      expect(status).to eq(0)
+      expect(out).to include("the check could NOT run: Rigor::Configuration::Error: plugin `rigor-nope`")
+      expect(out).to include("This is not a clean result")
+      expect(out).to include("The `--deep` check did NOT complete")
+      expect(out).to include("→ rigor-ci-setup —")
+    end
+
+    it "skips the check entirely when the project has no Rigor config" do
+      allow(Rigor::CLI::CheckInvocation).to receive(:attempt)
+      _status, out, = describe_in({})
+      expect(Rigor::CLI::CheckInvocation).not_to have_received(:attempt)
+      expect(out).to include("skipped — this project has no Rigor configuration")
+      expect(out).to include("→ rigor-project-init —")
+    end
+
+    it "is reachable through the top-level `rigor describe --deep` alias" do
+      stub_check(diagnostics: [diagnostic(rule: "call.undefined-method")])
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, ".rigor.dist.yml"), "target_ruby: '3.3'\n")
+        out = StringIO.new
+        Dir.chdir(dir) { Rigor::CLI.new(%w[describe --deep], out: out, err: StringIO.new).run }
+        expect(out.string).to include("## Deep check (--deep)")
+        expect(out.string).to include("→ rigor-baseline-reduce —")
+      end
+    end
+
+    it "rejects an unknown option rather than silently ignoring it" do
+      status, _out, err = run(%w[describe --deeep])
+      expect(status).to eq(Rigor::CLI::EXIT_USAGE)
+      expect(err).to include("unknown option for `describe`: --deeep")
+    end
+
+    # End-to-end: no stubs, a real `rigor check` over a real (tiny) project — the shared invocation helper, the
+    # engine, and the routing all in one pass.
+    it "runs a real check and routes on its result" do
+      _status, out, = describe_in(
+        {
+          ".rigor.dist.yml" => "target_ruby: '3.4'\npaths:\n  - lib\n",
+          "lib/a.rb" => "# frozen_string_literal: true\nx = 1\nx.no_such_method_at_all\n"
+        }
+      )
+      expect(out).to include("## Deep check (--deep)")
+      expect(out).to include("→ rigor-baseline-reduce — a `--deep` check reported 1 error diagnostic(s)")
     end
   end
 


### PR DESCRIPTION
Closes #148.

ADR-73's field trial taught check-aware routing to the **agent-prompt** only; the headline recommendation still saw nothing but file presence. The ADR recorded two ways to close that — this takes the opt-in one. The un-flagged command keeps WD2's presence-only, side-effect-free contract exactly; `--deep` is the caller asking for an analysis.

**The boundary is enforced by what gets loaded, not by discipline.** The probe lives in its own file that `SkillDescribe` requires only when the flag is present, so an un-flagged `describe` never pulls the engine in — which is also what keeps ADR-87's engine-free path intact.

## The prerequisite the ADR named

`CheckInvocation` is one place where a CLI command turns a `Configuration` into an `Analysis::Result`. `CheckCommand` and `DoctorCommand` were both hand-rolling it; both now go through it.

Its `attempt` variant returns an `Outcome` carrying **exactly one** of `result` or `error`, so a routing caller cannot read "could not run" as "ran clean". A `--deep` check that fails says so, falls back to the presence-only headline, and tells the agent *not* to treat the project as clean. Exit status stays 0.

## Routing

Order is **doctor → monkey-patch → baseline**: a hollow analysis makes every other count meaningless.

| Deep result | Headline |
| --- | --- |
| RBS env built to 0 classes, or a `configuration-error` diagnostic | `rigor-doctor` |
| Proven project monkey-patches ≥ ⅓ of the errors | `rigor-monkeypatch-resolve` |
| Any remaining errors | `rigor-baseline-reduce` |
| Clean | unchanged — presence-only headline stands |

**The ⅓ share is a review change on top of the implementation.** As written, any single proven site took the headline. `project_definition_site` is engine-proven evidence — but evidence of a *site* is not evidence that clearing it is the next thing to do. `pre_eval:` is the shortest path only when it materially changes the count, and one proven site beside four hundred unrelated errors is a true finding pointing at the wrong workflow. The ADR's own vocabulary says "a monkey-patch *cluster*". Below the share the sites are still named in the baseline recommendation, so the finding survives even when the headline does not follow it.

## Weak signals are deliberately not routed on

- "Framework calls typing as `Dynamic` with no matching plugins" — no result-level field proves it; the presence probe already covers the strong case (`rails_unconfigured`). The `--deep` prompt says so and leaves the call to the reader.
- A bare `call.unresolved-toplevel` count — unlike `project_definition_site` there is no evidence field behind it, so any threshold would be a guess.
- A failed `--deep` check produces **no** route rather than a "probably `rigor-doctor`" guess.

## Verification

`make verify` green — 8,213 examples, `make check` + `make check-plugins` clean, `make lint` 906 files clean, `make docs-check` 310. `spec/rigor/cli/` 269 examples, including one **unstubbed end-to-end** example that runs a real check over a tmp project and asserts the routing, plus two that prove the un-flagged path reaches neither `CheckInvocation.attempt` nor the probe.

## For a reviewer

- **The un-flagged output is not byte-identical**: it gained a two-line pointer advertising the flag. Behaviour is unchanged, but that text becomes public vocabulary at v1.0 under ADR-50 WD1, so it is worth an explicit read.
- **`--deep` uses the configured cache and worker count, so it writes `.rigor/cache`** — chosen because the flag is documented as "runs `rigor check`" and should behave like it (fast on a warm cache) rather than forcing a full analysis every invocation. `CheckInvocation::READ_ONLY_OPTIONS` is a one-constant flip if you would rather `describe` never write.
- ADR-73's "headline check-awareness" open decision was still marked **Deferred**; it now records shape (b) as settled and why WD2 is untouched.