### PR TITLE
Refresh the perf baseline after the stub-detection change

### DIFF
--- a/bench/baseline.json
+++ b/bench/baseline.json
@@ -1,13 +1,13 @@
 {
   "calibrated": true,
-  "calibrated_at": "2026-07-30T01:04:00Z",
-  "calibrated_on": "ubuntu-latest (GitHub Actions), master @ run 30504551099",
-  "note": "Linux CI measurements. wall_s is wider than local macOS (runner noise); allocations is the tight signal. Refresh by triggering release-gate.yml, downloading the bench-baseline-* artifact, and committing its targets here — that artifact is now produced on every run, not only an uncalibrated one, which is why this refresh was missable before. Recalibrated DOWN from the v0.3.0 cut's 32,403,338: `lib` self-check allocations fell to 23,521,131 (-27.4%) when e3b132a3 declared `Inference::VoidOrigin` in sig/. That single dangling reference was the tree's only unresolved type, and therefore the only reason `Environment::RbsLoader.stub_missing_referenced_types` ran a second confirmatory pass building all ~1,917 project classes; with sig/ self-consistent the fixpoint converges on pass 1 and the second pass is gone. This is a sig correctness fix, NOT a Rigor performance win — no other project benefits from it, and docs/notes/20260725-check-allocation-attribution.md predicted this exact figure before the fix landed. Refreshed so the 5% allocation band keeps its teeth: against the stale target it permitted 34,023,505, i.e. +44% over the real cost. wall_s and peak_rss_kb come from the same run.",
+  "calibrated_at": "2026-07-30T12:00:03Z",
+  "calibrated_on": "ubuntu-latest (GitHub Actions), master @ run 30540710607",
+  "note": "Linux CI measurements. wall_s is wider than local macOS (runner noise); allocations is the tight signal. Refresh by triggering release-gate.yml, downloading the bench-baseline-* artifact, and committing its targets here — that artifact is produced on every run, not only an uncalibrated one. Recalibrated DOWN from 23,521,131 (the 2026-07-30 sig-correctness recalibration): `lib` allocations fell to 15,769,515 (-33.0%) when #207 replaced the referenced-type stub pass's detection half. It had built every project class instance- and singleton-side with a throwaway RBS::DefinitionBuilder to read the missing name out of NoTypeFoundError (7.84M allocations, a third of the run); detection now reads the declarations and applies RBS's own membership test, at ~25k. Unlike the previous refresh this IS a Rigor performance win — every project that ships RBS through `signature_paths:` benefits, measured -83.6% on a Rails-shaped app (docs/notes/20260730-stub-pass1-static-detection-evaluation.md). #237, merged alongside, also stops the stub fixpoint burning all five passes when a batch cannot be synthesized. Refreshed so the 5% allocation band keeps its teeth: against the stale target it permitted 24,697,188, i.e. +57% over the real cost. wall_s and peak_rss_kb come from the same run.",
   "targets": {
     "lib": {
-      "wall_s": 15.015,
-      "allocations": 23521131,
-      "peak_rss_kb": 319612,
+      "wall_s": 9.106,
+      "allocations": 15769515,
+      "peak_rss_kb": 301900,
       "diagnostics": 1
     }
   }


### PR DESCRIPTION
Follow-up to #240. The committed baseline anchored the perf gate's ceiling at a cost the code no longer pays.

## Why now

The first release-gate run after the merge ([30540710607](https://github.com/rigortype/rigor/actions/runs/30540710607)) printed the staleness notice #233 added, which is exactly the case it was written for:

```
STALE lib allocations: 15769515 is 33.0% below baseline 23521131;
  the +5% band still permits 24697188 (+57% over the real cost)
```

The band is a percentage *of the baseline*, so an unfolded improvement silently widens the real ceiling. +57% of headroom is not a gate.

## New targets

Linux CI measurement from that run, on merged master:

| metric | before | after |
| --- | --- | --- |
| allocations | 23,521,131 | **15,769,515** (−33.0%) |
| wall_s | 15.015 | 9.106 |
| peak_rss_kb | 319,612 | 301,900 |

Unlike the [previous refresh](https://github.com/rigortype/rigor/pull/233) — which followed a `sig/` correctness fix that only this repository benefited from — this one records a real engine win: #207 stopped the referenced-type stub pass from building every project class to find dangling references (7.84M allocations → ~25k), and every project that ships RBS through `signature_paths:` benefits. The `note` field says which kind of recalibration this is, since the distinction is the thing a future reader needs.

## Armed, not just quiet

Verified locally after the refresh: 15,870,819 allocations passes inside the new +5% band (16,557,991) with no staleness notice. The ceiling is now 16.56M rather than 24.70M.
