### PR TITLE
Read Data.define / Struct.new classes in sig-gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[sig-gen]** `rigor sig-gen` now reads a class built by `Data.define(...)` / `Struct.new(...)`, in both the `Point = Data.define(:x, :y)` and `class Point < Data.define(:x, :y)` forms ([#227](https://github.com/rigortype/rigor/issues/227)).
+  - Previously the members, the constructors, and the `::Data` / `::Struct` ancestry were all absent, and a `do ... end` block's methods were reported against the enclosing namespace — which then printed as a `class` even when it was a `module`.
+  - The generated declaration carries the member readers (plus writers, for a mutable Struct), a `.new` / `.[]` signature matching the constructor forms the class actually accepts, and the correct superclass. Under `--params=observed`, member types come from the `.new` call sites the observation scan sees.
 - **[sig-gen]** `rigor sig-gen --write` now refuses, by name and with a non-zero exit, to update a signature file that is not valid UTF-8, instead of crashing with a stack trace ([#231](https://github.com/rigortype/rigor/pull/231)).
 - **[engine]** A project `.rbs` file (or a plugin-synthesized inline-RBS contribution) that is not valid UTF-8 is now quarantined with a warning naming the file, instead of reaching the RBS parser — where it crashed `rigor check` with a bare `ArgumentError` on rbs 4.1, and could hang the process outright on older rbs releases ([#230](https://github.com/rigortype/rigor/pull/230)).
 - **[inference]** `Resolv.new([Resolv::Hosts.new, ...])` no longer false-fires `call.argument-type-mismatch` when the installed `rbs` predates 4.1; a core overlay backports the array-of-resolvers overload upstream added in ruby/rbs#2960 ([#230](https://github.com/rigortype/rigor/pull/230)).

--- a/lib/rigor/sig_gen.rb
+++ b/lib/rigor/sig_gen.rb
@@ -3,6 +3,7 @@
 require_relative "sig_gen/classification"
 require_relative "sig_gen/method_candidate"
 require_relative "sig_gen/observed_call"
+require_relative "sig_gen/meta_class_shape"
 require_relative "sig_gen/type_elaborator"
 require_relative "sig_gen/observation_collector"
 require_relative "sig_gen/generator"

--- a/lib/rigor/sig_gen/generator.rb
+++ b/lib/rigor/sig_gen/generator.rb
@@ -12,6 +12,7 @@ require_relative "../source/node_children"
 require_relative "../inference/def_return_typer"
 require_relative "../inference/scope_indexer"
 require_relative "../inference/rbs_type_translator"
+require_relative "meta_class_shape"
 require_relative "rbs_validity"
 
 module Rigor
@@ -61,6 +62,7 @@ module Rigor
         @module_function_methods = Set.new
         @class_shells = Set.new
         @class_superclasses = {}
+        @meta_layouts = {}
         # Whole-run, NOT per-file: a rendering defect is reported once at the end of the run.
         @unrenderable = []
       end
@@ -114,7 +116,13 @@ module Rigor
         @module_function_methods = Set.new
         @class_shells = Set.new
         @class_superclasses = {}
+        @meta_layouts = collect_meta_layouts(scope_index)
+        register_meta_classes
         defs = collect_method_definitions(parse_result.value)
+        # Candidate construction freezes the per-file maps above (see {#build_candidate}), so every registration
+        # pass has to be finished before the first `build_candidate` call. Meta members lead the RETURNED order —
+        # a value class's members and constructors read first, ahead of the methods its block body defines.
+        meta_candidates = collect_meta_member_candidates(path, scope_index)
         candidates_from_defs = defs.filter_map do |def_node, class_name, kind|
           # An analyzer bug typing one def's body must cost only that def's candidate, never the whole
           # `rigor sig-gen` run. The `check` path recovers each *file* this way (worker_session.rb); sig-gen
@@ -125,7 +133,8 @@ module Rigor
           nil
         end
         obs_ivar_map = build_observed_ivar_map(parse_result.value)
-        candidates_from_defs + collect_attr_candidates(parse_result.value, path, scope_index, obs_ivar_map)
+        meta_candidates + candidates_from_defs +
+          collect_attr_candidates(parse_result.value, path, scope_index, obs_ivar_map)
       end
 
       # Walks the AST collecting `(def_node, class_name, kind)` tuples for every `def` Rigor can re-type. Slice 1
@@ -163,8 +172,11 @@ module Rigor
           collect_def_node(node, prefix, in_singleton_class, module_function_active, out)
           return
         when Prism::ConstantWriteNode
-          register_data_struct_shell(node, prefix)
-          # fall through to recurse into the RHS so a trailing `do ... end` block carrying defs is still walked.
+          body = meta_block_body(node, prefix)
+          if body
+            walk_defs(body, prefix + [node.name.to_s], false, false, out)
+            return
+          end
         when Prism::StatementsNode
           walk_statements(node, prefix, in_singleton_class, module_function_active, out)
           return
@@ -192,8 +204,8 @@ module Rigor
       # collapse the whole env (the 2026-07-04 redmine `GitAdapter < AbstractAdapter` crash). Only a plain
       # constant superclass is emittable: `class X < Foo` / `class X < Foo::Bar` yields the source token verbatim
       # (RBS resolves it relative to the emitted namespace, matching Ruby's lexical scope). A computed
-      # superclass (`Struct.new`, `Data.define`, `Class.new`, any `CallNode`) is left unrecorded — those flow
-      # through the {#register_data_struct_shell} shell path or are simply un-representable, and guessing would
+      # superclass (`Class.new`, any other `CallNode`) is left unrecorded — a `Data.define` / `Struct.new` one is
+      # already carried by {#register_meta_classes}, and the rest are un-representable, where guessing would
       # misfold.
       def record_superclass(node, full)
         return unless node.is_a?(Prism::ClassNode)
@@ -202,37 +214,60 @@ module Rigor
         @class_superclasses[full] = superclass if superclass
       end
 
-      # ADR-14 gap-#3 (e): recognises `Const = Data.define(...)` and `Const = Struct.new(...)` as class
-      # declarations. The runtime side stamps a brand-new anonymous class at the RHS and binds it to `Const`, so
-      # the generated RBS needs an explicit `class Const` declaration even though no `class Const ... end` block
-      # appears in source. Without it, references to `Const` in return types fail to resolve under Steep (the
-      # canonical case is `GemResolver::Resolved | GemResolver::Unresolvable` where
-      # `Unresolvable = Data.define(:gem_name, :reason)`).
-      #
-      # The walker records the fully-qualified constant name in `@class_shells` (carried through to every
-      # candidate so the writer's tree-builder picks it up) AND in `@namespace_kinds` so the leaf's `class`
-      # keyword wins over the intermediate-segment `module` default.
-      def register_data_struct_shell(node, prefix)
-        return unless data_or_struct_call?(node.value)
+      # The ADR-48 member layouts for this file, in one table keyed by qualified class name. Reading the engine's
+      # own tables instead of re-recognising `Data.define` / `Struct.new` here is what keeps sig-gen's view of a
+      # value class from drifting from the analyser's: the walker that populates them ({Inference::ScopeIndexer})
+      # already covers the constant-assigned form (`Point = Data.define(:x, :y)`), the named-subclass form
+      # (`class Point < Data.define(:x, :y)`), a `::Data` receiver, and the `keyword_init:` flag. sig-gen's earlier
+      # private recogniser covered none of the last three and was the reason #227's output was wrong rather than
+      # merely thin.
+      MetaLayout = Data.define(:kind, :member_names, :keyword_init)
+      private_constant :MetaLayout
 
-        full = (prefix + [node.name.to_s]).join("::")
-        @class_shells << full
-        @namespace_kinds[full] = :class
+      def collect_meta_layouts(scope_index)
+        scope = scope_index.each_value.first
+        return {} if scope.nil?
+
+        layouts = {}
+        scope.data_member_layouts.each do |name, members|
+          layouts[name] = MetaLayout.new(kind: :data, member_names: members, keyword_init: false)
+        end
+        scope.struct_member_layouts.each do |name, layout|
+          layouts[name] = MetaLayout.new(kind: :struct, member_names: layout[:members],
+                                         keyword_init: layout[:keyword_init])
+        end
+        layouts
       end
 
-      DATA_STRUCT_SHELL_HEADS = {
-        "Data" => :define,
-        "Struct" => :new
-      }.freeze
-      private_constant :DATA_STRUCT_SHELL_HEADS
+      # ADR-14 gap-#3 (e): a `Const = Data.define(...)` / `Const = Struct.new(...)` assignment declares a class the
+      # source never spells with a `class` keyword — the runtime stamps an anonymous class at the rvalue and binds
+      # it to `Const` — so the generated RBS needs an explicit `class Const` of its own. Without it, references to
+      # `Const` in a return type fail to resolve under Steep (the canonical case is
+      # `GemResolver::Resolved | GemResolver::Unresolvable`, where `Unresolvable = Data.define(:gem_name, :reason)`).
+      #
+      # Every layout-carrying class therefore gets the `class` keyword in `@namespace_kinds` (so the leaf wins over
+      # the intermediate-segment `module` default), its `::Data` / `::Struct[untyped]` ancestry, and a `@class_shells`
+      # entry so the writer declares it even when every member candidate is suppressed as already-declared. The
+      # named-subclass form is registered too: its `class` keyword is not in question, but its computed superclass
+      # is exactly what {#record_superclass} refuses to guess at.
+      def register_meta_classes
+        @meta_layouts.each do |class_name, layout|
+          @namespace_kinds[class_name] = :class
+          @class_shells << class_name
+          @class_superclasses[class_name] = MetaClassShape::SUPERCLASSES.fetch(layout.kind)
+        end
+      end
 
-      def data_or_struct_call?(value)
-        return false unless value.is_a?(Prism::CallNode)
+      # The `do ... end` body of a `Const = Data.define(...) do ... end` assignment, when `Const` carries a layout.
+      # Defs inside that block bind on `Const`, NOT on the enclosing namespace — the runtime `class_eval`s the block
+      # into the anonymous class it just stamped. Attributing them to the enclosing namespace is what made sig-gen
+      # report `VoidOrigin#label` against `Rigor::Inference` and then, because a method-bearing leaf defaults to the
+      # `class` keyword, redeclare that module as a class (#227).
+      def meta_block_body(node, prefix)
+        return nil unless node.value.is_a?(Prism::CallNode)
+        return nil unless @meta_layouts.key?((prefix + [node.name.to_s]).join("::"))
 
-        receiver = value.receiver
-        return false unless receiver.is_a?(Prism::ConstantReadNode)
-
-        DATA_STRUCT_SHELL_HEADS[receiver.name.to_s] == value.name
+        node.value.block&.body
       end
 
       # Module / class bodies are walked through the `walk_statements` path so `module_function` (no-args)
@@ -824,6 +859,12 @@ module Rigor
           # Skip method bodies — attr_* there would refer to whatever the method is doing dynamically, not a
           # class-level declaration.
           return
+        when Prism::ConstantWriteNode
+          body = meta_block_body(node, prefix)
+          if body
+            walk_attr_calls(body, prefix + [node.name.to_s], false, ctx)
+            return
+          end
         when Prism::CallNode
           collect_attr_call(node, prefix, in_singleton_class, ctx)
         end
@@ -1064,6 +1105,64 @@ module Rigor
         when :reader then "def #{method_name}: () -> #{wrapped}"
         when :writer then "def #{method_name}: (#{erased}) -> #{wrapped}"
         end
+      end
+
+      # One candidate per member accessor and constructor {MetaClassShape} renders for each layout-carrying class.
+      # These are the members no `def` or `attr_*` in the source declares, so nothing else in sig-gen can find them —
+      # and once `register_meta_classes` has declared the class, an undeclared member reads as a missing one.
+      def collect_meta_member_candidates(path, scope_index)
+        return [] if @meta_layouts.empty?
+
+        scope = scope_index.each_value.first
+        environment = scope&.environment
+        @meta_layouts.flat_map do |class_name, layout|
+          types = meta_member_types(class_name, layout.member_names)
+          shape = MetaClassShape.of(
+            kind: layout.kind, members: layout.member_names, keyword_init: layout.keyword_init,
+            member_types: types.transform_values { |type| paren_wrap_union(union_erase([type])) }
+          )
+          shape.member_decls.filter_map do |member|
+            meta_member_candidate(path, class_name, member, types, scope, environment)
+          end
+        end
+      end
+
+      def meta_member_candidate(path, class_name, member, types, scope, environment)
+        existing = lookup_existing_method(class_name, member.method_name, member.kind, environment, scope)
+        return nil if declared_on_class_itself?(existing, class_name)
+
+        build_candidate(
+          path: path, class_name: class_name, method_name: member.method_name, kind: member.kind,
+          classification: Classification::NEW_METHOD,
+          inferred_return: types[member.source_member] || Type::Combinator.untyped,
+          rbs: member.rbs
+        )
+      end
+
+      # Whether an RBS declaration found for a member is the user's own, i.e. sits on this very class. Inheritance
+      # is the whole point of the distinction: `::Data.new: () -> bot` and `::Struct.new`'s factory both answer the
+      # `.new` lookup for every value class, and deferring to them is what leaves the arity false positive in place.
+      def declared_on_class_itself?(method_def, class_name)
+        return false if method_def.nil?
+        return false unless method_def.respond_to?(:defined_in)
+
+        method_def.defined_in.to_s.delete_prefix("::") == class_name
+      end
+
+      # `--params=observed` member types. {ObservationCollector} routes `Point.new(...)` call sites to
+      # `[class_name, :initialize]`, so a keyword call site names its member directly, while a positional one is
+      # matched by index — and only from call sites whose arity covers the whole member list, so a one-argument
+      # `Point.new(attrs)` shim cannot type member 0 as `Hash`. Empty without `--params=observed`.
+      def meta_member_types(class_name, members)
+        observations = @observations[[class_name, :initialize]] || []
+        return {} if observations.empty?
+
+        full_arity = observations.select { |obs| obs.positional.size == members.size }
+        members.each_with_index.to_h do |member, index|
+          observed = observations.filter_map { |obs| obs.keyword[member] } +
+                     full_arity.filter_map { |obs| obs.positional[index] }
+          [member, observed.empty? ? nil : Type::Combinator.union(*observed)]
+        end.compact
       end
     end
   end

--- a/lib/rigor/sig_gen/meta_class_shape.rb
+++ b/lib/rigor/sig_gen/meta_class_shape.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Rigor
+  module SigGen
+    # The RBS surface of a class the runtime builds from `Data.define(...)` / `Struct.new(...)` — its ancestry, its
+    # synthesised member accessors, and its constructors — rendered from an ADR-48 member layout.
+    #
+    # Declaring the class without them would be worse than not declaring it at all. `::Data`'s own RBS declares
+    # `def self.new: () -> bot` and `::Struct`'s declares only the `Struct.new("Name", :a, :b)` factory, so a
+    # subclass that carries no `.new` of its own turns every `Point.new(1, 2)` into a false-positive arity error —
+    # where the undeclared class it replaced merely typed as `Dynamic` and reported nothing. The same reasoning
+    # covers the member readers and `.[]` (`Point[1, 2]`, which `::Data`'s RBS does not declare): narrowing dispatch
+    # from `Dynamic` to a nominal class means everything the runtime synthesises must be declared, or it reads as
+    # missing.
+    #
+    # Member types arrive already erased to RBS and already parenthesised for return position. One pre-wrapped
+    # string serves every position this module interpolates into — `(a: (String | Integer))`,
+    # `((String | Integer) a)`, `?(String | Integer) a` all parse and validate.
+    module MetaClassShape
+      # `::Struct` is generic (`class Struct[E]`), and RBS rejects a bare `< ::Struct` with
+      # `InvalidTypeApplicationError`. `untyped` is the only element type a layout can justify.
+      SUPERCLASSES = { data: "::Data", struct: "::Struct[untyped]" }.freeze
+
+      # `method_name` / `kind` feed the writer's existing-member matching. `source_member` is the layout member a
+      # reader / writer derives from, and nil for a constructor, so the caller can attach the member's carrier to
+      # the candidate it builds.
+      Member = ::Data.define(:method_name, :kind, :rbs, :source_member)
+      Shape = ::Data.define(:superclass, :member_decls)
+
+      module_function
+
+      # @param kind [:data, :struct]
+      # @param members [Array<Symbol>] ordered member names from the ADR-48 layout.
+      # @param member_types [Hash{Symbol => String}] erased RBS spellings; a member with no entry renders `untyped`.
+      # @param keyword_init [Boolean] the `Struct.new(..., keyword_init: true)` flag; ignored for `:data`.
+      # @return [Shape]
+      def of(kind:, members:, member_types: {}, keyword_init: false)
+        types = members.to_h { |member| [member, member_types[member] || "untyped"] }
+        accessors = kind == :struct ? struct_accessors(members, types) : readers(members, types)
+        Shape.new(superclass: SUPERCLASSES.fetch(kind),
+                  member_decls: accessors + constructors(kind, members, types, keyword_init))
+      end
+
+      def readers(members, types)
+        members.map do |member|
+          Member.new(method_name: member, kind: :instance, source_member: member,
+                     rbs: "def #{member}: () -> #{types[member]}")
+        end
+      end
+
+      # A Struct's members are mutable, so each one contributes a writer too. The writer returns the assigned
+      # value's type — Ruby's assignment semantics, and the spelling the `attr_writer` path already emits.
+      def struct_accessors(members, types)
+        writers = members.map do |member|
+          Member.new(method_name: :"#{member}=", kind: :instance, source_member: member,
+                     rbs: "def #{member}=: (#{types[member]}) -> #{types[member]}")
+        end
+        readers(members, types) + writers
+      end
+
+      # `.new` and its `.[]` alias share one overload list.
+      def constructors(kind, members, types, keyword_init)
+        overloads = constructor_overloads(kind, members, types, keyword_init).join(" | ")
+        %i[new []].map do |name|
+          Member.new(method_name: name, kind: :singleton, source_member: nil, rbs: "def self.#{name}: #{overloads}")
+        end
+      end
+
+      # `Data` requires every member; a Struct fills a missing one with `nil`, so its positions are all optional.
+      #
+      # `keyword_init: true` accepts keyword arguments only. Every other layout gets BOTH forms, because the flag
+      # reads `false` for an absent `keyword_init:` as well as for a literal `keyword_init: false` — and since Ruby
+      # 3.2 the absent case, by far the dominant one, accepts both. Emitting both is the false-positive-free reading
+      # of an ambiguity the layout cannot resolve.
+      def constructor_overloads(kind, members, types, keyword_init)
+        optional = kind == :struct ? "?" : ""
+        keyword = "(#{members.map { |m| "#{optional}#{m}: #{types[m]}" }.join(', ')}) -> instance"
+        return [keyword] if kind == :struct && keyword_init
+
+        [keyword, "(#{members.map { |m| "#{optional}#{types[m]} #{m}" }.join(', ')}) -> instance"]
+      end
+    end
+  end
+end

--- a/lib/rigor/sig_gen/renderer.rb
+++ b/lib/rigor/sig_gen/renderer.rb
@@ -66,7 +66,7 @@ module Rigor
 
       def render_classes(items)
         items.group_by(&:class_name).each do |class_name, methods|
-          @out.puts("class #{class_name}")
+          @out.puts(declaration_header(methods.first, class_name))
           methods.each do |candidate|
             tag = case candidate.classification
                   when Classification::NEW_METHOD then "[new]"
@@ -79,6 +79,17 @@ module Rigor
           end
           @out.puts("end")
         end
+      end
+
+      # The keyword and ancestry for a printed group, from the same per-file maps the `--write` path reads. Print
+      # mode used to hard-code `class`, which turned a module into a class the moment it held an emittable method —
+      # output that raises `RBS::DuplicatedDeclarationError` on load if the real `module` is declared anywhere else
+      # (#227). Defaulting to `class` when the map has no entry keeps the pre-existing spelling for a leaf class.
+      def declaration_header(candidate, class_name)
+        return "module #{class_name}" if candidate.namespace_kinds[class_name] == :module
+
+        superclass = candidate.class_superclasses[class_name]
+        superclass ? "class #{class_name} < #{superclass}" : "class #{class_name}"
       end
 
       def render_diff(candidates)

--- a/sig/rigor/inference/void_origin.rbs
+++ b/sig/rigor/inference/void_origin.rbs
@@ -1,8 +1,8 @@
 module Rigor
   module Inference
-    # `VoidOrigin = Data.define(:class_name, :method_name, :kind)`. Declared as a `::Data` subclass because
-    # that is the shape the runtime actually builds; `sig-gen` cannot yet read a `Data.define` assignment
-    # (it reports the block body's `#label` against the enclosing namespace and drops the members).
+    # `VoidOrigin = Data.define(:class_name, :method_name, :kind)`. Declared as a `::Data` subclass because that
+    # is the shape the runtime actually builds. `sig-gen` reads this form since #227 and generates the same
+    # structure; the member types are hand-narrowed from the `untyped` only `--params=observed` could improve on.
     class VoidOrigin < ::Data
       attr_reader class_name: String
       attr_reader method_name: Symbol
@@ -10,6 +10,9 @@ module Rigor
 
       def self.new: (class_name: String, method_name: Symbol, kind: Symbol) -> instance
                   | (String class_name, Symbol method_name, Symbol kind) -> instance
+
+      def self.[]: (class_name: String, method_name: Symbol, kind: Symbol) -> instance
+                 | (String class_name, Symbol method_name, Symbol kind) -> instance
 
       # A human-facing `Class#method` / `Class.method` label for the diagnostic message.
       def label: () -> String

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -1243,6 +1243,28 @@ RSpec.describe Rigor::CLI do
       expect(out).to include("sig-gen")
     end
 
+    # Issue #227: print mode hard-coded the `class` keyword, so a module holding an emittable method was printed as
+    # a class — RBS::DuplicatedDeclarationError once the real `module` declaration is loaded alongside it.
+    it "prints the source's own module / class keyword and a Data class's ancestry" do
+      path = write_fixture("lib/shapes.rb", <<~RUBY)
+        module Geometry
+          Pair = Data.define(:left)
+
+          def self.origin
+            "0,0"
+          end
+        end
+      RUBY
+
+      status, out, err = run_cli("sig-gen", path)
+
+      expect(err).to eq("")
+      expect(status).to eq(0)
+      expect(out).to include("module Geometry")
+      expect(out).to include("class Geometry::Pair < ::Data")
+      expect(out).not_to include("class Geometry\n")
+    end
+
     describe "--params=observed (slice 3)" do
       def write_observed_project
         config_path = File.join(tmpdir, ".rigor.yml")

--- a/spec/rigor/sig_gen/generator_spec.rb
+++ b/spec/rigor/sig_gen/generator_spec.rb
@@ -199,6 +199,128 @@ RSpec.describe Rigor::SigGen::Generator do
     end
   end
 
+  # Issue #227. Before this, a `Const = Data.define(...) do ... end` assignment produced output that was WRONG,
+  # not merely thin: the block body's methods were attributed to the enclosing namespace (which then rendered as
+  # a `class` even when it was a `module`), and the members, the constructors, and the `::Data` ancestry were all
+  # absent — so the class the file actually defines never appeared.
+  describe "Data.define / Struct.new member and constructor emission (#227)" do
+    def run_for(source, **)
+      path = write_fixture("lib/shapes.rb", source)
+      generator(paths: [path], **).run
+    end
+
+    def rbs_for(candidates, class_name)
+      candidates.select { |c| c.class_name == class_name }.filter_map(&:rbs)
+    end
+
+    it "attributes a block body's defs to the constant, not the enclosing namespace" do
+      candidates = run_for(<<~RUBY)
+        module Outer
+          Shell = Data.define(:a) do
+            def label
+              "x"
+            end
+          end
+        end
+      RUBY
+
+      label = candidates.find { |c| c.method_name == :label }
+      expect(label.class_name).to eq("Outer::Shell")
+      expect(label.namespace_kinds["Outer"]).to eq(:module)
+    end
+
+    it "declares the members, both constructors, and the ::Data ancestry" do
+      candidates = run_for("module Outer\n  Shell = Data.define(:a, :b)\nend\n")
+
+      expect(rbs_for(candidates, "Outer::Shell")).to eq(
+        ["def a: () -> untyped",
+         "def b: () -> untyped",
+         "def self.new: (a: untyped, b: untyped) -> instance | (untyped a, untyped b) -> instance",
+         "def self.[]: (a: untyped, b: untyped) -> instance | (untyped a, untyped b) -> instance"]
+      )
+      expect(candidates.first.class_superclasses["Outer::Shell"]).to eq("::Data")
+    end
+
+    it "declares writers and optional constructor positions for a Struct" do
+      candidates = run_for("Point = Struct.new(:x)\n")
+
+      expect(rbs_for(candidates, "Point")).to eq(
+        ["def x: () -> untyped",
+         "def x=: (untyped) -> untyped",
+         "def self.new: (?x: untyped) -> instance | (?untyped x) -> instance",
+         "def self.[]: (?x: untyped) -> instance | (?untyped x) -> instance"]
+      )
+      expect(candidates.first.class_superclasses["Point"]).to eq("::Struct[untyped]")
+    end
+
+    it "drops the positional constructor form under keyword_init: true" do
+      candidates = run_for("Point = Struct.new(:x, keyword_init: true)\n")
+
+      expect(rbs_for(candidates, "Point")).to include("def self.new: (?x: untyped) -> instance")
+    end
+
+    # The named-subclass form already got its `class` keyword from the source; what it never got was the computed
+    # superclass (`record_superclass` refuses to guess at a CallNode) or the members.
+    it "covers the `class X < Data.define(...)` form too" do
+      candidates = run_for("class Named < Data.define(:id)\nend\n")
+
+      expect(rbs_for(candidates, "Named")).to include("def id: () -> untyped")
+      expect(candidates.first.class_superclasses["Named"]).to eq("::Data")
+    end
+
+    it "leaves a member the class itself already declares to the user" do
+      write_fixture("sig/shapes.rbs", <<~RBS)
+        class Point < ::Data
+          attr_reader x: Integer
+        end
+      RBS
+      candidates = run_for("Point = Data.define(:x, :y)\n", signature_paths: [File.join(tmpdir, "sig")])
+
+      expect(rbs_for(candidates, "Point")).to include("def y: () -> untyped")
+      expect(rbs_for(candidates, "Point")).not_to include("def x: () -> untyped")
+    end
+
+    # `::Data.new: () -> bot` answers the `.new` lookup for every value class. Deferring to it as if it were the
+    # user's own declaration is what would leave the arity false positive in place.
+    it "still declares .new when only the inherited ::Data one is visible" do
+      write_fixture("sig/shapes.rbs", "class Point < ::Data\nend\n")
+      candidates = run_for("Point = Data.define(:x)\n", signature_paths: [File.join(tmpdir, "sig")])
+
+      expect(rbs_for(candidates, "Point")).to include(
+        "def self.new: (x: untyped) -> instance | (untyped x) -> instance"
+      )
+    end
+
+    it "types members from `.new` observations under --params=observed" do
+      path = write_fixture("lib/shapes.rb", "Point = Data.define(:x, :y)\n")
+      observations = {
+        ["Point", :initialize] => [
+          Rigor::SigGen::ObservedCall.new(keyword: { x: Rigor::Type::Combinator.constant_of("a") }),
+          [Rigor::Type::Combinator.constant_of(1), Rigor::Type::Combinator.constant_of(2)]
+        ]
+      }
+      config = Rigor::Configuration.new(Rigor::Configuration::DEFAULTS)
+
+      candidates = described_class.new(configuration: config, paths: [path], observations: observations).run
+
+      expect(candidates.select { |c| c.class_name == "Point" }.filter_map(&:rbs))
+        .to include('def x: () -> ("a" | 1)', "def y: () -> 2")
+    end
+
+    # A one-argument `Point.new(attrs)` shim must not type member 0 as that argument's type: the arities disagree,
+    # so the call site says nothing about which member each position feeds.
+    it "ignores positional observations whose arity does not cover the member list" do
+      path = write_fixture("lib/shapes.rb", "Point = Data.define(:x, :y)\n")
+      observations = { ["Point", :initialize] => [[Rigor::Type::Combinator.constant_of("attrs")]] }
+      config = Rigor::Configuration.new(Rigor::Configuration::DEFAULTS)
+
+      candidates = described_class.new(configuration: config, paths: [path], observations: observations).run
+
+      expect(candidates.select { |c| c.class_name == "Point" }.filter_map(&:rbs))
+        .to include("def x: () -> untyped")
+    end
+  end
+
   describe "superclass capture (ADR-14)" do
     it "records a plain-constant superclass on every candidate" do
       src = <<~RUBY
@@ -233,7 +355,23 @@ RSpec.describe Rigor::SigGen::Generator do
       expect(candidate.class_superclasses["Scm::Adapters::GitAdapter"]).to eq("AbstractAdapter")
     end
 
-    it "does not record a computed superclass (Struct.new / Class.new)" do
+    # A computed superclass is un-representable in RBS and guessing would misfold. The `Data.define` / `Struct.new`
+    # pair is the exception the ADR-48 layouts let us resolve exactly (#227) — everything else stays unrecorded.
+    it "does not record a computed superclass it cannot resolve" do
+      src = <<~RUBY
+        Base = Class.new
+        class Point < Class.new(Base)
+          def norm; 1; end
+        end
+      RUBY
+      path = write_fixture("lib/point.rb", src)
+
+      candidate = generator(paths: [path]).run.find { |c| c.method_name == :norm }
+
+      expect(candidate.class_superclasses).not_to have_key("Point")
+    end
+
+    it "records the synthesised ancestry of a `class X < Struct.new(...)`" do
       src = <<~RUBY
         class Point < Struct.new(:x, :y)
           def norm; 1; end
@@ -243,7 +381,7 @@ RSpec.describe Rigor::SigGen::Generator do
 
       candidate = generator(paths: [path]).run.find { |c| c.method_name == :norm }
 
-      expect(candidate.class_superclasses).not_to have_key("Point")
+      expect(candidate.class_superclasses["Point"]).to eq("::Struct[untyped]")
     end
   end
 

--- a/spec/rigor/sig_gen/meta_class_shape_spec.rb
+++ b/spec/rigor/sig_gen/meta_class_shape_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+RSpec.describe Rigor::SigGen::MetaClassShape do
+  def rbs_lines(shape) = shape.member_decls.map(&:rbs)
+
+  describe "a Data layout" do
+    subject(:shape) { described_class.of(kind: :data, members: %i[amount unit]) }
+
+    it "inherits ::Data" do
+      expect(shape.superclass).to eq("::Data")
+    end
+
+    it "declares one reader per member and no writer" do
+      expect(rbs_lines(shape)).to include("def amount: () -> untyped", "def unit: () -> untyped")
+      expect(rbs_lines(shape)).to all(satisfy { |line| !line.include?("=:") })
+    end
+
+    # `::Data.new` is declared `() -> bot`, so a subclass that inherits it turns every construction into an arity
+    # error. Both call forms exist at runtime, and `.[]` is absent from `::Data`'s RBS entirely.
+    it "declares .new and its .[] alias with the keyword and positional forms" do
+      expected = "(amount: untyped, unit: untyped) -> instance | (untyped amount, untyped unit) -> instance"
+
+      expect(rbs_lines(shape)).to include("def self.new: #{expected}", "def self.[]: #{expected}")
+    end
+
+    it "requires every member — a Data member has no default" do
+      expect(rbs_lines(shape).grep(/self\.new/).first).not_to include("?")
+    end
+
+    it "renders the supplied member types verbatim" do
+      shape = described_class.of(kind: :data, members: %i[amount unit],
+                                 member_types: { amount: "Integer", unit: "(String | Symbol)" })
+
+      expect(rbs_lines(shape)).to include(
+        "def amount: () -> Integer",
+        "def unit: () -> (String | Symbol)",
+        "def self.new: (amount: Integer, unit: (String | Symbol)) -> instance " \
+        "| (Integer amount, (String | Symbol) unit) -> instance"
+      )
+    end
+  end
+
+  describe "a Struct layout" do
+    subject(:shape) { described_class.of(kind: :struct, members: %i[x y]) }
+
+    # RBS rejects a bare `< ::Struct` with InvalidTypeApplicationError — `class Struct[E]` is generic.
+    it "inherits ::Struct with an explicit type argument" do
+      expect(shape.superclass).to eq("::Struct[untyped]")
+    end
+
+    it "declares a writer alongside each reader" do
+      expect(rbs_lines(shape)).to include("def x: () -> untyped", "def x=: (untyped) -> untyped")
+    end
+
+    # A Struct fills an omitted member with nil, so `Point.new(1)` is legal.
+    it "makes every constructor position optional" do
+      expect(rbs_lines(shape)).to include(
+        "def self.new: (?x: untyped, ?y: untyped) -> instance | (?untyped x, ?untyped y) -> instance"
+      )
+    end
+
+    it "drops the positional form under keyword_init: true" do
+      shape = described_class.of(kind: :struct, members: %i[x y], keyword_init: true)
+
+      expect(rbs_lines(shape)).to include("def self.new: (?x: untyped, ?y: untyped) -> instance")
+    end
+  end
+
+  it "marks a constructor with no source member so the caller cannot attach a member carrier to it" do
+    shape = described_class.of(kind: :data, members: %i[a])
+
+    by_name = shape.member_decls.to_h { |member| [member.method_name, member] }
+    expect(by_name[:a].source_member).to eq(:a)
+    expect(by_name[:new].source_member).to be_nil
+    expect(by_name[:new].kind).to eq(:singleton)
+  end
+end


### PR DESCRIPTION
Closes #227.

## What was wrong

`rigor sig-gen` could not read a class defined by assigning `Data.define` / `Struct.new` to a constant. Against `lib/rigor/inference/void_origin.rb` it produced:

```
class Rigor::Inference
  # [new]
  def label: () -> String
end
```

Three faults: `Rigor::Inference` is a **module** emitted as a `class`, `VoidOrigin` — the class the file defines — is absent, and the members plus the `::Data` ancestry are gone. It is what forced `sig/rigor/inference/void_origin.rbs` to be hand-authored against the AGENTS.md "prefer sig-gen" policy.

## What it produces now

```rbs
module Geometry
  class VoidOrigin < ::Data
    def class_name: () -> untyped
    def method_name: () -> untyped
    def kind: () -> untyped
    def self.new: (class_name: untyped, ...) -> instance | (untyped class_name, ...) -> instance
    def self.[]: (class_name: untyped, ...) -> instance | (untyped class_name, ...) -> instance
    def label: () -> String
  end
end
```

Covered forms: `Const = Data.define(...)`, the same with a `do ... end` block, `Const = Struct.new(...)`, `keyword_init: true`, and `class X < Data.define(...)` — the last being by far the dominant form in this repo, and one that was missing its members and its ancestry too.

## Three decisions worth review

**Read the ADR-48 layouts, don't re-recognise the syntax.** `ScopeIndexer` already builds `data_member_layouts` / `struct_member_layouts` for both forms, resolves a `::Data` receiver, requires literal Symbol members, and carries `keyword_init:`. sig-gen's private recogniser had none of the last three, and that divergence is why the output was wrong rather than thin. Reading the engine's own tables makes the two unable to drift.

**Emitting `.new` / `.[]` is FP prevention, not completeness.** Declaring the class narrows dispatch from `Dynamic` to a nominal, so from that point anything the runtime synthesises but RBS does not declare reads as *missing*. `::Data.new` is declared `() -> bot` and `::Struct`'s is the `Struct.new("Name", :a, :b)` factory — inheriting either turns every `Point.new(1, 2)` into an arity error, i.e. this change would have *introduced* a false positive without them. `.[]` is absent from `::Data`'s RBS entirely. Relatedly, suppression keys on `defined_in` rather than on the lookup succeeding: deferring to an inherited `::Data.new` as though it were the user's own declaration is what would leave that FP in place.

**`keyword_init: false` emits both constructor forms.** The layout flag reads `false` for an absent `keyword_init:` as well as a literal `false`, and since Ruby 3.2 the absent case — the dominant one — accepts both positional and keyword. Emitting both is the FP-free reading of an ambiguity the layout cannot resolve.

## Verification

- `make verify` clean (8,312 examples), `make check` / `make check-plugins` / `make docs-check` clean, `rbs -I sig validate` clean, `git diff --check` clean.
- RBS spellings probed against `rbs validate` before being committed to, not reasoned about: a bare `< ::Struct` is an `InvalidTypeApplicationError` (hence `::Struct[untyped]`), while parenthesised unions in every interpolated position and members named `type` / `class` / `self` / `end` all validate.
- End-to-end on a fixture covering all five forms: the written file passes `rbs validate`, and `rigor check` reports nothing across keyword, positional, `.[]`, partial-positional Struct, `keyword_init`, and member-write call sites — while still catching an undefined member, which is signal the old `Dynamic` receiver could not produce.

## Note on the emitted spelling

The issue's illustrative shape used `attr_reader x: T`; this emits the long-form `def x: () -> T` instead, following the existing `attr_*` path's documented reason — the long form is what the writer's `MethodDefinition`-based merge understands, and its existing-member detection already treats a target-side `attr_reader` as the same member, so no duplicate is inserted either way.