### PR TITLE
Guard argument-type-mismatch on an inferred-param receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[inference]** Under the opt-in `parameter_inference:`, `call.argument-type-mismatch` no longer fires when the *receiver's* type came from call-site parameter inference ([#205](https://github.com/rigortype/rigor/issues/205)).
+  - An inferred parameter type is a lower bound, so a method contract resolved through it is speculative; the guard already declined on inferred arguments but missed the receiver side. Surfaced by Rigor's own self-check, where the seeded receiver flagged a correct call against an upstream RBS signature stricter than its implementation.
 - **[sig-gen]** `rigor sig-gen` now reads a class built by `Data.define(...)` / `Struct.new(...)`, in both the `Point = Data.define(:x, :y)` and `class Point < Data.define(:x, :y)` forms ([#227](https://github.com/rigortype/rigor/issues/227)).
   - Previously the members, the constructors, and the `::Data` / `::Struct` ancestry were all absent, and a `do ... end` block's methods were reported against the enclosing namespace — which then printed as a `class` even when it was a `module`.
   - The generated declaration carries the member readers (plus writers, for a mutable Struct), a `.new` / `.[]` signature matching the constructor forms the class actually accepts, and the correct superclass. Under `--params=observed`, member types come from the `.new` call sites the observation scan sees.

--- a/lib/rigor/analysis/check_rules.rb
+++ b/lib/rigor/analysis/check_rules.rb
@@ -2075,11 +2075,23 @@ module Rigor
           param_overrides = Rigor::RbsExtended.param_type_override_map(method_def, environment: scope.environment)
           mismatch = argument_mismatch(method_def.method_types, call_node, scope, param_overrides)
           return nil if mismatch.nil?
-          # ADR-67 WD6b — the mismatching argument is an inferred-parameter local, whose type is an
-          # open-call-site lower bound; firing argument-type-mismatch against it is an FP by construction.
-          return nil if inferred_param_argument?(mismatch[:node], scope)
+          return nil if inferred_param_mismatch_verdict?(call_node, mismatch, scope)
 
           build_argument_type_diagnostic(path, call_node, class_name, mismatch)
+        end
+
+        # ADR-67 WD6b — an argument-type-mismatch verdict resting on an open-call-site lower bound, on
+        # either side of the call. The ARGUMENT side: the mismatching argument is an inferred-parameter
+        # local, so firing against it is an FP by construction. The RECEIVER side: when the receiver roots
+        # at an inferred parameter, the method whose parameter contract the argument was checked against
+        # was itself resolved through a lower-bound type, so the whole verdict is speculative. The 2026-07-30
+        # self-check surfaced the receiver half as a guard hole: seeding `env : RBS::Environment` activated
+        # this rule on `env.unload(culprits)` and flagged a correct Array argument against `unload`'s
+        # declared `Set[Pathname]` — an upstream signature stricter than its implementation, exactly the FP
+        # class WD6b exists to suppress. The other guarded rules already declined on a param-rooted
+        # receiver; this brings argument-type-mismatch in line.
+        def inferred_param_mismatch_verdict?(call_node, mismatch, scope)
+          inferred_param_argument?(mismatch[:node], scope) || inferred_param_receiver?(call_node, scope)
         end
 
         # Single overload → the exact per-argument acceptance (unchanged).

--- a/spec/rigor/analysis/parameter_inference_check_walk_spec.rb
+++ b/spec/rigor/analysis/parameter_inference_check_walk_spec.rb
@@ -81,4 +81,43 @@ RSpec.describe "ADR-67 WD6 check-walk parameter inference" do
     call_rules = rules(run(param_source, parameter_inference: false)).select { |rule| rule.to_s.start_with?("call.") }
     expect(call_rules).to be_empty
   end
+
+  # WD6b, receiver side — argument-type-mismatch must decline when the RECEIVER roots at an inferred
+  # parameter: the method whose parameter contract the argument was checked against was resolved through a
+  # lower-bound type, so the verdict is speculative. Found by the 2026-07-30 self-check: seeding
+  # `env : RBS::Environment` flagged `env.unload(culprits)`'s Array argument against `unload`'s declared
+  # `Set[Pathname]` — a signature stricter than upstream's implementation, the FP class WD6b suppresses.
+  describe "argument-type-mismatch on an inferred-parameter receiver" do
+    let(:receiver_source) do
+      <<~RUBY
+        class Widget
+          def go
+            pick([1, 2])
+          end
+
+          def pick(items)
+            items.fetch("x")
+          end
+        end
+      RUBY
+    end
+
+    it "declines under the gate (the receiver's type is an open-call-site lower bound)" do
+      diagnostics = run(receiver_source, parameter_inference: true)
+      expect(rules(diagnostics)).not_to include("call.argument-type-mismatch")
+    end
+
+    it "is byte-identical to the gate-off run" do
+      on = run(receiver_source, parameter_inference: true).map(&:to_h)
+      off = run(receiver_source, parameter_inference: false).map(&:to_h)
+      expect(on).to eq(off)
+    end
+
+    # The positive control: the same bad argument on a directly-typed receiver DOES fire, so the silence
+    # above is the guard, not the rule being inert on Array#fetch.
+    it "still fires on a directly-typed receiver" do
+      direct = "class Widget\n  def go\n    [1, 2].fetch(\"x\")\n  end\nend\n"
+      expect(rules(run(direct, parameter_inference: true))).to include("call.argument-type-mismatch")
+    end
+  end
 end


### PR DESCRIPTION
Part of #205's evidence gathering — and a live WD6b guard hole it surfaced.

## The finding

Re-measuring the `parameter_inference:` cost on current master for #205, the gate-on run over Rigor's own `lib` produced **one new error** — WD6d's measured promise is zero new firings:

```
lib/rigor/environment/rbs_loader.rb:135:30 error call.argument-type-mismatch:
  argument type mismatch at `unload' on RBS::Environment:
  expected Set[::Pathname] | Set[::RBS::Buffer], got non-empty-array[Dynamic[top]]
```

The code is correct: `RBS::Environment#unload` iterates any enumerable of names (`references/rbs/lib/rbs/environment.rb:1003`), so its declared `Set[Pathname]` is stricter than its implementation. A false positive of exactly the class [ADR-67](https://github.com/rigortype/rigor/blob/master/docs/adr/67-parameter-type-inference.md) WD6b exists to suppress.

## The hole

The WD6b guard for `call.argument-type-mismatch` declined only when the mismatching **argument** roots at an inferred parameter. Here the argument (`culprits`) does not — the **receiver** (`env`, seeded to `RBS::Environment` from its single call site) does. And the receiver is where the speculation lives: the method contract the argument was checked against was itself resolved through a lower-bound type, so the whole verdict is speculative. The other guarded rules (`undefined-method`, `wrong-arity`, `possible-nil-receiver`, `visibility-mismatch`) already decline on a param-rooted receiver; this brings `argument-type-mismatch` in line.

One-line predicate change (`inferred_param_mismatch_verdict?` = argument-side OR receiver-side), gate-off behaviour untouched by construction (`inferred_param?` is false with an empty table).

## Verification

- Gate-on over `lib` is back to byte-identical with gate-off (1 diagnostic, the missing-gem info).
- The regression spec carries its own **positive control** — the same bad argument (`[1,2].fetch("x")`) on a directly-typed receiver still fires — so the new silence is provably the guard, not the rule going inert. The fixture shape was chosen empirically (probed five candidates; `Array#fetch` is the one that fires on a direct receiver).
- `make verify` clean (8,319 examples, rubocop 912 files), `make check` clean, `git diff --check` clean.

## Note for #205

This datum cuts both ways and will be recorded as such: the guard held on six corpus targets at WD6 landing but not on the seventh (our own tree), which strengthens the case that a default flip needs the mutation-oracle honesty check WD6b names — and it is one more confirmed FP the guard now suppresses correctly.