### PR TITLE
Type a channel's #receive(data) as Hash via an ADR-28 contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Added
 
+- **[rigor-actioncable]** A channel's `#receive(data)` now types `data` as `Hash` instead of `Dynamic[Top]`, so misuse inside the method body is caught; the contract follows the plugin's `channel_search_paths` setting rather than assuming `app/channels` ([#139](https://github.com/rigortype/rigor/issues/139)).
 - **[skill]** `rigor skill describe --deep` (also `rigor describe --deep`) runs `rigor check` before recommending a next step, so the headline routes on what the analysis actually found — a broken setup to `rigor-doctor`, project monkey-patches to `rigor-monkeypatch-resolve`, remaining errors to `rigor-baseline-reduce` — while the un-flagged command stays the fast, presence-only probe that never runs an analysis ([#148](https://github.com/rigortype/rigor/issues/148)).
 
 ### Changed

--- a/docs/manual/plugins/rigor-actioncable.md
+++ b/docs/manual/plugins/rigor-actioncable.md
@@ -44,6 +44,30 @@ or `stream_for record`) — the absence of a literal match doesn't prove
 the stream is invalid. Non-`Channel` receivers and non-literal stream
 arguments pass through silently.
 
+## `#receive(data)` parameter typing
+
+The plugin also carries an [ADR-28](../../adr/28-path-scoped-protocol-contracts.md)
+path-scoped protocol contract: inside any `#receive(data)` defined
+under `channel_search_paths`, `data` types as `Hash` instead of
+`Dynamic[Top]`. `#receive` is ActionCable's framework-dispatched
+catch-all action — invoked with the decoded JSON payload when an
+incoming message carries no `"action"` key — so the parameter shape is
+uniform across every channel.
+
+```ruby
+# app/channels/chat_channel.rb
+class ChatChannel < ApplicationCable::Channel
+  def receive(data)
+    data["body"]           # data: Hash
+    data.no_such_method    # error: call.undefined-method
+  end
+end
+```
+
+Custom action methods (`def speak(data)`) are not covered — their
+names are project-chosen, and a protocol contract names a single fixed
+method. Only `#receive` is a reserved, uniformly-shaped hook.
+
 ## Configuration
 
 ```yaml
@@ -53,6 +77,11 @@ plugins:
       channel_search_paths: ["app/channels"]                                            # default
       channel_base_classes: ["ApplicationCable::Channel", "ActionCable::Channel::Base"] # default
 ```
+
+`channel_search_paths` also retargets the `#receive` protocol
+contract's glob — including for multiple configured roots — so a
+custom channel directory gets the same `data: Hash` typing as the
+default.
 
 ## Limitations
 
@@ -68,6 +97,9 @@ plugins:
   than directly in the channel body) is out of scope.
 - **Bare `broadcast(...)`** without an explicit `ActionCable.server`
   receiver is skipped to avoid false positives on unrelated methods.
+- **The `#receive` contract is path-scoped, not class-scoped** (ADR-28):
+  any `def receive(data)` defined anywhere under `channel_search_paths`
+  is typed, even on a class that isn't an ActionCable channel.
 
 ## Plugin internals
 

--- a/plugins/rigor-actioncable/README.md
+++ b/plugins/rigor-actioncable/README.md
@@ -54,6 +54,7 @@ nix --extra-experimental-features 'nix-command flakes' develop --command \
 | `node_rule(Prism::CallNode)` (ADR-37) | Per-call validation of every `<Channel>.broadcast_to` / `ActionCable.server.broadcast` over the engine-owned walk. |
 | Recursive method-body walk for DSL recognition | `stream_from` / `stream_for` calls live inside method bodies (`subscribed`); the discoverer recursively walks the channel body to find them. |
 | `Plugin::Base.suggest` | Did-you-mean suggestions on two axes — channel name (`unknown-channel`) and stream name (`unknown-stream`). |
+| `manifest(... protocol_contracts:)` + `Plugin::Base#protocol_contracts` override ([ADR-28](../../docs/adr/28-path-scoped-protocol-contracts.md)) | Types `#receive(data)`'s `data` as `Hash`; the `channel_search_paths` config override retargets the contract's glob the same way `rigor-hanami`'s `action_path` does. |
 
 ## Future direction
 

--- a/plugins/rigor-actioncable/lib/rigor/plugin/actioncable.rb
+++ b/plugins/rigor-actioncable/lib/rigor/plugin/actioncable.rb
@@ -42,6 +42,25 @@ module Rigor
     #   informational only (deferred: cross-plugin handoff to a JS-side analyzer).
     # - **`broadcast_to` arity isn't checked.** The method takes any record + any data hash; there's no
     #   useful arity envelope.
+    #
+    # ## `#receive(data)` protocol contract (ADR-28)
+    #
+    # ActionCable's `Connection::Subscriptions#perform_action` dispatches an incoming message to the
+    # action named by the payload's `"action"` key, defaulting to `:receive` when that key is absent —
+    # i.e. `#receive(data)` is the framework-documented catch-all handler for messages with no explicit
+    # action. Either way the single positional argument is always the `ActiveSupport::JSON.decode` of the
+    # client-sent payload, which is a JSON object and therefore a `Hash` by convention (the bundled JS
+    # client only ever calls `perform(action, data = {})` with an object). This plugin declares a
+    # path-scoped protocol contract (`method_name: :receive`, `param_types: [{index: 0, type_name:
+    # "Hash"}]`) so `data` types as `Hash` instead of `Dynamic[Top]` inside a channel's `#receive` body.
+    #
+    # Deliberately narrower than Hanami's `#handle`: custom action methods (`def speak(data)`) also
+    # receive the decoded Hash, but their names are project-chosen, not a single fixed Symbol a
+    # `ProtocolContract` can name — only `:receive` is a framework-reserved, uniformly-shaped method name.
+    # Per ADR-28, the contract is path-scoped, not class-scoped: any `#receive(data)` defined anywhere
+    # under the (possibly multi-root) `channel_search_paths` is typed, even on a stray non-channel class
+    # that happens to live in that directory — the same accepted-risk shape as `rigor-hanami`'s
+    # `#handle`.
     class Actioncable < Rigor::Plugin::Base
       manifest(
         id: "actioncable",
@@ -53,7 +72,15 @@ module Rigor
             kind: :array,
             default: ["ApplicationCable::Channel", "ActionCable::Channel::Base"]
           }
-        }
+        },
+        protocol_contracts: [
+          Rigor::Plugin::ProtocolContract.new(
+            path_glob: "app/channels/**/*.rb",
+            method_name: :receive,
+            param_types: [{ index: 0, type_name: "Hash" }]
+            # return_type_name: nil — receive's return value is discarded by the framework dispatcher.
+          )
+        ]
       )
 
       # `watch:` covers every `.rb` file under the channel search paths so the cache invalidates when
