### PR TITLE
Show inferred types in the playground by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 ### Changed
 
 - **[plugin API]** `Plugin::Base.producer` accepts a `generation_cap:` declaring how many generations of a producer's cache entries survive a compaction pass; it defaults to the previous behaviour (unbounded, reaped only by the `cache.max_bytes` LRU pass), so a whole-project producer that orphans its previous entry on every run can now keep its own cache slice from growing ([#151](https://github.com/rigortype/rigor/issues/151)).
+- **[playground]** The browser playground now shows inferred types on first load: the "Show types" overlay is on by default in both the hosted and WASM builds, and the toolbar button starts in its "Hide types" state so the toggle still turns it off.
 - **[plugin API]** *(breaking, unpinned surface)* `Cache::Store#fetch_or_compute` and `#fetch_or_validate` now require a `generation_cap:` argument. A plugin that reaches for the store directly rather than through `Plugin::Base.producer` must pass one — `:unbounded` reproduces the previous behaviour exactly. There is deliberately no default: a cache slice that silently grows without bound is the failure this argument exists to make unrepresentable, and no single default is right for both whole-project and per-file producers ([#151](https://github.com/rigortype/rigor/issues/151)).
 
 ### Performance

--- a/apps/rigor-playground/frontend/README.md
+++ b/apps/rigor-playground/frontend/README.md
@@ -24,7 +24,8 @@ ADR references:
   rendering returned diagnostics as wavy underlines and an
   expandable list panel.
 - A "Show types" / "Hide types" toggle that overlays
-  per-expression type annotations via `POST /annotate-lines`.
+  per-expression type annotations via `POST /annotate-lines`,
+  on by default.
 - Dark / light / auto theme switching.
 
 ## Local development

--- a/apps/rigor-playground/frontend/index.html
+++ b/apps/rigor-playground/frontend/index.html
@@ -577,7 +577,7 @@
     <span id="status" aria-live="polite">Ready</span>
     <div class="toolbar">
       <button class="btn" id="theme-btn" title="Cycle theme (Dark / Light / Auto)" aria-label="Toggle theme">Dark</button>
-      <button class="btn" id="type-btn" aria-pressed="false"><i class="fa-solid fa-eye" aria-hidden="true"></i><span>Show types</span></button>
+      <button class="btn active" id="type-btn" aria-pressed="true"><i class="fa-solid fa-eye-slash" aria-hidden="true"></i><span>Hide types</span></button>
     </div>
   </header>
 
@@ -821,7 +821,10 @@ AscDesc.new.ascdesc(:bad)
     // ── State ─────────────────────────────────────────────────────────────
 
     let debounceTimer    = null
-    let typesVisible     = false
+    // Types are on by default — the overlay is the point of the playground.
+    // The toolbar button's markup starts in its pressed ("Hide types") state to
+    // match, and the boot check paints the first annotations.
+    let typesVisible     = true
     let lastDiagnostics  = []
 
     // ── Theme ─────────────────────────────────────────────────────────────

--- a/apps/rigor-playground/wasm/index.html
+++ b/apps/rigor-playground/wasm/index.html
@@ -228,7 +228,7 @@
     <span id="status" aria-live="polite">Loading…</span>
     <div class="toolbar">
       <button class="btn" id="theme-btn" title="Cycle theme">Dark</button>
-      <button class="btn" id="type-btn" aria-pressed="false"><i class="fa-solid fa-eye" aria-hidden="true"></i><span>Show types</span></button>
+      <button class="btn active" id="type-btn" aria-pressed="true"><i class="fa-solid fa-eye-slash" aria-hidden="true"></i><span>Hide types</span></button>
       <button class="btn" id="trace-btn" aria-pressed="false" title="Replay how the engine infers each type"><i class="fa-solid fa-film" aria-hidden="true"></i><span>Trace types</span></button>
     </div>
   </header>
@@ -729,7 +729,10 @@ AscDesc.new.ascdesc(:bad)
       parent: document.getElementById("editor")
     })
 
-    let debounceTimer = null, typesVisible = false
+    // Types are on by default — the overlay is the point of the playground. The
+    // toolbar button's markup starts in its pressed ("Hide types") state to
+    // match, and the first post-boot check paints the annotations.
+    let debounceTimer = null, typesVisible = true
 
     // ── Theme toggle ─────────────────────────────────────────────────────────
     const THEME_CYCLE = ["dark", "light", "system"], THEME_LABELS = { dark: "Dark", light: "Light", system: "Auto" }


### PR DESCRIPTION
The type overlay is the playground's distinguishing feature, but a first-time visitor had to find the toolbar toggle before seeing a single inferred type. This turns it on by default.

- `typesVisible` starts `true`; the initial check already calls `annotate-lines` whenever the flag is set, so no boot-path change was needed beyond the default.
- The `#type-btn` markup starts in its pressed state (`aria-pressed="true"`, `.active`, eye-slash icon, "Hide types") so the button and the state do not disagree before the first click.
- Both frontends move together: `frontend/index.html` (hosted, Rack backend) and `wasm/index.html` (ruby.wasm build, which shares the toggle code).

## Verification

`make verify` green (HTML-only change). The hosted frontend was driven in a browser against a stub backend: at load the button reads "Hide types" (`aria-pressed=true`, `.active`) and 7 annotation widgets paint without a click; one click clears them and flips the label to "Show types"; a second click restores both. No console errors. The WASM page was loaded statically — its button paints in the same default-on state; the VM itself cannot boot in this checkout (`rigor-playground.wasm` is not built), so its annotation path is unverified there and rides on the shared toggle code.