### PR TITLE
Recalibrate the perf baseline and notice when it goes stale

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -9,7 +9,7 @@ run as an advisory job in the release gate
 |---|---|
 | `baseline.json` | The committed per-target baseline metrics (wall / allocations / peak-RSS). Ships **uncalibrated**; activate by committing a CI-measured baseline (see below). |
 | `thresholds.yml` | The tunable tolerance band — the reviewed knob for how much each metric may regress before the gate fails. |
-| `baseline.updated.json` | **Not committed** (gitignored). The suggested baseline `make bench-perf` writes when the committed baseline is uncalibrated, or for inspection. |
+| `baseline.updated.json` | **Not committed** (gitignored). The suggested baseline `make bench-perf` writes on **every** run — this is the file a refresh commits from. |
 
 The benchmark runs `rigor check --no-cache` in-process over a target (default
 `lib`) and measures wall time, `GC.stat(:total_allocated_objects)`, and peak
@@ -35,3 +35,11 @@ make bench-perf
 When a Rigor change legitimately shifts the numbers (a perf win, or an
 accepted cost), refresh the baseline the same way — deliberately, as a
 reviewed commit, never silently.
+
+Refreshing matters in **both** directions. The band is a percentage of the
+baseline, not of the current cost, so an improvement left unrefreshed widens
+the real ceiling instead of tightening it: after `lib` allocations fell 27%,
+the +5% band still permitted +44% over the true number. The gate only fails
+on regressions — an improvement is not one — so `make bench-perf` prints a
+`STALE` notice when allocations fall more than `stale_pct` below the
+baseline. Treat it as a request for a reviewed refresh, not a failure.