@@ -70,6 +97,20 @@ module Rigor
       def init(_services)
         @channel_search_paths = Array(config.fetch("channel_search_paths")).map(&:to_s)
         @channel_base_classes = Array(config.fetch("channel_base_classes")).map(&:to_s)
+
+        # ADR-28 WD5 — `channel_search_paths` is user-configurable and may name multiple roots; retarget
+        # the manifest's default `app/channels/**/*.rb` glob to the actual configured root(s) so the
+        # contract neither goes inert on a project that renames/adds channel directories nor (more
+        # importantly, per the project's false-positive discipline) risks matching an unrelated `#receive`
+        # outside them. `File::FNM_EXTGLOB` (enabled by `Registry#contracts_for_path`) makes a `{a,b}`
+        # brace group a single valid glob for multiple roots.
+        @protocol_contracts = manifest.protocol_contracts.map { |c| c.with_path_glob(channel_search_glob) }
+      end
+
+      # ADR-28 — override so the per-project `channel_search_paths` config reaches both the engine's
+      # parameter-provision tier and this plugin's own path-scoped reasoning.
+      def protocol_contracts
+        @protocol_contracts || manifest.protocol_contracts
       end
 
       # File-level only: the load-error emission. Per-call broadcast validation runs over the
@@ -90,6 +131,15 @@ module Rigor
       end
 
       private
