### PR TITLE
Compose parameter_inference with --incremental via a table diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Added
 
+- **[rigor check]** `parameter_inference:` now composes with `--incremental` instead of being refused with exit 64 ([#204](https://github.com/rigortype/rigor/issues/204)).
+  - An incremental run recomputes the call-site parameter table and re-checks any method whose inferred parameter types moved — so editing only a *caller* correctly refreshes the *callee's* diagnostics, the staleness the old mutual exclusion existed to prevent. `--verify-incremental` runs under the gate too.
 - **[rigor-rbs-inline]** An inline-RBS annotation that Rigor parses but does not honour is now reported as `plugin.rbs-inline.source-rbs-annotation-not-honoured` (info) instead of being dropped in silence ([#229](https://github.com/rigortype/rigor/issues/229)).
   - There are two inline-RBS implementations, and they spell `module-self` differently: Rigor reads `# @rbs module-self Foo`, while `rbs`'s own inline documentation shows `# @rbs module-self: Foo`. The second form previously contributed nothing, with the annotation comment still echoed into the generated RBS — so the omission was invisible. The rest of the file's annotations are unaffected, and the diagnostic says so.
   - The manual chapter now states which dialect Rigor reads and what differs.

--- a/docs/adr/67-parameter-type-inference.md
+++ b/docs/adr/67-parameter-type-inference.md
@@ -238,6 +238,29 @@ this ADR always said must land with it. Four working decisions:
   carry; a cached file whose param seeds changed would serve stale results. Slice 1:
   `parameter_inference:` and `--incremental` are mutually exclusive (the gate refuses,
   with a message), and the edge wiring is the named follow-up before they compose.
+
+  *Lifted 2026-07-30 (#204) — by a table diff, not edge recording.* The pre-pass is
+  whole-project by design, so the incremental session recomputes the table each recheck
+  and diffs it against the snapshot's stored copy (`Type#==`, the same comparison the
+  collector's own fixpoint termination uses): a changed `[class, method, kind]` entry
+  re-analyses the callee's file and feeds its `[file, symbol]` pair into the ADR-46
+  slice-4 symbol fan-out — a seed change shifts the callee's inferred return exactly the
+  way a body edit does, so it reuses the same audited dependents machinery. A missing
+  invalidation edge is impossible by construction (the diff compares ground truth, not a
+  recorded approximation), which is why this shape won over the caller→callee edge
+  recording the follow-up first sketched: it also handles a caller *appearing* in a
+  previously-unrelated file, a caller vanishing, and the fail-soft empty table (every
+  stored entry reads as removed → those callees re-check) for free. A
+  `parameter_inference:` toggle re-fingerprints the snapshot (configuration is part of
+  the global fingerprint), so the gate state is constant across a snapshot's lifetime.
+  When no file moved, the collector's inputs are unchanged and the re-collect is skipped
+  — the ADR-87 null-recheck fast path stays collect-free. The table rides the snapshot
+  under the ADR-89 WD2 Marshal-clean filter (a dropped entry re-checks its callee), and
+  the diff's pairs deliberately bypass the WD2 behavioural-stability pruning, which
+  re-evaluates returns under the OLD seeds — the wrong oracle when the seeds are what
+  moved. Gate: the composition specs' full-run-oracle byte-identity plus
+  `--verify-incremental`, which now runs (and seeds the subset from the baseline's own
+  table).
 - **WD6d — the measurement gate (the WD4-of-ADR-93 pattern).** With the gate off: the
   corpus is byte-identical by construction (empty table no-op). With the gate on:
   (1) every diagnostic delta on mail/kramdown/haml/liquid + mastodon models + redmine app

--- a/lib/rigor/analysis/incremental_session.rb
+++ b/lib/rigor/analysis/incremental_session.rb
@@ -93,6 +93,13 @@ module Rigor
         # ADR-89 WD2 — per-def observed-key return summaries: [path, symbol] => { keys:, returns:, effects: }.
         # Harvested from the ADR-84 return memo after each run; drives the behavioural-stability gate.
         @return_summaries = {}
+        # ADR-67 WD6c lift — the `parameter_inference:` seed table the cached diagnostics were computed
+        # under (`{}` when the gate is off — the gate state is constant across a snapshot's lifetime because
+        # the configuration is part of the global fingerprint). A recheck recomputes the table fresh and
+        # diffs it against this: the pre-pass is whole-project by design, so the fresh table is ground truth
+        # and a missing invalidation edge is impossible by construction — the reason this is a table diff
+        # and not the caller→callee edge recording #204 first sketched.
+        @param_table = {}
         # ADR-88 WD1 — the plugin fact-surface digest computed for THIS invocation (nil until a
         # `#run_incremental` pass runs / a plugin-free project) and the reporting flags a caller (the CLI
         # banner + `--cache-stats`) reads after `#run_incremental`. `@last_runner` is the analysis runner the
@@ -120,6 +127,9 @@ module Rigor
         @seed_bundles = runner.seed_bundles # ADR-85 WD2 — the freshly built bundle set for the next run.
         absorb_dependency_graph(runner)
         @return_summaries = runner.return_summaries # ADR-89 WD2 — the full-run behavioural surface.
+        # ADR-67 WD6c lift — the seed table the runner's own pre-pass computed ({} when the gate is off).
+        # Reading it back, rather than computing it here, keeps the baseline single-collect.
+        @param_table = runner.param_inferred_types
         @cache = per_file(diagnostics)
         @digests = @analyzed.to_h { |path| [path, pack_digest(path)] }
         diagnostics
@@ -134,14 +144,24 @@ module Rigor
         added = current - previous
         removed = previous - current
         changed = changed_paths(current & previous)
-        affected = affected_closure(changed, added, removed)
+        # ADR-67 WD6c lift — recompute the whole-project inferred-param table BEFORE deciding the closure,
+        # and diff it against the snapshot's copy: an entry that moved (because a caller's argument type
+        # changed, a caller appeared, or one vanished) invalidates the CALLEE's file and its symbol
+        # dependents, none of which the file-digest tier can see (the callee's text is unchanged).
+        fresh_params = fresh_param_table(current, changed, added, removed)
+        param_files, param_pairs = param_seed_invalidation(fresh_params)
+        affected = affected_closure(changed, added, removed, param_files, param_pairs)
         analyze_set = affected & current
-        runner = build_runner(analyze_only: analyze_set, record_dependencies: true)
+        # The freshly collected table is handed to the runner so the run seeds from the SAME table the diff
+        # was decided on (and the collector runs once per recheck, not twice).
+        runner = build_runner(analyze_only: analyze_set, record_dependencies: true,
+                              param_inferred_types: fresh_params)
         fresh = run_runner(runner).diagnostics
         @last_runner = runner # ADR-88 WD1 — the post-hoc fact-surface fingerprint reads this prepared registry.
         reused = (current & previous) - affected.to_a
         merged = fresh + reused.flat_map { |path| @cache[path] || [] }
         absorb(runner, fresh, current, analyze_set, removed)
+        @param_table = fresh_params
         Recheck.new(diagnostics: merged, changed: changed.to_set, added: added.to_set,
                     removed: removed.to_set, affected: affected, reused: reused.to_set)
       end
@@ -151,7 +171,15 @@ module Rigor
       # *appeared* in a changed OR added file (slice 3 — a now-defined `call.unresolved-toplevel` target or
       # `def.override-*` ancestor), and the consumers of every removed file (which now miss what it
       # provided). An added file has no before-state, so all its symbols / classes appear.
-      def affected_closure(changed, added, removed)
+      #
+      # ADR-67 WD6c lift — `param_files` / `param_pairs` are the callee files (and their `[file, symbol]`
+      # pairs) whose inferred-param seeds moved since the snapshot. Their text is unchanged, so they enter
+      # the closure here: the files themselves re-analyse (their in-body diagnostics were computed under the
+      # old seeds), and their pairs join the SYMBOL fan-out — a seed change shifts the callee's inferred
+      # return exactly the way a body edit does, so it reuses the same audited dependents machinery. The
+      # pairs join AFTER the ADR-89 WD2 behavioural-stability pruning: that gate re-evaluates returns under
+      # the snapshot's OLD seeds, which is the wrong oracle for a pair whose seeds are the thing that moved.
+      def affected_closure(changed, added, removed, param_files = Set.new, param_pairs = Set.new)
         scan = changed + added
         # Parse the changed / added set ONCE for the per-symbol fingerprints, the class declarations, AND the
         # ADR-89 WD1 declaration signatures. They were separate `discovered_def_index_for_paths` passes over
@@ -176,11 +204,21 @@ module Rigor
         # previously-observed call key + content-mutation effects) is unchanged is behaviourally stable: its
         # symbol dependents' cached diagnostics stay valid, so drop them. `symbol_pairs` is `changed_pairs`
         # minus those stable pairs, and only it (not `changed_pairs`) drives the symbol-dependent fan-out.
-        symbol_pairs = behaviourally_unstable_pairs(changed_pairs, unstable, scan_index)
+        symbol_pairs = behaviourally_unstable_pairs(changed_pairs, unstable, scan_index) | param_pairs
         base = dependents_base(unstable, symbol_pairs)
         closure = base | changed.to_set | added.to_set | negative_affected(scan, new_fps, new_class_decls)
+        closure = param_seed_closure(closure, param_files)
         removed.each { |path| closure |= @dependents[path] || Set.new }
         closure.freeze
+      end
+
+      # ADR-67 WD6c lift — the seed-invalidated callees' own contribution to the closure: the files
+      # themselves, plus — on a pre-slice-4 snapshot with no symbol edges, where the pairs' symbol fan-out
+      # found nothing — their file-level dependents (wider, always sound).
+      def param_seed_closure(closure, param_files)
+        closure |= param_files
+        param_files.each { |path| closure |= @dependents[path] || Set.new } if @symbol_sources.empty?
+        closure
       end
 
       # The dependents contributed by the declaration-unstable changed files and the behaviourally-unstable
@@ -192,6 +230,47 @@ module Rigor
         else
           Incremental.affected(unstable, @dependents)
         end
+      end
+
+      # ADR-67 WD6c lift — the fresh whole-project inferred-param table for this recheck ({} when the gate
+      # is off). When NO file moved, the collector's inputs are unchanged — the project files are identical,
+      # and the env-side inputs (configuration, `sig/`, the gem set, the engine version) are constant under
+      # a matched snapshot fingerprint — so the stored table is provably identical and the whole-project
+      # re-collect is skipped (the ADR-87 null-recheck fast path stays collect-free).
+      def fresh_param_table(current, changed, added, removed)
+        return {} unless @configuration.parameter_inference
+        return @param_table if changed.empty? && added.empty? && removed.empty?
+
+        build_runner.collect_param_inference_table(current)
+      end
+
+      # ADR-67 WD6c lift — the `[files, pairs]` the fresh table invalidates. For every `[class, method,
+      # kind]` entry that differs from the snapshot's copy (added, removed, or value-changed — `Type#==`
+      # structural equality, the same comparison the collector's own fixpoint termination uses, already
+      # exercised across Marshal round-trips by its fork workers), every snapshot file defining that symbol
+      # re-analyses and its `[file, symbol]` pair joins the symbol fan-out. An entry attributable to NO
+      # snapshot file is a def that first appeared in this edit: its file is in the changed/added set (so it
+      # re-analyses anyway) and its prior callers are the negative-dependency closure's job — nothing is
+      # lost by skipping it here. The restored types are compared and then DISCARDED (the run seeds from the
+      # fresh table), so a cache-carried stale memo ivar can never poison a live lookup.
+      def param_seed_invalidation(fresh_params)
+        return [Set.new, Set.new] if fresh_params.equal?(@param_table) || @param_table == fresh_params
+
+        files = Set.new
+        pairs = Set.new
+        (@param_table.keys | fresh_params.keys).each do |key|
+          next if @param_table[key] == fresh_params[key]
+
+          class_name, method_name, kind = key
+          symbol = "#{class_name}#{kind == :singleton ? '.' : '#'}#{method_name}"
+          @symbol_fingerprints.each do |path, symbols|
+            next unless symbols.key?(symbol)
+
+            files << path
+            pairs << [path, symbol]
+          end
+        end
+        [files, pairs]
       end
 
       # ADR-89 WD2 — `changed_pairs` minus the behaviourally-STABLE pairs whose symbol dependents may be
@@ -266,7 +345,9 @@ module Rigor
       # mutating session state. Returns the merged diagnostics.
       def reanalyze_subset(subset)
         affected = subset.to_set
-        runner = build_runner(analyze_only: affected)
+        # ADR-67 WD6c lift — seed the subset run from the baseline's own table so the verification engine
+        # exercises the exact seeds the served cache entries were computed under (and skips a re-collect).
+        runner = build_runner(analyze_only: affected, param_inferred_types: @param_table)
         fresh = run_runner(runner).diagnostics
         reused = @analyzed - affected.to_a
         fresh + reused.flat_map { |path| @cache[path] || [] }
@@ -386,6 +467,7 @@ module Rigor
         @missing           = payload.missing || {}
         @class_decls       = payload.class_decls || {}
         @return_summaries  = payload.return_summaries || {}
+        @param_table       = payload.param_table || {} # ADR-67 WD6c lift — the seeds the cache was built under.
         @symbol_dependents = Incremental.invert_symbols(@symbol_sources)
         @ancestry_dependents = Incremental.invert(@ancestry_sources)
         @negative_dependents = Incremental.invert(@missing)
@@ -398,7 +480,8 @@ module Rigor
           symbol_fingerprints: @symbol_fingerprints, missing: @missing,
           class_decls: @class_decls, seed_bundles: @seed_bundles,
           plugin_fact_digest: @plugin_fact_digest,
-          return_summaries: marshal_safe_return_summaries
+          return_summaries: marshal_safe_return_summaries,
+          param_table: marshal_safe_param_table
         )
       end
 
@@ -411,6 +494,18 @@ module Rigor
         @return_summaries.each_with_object({}) do |(key, summary), safe|
           Marshal.dump(summary)
           safe[key] = summary
+        rescue StandardError
+          next
+        end
+      end
+
+      # ADR-67 WD6c lift — the param table filtered to Marshal-clean entries, the same guard (and reason) as
+      # {#marshal_safe_return_summaries} above. A dropped entry re-appears as "added" in the next recheck's
+      # diff, so its callee re-checks — the conservative direction.
+      def marshal_safe_param_table
+        @param_table.each_with_object({}) do |(key, params), safe|
+          Marshal.dump(params)
+          safe[key] = params
         rescue StandardError
           next
         end

--- a/lib/rigor/analysis/runner.rb
+++ b/lib/rigor/analysis/runner.rb
@@ -100,7 +100,7 @@ module Rigor
                      plugin_requirer: nil, workers: 0, collect_stats: true,
                      buffer: nil, prebuilt: nil, environment: nil,
                      record_dependencies: false, record_self_calls: false, analyze_only: nil,
-                     seed_bundles: nil, collect_seed_bundles: false)
+                     seed_bundles: nil, collect_seed_bundles: false, param_inferred_types: nil)
         @configuration = configuration
         @explain = explain
         @cache_store = enforce_read_only_cache(cache_store, buffer)
@@ -140,6 +140,12 @@ module Rigor
         @collect_seed_bundles = collect_seed_bundles
         @restored_seed_bundles = seed_bundles || {}
         @seed_bundles = {}.freeze
+        # ADR-67 WD6c lift — a precomputed inferred-param table. When the incremental session already ran the
+        # collector (it must, to diff the table against its snapshot BEFORE deciding the re-analyse closure),
+        # it hands the result here so `seed_parameter_inference` seeds without a second whole-project collect
+        # — and so the table the diff was decided on and the table this run seeds from are the SAME object,
+        # not merely an equal recomputation. nil (the default) keeps the runner self-sufficient.
+        @param_inferred_types_override = param_inferred_types
         @file_dependencies = {}
         @plugin_registry = Plugin::Registry::EMPTY
         @dependency_source_index = DependencySourceInference::Index::EMPTY
@@ -322,6 +328,32 @@ module Rigor
           files.each { |file| result[file] << class_name }
         end
         result.transform_values(&:freeze).freeze
+      end
+
+      # ADR-67 WD6c lift — the inferred-param table this run seeded from (frozen; empty when
+      # `parameter_inference:` is off or the pre-pass failed soft). The incremental session reads it back
+      # after a baseline so the snapshot records the seeds the cached diagnostics were computed under.
+      def param_inferred_types
+        @project_param_inferred_types
+      end
+
+      # ADR-67 WD6c lift — computes the whole-project inferred-param table without running an analysis.
+      # The incremental session calls this BEFORE deciding its re-analyse closure: the table's diff against
+      # the snapshot's stored table is what invalidates a callee whose seeds moved because a *caller* file
+      # changed. Same collector invocation as {#seed_parameter_inference} (one round, same workers), so the
+      # session-computed table and an in-run collect are byte-identical by construction. Fails soft to the
+      # empty table — which the caller's diff then treats as "every stored entry removed", the conservative
+      # direction (those callees re-check).
+      def collect_param_inference_table(files)
+        return {}.freeze unless @configuration.parameter_inference
+
+        environment = @pool_coordinator.resolve_sequential_environment(source_files: files)
+        Inference::ParameterInferenceCollector.collect(
+          files: files, environment: environment,
+          target_ruby: @configuration.target_ruby, max_rounds: 1, workers: @workers
+        )
+      rescue StandardError
+        {}.freeze
       end
 
       # ADR-89 WD2 — the per-method observed-key return summaries the run's ADR-84 return memo just captured.
@@ -510,6 +542,11 @@ module Rigor
       # error must never break a run, so the table stays empty and the run proceeds unseeded.
       def seed_parameter_inference(expansion, environment)
         return environment unless @configuration.parameter_inference
+
+        if @param_inferred_types_override
+          @project_param_inferred_types = @param_inferred_types_override
+          return environment
+        end
 
         files = expansion.fetch(:files)
         environment ||= @pool_coordinator.resolve_sequential_environment(source_files: files)

--- a/lib/rigor/cache/incremental_snapshot.rb
+++ b/lib/rigor/cache/incremental_snapshot.rb
@@ -38,8 +38,11 @@ module Rigor
       # bundle (the per-def parameter-shape / visibility / ancestry surface the declaration-stability gate
       # compares) and WD2 adds `return_summaries` (per-def observed-key return descriptors + mutation-effect
       # sets the behavioural-stability gate compares); a pre-10 blob mismatches the SCHEMA gate and loads as
-      # nil (a clean cold rebuild — no migration).
-      SCHEMA = 10
+      # nil (a clean cold rebuild — no migration). 11: ADR-67 WD6c lift adds `param_table` (the inferred-param
+      # seed table the run's diagnostics were computed under, diffed on the next recheck to invalidate a
+      # callee whose seeds moved because a caller changed); a pre-11 blob mismatches the SCHEMA gate and
+      # loads as nil (a clean cold rebuild — no migration).
+      SCHEMA = 11
 
       # The persisted per-file state.
       # `cache` maps an analyzed file to its diagnostics.
@@ -68,10 +71,16 @@ module Rigor
       # (Marshal-clean type tuples), their `describe(:short)` return descriptors, and the content-mutated
       # parameter positions. A recheck re-evaluates a declaration-stable changed callee at these keys and,
       # when every return + the effects are unchanged, skips its symbol dependents.
+      # ADR-67 WD6c lift:
+      # `param_table` is the `parameter_inference:` seed table (`[class, method, kind] => {param => Type}`)
+      # the run that wrote the snapshot seeded its analysis from — `{}` when the gate is off. A recheck
+      # recomputes the table fresh (the pre-pass is whole-project by design) and diffs it against this copy;
+      # a changed entry invalidates the callee's file and its symbol dependents. The types are Marshal-clean
+      # by the session's per-entry filter; a dropped entry re-checks its callee, the conservative direction.
       Payload = Data.define(:cache, :sources, :digests, :analyzed,
                             :symbol_sources, :ancestry_sources, :symbol_fingerprints,
                             :missing, :class_decls, :seed_bundles, :plugin_fact_digest,
-                            :return_summaries)
+                            :return_summaries, :param_table)
 
       # The global fingerprint that gates a snapshot load: a digest of the inputs whose change requires a full
       # rebuild — the engine version + schema, the resolved configuration, the analysis **roots** (the path
@@ -127,6 +136,12 @@ module Rigor
         data = Marshal.load(Zlib::Inflate.inflate(File.binread(@path))) # rubocop:disable Security/MarshalLoad
         return nil unless data.is_a?(Hash) && data[:schema] == SCHEMA && data[:fingerprint] == fingerprint
 
+        payload_from(data)
+      rescue StandardError
+        nil
+      end
+
+      def payload_from(data)
         Payload.new(
           cache: data[:cache], sources: data[:sources],
           digests: data[:digests], analyzed: data[:analyzed],
@@ -137,11 +152,11 @@ module Rigor
           class_decls: data[:class_decls] || {},
           seed_bundles: data[:seed_bundles] || {},
           plugin_fact_digest: data[:plugin_fact_digest],
-          return_summaries: data[:return_summaries] || {}
+          return_summaries: data[:return_summaries] || {},
+          param_table: data[:param_table] || {}
         )
-      rescue StandardError
-        nil
       end
+      private :payload_from
 
       # Persist `payload` under `fingerprint`. Writes via a temp file + atomic rename so a concurrent reader
       # never sees a half-written snapshot. Returns true on success, false on any failure (never raises).
@@ -158,7 +173,8 @@ module Rigor
           class_decls: payload.class_decls,
           seed_bundles: payload.seed_bundles,
           plugin_fact_digest: payload.plugin_fact_digest,
-          return_summaries: payload.return_summaries
+          return_summaries: payload.return_summaries,
+          param_table: payload.param_table
         )
         blob = Zlib::Deflate.deflate(raw)
         tmp = "#{@path}.#{Process.pid}.tmp"

