### PR TITLE
Reclaim a cache shard directory once its last entry is evicted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[cache]** `rigor check` now removes a cache shard directory once its last entry is evicted, instead of leaving an empty directory behind permanently ([#216](https://github.com/rigortype/rigor/issues/216)).
 - **[sig-gen]** Updating an existing signature file now lands on the same nested layout a fresh generation would write — a class is placed inside its parent's block, and a flat `class Foo` / `class Foo::Bar` pair the file already carried is folded into one nested tree — so getting the canonical shape no longer means deleting the target `.rbs` and regenerating it ([#153](https://github.com/rigortype/rigor/issues/153)).
 
 ## [0.3.0] - 2026-07-19

--- a/docs/internal-spec/cache.md
+++ b/docs/internal-spec/cache.md
@@ -468,6 +468,18 @@ enforcing a size budget, so an explicitly unbounded store
 `max_bytes:` being set. Any filesystem error during any pass is
 swallowed — `evict!` must never break a run.
 
+Every unlink in all three passes is followed by a best-effort
+`Dir.rmdir` on the shard directory (`entry_path`'s `key[0, 2]`
+component) that held the file, removing it when the unlink just
+emptied it. A shard is created on write (`FileUtils.mkdir_p`) and
+nothing else ever deletes it, so without this an evicted generation
+or a swept temp file left an empty shard directory behind
+permanently. This is cosmetic only — inode reclaim, not part of the
+eviction policy — and races (a concurrent writer's `mkdir_p`
+recreating the shard, or another pass already having removed it) are
+swallowed the same way any other filesystem error in these passes
+is.
+
 ## `Rigor::Cache::IncrementalSnapshot` (ADR-46)
 
 The persistent artefact behind `rigor check --incremental`. Distinct from

--- a/lib/rigor/cache/store.rb
+++ b/lib/rigor/cache/store.rb
@@ -300,7 +300,7 @@ module Rigor
         entries.each do |entry|
           break if total <= @max_bytes
 
-          total -= entry[:bytes] if unlink_entry(entry[:path])
+          total -= entry[:bytes] if unlink_entry_and_shard?(entry[:path])
         end
         nil
       rescue StandardError
@@ -593,7 +593,7 @@ module Rigor
           next unless File.file?(path)
           next if File.mtime(path) > cutoff
 
-          unlink_entry(path)
+          unlink_entry_and_shard?(path)
         rescue StandardError
           next
         end
@@ -609,11 +609,9 @@ module Rigor
           cap = nil if cap == UNBOUNDED_GENERATIONS
           next if cap.nil? || producer_entries.size <= cap
 
-          producer_entries.sort_by { |entry| [entry[:mtime], entry[:path]] }
-                          .first(producer_entries.size - cap)
-                          .each do |entry|
-            removed[entry[:path]] = true if unlink_entry(entry[:path])
-          end
+          excess = producer_entries.sort_by { |entry| [entry[:mtime], entry[:path]] }
+                                   .first(producer_entries.size - cap)
+          excess.each { |entry| removed[entry[:path]] = true if unlink_entry_and_shard?(entry[:path]) }
         end
         return entries if removed.empty?
 
@@ -625,6 +623,29 @@ module Rigor
         true
       rescue StandardError
         false
+      end
+
+      # {#unlink_entry} plus a best-effort {#rmdir_if_empty} of the shard directory the unlinked file left
+      # behind. Shared by every eviction/sweep pass so an emptied shard is cleaned up wherever an entry (or
+      # stale temp file) is removed, per the issue #216 fossil fix.
+      def unlink_entry_and_shard?(path)
+        return false unless unlink_entry(path)
+
+        rmdir_if_empty(File.dirname(path))
+        true
+      end
+
+      # Removes `dir` — a shard directory (`entry_path`'s `key[0, 2]` component) — when the unlink that
+      # just preceded this call was the one to empty it. Best-effort and rescued the same way
+      # {#unlink_entry} is: a concurrent writer's `FileUtils.mkdir_p` recreating the shard between the
+      # unlink and this call (`Errno::ENOTEMPTY`) or another pass already having removed it
+      # (`Errno::ENOENT`) are both benign outcomes, never a reason to break the eviction/sweep pass. This
+      # is purely cosmetic (inode reclaim) — it never decides which ENTRIES are evicted, only tidies the
+      # directory left behind once they are gone.
+      def rmdir_if_empty(dir)
+        Dir.rmdir(dir)
+      rescue StandardError
+        nil
       end
 
       # Returns an array of `{ path:, producer:, mtime:, bytes: }` hashes for every `.entry` file under the

--- a/spec/rigor/cache/store_spec.rb
+++ b/spec/rigor/cache/store_spec.rb
@@ -689,6 +689,29 @@ RSpec.describe Rigor::Cache::Store do
 
       expect(File.mtime(path)).to be > old_mtime
     end
+
+    it "removes a shard directory the LRU pass empties, but keeps one still holding an entry" do
+      capped = described_class.new(root: cache_root, max_bytes: 15)
+
+      old_shard = File.join(cache_root, "evict.test", "aa")
+      keep_shard = File.join(cache_root, "evict.test", "bb")
+      FileUtils.mkdir_p(old_shard)
+      FileUtils.mkdir_p(keep_shard)
+
+      old_path = File.join(old_shard, "old.entry")
+      keep_path = File.join(keep_shard, "keep.entry")
+      File.write(old_path, "x" * 10)
+      File.write(keep_path, "y" * 10)
+      File.utime(Time.now - 60, Time.now - 60, old_path)
+      File.utime(Time.now, Time.now, keep_path)
+
+      capped.evict!
+
+      expect(File.exist?(old_path)).to be(false)
+      expect(Dir.exist?(old_shard)).to be(false)
+      expect(File.exist?(keep_path)).to be(true)
+      expect(Dir.exist?(keep_shard)).to be(true)
+    end
   end
 
   describe "read_only: true (editor mode — slice 3)" do
@@ -934,6 +957,30 @@ RSpec.describe Rigor::Cache::Store do
           .to contain_exactly(paths[2], paths[3])
       end
     end
+
+    it "removes a shard directory the generation-cap pass empties, but keeps one still holding a survivor" do
+      st = described_class.new(root: cache_root, max_bytes: nil)
+      st.send(:declare_generation_cap, "whole.project2", 1)
+
+      old_shard = File.join(cache_root, "whole.project2", "aa")
+      keep_shard = File.join(cache_root, "whole.project2", "bb")
+      FileUtils.mkdir_p(old_shard)
+      FileUtils.mkdir_p(keep_shard)
+
+      old_path = File.join(old_shard, "old.entry")
+      keep_path = File.join(keep_shard, "keep.entry")
+      File.write(old_path, "x")
+      File.write(keep_path, "y")
+      File.utime(Time.now - 60, Time.now - 60, old_path)
+      File.utime(Time.now, Time.now, keep_path)
+
+      st.evict!
+
+      expect(File.exist?(old_path)).to be(false)
+      expect(Dir.exist?(old_shard)).to be(false)
+      expect(File.exist?(keep_path)).to be(true)
+      expect(Dir.exist?(keep_shard)).to be(true)
+    end
   end
 
   describe "#evict! (stale temp-file cleanup)" do
@@ -950,6 +997,20 @@ RSpec.describe Rigor::Cache::Store do
 
       expect(File.exist?(stale)).to be(false)
       expect(File.exist?(fresh)).to be(true)
+      expect(Dir.exist?(File.dirname(stale))).to be(true)
+    end
+
+    it "removes the shard directory when sweeping the last stale temp file empties it" do
+      stale = File.join(cache_root, "p", "ef", "cdef.entry.tmp.123.deadbeef")
+      FileUtils.mkdir_p(File.dirname(stale))
+      File.write(stale, "x")
+      old_time = Time.now - ((60 * 60) + 60)
+      File.utime(old_time, old_time, stale)
+
+      described_class.new(root: cache_root, max_bytes: nil).evict!
+
+      expect(File.exist?(stale)).to be(false)
+      expect(Dir.exist?(File.dirname(stale))).to be(false)
     end
   end
 end


### PR DESCRIPTION
Closes #216.

A shard directory is created on write and nothing ever removed it, so every evicted generation left an empty directory behind permanently. Found while measuring the generation cap for #151: one real cache carried **57 shard directories for 16 live entries, 44 of them empty**.

## All three passes leave the same fossil

Not just the generation-cap pass the issue named:

- the **LRU byte-cap** pass unlinks the same way;
- the **stale temp-file sweep** — a `.tmp.*` lives in its target's shard, so sweeping one from an otherwise-empty shard (a write that died before its rename) leaves the directory behind too.

One helper covers all three. `atomically_replace`'s own tmp cleanup is deliberately untouched: it is in the write path, not an eviction pass.

## It cannot break a run

The rmdir happens only after an unlink already succeeded, and it swallows the two conditions that make it fail: a concurrent writer's `mkdir_p` recreating the shard between the unlink and the rmdir (`ENOTEMPTY`), and another pass having removed it already (`ENOENT`). The blanket rescue matches every other best-effort filesystem helper in this file (`unlink_entry`, `touch_for_lru`, `fsync_directory`) rather than introducing a second idiom for the same job.

Cosmetic and inode-only. **Which entries get evicted is untouched.**

## Verification

`spec/rigor/cache/` 199 examples green (4 new, covering all three passes: a shard the pass empties is gone, a shard still holding an entry survives). The new examples hand-fabricate two shard directories with deterministic mtimes and sizes rather than relying on hash-derived key placement, so *which* shard empties is controlled rather than probabilistic. RuboCop clean on both touched files.

`docs/internal-spec/cache.md` gains a paragraph on the behaviour — it documented the three passes' unlink behaviour and said nothing about the directories.

The full `make verify` on this branch is CI's run: the local working tree carries three other agents' concurrent changes, so a local full-suite result could not be attributed to this change alone.