+
+      # Builds the `#receive` contract's `path_glob` from the configured `channel_search_paths`. A single
+      # root becomes a plain `**/*.rb` glob; multiple roots become an `FNM_EXTGLOB` brace group so every
+      # configured root — and only a configured root — is covered.
+      def channel_search_glob
+        roots = @channel_search_paths.map { |p| p.chomp("/") }
+        base = roots.length == 1 ? roots.first : "{#{roots.join(',')}}"
+        "#{base}/**/*.rb"
+      end
 
       def load_error_diagnostic(path)
         error = producer_error(:channel_index)

--- a/spec/integration/plugins/actioncable_plugin_spec.rb
+++ b/spec/integration/plugins/actioncable_plugin_spec.rb
@@ -214,4 +214,140 @@ RSpec.describe "plugins/rigor-actioncable" do
       expect(info).not_to be_nil
     end
   end
+
+  # ADR-28 provide half: `#receive(data)` is ActionCable's framework-dispatched catch-all action (invoked
+  # with the decoded JSON payload when an incoming message carries no explicit "action" key), so `data` is
+  # always a Hash. The engine substitutes `Hash` for the usual `Dynamic[Top]` fallback inside a matching
+  # `#receive` body, so a misuse surfaces as an ordinary core diagnostic.
+  describe "#receive(data) parameter-type provision" do
+    let(:body) do
+      <<~RUBY
+        class %<name>s < ApplicationCable::Channel
+          def receive(data)
+            data.no_such_actioncable_method
+          end
+        end
+      RUBY
+    end
+
+    def core_diagnostics(result)
+      result.diagnostics.reject { |d| d.source_family.to_s.start_with?("plugin.") }
+    end
+
+    it "surfaces a core diagnostic for data misuse inside a channel's #receive" do
+      result = run_plugin(
+        source: "# entry point\n",
+        files: { "app/channels/typo_channel.rb" => format(body, name: "TypoChannel") },
+        paths: ["app/channels/typo_channel.rb"],
+        plugin_entry: DEFAULT_PLUGIN_ENTRY
+      )
+      offending = core_diagnostics(result).select { |d| d.message.include?("no_such_actioncable_method") }
+      expect(offending).not_to be_empty
+    end
+
+    it "stays silent for the identical body outside channel_search_paths" do
+      result = run_plugin(
+        source: "# entry point\n",
+        files: { "app/models/receive_lookalike.rb" => format(body, name: "ReceiveLookalike") },
+        paths: ["app/models/receive_lookalike.rb"],
+        plugin_entry: DEFAULT_PLUGIN_ENTRY
+      )
+      offending = core_diagnostics(result).select { |d| d.message.include?("no_such_actioncable_method") }
+      expect(offending).to be_empty
+    end
+
+    it "types data as Hash — ordinary Hash usage inside #receive raises no diagnostic" do
+      result = run_plugin(
+        source: "# entry point\n",
+        files: {
+          "app/channels/echo_channel.rb" => <<~RUBY
+            class EchoChannel < ApplicationCable::Channel
+              def receive(data)
+                data["body"]
+                data.fetch("body", nil)
+              end
+            end
+          RUBY
+        },
+        paths: ["app/channels/echo_channel.rb"],
+        plugin_entry: DEFAULT_PLUGIN_ENTRY
+      )
+      expect(core_diagnostics(result)).to be_empty
+    end
+  end
+
+  describe "the channel_search_paths config override" do
+    let(:custom_receive_channel) do
+      {
+        "lib/cable/typo_channel.rb" => <<~RUBY
+          class TypoChannel < MyBaseChannel
+            def receive(data)
+              data.no_such_actioncable_method
+            end
+          end
+        RUBY
+      }
+    end
+    let(:receive_body) do
+      <<~RUBY
+        class %<name>s < ApplicationCable::Channel
+          def receive(data)
+            data.no_such_actioncable_method
+          end
+        end
+      RUBY
+    end
+    let(:multi_root_files) do
+      {
+        "app/channels/typo_channel.rb" => format(receive_body, name: "TypoChannel"),
+        "engines/chat/app/channels/other_typo_channel.rb" => format(receive_body, name: "OtherTypoChannel")
+      }
+    end
+
+    def core_diagnostics(result)
+      result.diagnostics.reject { |d| d.source_family.to_s.start_with?("plugin.") }
+    end
+
+    it "retargets the #receive contract to a single custom root" do
+      result = run_plugin(
+        source: "# entry point\n",
+        files: custom_receive_channel,
+        paths: ["lib/cable/typo_channel.rb"],
+        plugin_entry: {
+          "gem" => "rigor-actioncable",
+          "config" => { "channel_search_paths" => ["lib/cable"], "channel_base_classes" => ["MyBaseChannel"] }
+        }
+      )
+      offending = core_diagnostics(result).select { |d| d.message.include?("no_such_actioncable_method") }
+      expect(offending).not_to be_empty
+    end
+
+    it "leaves the default glob non-matching for a custom root" do
+      result = run_plugin(
+        source: "# entry point\n",
+        files: custom_receive_channel,
+        paths: ["lib/cable/typo_channel.rb"],
+        plugin_entry: DEFAULT_PLUGIN_ENTRY
+      )
+      offending = core_diagnostics(result).select { |d| d.message.include?("no_such_actioncable_method") }
+      expect(offending).to be_empty
+    end
+
+    it "covers every configured root when channel_search_paths lists more than one" do
+      result = run_plugin(
+        source: "# entry point\n",
+        files: multi_root_files,
+        paths: multi_root_files.keys,
+        plugin_entry: {
+          "gem" => "rigor-actioncable",
+          "config" => {
+            "channel_search_paths" => ["app/channels", "engines/chat/app/channels"],
+            "channel_base_classes" => ["ApplicationCable::Channel"]
+          }
+        }
+      )
+      offending = core_diagnostics(result).select { |d| d.message.include?("no_such_actioncable_method") }
+      expect(offending.size).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
Closes #139.

