### PR TITLE
Detect dangling referenced types by reading, not building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
   - There are two inline-RBS implementations, and they spell `module-self` differently: Rigor reads `# @rbs module-self Foo`, while `rbs`'s own inline documentation shows `# @rbs module-self: Foo`. The second form previously contributed nothing, with the annotation comment still echoed into the generated RBS — so the omission was invisible. The rest of the file's annotations are unaffected, and the diagnostic says so.
   - The manual chapter now states which dialect Rigor reads and what differs.
 
+### Performance
+
+- **[rigor check]** A cold run on a project that ships RBS spends roughly a third fewer allocations: the signature scan that looks for references to undeclared types no longer builds every class in the project to find them ([#207](https://github.com/rigortype/rigor/issues/207)).
+  - It reads the declarations instead, applying the same membership test RBS itself applies, so the same names are found. On Rigor's own `lib` that scan falls from 7.84M allocations to 25k — 33% of the run to 0.15% — and on a Rails-shaped project the whole run drops 84%. Diagnostics are unchanged across the eight RBS-shipping projects the change was measured on.
+
 ### Fixed
 
 - **[inference]** Under the opt-in `parameter_inference:`, `call.argument-type-mismatch` no longer fires when the *receiver's* type came from call-site parameter inference ([#205](https://github.com/rigortype/rigor/issues/205)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
   - There are two inline-RBS implementations, and they spell `module-self` differently: Rigor reads `# @rbs module-self Foo`, while `rbs`'s own inline documentation shows `# @rbs module-self: Foo`. The second form previously contributed nothing, with the annotation comment still echoed into the generated RBS — so the omission was invisible. The rest of the file's annotations are unaffected, and the diagnostic says so.
   - The manual chapter now states which dialect Rigor reads and what differs.
 
-### Performance
+### Changed
 
 - **[rigor check]** A cold run on a project that ships RBS spends roughly a third fewer allocations: the signature scan that looks for references to undeclared types no longer builds every class in the project to find them ([#207](https://github.com/rigortype/rigor/issues/207)).
   - It reads the declarations instead, applying the same membership test RBS itself applies, so the same names are found. On Rigor's own `lib` that scan falls from 7.84M allocations to 25k — 33% of the run to 0.15% — and on a Rails-shaped project the whole run drops 84%. Diagnostics are unchanged across the eight RBS-shipping projects the change was measured on.

--- a/lib/rigor/environment/rbs_loader.rb
+++ b/lib/rigor/environment/rbs_loader.rb
@@ -153,11 +153,10 @@ module Rigor
         # calls to `Dynamic[Top]` instead (the same no-false-positive contract as the dependency-source
         # tier).
         #
-        # Detection re-uses RBS's own builder (correct by construction): build every PROJECT class and read
-        # the missing name out of the raised error. Bounded to `signature_paths` classes (stdlib / vendored
-        # RBS is well-formed) and to {MAX_STUB_PASSES} iterations — a fresh stub can expose a deeper
-        # reference the first build error hid, but empty stubs reference nothing, so the fixpoint converges
-        # quickly.
+        # Detection reads the PROJECT declarations and mirrors rbs's own membership test
+        # ({.unresolved_referenced_types}); it is bounded to `signature_paths` classes (stdlib / vendored RBS
+        # is well-formed) and to {MAX_STUB_PASSES} iterations — a fresh stub can expose a deeper reference the
+        # first pass could not see past, but empty stubs reference nothing, so the fixpoint converges quickly.
         MAX_STUB_PASSES = 5
 
         def stub_missing_referenced_types(base_env, resolved, project_files)
@@ -305,26 +304,122 @@ module Rigor
           end
         end
 
-        # Builds every project class (instance + singleton side) and returns the `::`-stripped names of the
-        # types whose absence raised `NoTypeFoundError`. Only the FIRST missing reference per class surfaces
-        # per build, which is why the caller loops.
+        # The `::`-stripped names of every type a PROJECT signature references that no loaded declaration
+        # provides — the input to {.append_stub_declarations}.
+        #
+        # Detection READS the declarations; it does not build them. Until #207 it built every project class
+        # instance- and singleton-side with a throwaway `RBS::DefinitionBuilder` and recovered the name from
+        # the raised `NoTypeFoundError` — correct by construction, and **7.84M allocations, a third of a cold
+        # `check lib`** on Rigor's own tree, to find nothing once `sig/` is self-consistent. The walk below
+        # costs ~21k.
+        #
+        # It mirrors rbs's raise sites, so the answer is the builder's:
+        #
+        # * `DefinitionBuilder#validate_type_presence` over the ARGS of a super class, a module `self` type,
+        #   and a mixin. The name itself is deliberately NOT checked: a missing super class or mixin raises
+        #   `NoSuperclassFoundError` / `NoMixinFoundError`, which this pass has never stubbed.
+        # * `VarianceCalculator#type` over every method type `validate_type_params` reaches, which raises for
+        #   `ClassInstance` / `Interface` / `Alias` only. It skips `initialize`, and it is not called for the
+        #   singleton side — so a name reachable only through `def initialize:` or `def self.x:` is not
+        #   reported here, exactly as the builder did not report it. Stubbing those names anyway cost
+        #   allocations on the corpus and changed no diagnostic.
+        #
+        # Membership is decided with the builder's own predicate ({.declared_reference?}), so a name reported
+        # here is one no declaration in the env provides. A resolvable name can never be reported, which is
+        # what keeps the stub safe: ADR-5 tier 2 trades precision for a fail-soft, and a stub for a name that
+        # WOULD have resolved would shadow a real type instead.
+        #
+        # One reduction in scope. The builder also walked each project class's ANCESTORS, so a dangling
+        # reference inside a *gem's* signature reachable from a project class was reported too; this walk
+        # reads project declarations only. No such name occurs across the eight RBS-shipping projects the
+        # change was measured on, and the cost of missing one is the fail-soft `Dynamic` ADR-5 tier 2 already
+        # accepts — not a false diagnostic. A project INTERFACE's own dangling reference is likewise not
+        # reported, and likewise was not by the builder (`validate_type_params` does not variance-walk the
+        # methods a class imports from an interface) — pinned by spec so the two stay together.
+        #
+        # Equivalence with the builder sweep is pinned by spec, which keeps the sweep as its oracle. Full
+        # evaluation: `docs/notes/20260730-stub-pass1-static-detection-evaluation.md`.
         def unresolved_referenced_types(env, project_files)
-          builder = ::RBS::DefinitionBuilder.new(env: env)
-          missing = []
-          env.class_decls.each do |type_name, entry|
+          missing = {}
+          checked = {}
+          env.class_decls.each_value do |entry|
             next unless project_entry?(entry, project_files)
 
-            %i[build_instance build_singleton].each do |build|
-              builder.public_send(build, type_name)
-            rescue ::RBS::NoTypeFoundError => e
-              name = e.message[/Could not find (\S+)/, 1]
-              missing << name.sub(/\A::/, "") if name
-            rescue ::RBS::BaseError
-              # Other build failures (duplicate decl, mixin cycle, ...) are not ours to repair here — leave
-              # them fail-soft.
+            entry_declarations(entry).each { |decl| collect_declaration_references(env, decl, missing, checked) }
+          end
+          missing.keys
+        end
+
+        # Decl-level references the builder validates: a super class's / module self type's / mixin's type
+        # ARGUMENTS, plus every member. `super_class` is a `Declarations::Class` accessor and `self_types` a
+        # `Declarations::Module` one, so both are reached behind a shape check.
+        def collect_declaration_references(env, decl, missing, checked)
+          if decl.respond_to?(:super_class)
+            decl.super_class&.args&.each { |arg| collect_type_references(env, arg, missing, checked) }
+          end
+          if decl.respond_to?(:self_types)
+            decl.self_types&.each do |self_type|
+              self_type.args.each { |arg| collect_type_references(env, arg, missing, checked) }
             end
           end
-          missing.uniq
+          collect_member_references(env, decl.members, missing, checked)
+        end
+
+        # Member-level references. `initialize` and the singleton side are skipped because
+        # `validate_type_params` never reaches them (see {.unresolved_referenced_types}); `:singleton_instance`
+        # (`def self?.x`) defines the instance side too, so it is NOT skipped.
+        def collect_member_references(env, members, missing, checked)
+          members.each do |member|
+            next if member.respond_to?(:kind) && member.kind == :singleton
+
+            case member
+            when ::RBS::AST::Members::MethodDefinition
+              next if member.name == :initialize
+
+              member.overloads.each do |overload|
+                collect_type_references(env, overload.method_type, missing, checked)
+              end
+            when ::RBS::AST::Members::AttrReader, ::RBS::AST::Members::AttrWriter,
+                 ::RBS::AST::Members::AttrAccessor
+              collect_type_references(env, member.type, missing, checked)
+            when ::RBS::AST::Members::Include, ::RBS::AST::Members::Extend,
+                 ::RBS::AST::Members::Prepend
+              member.args.each { |arg| collect_type_references(env, arg, missing, checked) }
+            end
+          end
+        end
+
+        # Walks one type (or method type) and appends the names no declaration provides. Only the three node
+        # classes `VarianceCalculator#type` raises for carry a checkable name; everything else is traversed for
+        # the types nested inside it.
+        def collect_type_references(env, type, missing, checked)
+          return if type.nil?
+
+          case type
+          when ::RBS::Types::ClassInstance, ::RBS::Types::Interface, ::RBS::Types::Alias
+            name = type.name
+            name = name.absolute! unless name.absolute?
+            missing[name.to_s.sub(/\A::/, "")] = true unless declared_reference?(env, name, checked)
+          end
+          return unless type.respond_to?(:each_type)
+
+          type.each_type do |nested|
+            collect_type_references(env, nested, missing, checked)
+          end
+        end
+
+        # `DefinitionBuilder#validate_type_name`'s membership test, memoised per env walk (a project's method
+        # signatures name the same handful of types over and over). A name whose normalization raises is
+        # treated as declared: repairing it is not this pass's job, and a wrong stub is the worse failure.
+        def declared_reference?(env, name, checked)
+          key = name.to_s
+          return checked[key] if checked.key?(key)
+
+          checked[key] = begin
+            env.type_name?(env.normalize_type_name(name))
+          rescue StandardError
+            true
+          end
         end
 
         # Normalises a `class_decls` entry's representative declaration across the gemspec's supported RBS
@@ -338,6 +433,24 @@ module Rigor
           elsif entry.respond_to?(:primary)
             primary = entry.primary
             primary.respond_to?(:decl) ? primary.decl : primary
+          end
+        end
+
+        # Collects the AST declaration nodes behind a `class_decls` entry across the supported RBS range (`rbs
+        # >= 3.0, < 5.0`). RBS 4's `ModuleEntry` / `ClassEntry` expose `each_decl` yielding bare AST
+        # declarations; RBS 3.x exposes `decls`, an array of `MultiEntry::D` wrappers whose `#decl` is the AST
+        # declaration. The single-`decl` shape is handled defensively so the loader survives an rbs-gem minor
+        # bump. Class-side because both the env-build detection walk and the instance-side
+        # `#names_synthesized_in` need it, and the guard must stay single-rooted.
+        def entry_declarations(entry)
+          if entry.respond_to?(:each_decl)
+            [].tap { |acc| entry.each_decl { |decl| acc << decl } }
+          elsif entry.respond_to?(:decls)
+            entry.decls.map { |d| d.respond_to?(:decl) ? d.decl : d }
+          elsif entry.respond_to?(:decl)
+            [entry.decl]
+          else
+            []
           end
         end
 
@@ -1044,30 +1157,13 @@ module Rigor
         return [] if e.nil?
 
         names = e.class_decls.filter_map do |type_name, entry|
-          decls = entry_declarations(entry)
+          decls = self.class.entry_declarations(entry)
           next if decls.empty?
           next unless decls.all? { |decl| synthetic_decl?(decl, buffer_name) }
 
           type_name.to_s.sub(/\A::/, "")
         end
         names.sort_by { |name| name.count("::") }
-      end
-
-      # Collects the AST declaration nodes behind a `class_decls` entry across the supported RBS range (`rbs
-      # >= 3.0, < 5.0`). RBS 4's `ModuleEntry` / `ClassEntry` expose `each_decl` yielding bare AST
-      # declarations; RBS 3.x exposes `decls`, an array of `MultiEntry::D` wrappers whose `#decl` is the AST
-      # declaration. The single-`decl` shape is handled defensively so the loader survives an rbs-gem minor
-      # bump.
-      def entry_declarations(entry)
-        if entry.respond_to?(:each_decl)
-          [].tap { |acc| entry.each_decl { |decl| acc << decl } }
-        elsif entry.respond_to?(:decls)
-          entry.decls.map { |d| d.respond_to?(:decl) ? d.decl : d }
-        elsif entry.respond_to?(:decl)
-          [entry.decl]
-        else
-          []
-        end
       end
 
       # True when an AST declaration was emitted into `buffer_name` (one of the synthetic-source sentinels)

--- a/spec/rigor/environment/rbs_loader_spec.rb
+++ b/spec/rigor/environment/rbs_loader_spec.rb
@@ -809,6 +809,157 @@ RSpec.describe Rigor::Environment::RbsLoader do
     end
   end
 
+  describe "referenced-type detection agrees with the builder sweep (#207)" do
+    # #207 replaced the detection half of the stub pass: it built every project class with a throwaway
+    # `RBS::DefinitionBuilder` (7.84M allocations, a third of a cold `check lib`) and read the missing name out
+    # of `NoTypeFoundError`. The sweep survives HERE, as the oracle the static walk must keep agreeing with —
+    # `docs/notes/20260730-stub-pass1-static-detection-evaluation.md` is the corpus-scale version of this test.
+    let(:tmpdir) { Dir.mktmpdir("rigor-rbs-loader-detect-spec-") }
+
+    after { FileUtils.rm_rf(tmpdir) }
+
+    def builder_sweep(env, project_files)
+      builder = RBS::DefinitionBuilder.new(env: env)
+      missing = []
+      env.class_decls.each do |type_name, entry|
+        next unless described_class.send(:project_entry?, entry, project_files)
+
+        %i[build_instance build_singleton].each do |build|
+          builder.public_send(build, type_name)
+        rescue RBS::NoTypeFoundError => e
+          name = e.message[/Could not find (\S+)/, 1]
+          missing << name.sub(/\A::/, "") if name
+        rescue RBS::BaseError
+          nil # other build failures are not this pass's to repair
+        end
+      end
+      missing.uniq
+    end
+
+    # Both detectors, run against the FIRST pass's env (later passes see the stubs already appended). Each
+    # fixture class carries exactly one missing name, so the builder's one-error-per-class limit cannot hide a
+    # difference.
+    def detect_both(source)
+      File.write(File.join(tmpdir, "shapes.rbs"), source)
+      captured = nil
+      allow(described_class).to receive(:unresolved_referenced_types).and_wrap_original do |original, *args|
+        env, project_files = args
+        result = original.call(*args)
+        captured ||= { builder: builder_sweep(env, project_files).sort, static: result.sort }
+        result
+      end
+      described_class.new(signature_paths: [tmpdir]).send(:env)
+      captured
+    end
+
+    # Fixture sources live outside the examples so each one reads as a table of positions rather than a wall
+    # of heredoc.
+    def validated_positions
+      <<~RBS
+        class ShapeReturn
+          def x: () -> RigorGoneReturn
+        end
+
+        class ShapeParam
+          def x: (RigorGoneParam a) -> void
+        end
+
+        class ShapeNested
+          def x: () -> RigorGoneNested::Deep
+        end
+
+        class ShapeGenericArg
+          def x: () -> Array[RigorGoneGenericArg]
+        end
+
+        class ShapeAttr
+          attr_reader v: RigorGoneAttr
+        end
+
+        class ShapeBlockParam
+          def x: () { (RigorGoneBlockParam) -> void } -> void
+        end
+
+        class ShapeInterface
+          def x: () -> _RigorGoneInterface
+        end
+
+        class ShapeAlias
+          def x: () -> rigor_gone_alias
+        end
+
+        class ShapeSuperArgs < Array[RigorGoneSuperArg]
+        end
+
+        class ShapeMixinArgs
+          include Enumerable[RigorGoneMixinArg]
+        end
+
+        module ShapeSelfTypeArgs : Enumerable[RigorGoneSelfTypeArg]
+        end
+      RBS
+    end
+
+    # `validate_type_params` skips `initialize` and is never called for the singleton side, instance-variable
+    # types are imported without validation, a missing super-class / mixin NAME raises a different error this
+    # pass has never stubbed, and the methods a class imports from an interface are not variance-walked.
+    # Reporting these anyway cost allocations on the corpus and changed no diagnostic, so the walk stops
+    # exactly where the builder stopped.
+    def unvalidated_positions
+      <<~RBS
+        class ShapeInitializeOnly
+          def initialize: (RigorGoneInitialize a) -> void
+        end
+
+        class ShapeSingletonOnly
+          def self.x: () -> RigorGoneSingleton
+        end
+
+        class ShapeIvarOnly
+          @v: RigorGoneIvar
+        end
+
+        class ShapeSuperName < RigorGoneSuperName
+        end
+
+        class ShapeMixinName
+          include RigorGoneMixinName
+        end
+
+        class ShapeAliasBody
+          type body = RigorGoneAliasBody
+          def x: () -> body
+        end
+
+        interface _RigorProbe
+          def x: () -> RigorGoneFromInterface
+        end
+
+        class ShapeIncludesInterface
+          include _RigorProbe
+        end
+      RBS
+    end
+
+    it "reports the same names for every position the builder validates" do
+      result = detect_both(validated_positions)
+
+      expect(result[:static]).to eq(result[:builder])
+      expect(result[:static]).to include(
+        "RigorGoneReturn", "RigorGoneParam", "RigorGoneNested::Deep", "RigorGoneGenericArg", "RigorGoneAttr",
+        "RigorGoneBlockParam", "_RigorGoneInterface", "rigor_gone_alias", "RigorGoneSuperArg",
+        "RigorGoneMixinArg", "RigorGoneSelfTypeArg"
+      )
+    end
+
+    it "reports nothing for the positions the builder does not validate" do
+      result = detect_both(unvalidated_positions)
+
+      expect(result[:static]).to eq(result[:builder])
+      expect(result[:static]).to be_empty
+    end
+  end
+
   describe "env via cache_store (v0.0.9 C2)" do
     let(:tmpdir) { Dir.mktmpdir("rigor-rbs-loader-env-spec-") }
     let(:cache_store) { Rigor::Cache::Store.new(root: File.join(tmpdir, ".rigor", "cache")) }


### PR DESCRIPTION
Closes #207. Implements the direction the evaluation cleared: [`docs/notes/20260730-stub-pass1-static-detection-evaluation.md`](https://github.com/rigortype/rigor/blob/master/docs/notes/20260730-stub-pass1-static-detection-evaluation.md). Sits on top of #238.

## What changed

`RbsLoader.unresolved_referenced_types` built every project class instance- and singleton-side with a throwaway `RBS::DefinitionBuilder` and recovered the missing name from `NoTypeFoundError` — **7.84M allocations, 33% of a cold `check lib`**, to find nothing once `sig/` is self-consistent.

It now walks the declarations and applies RBS's own membership test. The walk mirrors the raise sites rather than approximating them:

- `DefinitionBuilder#validate_type_presence` over super-class / module self-type / mixin type **args** (`definition_builder.rb:219`, `:237`, `:283`) — the mixin or super-class *name* is deliberately not checked, since a missing one raises `NoSuperclassFoundError` / `NoMixinFoundError`, which this pass has never stubbed;
- `VarianceCalculator#type` over the method types `validate_type_params` reaches (`variance_calculator.rb:158`), which raises for `ClassInstance` / `Interface` / `Alias` only, skips `initialize` (`definition_builder.rb:529`), and never runs for the singleton side.

Membership is `env.type_name?(env.normalize_type_name(name.absolute!))` — the builder's own predicate — so a name is reported only when no declaration in the env provides it. The FP #207 was gated on (stubbing a name that *would* have resolved) cannot arise from that predicate; what was genuinely open was the scope, and the evaluation measured it: reporting the positions the builder does not validate changes no diagnostic and costs **+11.3%** allocations on binpacker.

## Cost

| target | before | after |
| --- | --- | --- |
| rigor `check lib`, pass 1 | 7,841,785 alloc / ~810ms | **24,661 / ~9ms** |
| rigor `check lib`, whole cold run | 23,808,281 | **16,030,045** (−32.7%), wall −0.6…−1.0s |
| herb | 7,011,335 | **4,257,187** (−39.3%, with #238) |
| conference-app | 30,399,182 | **4,980,766** (−83.6%) |

Three paired runs on rigor; within-arm spread ~30 objects.

## Equivalence and FP gate

- The builder sweep survives **in spec** as the oracle: `static == builder` over a table of eleven validated positions (return / param / block param / nested / generic arg / attr / interface / alias / super args / mixin args / module self-type args) and six unvalidated ones (`initialize`-only, singleton-only, `@ivar`-only, missing super-class name, missing mixin name, alias body, plus a project interface's own reference — none of which the builder reported either).
- `rigor check --no-cache --format json` over the eight RBS-shipping projects (rigor `lib`, textbringer, herb, haml, kramdown, rgl, binpacker, conference-app): **diagnostic-identical, zero new firings.**
- `make verify` green (13 spec groups, 0 failures; rubocop clean; `check` and `check-plugins` clean), `make docs-check` green.

## One scope reduction, stated

The builder also walked each project class's **ancestors**, so a dangling reference inside a *gem's* signature reachable from a project class was reported too. This walk reads project declarations only. No such name occurs across the eight projects measured, and the cost of missing one is the fail-soft `Dynamic` ADR-5 tier 2 already accepts — not a false diagnostic. Documented at the method.

## Side finding

Rigor's own `make check` flagged `self.class.entry_declarations(...)` as undefined — a **false** `call.undefined-method` when an instance method masks a same-named `class << self` method on an RBS-known class. Filed with a minimal repro as #239. Sidestepped here by keeping the rbs-version shape guard single-rooted on the class side, which is where both callers want it anyway.