--- a/lib/rigor/cli/check_command.rb
+++ b/lib/rigor/cli/check_command.rb
@@ -48,9 +48,6 @@ module Rigor
 
         configuration = load_check_configuration(options)
         configuration = apply_bleeding_edge_override(configuration, options)
-        conflict = parameter_inference_incremental_conflict(configuration, options)
-        return conflict unless conflict.nil?
-
         config_warnings = warn_unresolved_config(configuration)
         cache_root = configuration.cache_path
         handle_clear_cache(cache_root) if options.fetch(:clear_cache)
@@ -141,25 +138,6 @@ module Rigor
         exit_code = result.success? ? 0 : 1
         exit_code = 1 if baseline_strict_violation?(raw_result.diagnostics, configuration, options)
         exit_code
-      end
-
-      # ADR-67 WD6c — `parameter_inference:` and the ADR-46 incremental modes are mutually exclusive in slice 1.
-      # The parameter table introduces cross-file edges (a caller's argument types drive a callee's body
-      # diagnostics) that the per-file dependency recorder does not yet carry, so a cached file whose parameter
-      # seeds changed would serve a stale result. Refuse with a message naming the ADR-46 gap rather than
-      # silently producing unsound incremental diagnostics; the edge wiring is the named follow-up. Returns the
-      # usage exit code on a conflict, or nil to proceed. `--verify-incremental` (the acceptance gate that runs
-      # incremental analysis) is caught here too.
-      def parameter_inference_incremental_conflict(configuration, options)
-        return nil unless configuration.parameter_inference
-        return nil unless options.fetch(:incremental) || options.fetch(:verify_incremental)
-
-        flag = options.fetch(:incremental) ? "--incremental" : "--verify-incremental"
-        @err.puts("rigor: parameter_inference: cannot combine with #{flag} — the call-site parameter table " \
-                  "introduces cross-file caller→callee edges the ADR-46 incremental dependency graph does not " \
-                  "yet record, so a cached file could serve a stale diagnostic. Run a full check (drop " \
-                  "#{flag}), or disable parameter_inference: for this run.")
-        CLI::EXIT_USAGE
       end
 
       # ADR-46 — the two incremental-analysis check modes both fully handle the run and return an exit code (so `run`

