### PR TITLE
Refuse sig-gen updates against invalid-UTF-8 signature files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
-- **[sig-gen]** `rigor sig-gen --write` now refuses, by name and with a non-zero exit, to update a signature file that is not valid UTF-8, instead of crashing with a stack trace.
+- **[sig-gen]** `rigor sig-gen --write` now refuses, by name and with a non-zero exit, to update a signature file that is not valid UTF-8, instead of crashing with a stack trace ([#231](https://github.com/rigortype/rigor/pull/231)).
 - **[engine]** A project `.rbs` file (or a plugin-synthesized inline-RBS contribution) that is not valid UTF-8 is now quarantined with a warning naming the file, instead of reaching the RBS parser — where it crashed `rigor check` with a bare `ArgumentError` on rbs 4.1, and could hang the process outright on older rbs releases ([#230](https://github.com/rigortype/rigor/pull/230)).
 - **[inference]** `Resolv.new([Resolv::Hosts.new, ...])` no longer false-fires `call.argument-type-mismatch` when the installed `rbs` predates 4.1; a core overlay backports the array-of-resolvers overload upstream added in ruby/rbs#2960 ([#230](https://github.com/rigortype/rigor/pull/230)).
 - **[docs]** Nine `README.md` links to the documentation site carried a stale `/reference/` path segment and 404'd; they now resolve ([#223](https://github.com/rigortype/rigor/pull/223), thank you @f440!).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[sig-gen]** `rigor sig-gen --write` now refuses, by name and with a non-zero exit, to update a signature file that is not valid UTF-8, instead of crashing with a stack trace.
 - **[engine]** A project `.rbs` file (or a plugin-synthesized inline-RBS contribution) that is not valid UTF-8 is now quarantined with a warning naming the file, instead of reaching the RBS parser — where it crashed `rigor check` with a bare `ArgumentError` on rbs 4.1, and could hang the process outright on older rbs releases ([#230](https://github.com/rigortype/rigor/pull/230)).
 - **[inference]** `Resolv.new([Resolv::Hosts.new, ...])` no longer false-fires `call.argument-type-mismatch` when the installed `rbs` predates 4.1; a core overlay backports the array-of-resolvers overload upstream added in ruby/rbs#2960 ([#230](https://github.com/rigortype/rigor/pull/230)).
 - **[docs]** Nine `README.md` links to the documentation site carried a stale `/reference/` path segment and 404'd; they now resolve ([#223](https://github.com/rigortype/rigor/pull/223), thank you @f440!).

--- a/lib/rigor/cli/sig_gen_command.rb
+++ b/lib/rigor/cli/sig_gen_command.rb
@@ -97,10 +97,11 @@ module Rigor
         results = writer.write_all(candidates)
 
         SigGen::Renderer.new(out: @out).render_write(results: results, format: options.fetch(:format))
-        # An assembled file that does not parse is refused rather than written. The user asked for a write and
-        # did not get one, so the command must not report success — a green `sig-gen --write` in CI would
-        # otherwise mean nothing.
-        results.any? { |result| result.action == :skipped_invalid_rbs } ? 1 : 0
+        # A refused write (an assembled file that does not parse, or an existing target that is not valid
+        # UTF-8) means the user asked for a write and did not get one, so the command must not report
+        # success — a green `sig-gen --write` in CI would otherwise mean nothing.
+        refusals = %i[skipped_invalid_rbs skipped_invalid_encoding]
+        results.any? { |result| refusals.include?(result.action) } ? 1 : 0
       end
 
       # Slice 3 — collect call-site argument observations when `--params=observed` is set. When `--observe=PATH` is not

--- a/lib/rigor/sig_gen/layout_index.rb
+++ b/lib/rigor/sig_gen/layout_index.rb
@@ -74,6 +74,12 @@ module Rigor
 
       def index_file(rbs_path, accumulator)
         source = rbs_path.read
+        # Pre-parser encoding guard (mirrors `Environment::RbsLoader.invalid_encoding?`): on rbs releases
+        # before 4.1 the C lexer could hang on an invalid UTF-8 byte, and a hang is the one failure the
+        # rescue below cannot absorb. Skipping is safe here for the same reason the rescue is — placement
+        # falls back as for any unparseable file, and the env loader's quarantine warning names the file.
+        return unless source.valid_encoding?
+
         _, _, decls = RBS::Parser.parse_signature(source)
         record_decls(decls, [], rbs_path, accumulator)
       rescue StandardError

--- a/lib/rigor/sig_gen/renderer.rb
+++ b/lib/rigor/sig_gen/renderer.rb
@@ -127,6 +127,7 @@ module Rigor
           when :updated then render_write_updated(result)
           when :skipped_outside_sig_root then render_write_skipped(result)
           when :skipped_invalid_rbs then render_write_invalid(result)
+          when :skipped_invalid_encoding then render_write_invalid_encoding(result)
           end
         end
       end
@@ -151,6 +152,13 @@ module Rigor
         @out.puts("REFUSED #{result.target_path} — the generated RBS does not parse, so it was not written")
         @out.puts("  #{result.error}")
         @out.puts("  This is a bug in Rigor's RBS rendering, not in your code — please report it.")
+      end
+
+      # The EXISTING target file is not valid UTF-8, so the writer will not merge into it — the opposite
+      # attribution from {#render_write_invalid}: this one is the file's problem, and the fix is the user's.
+      def render_write_invalid_encoding(result)
+        @out.puts("REFUSED #{result.target_path} — the existing file is not valid UTF-8, so it was not updated")
+        @out.puts("  Re-save the file as UTF-8 and re-run; sig-gen never modifies a file it cannot read faithfully.")
       end
 
       def render_write_json(results)

--- a/lib/rigor/sig_gen/write_result.rb
+++ b/lib/rigor/sig_gen/write_result.rb
@@ -11,13 +11,15 @@ module Rigor
     # - `target_path` — `.rbs` file the writer was responsible for (`nil` when the source path falls outside
     #   the project signature tree, in which case `action` is `:skipped_outside_sig_root`).
     # - `action` — one of `:created` / `:updated` / `:noop` / `:skipped_outside_sig_root` /
-    #   `:skipped_invalid_rbs`.
+    #   `:skipped_invalid_rbs` / `:skipped_invalid_encoding`.
     # - `applied` — the {MethodCandidate}s that actually landed on disk.
     # - `skipped` — the {MethodCandidate}s the writer declined (e.g. tighter-return without `--overwrite`). Each
     #   entry pairs the candidate with a skip reason keyword (`:user_authored`).
-    # - `error` — the parse error, when `action` is `:skipped_invalid_rbs`: the file the writer assembled does
-    #   not parse, so it was NOT written (writing it would poison the project's sig tree — the consumer
-    #   quarantines an unparseable `.rbs`, taking every other type in that file down with it).
+    # - `error` — the refusal cause, when `action` is a refusal: for `:skipped_invalid_rbs` the file the writer
+    #   assembled does not parse, so it was NOT written (writing it would poison the project's sig tree — the
+    #   consumer quarantines an unparseable `.rbs`, taking every other type in that file down with it); for
+    #   `:skipped_invalid_encoding` the EXISTING target file is not valid UTF-8, so the writer refuses to merge
+    #   into content it cannot read faithfully.
     class WriteResult
       attr_reader :source_path, :target_path, :action, :applied, :skipped, :error
 

--- a/lib/rigor/sig_gen/writer.rb
+++ b/lib/rigor/sig_gen/writer.rb
@@ -275,6 +275,18 @@ module Rigor
 
       def update_existing(source_path, target, candidates)
         source = target.read
+        # Pre-parser encoding guard, mirroring `Environment::RbsLoader.invalid_encoding?`: handed invalid
+        # UTF-8, `RBS::Parser` raises a bare `ArgumentError` on rbs 4.1 (not the `ParsingError` that
+        # `parse_signature` below rescues) and could hang outright on the older releases the gemspec
+        # supports. The refusal is loud — unlike an unparseable file (`:noop`, surfaced by `rigor check`'s
+        # own quarantine warning), a mojibake file would otherwise fail with a stack trace naming neither
+        # the file nor the fix.
+        unless source.valid_encoding?
+          return WriteResult.new(source_path: source_path, target_path: target,
+                                 action: :skipped_invalid_encoding,
+                                 error: "#{target} is not valid UTF-8")
+        end
+
         decls = parse_signature(source)
         return WriteResult.new(source_path: source_path, target_path: target, action: :noop) if decls.nil?
 

--- a/spec/rigor/sig_gen/layout_index_spec.rb
+++ b/spec/rigor/sig_gen/layout_index_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe Rigor::SigGen::LayoutIndex do
     expect(index(File.join(tmpdir, "sig")).file_for("Foo")).to eq(Pathname(path))
   end
 
+  it "skips an invalid-UTF-8 sig file before it reaches the parser, keeping its siblings indexed" do
+    # Pre-parser encoding guard: rbs releases before 4.1 could hang the C lexer on an invalid byte — a
+    # failure the index's rescue cannot absorb — so the file must be rejected on encoding alone. `\xE9` is a
+    # bare Latin-1 é, invalid in UTF-8; the declarations around it are well-formed.
+    good = write_sig("sig/foo.rbs", "class Foo\nend\n")
+    File.binwrite(File.join(tmpdir, "sig/broken.rbs"), "class Broken\nend\n# caf\xE9\n")
+    idx = index(File.join(tmpdir, "sig"))
+
+    expect(idx.file_for("Foo")).to eq(Pathname(good))
+    expect(idx.file_for("Broken")).to be_nil
+  end
+
   it "walks nested modules / classes and indexes fully-qualified names" do
     path = write_sig("sig/all.rbs", <<~RBS)
       module Outer

--- a/spec/rigor/sig_gen/writer_spec.rb
+++ b/spec/rigor/sig_gen/writer_spec.rb
@@ -67,6 +67,27 @@ RSpec.describe Rigor::SigGen::Writer do
     end
   end
 
+  # Pre-parser encoding guard: handed invalid UTF-8, `RBS::Parser` raises a bare `ArgumentError` on rbs 4.1
+  # (escaping the writer's `ParsingError` rescue and crashing the whole `--write` run) and could hang the C
+  # lexer on the older releases the gemspec supports. The writer must refuse the file on encoding alone,
+  # loudly and byte-for-byte untouched.
+  describe "target-encoding guard" do
+    it "refuses to update an existing file that is not valid UTF-8, naming it" do
+      target = File.join(tmpdir, "sig/foo.rbs")
+      FileUtils.mkdir_p(File.dirname(target))
+      # `\xE9` is a bare Latin-1 é — invalid in UTF-8; the RBS around it is otherwise well-formed.
+      original = "class Foo\n  def existing: () -> String\nend\n# caf\xE9\n".b
+      File.binwrite(target, original)
+
+      result = writer.write("lib/foo.rb", [candidate(method_name: :h, rbs: "def h: () -> Integer")])
+
+      expect(result.action).to eq(:skipped_invalid_encoding)
+      expect(result.error).to include(target)
+      expect(result.error).to include("not valid UTF-8")
+      expect(File.binread(target)).to eq(original)
+    end
+  end
+
   describe "create new sig file" do
     it "writes a class declaration with the candidate methods when no target exists" do
       result = writer.write("lib/foo.rb", [candidate(method_name: :n, rbs: "def n: () -> Integer")])


### PR DESCRIPTION
Follow-up to #230, closing the same bug class on the sig-gen path (flagged there as out of scope).

`rigor sig-gen --write` re-parses existing project `.rbs` files without checking their encoding. On rbs 4.1 an invalid byte raises a bare `ArgumentError` out of `RBS::Parser.magic_comment`'s regex — not a `ParsingError`, so the writer's rescue misses it and the run crashes with a stack trace naming neither the file nor the fix. On the older releases the gemspec supports, the C lexer could hang (fixed upstream in ruby/rbs#2973/#2983); a hang escapes every rescue.

### What changed

- **`Writer#update_existing`** refuses loudly: new `:skipped_invalid_encoding` WriteResult naming the file, renderer output telling the user to re-save as UTF-8, and a **non-zero exit** under the existing rationale ("the user asked for a write and did not get one"). Reusing `:skipped_invalid_rbs` was wrong by attribution — its message says "this is a bug in Rigor, please report it".
- **`LayoutIndex#index_file`** skips quietly, matching its documented handling of unparseable files (its `rescue StandardError` already caught the 4.1 `ArgumentError`; the guard's value there is the pre-4.1 hang). The env loader's quarantine warning (#230) is where the user learns the file's name.
- `RbsValidity` deliberately untouched — it parses sig-gen's own rendered output.

### Verification

- `make verify` green (8,291 examples), `git diff --check` clean.
- Mutation honesty: reverting the writer guard turns the new spec red with exactly the predicted `ArgumentError`. The layout-index guard's failure mode (a hang) only exists before rbs 4.1, so its spec pins skip-and-keep-siblings behaviour instead.
- No local rbs-compat rerun: the change adds a pure-Ruby `valid_encoding?` pre-check and touches no rbs API surface; `spec/rigor/environment` (the compat job's scope) is unchanged.