--- a/bench/baseline.json
+++ b/bench/baseline.json
@@ -1,13 +1,13 @@
 {
   "calibrated": true,
-  "calibrated_at": "2026-07-19T00:00:00Z",
-  "calibrated_on": "ubuntu-latest (GitHub Actions), release/0.3.0 @ run 29688276809",
-  "note": "Linux CI measurements. wall_s is wider than local macOS (runner noise); allocations is the tight signal. Refresh by triggering release-gate.yml, downloading the bench-baseline-* artifact, and committing its targets here. Recalibrated for the v0.3.0 cut: the previous baseline was set mid-cycle after the performance arc (PRs #74-#82, allocations 22.24M), and ~54 merges landed after it. The `lib` self-check allocations rose to 32.40M (+45.7%) — legitimate default-on feature work added since that baseline, dominated by the five new AST-walking diagnostic rules (PR #101: flow.duplicate-hash-key, flow.return-in-ensure, flow.shadowed-rescue-clause, call.raise-non-exception, and the suppression rules) and the scalar-key HashShape + Kernel value typing (PR #102). The OSS-corpus (Mastodon) sweep stayed GREEN on the release run (no new false positives), so the rise is honest work, not a correctness regression; the targets are refreshed to the current cost so the 5% allocation band keeps its teeth. wall_s and peak_rss_kb moved with the same workload growth and are refreshed alongside. Follow-up (does not block this cut): the new rules run as standalone walks and are candidates for folding into the shared RuleWalk to recover some of the allocation cost.",
+  "calibrated_at": "2026-07-30T01:04:00Z",
+  "calibrated_on": "ubuntu-latest (GitHub Actions), master @ run 30504551099",
+  "note": "Linux CI measurements. wall_s is wider than local macOS (runner noise); allocations is the tight signal. Refresh by triggering release-gate.yml, downloading the bench-baseline-* artifact, and committing its targets here — that artifact is now produced on every run, not only an uncalibrated one, which is why this refresh was missable before. Recalibrated DOWN from the v0.3.0 cut's 32,403,338: `lib` self-check allocations fell to 23,521,131 (-27.4%) when e3b132a3 declared `Inference::VoidOrigin` in sig/. That single dangling reference was the tree's only unresolved type, and therefore the only reason `Environment::RbsLoader.stub_missing_referenced_types` ran a second confirmatory pass building all ~1,917 project classes; with sig/ self-consistent the fixpoint converges on pass 1 and the second pass is gone. This is a sig correctness fix, NOT a Rigor performance win — no other project benefits from it, and docs/notes/20260725-check-allocation-attribution.md predicted this exact figure before the fix landed. Refreshed so the 5% allocation band keeps its teeth: against the stale target it permitted 34,023,505, i.e. +44% over the real cost. wall_s and peak_rss_kb come from the same run.",
   "targets": {
     "lib": {
-      "wall_s": 16.927,
-      "allocations": 32403338,
-      "peak_rss_kb": 328108,
+      "wall_s": 15.015,
+      "allocations": 23521131,
+      "peak_rss_kb": 319612,
       "diagnostics": 1
     }
   }

--- a/bench/thresholds.yml
+++ b/bench/thresholds.yml
@@ -17,3 +17,12 @@
 wall_pct: 20
 allocations_pct: 5
 rss_pct: 10
+
+# How far BELOW the baseline allocations may fall before the run prints a
+# staleness notice. Not a failure — an improvement is not a regression — but
+# an unrefreshed baseline silently widens the real ceiling, because the band
+# is a percentage of the baseline rather than of the current cost. A 27% drop
+# once left the +5% band permitting +44% over the real number, with nothing
+# saying so. Allocations only; wall and RSS drift with runner noise and would
+# make this fire spuriously.
+stale_pct: 15

--- a/tool/bench.rb
+++ b/tool/bench.rb
@@ -79,7 +79,7 @@ end
 # Tiny `key: int` reader so the gate stays dependency-free. Lines that are
 # blank or start with `#` are ignored; only the known band keys are honoured.
 def load_thresholds(path)
-  band = { "wall_pct" => 10, "allocations_pct" => 5, "rss_pct" => 10 }
+  band = { "wall_pct" => 10, "allocations_pct" => 5, "rss_pct" => 10, "stale_pct" => 15 }
   return band unless File.readable?(path)
 
   File.foreach(path, encoding: "UTF-8") do |line|
@@ -106,21 +106,51 @@ baseline =
   end
 band = load_thresholds(options[:thresholds])
 
+# The suggestion sibling is written on EVERY run, not only an uncalibrated one. `bench/baseline.json`'s own refresh
+# instructions say to trigger release-gate.yml and commit the uploaded artifact's targets — and that produced nothing
+# whenever the baseline was calibrated, i.e. in the only state a refresh is ever wanted, with the workflow's
+# `if-no-files-found: ignore` swallowing the gap. Writing it unconditionally is what makes the documented procedure
+# work; the file is gitignored, so a local run still never touches the committed baseline.
+suggested = {
+  "calibrated" => true,
+  "calibrated_at" => Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
+  "targets" => results
+}
+out_path = options[:write] || "#{options[:baseline].sub(/\.json\z/, '')}.updated.json"
+File.write(out_path, "#{JSON.pretty_generate(suggested)}\n")
+
 unless baseline["calibrated"]
-  fresh = {
-    "calibrated" => true,
-    "calibrated_at" => Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
-    "targets" => results
-  }
-  out_path = options[:write] || "#{options[:baseline].sub(/\.json\z/, '')}.updated.json"
-  File.write(out_path, "#{JSON.pretty_generate(fresh)}\n")
   puts "First run — baseline uncalibrated; suggested baseline written to #{out_path}:"
   puts JSON.pretty_generate(results)
   puts "(Commit a CI-measured baseline as bench/baseline.json to activate the gate.)"
   exit 0
 end
 
+# A one-sided gate loses its teeth silently. The band is a percentage OF THE BASELINE, so a real improvement that is
+# never folded back in leaves the ceiling anchored at the old cost: after `lib` allocations fell 32.40M → 23.52M
+# (a `sig/` correctness fix removed a whole `stub_missing_referenced_types` pass), the +5% band still permitted 34.02M
+# — +44% over the real cost, and no run said so. This notice is the counterweight. It never fails the build: an
+# improvement is not a regression, and the only action it asks for is a reviewed baseline commit.
+#
+# Allocations only, deliberately. It is the deterministic signal (`thresholds.yml`); wall and RSS drift with runner
+# noise, and a staleness notice that fires on noise is one people learn to scroll past — the same false-positive cost
+# the analyzer's own rules are held to.
+STALENESS_METRIC = "allocations"
+
+# The notice text, or nil when the metric is not the deterministic one or the drop is inside `stale_pct`. `headroom`
+# is what actually matters to a reader: how far the current cost could grow before the unrefreshed band notices.
+def staleness_notice(target, metric, now_value, base_value, pct, limit, stale_pct)
+  return nil unless metric == STALENESS_METRIC
+  return nil unless now_value < base_value * (1 - (stale_pct / 100.0))
+
+  drop = ((1 - (now_value.to_f / base_value)) * 100).round(1)
+  headroom = (((limit / now_value.to_f) - 1) * 100).round
+  "STALE #{target} #{metric}: #{now_value} is #{drop}% below baseline #{base_value}; " \
+    "the +#{pct}% band still permits #{limit.round} (+#{headroom}% over the real cost)"
+end
+
 regressions = []
+stale = []
 results.each do |target, now|
   base = baseline.dig("targets", target)
   unless base
@@ -144,8 +174,16 @@ results.each do |target, now|
                      "(+#{delta}% vs baseline #{b}, band +#{pct}%)"
     else
       puts "OK   #{target} #{metric}: #{n} ≤ #{limit.round} (baseline #{b})"
+      notice = staleness_notice(target, metric, n, b, pct, limit, band["stale_pct"])
+      stale << notice if notice
     end
   end
+end
+
+unless stale.empty?
+  warn "Perf-benchmark baseline looks stale:"
+  stale.each { |s| warn "  #{s}" }
+  warn "  Recalibrate from a Linux CI run: commit #{out_path}'s targets as #{options[:baseline]}."
 end
 
 if regressions.empty?


### PR DESCRIPTION
Part of #207. This is the measurement half — no engine change.

## What the numbers actually are

| metric | baseline claimed | Linux CI, master | delta |
| --- | --- | --- | --- |
| `lib` allocations | 32,403,338 | **23,521,131** | **−27.4%** |
| `lib` wall_s | 16.927 | 15.015 | −11.3% |
| `lib` peak_rss_kb | 328,108 | 319,612 | −2.6% |

Measured on [run 30504551099](https://github.com/rigortype/rigor/actions/runs/30504551099) (`ubuntu-latest`). My local macOS allocations came to 23,620,137 — within 0.4%, which is the portability `tool/bench.rb` claims for the metric.

## Where the 8.9M went

e3b132a3 (2026-07-29) declared `Inference::VoidOrigin` in `sig/`. That was the tree's **only** unresolved referenced type, so it was the only reason `Environment::RbsLoader.stub_missing_referenced_types` ran a second confirmatory pass — a pass that builds all ~1,917 project classes to discover nothing. Probing `unresolved_referenced_types` confirms it: pass 1 now reports `found=[]` and the method is never called again.

[`docs/notes/20260725-check-allocation-attribution.md`](https://github.com/rigortype/rigor/blob/master/docs/notes/20260725-check-allocation-attribution.md) predicted this exact figure four days *before* the fix landed, along with the instruction to recalibrate alongside it and to explicitly not count it as a performance win. It is a `sig/` correctness fix; no other project benefits.

## Why the recalibration was missed, and both fixes

**The gate is one-sided.** It fails only above the band, so the 27% drop was reported as `OK` twice on the v0.3.1 release run and said nothing. Because the band is a percentage *of the baseline*, the stale target left the +5% allocations band permitting 34,023,505 — **+44% over the real cost**. The teeth were gone, silently.

`make bench-perf` now prints a `STALE` notice when allocations fall more than `stale_pct` (new, 15%) below baseline. It never fails the build — an improvement is not a regression, and the only action it asks for is a reviewed baseline commit. Limited to allocations on purpose: it is the deterministic signal, while wall and RSS drift with runner noise, and a notice that fires on noise is one people learn to scroll past.

**The documented refresh path did not work.** `bench/baseline.json`'s own note says to trigger release-gate.yml and commit the uploaded artifact's targets. But `tool/bench.rb` wrote the suggestion file only when the baseline was *uncalibrated* — the one state in which nobody wants a refresh — and the workflow's `if-no-files-found: ignore` then swallowed the empty upload. I hit this directly: dispatching the workflow produced no `bench-baseline-*` artifact at all. It is now written on every run.

## Verification

Both directions of the new notice, since a probe that cannot report a negative is not evidence:

```
# against the OLD target
STALE lib allocations: 23620138 is 27.1% below baseline 32403338; the +5% band still permits 34023505 (+44% over the real cost)
OK   lib allocations: 23620138 ≤ 34023505 (baseline 32403338)
All perf-benchmark checks passed.

# against the NEW target — silent
OK   lib allocations: 23620147 ≤ 24697188 (baseline 23521131)
All perf-benchmark checks passed.
```

`rubocop tool/bench.rb` clean, `make docs-check` clean. No `lib/` or `spec/` file is touched, so the analyzer is unaffected.

## What this does not do

It does not take the remaining lever. Pass 1 still builds every project class and throws the definitions away — 7.84M allocations, now **33% of the whole run**, to find nothing on a clean project. That is the largest single item left in #207 and is tracked there; it needs a design call about detecting dangling references without a full `DefinitionBuilder` sweep, which carries real FP risk (stubbing a name that would have resolved shadows a real type).