--- a/lib/rigor/configuration.rb
+++ b/lib/rigor/configuration.rb
@@ -61,7 +61,9 @@ module Rigor
       # seed, so an undeclared `def` / `initialize` / setter parameter is typed to the union of its resolved
       # call-site argument types (precision-additive only — the in-body negative rules decline on the inferred
       # lower bound, WD6b). `false` (the default, resolved off by every severity profile) keeps the table empty
-      # and the run byte-identical to today. Mutually exclusive with `--incremental` (WD6c).
+      # and the run byte-identical to today. Composes with `--incremental` (the WD6c mutual exclusion is
+      # lifted): the incremental session recomputes the table each run and diffs it against its snapshot,
+      # re-checking any callee whose seeds moved.
       "parameter_inference" => false,
       "cache" => {
         "path" => ".rigor/cache",

--- a/spec/rigor/analysis/incremental_session_spec.rb
+++ b/spec/rigor/analysis/incremental_session_spec.rb
@@ -1200,4 +1200,135 @@ RSpec.describe Rigor::Analysis::IncrementalSession do
       end
     end
   end
+
+  # ADR-67 WD6c lift — `parameter_inference:` composes with the incremental session. The collector pre-pass
+  # is whole-project by design, so each recheck recomputes the seed table and diffs it against the
+  # snapshot's copy: a changed entry re-checks the CALLEE file (whose own text never moved) and its symbol
+  # dependents. `Rigor.dump_type` on the seeded parameter makes the seed byte-visible in the diagnostics —
+  # the WD6b guard means a seed change never ADDS a negative diagnostic, so without it the full-run oracle
+  # comparison would be vacuous.
+  describe "parameter_inference composition (ADR-67 WD6c lift)" do
+    def pi_configuration(dir)
+      Rigor::Configuration.new("paths" => [dir], "parameter_inference" => true)
+    end
+
+    def pi_full_run(dir)
+      Rigor::Analysis::Runner.new(
+        configuration: pi_configuration(dir), cache_store: nil, environment: shared_environment
+      ).run.diagnostics
+    end
+
+    def pi_session(dir)
+      described_class.new(configuration: pi_configuration(dir), environment: shared_environment)
+    end
+
+    def write_callee(dir)
+      path = File.join(dir, "callee.rb")
+      write_once(path, <<~RUBY)
+        class Callee
+          def run(x)
+            Rigor.dump_type(x)
+          end
+        end
+      RUBY
+      path
+    end
+
+    def write_caller(dir, arg:, extra: nil)
+      path = File.join(dir, "caller.rb")
+      File.write(path, <<~RUBY)
+        class Caller
+          def go
+            #{extra}
+            Callee.new.run(#{arg})
+          end
+        end
+      RUBY
+      path
+    end
+
+    def dump_messages(diagnostics)
+      diagnostics.select { |d| d.rule == "dump.type" }.map(&:message)
+    end
+
+    it "re-checks the callee when a caller's argument type changes (the callee's own text unchanged)" do
+      Dir.mktmpdir do |dir|
+        callee = write_callee(dir)
+        caller_path = write_caller(dir, arg: "1")
+        session = pi_session(dir)
+        baseline = session.baseline
+        expect(dump_messages(baseline)).to eq(["dump_type: Integer"])
+
+        write_caller(dir, arg: '"s"')
+        recheck = session.recheck
+
+        # The file-digest tier sees only the caller; the param-table diff is what pulls the callee in.
+        expect(recheck.changed).to eq(Set[caller_path])
+        expect(recheck.affected).to include(callee)
+        expect(dump_messages(recheck.diagnostics)).to eq(["dump_type: String"])
+        expect(sorted(recheck.diagnostics)).to eq(sorted(pi_full_run(dir)))
+      end
+    end
+
+    it "keeps the callee cached when a caller edit leaves the argument types unchanged" do
+      Dir.mktmpdir do |dir|
+        callee = write_callee(dir)
+        caller_path = write_caller(dir, arg: "1")
+        session = pi_session(dir)
+        session.baseline
+
+        write_caller(dir, arg: "1", extra: "@noise = :extra")
+        recheck = session.recheck
+
+        # Same seed table on both sides of the diff → no param invalidation; the callee is served from
+        # cache. This is the precision half — the diff must not degrade every caller edit into a
+        # whole-project re-check.
+        expect(recheck.affected).to eq(Set[caller_path])
+        expect(recheck.reused).to include(callee)
+        expect(sorted(recheck.diagnostics)).to eq(sorted(pi_full_run(dir)))
+      end
+    end
+
+    it "invalidates across the persisted snapshot (the diff runs against Marshal-restored types)" do
+      Dir.mktmpdir do |dir|
+        callee = write_callee(dir)
+        write_caller(dir, arg: "1")
+        config = pi_configuration(dir)
+        fp = fingerprint(config, dir)
+        snapshot = Rigor::Cache::IncrementalSnapshot.new(root: File.join(dir, ".cache"))
+
+        _cold, warm_first = described_class.new(configuration: config, environment: shared_environment)
+                                           .run_incremental(snapshot: snapshot, fingerprint: fp)
+        expect(warm_first).to be(false)
+
+        write_caller(dir, arg: '"s"')
+        session = described_class.new(configuration: config, environment: shared_environment)
+        diagnostics, warm = session.run_incremental(snapshot: snapshot, fingerprint: fp)
+
+        expect(warm).to be(true)
+        expect(dump_messages(diagnostics)).to eq(["dump_type: String"])
+        expect(sorted(diagnostics)).to eq(sorted(pi_full_run(dir)))
+        expect(session.analyzed_files).to include(callee)
+      end
+    end
+
+    it "matches the full-run oracle on a no-edit warm recheck without re-collecting the table" do
+      Dir.mktmpdir do |dir|
+        write_callee(dir)
+        write_caller(dir, arg: "1")
+        session = pi_session(dir)
+        session.baseline
+        oracle = sorted(pi_full_run(dir)) # computed BEFORE the mock — the oracle's own collect is legitimate
+
+        # No file moved → the collector's inputs are unchanged, so the recheck must skip the whole-project
+        # re-collect (the ADR-87 null-recheck fast path) and still serve the exact baseline result.
+        allow(Rigor::Inference::ParameterInferenceCollector).to receive(:collect)
+        recheck = session.recheck
+
+        expect(Rigor::Inference::ParameterInferenceCollector).not_to have_received(:collect)
+        expect(recheck.affected).to be_empty
+        expect(sorted(recheck.diagnostics)).to eq(oracle)
+      end
+    end
+  end
 end

--- a/spec/rigor/cache/incremental_snapshot_spec.rb
+++ b/spec/rigor/cache/incremental_snapshot_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe Rigor::Cache::IncrementalSnapshot do
       class_decls: { "b.rb" => Set["Foo"] },
       seed_bundles: { "b.rb" => { digest: "sha-b", classes: { "Foo" => nil }, methods: {} } },
       plugin_fact_digest: "fact-digest-abc",
-      return_summaries: { ["b.rb", "Foo#bar"] => { keys: [], returns: ["Integer"], effects: [0] } }
+      return_summaries: { ["b.rb", "Foo#bar"] => { keys: [], returns: ["Integer"], effects: [0] } },
+      # ADR-67 WD6c lift — the inferred-param seed table the run's diagnostics were computed under.
+      param_table: { ["Foo", :bar, :instance] => { value: "Integer-stand-in" } }
     )
   end
 

--- a/spec/rigor/cli/check_command_spec.rb
+++ b/spec/rigor/cli/check_command_spec.rb
@@ -44,15 +44,23 @@ RSpec.describe Rigor::CLI::CheckCommand do
     expect(out).to include("error(s) in")
   end
 
-  # ADR-67 WD6c — `parameter_inference:` and the ADR-46 incremental modes are mutually exclusive in slice 1.
-  it "refuses parameter_inference: combined with --incremental (WD6c)" do
+  # ADR-67 WD6c lift — `parameter_inference:` composes with `--incremental`: the session diffs the
+  # freshly collected param table against the snapshot's copy and re-checks any callee whose seeds moved,
+  # so the earlier mutual-exclusion refusal (exit 64) is gone. The cross-run soundness property itself is
+  # asserted in `incremental_session_spec.rb`; this is the CLI wiring.
+  it "composes parameter_inference: with --incremental (WD6c lifted)" do
     File.write(".rigor.yml", "paths:\n  - clean.rb\nparameter_inference: true\n")
     File.write("clean.rb", "x = 1\n")
 
-    status, _out, err = run(["--no-cache", "--no-ci-detect", "--no-stats", "--incremental", "clean.rb"])
+    cold_status, cold_out, cold_err = run(["--no-ci-detect", "--no-stats", "--incremental", "clean.rb"])
+    warm_status, warm_out, warm_err = run(["--no-ci-detect", "--no-stats", "--incremental", "clean.rb"])
 
-    expect(status).to eq(Rigor::CLI::EXIT_USAGE)
-    expect(err).to include("parameter_inference: cannot combine with --incremental")
+    expect(cold_status).to eq(0)
+    expect(warm_status).to eq(0)
+    expect(cold_err).to include("--incremental cold")
+    expect(warm_err).to include("--incremental warm")
+    expect(cold_out).to include("No diagnostics")
+    expect(warm_out).to include("No diagnostics")
   end
 
   it "allows parameter_inference: on a full (non-incremental) check" do


### PR DESCRIPTION
Closes #204 — lifts ADR-67 WD6c.

## The design call, and why it is not the one the issue sketched

#204 proposed recording caller→callee-param **edges** at the collector, with the constraint "a missing edge is unsound". This lands a strictly stronger shape: **no edges at all**. The pre-pass is whole-project by design (`Runner#seed_parameter_inference` scans every file regardless of `analyze_only`), so the freshly recomputed table *is* ground truth. The incremental session collects it before deciding the closure, diffs it against the snapshot's stored copy, and for every moved `[class, method, kind]` entry re-analyses the callee's file and feeds its `[file, symbol]` pair into the existing ADR-46 slice-4 symbol fan-out.

A missing invalidation edge is thereby impossible **by construction** — the diff compares values, not a recorded approximation. Three cases the edge design would have had to handle specially fall out for free:

- a caller **appearing** in a previously-unrelated file (no prior edge could exist),
- a caller vanishing,
- the collector failing soft to `{}` (every stored entry reads as removed → those callees re-check).

A `parameter_inference:` toggle is also free: configuration is already inside the snapshot's global fingerprint, so the gate state is constant across a snapshot's lifetime.

## Soundness boundaries worth reviewing

- **The diff's pairs bypass the ADR-89 WD2 behavioural-stability pruning.** That gate re-evaluates a callee's return under the snapshot's *old* seeds — the wrong oracle when the seeds are exactly what moved. Pairs are unioned in after the pruning.
- **Second-order consumers ride the audited machinery.** A seed change shifts the callee's inferred return the way a body edit does, so its symbol dependents (callers reading that return through `try_user_method_inference`) are exactly the slice-4 fan-out — plus a file-level fallback on a pre-slice-4 snapshot with no symbol edges.
- **The type comparison is the collector's own.** `Type#==` is what terminates the collector's fixpoint (`rounded == table`), already exercised across Marshal round-trips by its fork workers. Restored types are compared and *discarded*, never seeded from — the run always seeds from the fresh table (which the session hands to the runner, so the diff basis and the seed are the same object and the collector runs once per recheck).
- **Snapshot**: SCHEMA 10 → 11; the table rides under the ADR-89 WD2 Marshal-clean per-entry filter (a dropped entry re-appears as "added" next diff → its callee re-checks, the conservative direction).
- **Null recheck stays collect-free**: no file moved + matched fingerprint ⇒ table provably unchanged, so the ADR-87 fast path pays nothing — pinned by a spy in the composition spec.

## The issue's acceptance gate

> the `--verify-incremental` harness must show `parameter_inference:` + `--incremental` byte-identical to a clean full run across an edit that changes a caller's argument type; the WD6c conflict spec is replaced by a composition spec

All three, plus an end-to-end CLI run on a two-file fixture:

```
run 1 (cold,  caller passes 1)   → dump_type: Integer
run 2 (warm,  no edit)           → dump_type: Integer
run 3 (warm,  caller now passes "s") → dump_type: String   ← the callee re-checked from a caller-only edit
```

`--verify-incremental` (which now runs under the gate, seeding the subset from the baseline's own table): `OK — incremental matches full`. The four composition specs assert byte-identity against a full-run oracle in **both** directions — invalidation when seeds move, and cache-serving when a caller edit leaves the argument types unchanged (the precision half, so the feature doesn't degrade every caller edit into a whole-project re-check). The cross-process spec exercises the diff against Marshal-restored types specifically. `Rigor.dump_type` is the observation channel because the WD6b guard means a seed change never *adds* a negative diagnostic — without it the oracle comparison would be vacuous.

## Verification

`make verify` clean (8,320 examples, rubocop 912 files), `make docs-check` clean, `git diff --check` clean. ADR-67 WD6c carries a dated lift note; the WD6c refusal in `CheckCommand` and its spec are gone.

## What this deliberately does not do

It does not touch #205 (default-on). The pre-pass cost (+37% wall on mastodon `app/models`, ~98% irreducible `ScopeIndexer.index`) is unchanged and is still paid on every incremental run with the gate on — composing with `--incremental` makes the *check walk* incremental, not the pre-pass.