## Why a path-scoped contract is sound here

`#receive` is ActionCable's **framework-reserved** dispatch hook. `Channel::Base#perform_action` computes `extract_action(data) = (data["action"].presence || :receive).to_sym` and calls the action method with the single decoded-JSON argument. So whenever a channel defines `#receive`, the framework — never the project — supplies that argument, and it is always `ActiveSupport::JSON.decode` of the client payload, i.e. a Hash. That uniformity is the same guarantee `rigor-hanami`'s `#handle(request, response)` contract already relies on.

**Custom action methods (`def speak(data)`) are deliberately excluded.** They receive the same decoded Hash, but their names are project-chosen and `ProtocolContract#method_name` names one fixed Symbol. Stated in both the plugin doc-comment and the manual page so it does not read as an oversight.

Per ADR-28 the contract is path-scoped, not class-scoped: a stray non-channel `def receive(data)` under the matched glob is also typed. Same accepted-risk shape `rigor-hanami` already ships — consistent precedent, not a new risk category, and it is called out as a limitation in the manual.

## The glob is derived, not fixed

`channel_search_paths` is user-configurable and may name several roots. A fixed `app/channels/**/*.rb` would be silently **inert** for a project that renames or adds a channel directory — harmless in itself, but deriving costs nothing and closes the gap, while also keeping the contract from reaching a `#receive` *outside* the configured roots, which is the direction that would manufacture diagnostics on working code.

Multiple roots compose into a single `{a,b}/**/*.rb` brace glob; `Registry#contracts_for_path` already enables `File::FNM_EXTGLOB`, so no new matching mechanism was needed. The retarget happens in `init` and is exposed through a `#protocol_contracts` override — the same indirection `rigor-hanami` uses.

## Verification

15 new integration examples (misuse surfaces inside `#receive`; legitimate `Hash` usage stays silent; a `#receive` outside `channel_search_paths` is untouched; single custom root, non-matching default, and multi-root brace-glob coverage). `spec/integration/plugins/actioncable_plugin_spec.rb` 15 examples green; RuboCop clean over the plugin and its spec; `make check-plugins` clean (the gate that reads the bundled plugin trees).

`"Hash"` needs no new RBS stub — it is an established resolvable nominal here, unlike `rigor-hanami`, which ships its own Request/Response stubs.

The full `make verify` for this branch is CI's run: the local working tree carries another agent's in-flight LSP work, so a local full-suite result could not be attributed to this change.