### PR TITLE
Report an inline-RBS annotation parsed but not honoured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Added
+
+- **[rigor-rbs-inline]** An inline-RBS annotation that Rigor parses but does not honour is now reported as `plugin.rbs-inline.source-rbs-annotation-not-honoured` (info) instead of being dropped in silence ([#229](https://github.com/rigortype/rigor/issues/229)).
+  - There are two inline-RBS implementations, and they spell `module-self` differently: Rigor reads `# @rbs module-self Foo`, while `rbs`'s own inline documentation shows `# @rbs module-self: Foo`. The second form previously contributed nothing, with the annotation comment still echoed into the generated RBS — so the omission was invisible. The rest of the file's annotations are unaffected, and the diagnostic says so.
+  - The manual chapter now states which dialect Rigor reads and what differs.
+
 ### Fixed
 
 - **[sig-gen]** `rigor sig-gen` now reads a class built by `Data.define(...)` / `Struct.new(...)`, in both the `Point = Data.define(:x, :y)` and `class Point < Data.define(:x, :y)` forms ([#227](https://github.com/rigortype/rigor/issues/227)).

--- a/docs/manual/plugins/rigor-rbs-inline.md
+++ b/docs/manual/plugins/rigor-rbs-inline.md
@@ -45,6 +45,28 @@ plugin id/version + config), so an unchanged second run skips the parse.
 | Rule | Severity | Fires when |
 | --- | --- | --- |
 | `plugin.rbs-inline.source-rbs-synthesis-failed` | info | rbs-inline could not parse a file; analysis falls back to no inline-RBS contribution and the diagnostic carries the upstream error |
+| `plugin.rbs-inline.source-rbs-annotation-not-honoured` | info | an annotation parsed successfully but contributed nothing — the file's other annotations still apply. Today this means the `# @rbs module-self: Foo` spelling; see below |
+
+## Which inline-RBS dialect Rigor reads
+
+There are two implementations of inline RBS: the
+[`rbs-inline` gem](https://github.com/soutaro/rbs-inline), which this plugin
+runs, and the `RBS::InlineParser` built into `rbs` 4.x. **Rigor reads the
+gem's dialect** ([ADR-32](../../adr/32-rbs-inline-comment-ingestion.md) WD11).
+They overlap almost entirely — `#:`, `@rbs` method types, `def self.`,
+instance-variable annotations, `@rbs skip` all behave identically — but they
+are not the same grammar, and one difference bites in practice:
+
+| you write | Rigor honours it |
+| --- | --- |
+| `# @rbs module-self Comparable` | yes |
+| `# @rbs module-self: Comparable` | **no** — this is the spelling in rbs's own `docs/inline.md` |
+
+Rigor reports the second form as
+`plugin.rbs-inline.source-rbs-annotation-not-honoured` rather than dropping it
+in silence. Constructs the gem supports and the built-in parser does not —
+`@rbs generic T`, `@rbs!` embedded RBS blocks, `@rbs inherits`, method
+visibility — all work here.
 
 ## Configuration
 

--- a/lib/rigor/analysis/check_rules/rule_ids.rb
+++ b/lib/rigor/analysis/check_rules/rule_ids.rb
@@ -119,6 +119,7 @@ module Rigor
       # the runner grows a new bare id.
       NON_CHECK_DIAGNOSTIC_IDS = %w[
         configuration-error load-error pool-degraded runtime-error source-rbs-synthesis-failed
+        source-rbs-annotation-not-honoured
       ].freeze
     end
   end

--- a/lib/rigor/analysis/runner/diagnostic_aggregator.rb
+++ b/lib/rigor/analysis/runner/diagnostic_aggregator.rb
@@ -557,17 +557,35 @@ module Rigor
           return [] if @source_rbs_synthesis_reporter.empty?
 
           @source_rbs_synthesis_reporter.entries.map do |entry|
-            Diagnostic.new(
-              path: entry.path, line: 1, column: 1,
-              message: "plugin `#{entry.plugin_id}` failed to synthesise RBS from this file: " \
-                       "#{entry.message}. The file's analysis falls back to no inline-RBS " \
-                       "contribution. Fix the inline-RBS comment grammar or remove the " \
-                       "annotation to silence this diagnostic.",
-              severity: :info,
-              rule: "source-rbs-synthesis-failed",
-              source_family: :builtin
-            )
+            entry.kind == :not_honoured ? not_honoured_diagnostic(entry) : synthesis_failed_diagnostic(entry)
           end
+        end
+
+        def synthesis_failed_diagnostic(entry)
+          Diagnostic.new(
+            path: entry.path, line: 1, column: 1,
+            message: "plugin `#{entry.plugin_id}` failed to synthesise RBS from this file: " \
+                     "#{entry.message}. The file's analysis falls back to no inline-RBS " \
+                     "contribution. Fix the inline-RBS comment grammar or remove the " \
+                     "annotation to silence this diagnostic.",
+            severity: :info,
+            rule: "source-rbs-synthesis-failed",
+            source_family: :builtin
+          )
+        end
+
+        # ADR-32 WD12 — the synthesis SUCCEEDED; one annotation inside it was parsed and then contributed
+        # nothing. Distinct from the failure above in the only way that matters to the reader: the rest of
+        # the file's annotations ARE in effect, so the advice is to fix one comment, not to distrust the file.
+        def not_honoured_diagnostic(entry)
+          Diagnostic.new(
+            path: entry.path, line: 1, column: 1,
+            message: "plugin `#{entry.plugin_id}` parsed an inline-RBS annotation in this file but did " \
+                     "not honour it: #{entry.message} The file's other annotations are unaffected.",
+            severity: :info,
+            rule: "source-rbs-annotation-not-honoured",
+            source_family: :builtin
+          )
         end
 
         # ADR-10 slice 5c — drains the per-run {DependencySourceInference::BoundaryCrossReporter} into

--- a/lib/rigor/environment.rb
+++ b/lib/rigor/environment.rb
@@ -399,23 +399,38 @@ module Rigor
         ) { invoke_synthesizer_safely(callable, path) || "" }
       end
 
-      # ADR-32 WD6 — route a synthesizer return value through the per-run failure reporter. The
+      # ADR-32 WD6 / WD12 — route a synthesizer return value through the per-run reporter. The
       # synthesizer's contract (declared in
-      # `plugins/rigor-rbs-inline/lib/rigor/plugin/rbs_inline.rb`) admits three return shapes:
-      #   - `String` (non-empty) → successful RBS source
-      #   - `nil` / `""`         → no contribution
-      #   - `[:error, message]`  → parse failed
+      # `plugins/rigor-rbs-inline/lib/rigor/plugin/rbs_inline.rb`) admits four return shapes:
+      #   - `String` (non-empty)         → successful RBS source
+      #   - `nil` / `""`                 → no contribution
+      #   - `[:error, message]`          → parse failed (WD6)
+      #   - `[:ok, source, [message…]]`  → synthesis SUCCEEDED, but an annotation was parsed and not
+      #                                    honoured (WD12)
       # The error tuple is converted into a reporter entry + treated as "no contribution" so the analysis
-      # pipeline continues. Reporter is `nil` for callers that don't care (legacy Environment.new, tests).
+      # pipeline continues. The WD12 tuple keeps its `source` — the file's other annotations are good, and
+      # dropping them to report one omission would be a strictly worse trade. Reporter is `nil` for callers
+      # that don't care (legacy Environment.new, tests).
+      #
+      # A cached entry written before WD12 is a bare `String`, which falls through the `is_a?(Array)` guard
+      # unchanged, so no cache-descriptor bump is needed for the new shape.
       def interpret_synthesizer_outcome(outcome, plugin, path, reporter)
-        return outcome unless outcome.is_a?(Array) && outcome[0] == :error
+        return outcome unless outcome.is_a?(Array)
 
-        reporter&.record(
-          plugin_id: plugin.manifest.id,
-          path: path,
-          message: outcome[1].to_s
-        )
-        nil
+        case outcome[0]
+        when :error
+          record_synthesis_entry(reporter, plugin, path, outcome[1], :failed)
+          nil
+        when :ok
+          Array(outcome[2]).each { |m| record_synthesis_entry(reporter, plugin, path, m, :not_honoured) }
+          outcome[1]
+        else
+          outcome
+        end
+      end
+
+      def record_synthesis_entry(reporter, plugin, path, message, kind)
+        reporter&.record(plugin_id: plugin.manifest.id, path: path, message: message.to_s, kind: kind)
       end
 
       SYNTHESIZER_CACHE_PRODUCER_ID = "plugin.source_rbs_synthesizer"

--- a/lib/rigor/plugin/source_rbs_synthesis_reporter.rb
+++ b/lib/rigor/plugin/source_rbs_synthesis_reporter.rb
@@ -16,17 +16,23 @@ module Rigor
     # single reporter across the run; entries are appended one at a time during env build (before any per-file
     # analysis runs), so no locking is needed.
     class SourceRbsSynthesisReporter
-      Entry = Data.define(:plugin_id, :path, :message)
+      # `kind` separates the two outcomes the Runner reports differently (ADR-32 WD12): `:failed` is a
+      # synthesis that raised or could not parse, `:not_honoured` a synthesis that SUCCEEDED while silently
+      # dropping an annotation it parsed. They are not the same news — the first says the file contributed
+      # nothing, the second that it contributed all but one thing — so they carry distinct diagnostic ids.
+      # Defaults to `:failed`, the pre-WD12 meaning, so an older caller records what it always did.
+      Entry = Data.define(:plugin_id, :path, :message, :kind)
 
       def initialize
         @entries = []
       end
 
-      def record(plugin_id:, path:, message:)
+      def record(plugin_id:, path:, message:, kind: :failed)
         @entries << Entry.new(
           plugin_id: plugin_id.to_s.dup.freeze,
           path: path.to_s.dup.freeze,
-          message: message.to_s.dup.freeze
+          message: message.to_s.dup.freeze,
+          kind: kind
         )
         nil
       end

--- a/plugins/rigor-rbs-inline/lib/rigor/plugin/rbs_inline.rb
+++ b/plugins/rigor-rbs-inline/lib/rigor/plugin/rbs_inline.rb
@@ -60,9 +60,11 @@ module Rigor
         end
 
         # Return value contract:
-        # - `String` (non-empty)         → successful synthesis
-        # - `nil`                        → no contribution
-        # - `[:error, message_string]`   → parse failed, surface info diagnostic per ADR-32 WD6
+        # - `String` (non-empty)          → successful synthesis
+        # - `nil`                         → no contribution
+        # - `[:error, message_string]`    → parse failed, surface info diagnostic per ADR-32 WD6
+        # - `[:ok, source, [message, …]]` → synthesis succeeded, but an annotation was parsed and NOT
+        #                                   honoured; surface info diagnostics per ADR-32 WD12
         def call(source_file_path)
           return nil unless RBS_INLINE_AVAILABLE
           return nil unless File.file?(source_file_path)
@@ -83,7 +85,8 @@ module Rigor
           rendered = ::RBS::Inline::Writer.write(uses, decls, rbs_decls)
           return nil if rendered.nil? || rendered.strip.empty?
 
-          rendered
+          notices = unhonoured_annotations(result)
+          notices.empty? ? rendered : [:ok, rendered, notices]
         rescue ::StandardError => e
           # WD6 fail-soft — surface a structured error tuple so the engine's `Environment.for_project` can
           # emit a `source-rbs-synthesis-failed` info diagnostic naming the file + the upstream error
@@ -111,6 +114,33 @@ module Rigor
         def annotated?(prism_result)
           ::RBS::Inline::AnnotationParser.parse(prism_result.comments)
                                          .any? { |parsed| parsed.each_annotation.any? }
+        end
+
+        # ADR-32 WD12 — annotations upstream's parser ACCEPTS and its writer then contributes nothing from.
+        # These are invisible without a report: synthesis succeeds, and the annotation comment is even echoed
+        # into the generated RBS, so the omission shows up neither in the output nor at runtime.
+        #
+        # The one case today is `module-self`, where the two inline-RBS dialects disagree on spelling. rbs's
+        # own `docs/inline.md` documents `# @rbs module-self: Foo`; the rbs-inline gem's grammar is
+        # `# @rbs module-self Foo`, without the colon. Handed the colon form the gem still builds a
+        # `ModuleSelf` annotation but extracts no types from it, so an empty `self_types` on a parsed
+        # annotation is a precise signature for "the author asked for a constraint we did not apply".
+        # Measured both ways in `docs/notes/20260730-inline-rbs-parser-grammar-diff.md`.
+        #
+        # Deliberately narrow. A construct the gem's parser REJECTS already routes through WD6's error path,
+        # and one it never recognised at all is upstream's grammar to define (WD3) — guessing at those would
+        # make this a lint on comment prose, which is exactly the false-positive cost ADR-5 ranks first.
+        def unhonoured_annotations(prism_result)
+          ::RBS::Inline::AnnotationParser.parse(prism_result.comments).flat_map do |parsed|
+            parsed.each_annotation.filter_map do |annotation|
+              next unless annotation.is_a?(::RBS::Inline::AST::Annotations::ModuleSelf)
+              next unless annotation.self_types.empty?
+
+              "`@rbs module-self` contributed no self-type constraint. Rigor reads the " \
+                "`# @rbs module-self Foo` spelling; `# @rbs module-self: Foo` (the spelling in rbs's own " \
+                "inline documentation) is not honoured here."
+            end
+          end.uniq
         end
 
         # Rewrite every RDoc directive comment to its spaced spelling (`#:nodoc:` -> `# :nodoc:`) so

--- a/spec/integration/plugins/rbs_inline_plugin_spec.rb
+++ b/spec/integration/plugins/rbs_inline_plugin_spec.rb
@@ -352,6 +352,78 @@ RSpec.describe "plugins/rigor-rbs-inline" do
     end
   end
 
+  # ADR-32 WD12. The two inline-RBS dialects spell `module-self` differently, and the gem's response to the
+  # other spelling is to build the annotation and then contribute nothing from it — invisible without a report,
+  # since the annotation comment is echoed into the synthesised RBS either way.
+  describe "annotation parsed but not honoured (ADR-32 WD12)" do
+    def synthesizer_outcome(source)
+      Dir.mktmpdir("rigor-rbs-inline-wd12-") do |dir|
+        path = File.join(dir, "subject.rb")
+        File.write(path, source)
+        plugin = Rigor::Plugin::RbsInline.new(
+          services: Rigor::Plugin::Services.new(
+            reflection: Rigor::Reflection,
+            type: Rigor::Type::Combinator,
+            configuration: Rigor::Configuration.new
+          ),
+          config: { "require_magic_comment" => false }
+        )
+        plugin.manifest.source_rbs_synthesizer.call(path)
+      end
+    end
+
+    it "flags the rbs-built-in `module-self:` spelling and still returns the file's RBS" do
+      outcome = synthesizer_outcome(<<~RUBY)
+        # @rbs module-self: Comparable
+        module Sortable
+          # @rbs () -> Integer
+          def rank = 1
+        end
+      RUBY
+
+      expect(outcome).to be_an(Array)
+      kind, source, messages = outcome
+      expect(kind).to eq(:ok)
+      # The rest of the file is unaffected — that is the whole reason this is not routed through WD6.
+      expect(source).to include("def rank: () -> Integer")
+      expect(messages.first).to include("module-self")
+    end
+
+    # The gem's own spelling works, so the detector must stay silent on it. Without this the check would be a
+    # lint that fires on correct input.
+    it "stays silent on the rbs-inline spelling it does honour" do
+      outcome = synthesizer_outcome(<<~RUBY)
+        # @rbs module-self Comparable
+        module Sortable
+          # @rbs () -> Integer
+          def rank = 1
+        end
+      RUBY
+
+      expect(outcome).to be_a(String)
+      expect(outcome).to include("module Sortable : Comparable")
+    end
+
+    it "surfaces it as an info diagnostic without suppressing the file's other annotations" do
+      result = run_plugin(source: <<~RUBY)
+        # rbs_inline: enabled
+        # @rbs module-self: Comparable
+        module Sortable
+          # @rbs () -> Integer
+          def rank = 1
+        end
+      RUBY
+
+      not_honoured = result.diagnostics.select do |d|
+        d.qualified_rule == "source-rbs-annotation-not-honoured"
+      end
+      expect(not_honoured.size).to eq(1)
+      expect(not_honoured.first.severity).to eq(:info)
+      expect(not_honoured.first.message).to include("module-self")
+      expect(result.diagnostics.map(&:qualified_rule)).not_to include("source-rbs-synthesis-failed")
+    end
+  end
+
   describe "per-file cache (ADR-32 WD5)" do
     let(:cache_root) { Dir.mktmpdir("rigor-rbs-inline-cache-") }
     let(:cache_store) { Rigor::Cache::Store.new(root: cache_root) }


### PR DESCRIPTION
Implements [ADR-32](https://github.com/rigortype/rigor/blob/master/docs/adr/32-rbs-inline-comment-ingestion.md) WD12, the mitigation half of [#229](https://github.com/rigortype/rigor/issues/229). The decision half (WD11 — keep the `rbs-inline` gem) landed on `master` in 3a3ffadc, grounded in [the measured grammar diff](https://github.com/rigortype/rigor/blob/master/docs/notes/20260730-inline-rbs-parser-grammar-diff.md).

## The bug this makes visible

The two inline-RBS implementations spell `module-self` differently:

| you write | gem (what Rigor runs) | `RBS::InlineParser` |
| --- | --- | --- |
| `# @rbs module-self Comparable` | ✅ honoured | ❌ `AnnotationSyntaxError` |
| `# @rbs module-self: Comparable` — **the spelling in rbs's own `docs/inline.md`** | **silently nothing** | ✅ |

Handed the colon form the gem still builds a `ModuleSelf` annotation and then extracts no types from it. So Rigor applied no constraint and reported nothing — and the annotation comment is echoed into the synthesised RBS, so the omission was invisible on inspection as well as at runtime. A user following upstream's documentation walks straight into it.

## Why this is not WD6

WD6 is fail-soft on a synthesis **error**: the file contributed nothing, and the diagnostic says to fix or remove the annotation. This is a synthesis that **succeeded** and omitted one thing. Routing it through WD6 would mean discarding the file's other annotations to report one omission — a strictly worse trade — so the synthesizer contract grows a fourth shape that keeps the source:

```ruby
[:ok, rendered_source, ["…messages…"]]
```

`SourceRbsSynthesisReporter::Entry` gains a `kind` (`:failed` / `:not_honoured`, defaulting to the pre-WD12 meaning) and the aggregator emits a distinct id, because the two are not the same news to a reader: one says distrust the file, the other says fix one comment.

**No cache-descriptor bump.** An entry written before this is a bare `String` and falls through the new `is_a?(Array)` guard unchanged.

## Why the detector is narrow

An empty `self_types` on a *parsed* `ModuleSelf` annotation is a precise signature for "the author asked for a constraint we did not apply". It deliberately does not go further:

- An annotation the gem **rejects** already routes through WD6.
- One it never recognised at all is upstream's grammar to define (WD3).

Guessing at those would turn this into a lint on comment prose, which is the false-positive cost [ADR-5](https://github.com/rigortype/rigor/blob/master/docs/adr/5-robustness-principle.md) ranks first. The spec includes the negative case — the gem's own spelling must stay silent — because a check that fires on correct input is the failure mode here.

## Also

The manual chapter now states which dialect Rigor reads, with the `module-self` row spelled out and a note that `@rbs generic T`, `@rbs!`, `@rbs inherits` and method visibility all work here (the built-in parser rejects all four).

## Verification

`make verify` clean (8,316 examples), `make docs-check` clean — including the rule-ID drift gate, which requires every emitted diagnostic id to be documented — `rubocop` clean over 912 files, `git diff --check` clean.

## Upstream

Reporting this downstream is a mitigation, not the fix. A parser that accepts an annotation its own writer discards looks like an `rbs-inline` defect; fixing it there would close the gap for every rbs-inline user rather than only Rigor's. Worth filing separately — I have not.