### PR TITLE
Keep both kinds when one name is defined on both sides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** A class that defines the same method name on both sides — `def helper` plus a `class << self` (or `def self.helper`) twin — no longer draws a false `call.undefined-method` on the class-side call ([#239](https://github.com/rigortype/rigor/issues/239)).
+  - The in-source method table records one kind per name, so the second definition erased the first and the method Rigor could see in the source read as missing. It now records both, including when the two definitions live in different files. Real instance: `Haml::Compiler::ScriptCompiler.find_and_preserve` on the `haml` gem, which declares that name as both a class method and an instance method.
 - **[inference]** Under the opt-in `parameter_inference:`, `call.argument-type-mismatch` no longer fires when the *receiver's* type came from call-site parameter inference ([#205](https://github.com/rigortype/rigor/issues/205)).
   - An inferred parameter type is a lower bound, so a method contract resolved through it is speculative; the guard already declined on inferred arguments but missed the receiver side. Surfaced by Rigor's own self-check, where the seeded receiver flagged a correct call against an upstream RBS signature stricter than its implementation.
 - **[sig-gen]** `rigor sig-gen` now reads a class built by `Data.define(...)` / `Struct.new(...)`, in both the `Point = Data.define(:x, :y)` and `class Point < Data.define(:x, :y)` forms ([#227](https://github.com/rigortype/rigor/issues/227)).

--- a/docs/internal-spec/reflection.md
+++ b/docs/internal-spec/reflection.md
@@ -57,7 +57,7 @@ The RBS-consulting methods accept **either** `scope:` **or** `environment:` (the
 ### Source-side discoveries
 
 - `Rigor::Reflection.discovered_class?(class_name, scope: Scope.empty)` — `true` when the analyzed source contains a class / module declaration. Does NOT consult the RBS loader (use `class_known?` for the union).
-- `Rigor::Reflection.discovered_method?(class_name, method_name, kind: :instance, scope: Scope.empty)` — `true` when `ScopeIndexer` recorded a `def` for the given method on the given class with the matching kind.
+- `Rigor::Reflection.discovered_method?(class_name, method_name, kind: :instance, scope: Scope.empty)` — `true` when `ScopeIndexer` recorded a `def` for the given method on the given class with the matching kind. The underlying table holds one value per method name, so a name defined on BOTH sides of a class (`def helper` plus a `class << self` twin) records `Scope::DiscoveryIndex::METHOD_KIND_BOTH` and MUST answer `true` for either kind — a writer that overwrites the other side's kind instead produces a false `call.undefined-method` on code that runs.
 
 ## Provenance
 

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -1275,14 +1275,38 @@ module Rigor
       end
 
       # Merges two `class_name => { method => kind }` tables, unioning the per-class method maps (so a seeded cross-file
-      # table and the current file's table combine instead of clobbering).
+      # table and the current file's table combine instead of clobbering). A name recorded on both sides — an instance
+      # `def` here and a `class << self` twin there — merges to {Scope::DiscoveryIndex::METHOD_KIND_BOTH} rather than
+      # letting the overlay's kind win (#239).
       def deep_merge_class_methods(base, overlay)
         return overlay if base.nil? || base.empty?
         return base if overlay.empty?
 
         base.merge(overlay) do |_class_name, base_methods, overlay_methods|
-          base_methods.merge(overlay_methods)
+          merge_method_kinds(base_methods, overlay_methods)
         end
+      end
+
+      # `{ method => kind }` union that promotes a kind disagreement to `METHOD_KIND_BOTH` instead of clobbering.
+      def merge_method_kinds(base_methods, overlay_methods)
+        base_methods.merge(overlay_methods) do |_method_name, base_kind, overlay_kind|
+          base_kind == overlay_kind ? base_kind : Scope::DiscoveryIndex::METHOD_KIND_BOTH
+        end
+      end
+
+      # The single write path into a `class_name => { method => kind }` existence table. Every recorder goes through
+      # it so a class that defines one name on both sides keeps both facts: the table is keyed by name alone, so a
+      # bare assignment silently replaced the other side's kind and `Scope#discovered_method?` then answered false for
+      # a method the source plainly defines (#239).
+      def record_method_kind(accumulator, class_name, method_name, kind)
+        table = (accumulator[class_name] ||= {})
+        recorded = table[method_name]
+        table[method_name] =
+          if recorded.nil? || recorded == kind
+            kind
+          else
+            Scope::DiscoveryIndex::METHOD_KIND_BOTH
+          end
       end
 
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize
@@ -1393,8 +1417,7 @@ module Rigor
         return if members.empty?
 
         class_name = qualified_prefix.join("::")
-        table = (accumulator[class_name] ||= {})
-        members.each { |member| table[member] ||= :instance }
+        members.each { |member| record_method_kind(accumulator, class_name, member, :instance) }
       end
 
       # The Symbol member names of a `Data.define(*Symbol)` / `Struct.new(*Symbol [, keyword_init:])` call. For
@@ -1412,8 +1435,7 @@ module Rigor
         class_name = qualified_prefix.join("::")
         singleton = def_singleton?(def_node, qualified_prefix, in_singleton_class)
         kind = singleton ? :singleton : :instance
-        accumulator[class_name] ||= {}
-        accumulator[class_name][def_node.name] = kind
+        record_method_kind(accumulator, class_name, def_node.name, kind)
       end
 
       # `def Foo.bar` inside `module Foo` (or `def Meta.init` inside `module Meta`) is semantically equivalent to `def
@@ -1918,7 +1940,7 @@ module Rigor
         class_name = qualified_prefix.join("::")
         new_name = alias_node.new_name.unescaped.to_sym
         kind = in_singleton_class ? :singleton : :instance
-        (accumulator[class_name] ||= {})[new_name] = kind
+        record_method_kind(accumulator, class_name, new_name, kind)
       end
 
       # Post-pass over the `def_nodes` accumulator: for every `alias` declaration inside a class body, if the original
@@ -1981,8 +2003,7 @@ module Rigor
         return if method_name.nil?
 
         class_name = qualified_prefix.join("::")
-        accumulator[class_name] ||= {}
-        accumulator[class_name][method_name] = in_singleton_class ? :singleton : :instance
+        record_method_kind(accumulator, class_name, method_name, in_singleton_class ? :singleton : :instance)
       end
 
       # The `attr_*` accessor macros that introduce methods Rigor must treat as source-declared. Without this, a class
@@ -2005,9 +2026,8 @@ module Rigor
           base = literal_method_name(arg)
           next if base.nil?
 
-          accumulator[class_name] ||= {}
-          accumulator[class_name][base] = kind if reader
-          accumulator[class_name][:"#{base}="] = kind if writer
+          record_method_kind(accumulator, class_name, base, kind) if reader
+          record_method_kind(accumulator, class_name, :"#{base}=", kind) if writer
         end
       end
 
@@ -2352,7 +2372,7 @@ module Rigor
         file_index[:def_nodes].each { |cn, methods| (acc[:def_nodes][cn] ||= {}).merge!(methods) }
         file_index[:singleton_def_nodes].each { |cn, methods| (acc[:singleton_def_nodes][cn] ||= {}).merge!(methods) }
         file_index[:method_visibilities].each { |cn, table| (acc[:method_visibilities][cn] ||= {}).merge!(table) }
-        file_index[:methods].each { |cn, table| (acc[:methods][cn] ||= {}).merge!(table) }
+        file_index[:methods].each { |cn, table| acc[:methods][cn] = merge_method_kinds(acc[:methods][cn] || {}, table) }
         fold_def_sources(acc, :def_sources, file_index[:def_sources])
         fold_def_sources(acc, :singleton_def_sources, file_index[:singleton_def_sources])
       end
@@ -2468,10 +2488,18 @@ module Rigor
 
       # Removes, per class, the method names that have a project `def` node, leaving only
       # accessor/alias/define_method-introduced methods in the cross-file suppression table.
+      #
+      # `def_nodes` is the INSTANCE-side table, so a name recorded on both sides keeps its singleton half: that half
+      # comes from a `def self.x` / `class << self` definition this rule never covered, and dropping it whole would
+      # reintroduce #239's false `call.undefined-method` across files.
       def subtract_def_methods(methods, def_nodes)
         methods.each_with_object({}) do |(class_name, table), out|
           defs = def_nodes[class_name] || {}
-          kept = table.reject { |method_name, _kind| defs.key?(method_name) }
+          kept = table.each_with_object({}) do |(method_name, kind), acc|
+            next acc[method_name] = kind unless defs.key?(method_name)
+
+            acc[method_name] = :singleton if kind == Scope::DiscoveryIndex::METHOD_KIND_BOTH
+          end
           out[class_name] = kept unless kept.empty?
         end
       end
@@ -2517,7 +2545,7 @@ module Rigor
           (acc[:method_visibilities][class_name] ||= {}).merge!(table)
         end
         file_methods.each do |class_name, table|
-          (acc[:methods][class_name] ||= {}).merge!(table)
+          acc[:methods][class_name] = merge_method_kinds(acc[:methods][class_name] || {}, table)
         end
       end
 

--- a/lib/rigor/scope.rb
+++ b/lib/rigor/scope.rb
@@ -394,11 +394,13 @@ module Rigor
     # recognised `define_method` invocation inside class/module bodies. The `rigor check` undefined-method and
     # wrong-arity rules consult this map to suppress diagnostics for methods the user has defined dynamically,
     # even when no RBS sig describes them.
+    # A name defined on both sides of one class records {DiscoveryIndex::METHOD_KIND_BOTH} and matches either kind.
     def discovered_method?(class_name, method_name, kind)
       table = @discovery.discovered_methods[class_name.to_s]
       return false unless table
 
-      table[method_name.to_sym] == kind
+      recorded = table[method_name.to_sym]
+      recorded == kind || recorded == DiscoveryIndex::METHOD_KIND_BOTH
     end
 
     # ADR-34 § "Decision" — predicate identifying a toplevel-shaped scope (no enclosing `class` / `module` body).

--- a/lib/rigor/scope/discovery_index.rb
+++ b/lib/rigor/scope/discovery_index.rb
@@ -37,6 +37,15 @@ module Rigor
       EMPTY_TABLE = {}.freeze
       private_constant :EMPTY_NODE_TABLE, :EMPTY_TABLE
 
+      # The third value a `discovered_methods` entry can hold, beside `:instance` and `:singleton`. One name may
+      # legitimately be defined on both sides of the same class (`def helper` plus a `class << self` twin), and the
+      # table is keyed by name alone — so before this existed the second `def` overwrote the first's kind and
+      # `Scope#discovered_method?` answered false for a method that is right there in the source. That is a false
+      # `call.undefined-method` on ordinary Ruby (#239), which outranks any worst-case reading (AGENTS.md
+      # § "Implementation Guidelines"). Writers promote to this instead of clobbering; readers treat it as matching
+      # either kind.
+      METHOD_KIND_BOTH = :both
+
       # The shared all-empty index `Scope.empty` (and every scope that never sees a seeding pass) points at — one
       # allocation per process.
       EMPTY = new(

--- a/spec/integration/singleton_instance_name_collision_spec.rb
+++ b/spec/integration/singleton_instance_name_collision_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+require "rigor"
+require "rigor/analysis/runner"
+require "rigor/configuration"
+
+# #239 — a false `call.undefined-method`. `Scope`'s in-source method table is keyed by method NAME, so a class that
+# defines one name on both sides (`def helper` plus a `class << self` twin) recorded whichever `def` the walk reached
+# last and lost the other kind. On an RBS-KNOWN class whose method the project's `sig/` does not declare, existence
+# falls to that table, so `self.class.helper(1)` read as undefined on code that runs fine.
+#
+# Surfaced by Rigor's own `make check` while landing #207, on `RbsLoader.entry_declarations` — the shape is ordinary
+# Ruby (a class-side helper and an instance-side helper sharing a name), which is why it belongs at the check level
+# and not only in the indexer's unit specs.
+RSpec.describe "a singleton method sharing a name with an instance method" do
+  # Only `call_class_side` / `call_instance_side` are declared, so `helper` existence comes from the source scan.
+  # `Alone` is the control: byte-identical minus the instance-side twin.
+  let(:rbs) do
+    <<~RBS
+      class Collides
+        def call_class_side: () -> Integer
+        def call_instance_side: () -> Integer
+      end
+
+      class Alone
+        def call_class_side: () -> Integer
+      end
+    RBS
+  end
+
+  let(:source) do
+    <<~RUBY
+      class Collides
+        class << self
+          def helper(value)
+            value
+          end
+        end
+
+        def helper(value)
+          value
+        end
+
+        def call_class_side
+          self.class.helper(1)
+        end
+
+        def call_instance_side
+          helper(1)
+        end
+      end
+
+      class Alone
+        class << self
+          def helper(value)
+            value
+          end
+        end
+
+        def call_class_side
+          self.class.helper(1)
+        end
+      end
+    RUBY
+  end
+
+  def write_project
+    FileUtils.mkdir_p("sig")
+    File.write(File.join("sig", "collides.rbs"), rbs)
+    File.write("app.rb", source)
+  end
+
+  def undefined_method_messages
+    configuration = Rigor::Configuration.new(
+      Rigor::Configuration::DEFAULTS.merge("paths" => %w[app.rb], "signature_paths" => %w[sig])
+    )
+    Rigor::Analysis::Runner.new(configuration: configuration, cache_store: nil)
+                           .run(%w[app.rb])
+                           .diagnostics
+                           .select { |d| d.rule == "call.undefined-method" }
+                           .map(&:message)
+  end
+
+  around do |example|
+    Dir.mktmpdir("rigor-singleton-collision-") do |dir|
+      Dir.chdir(dir) { example.run }
+    end
+  end
+
+  it "resolves both sides of the collision without a false undefined-method" do
+    write_project
+
+    expect(undefined_method_messages).to be_empty
+  end
+
+  it "still reports a name that really is absent on the singleton side" do
+    # The control the silence above needs: the rule is not merely mute on this class.
+    File.write("app.rb", source.sub("self.class.helper(1)", "self.class.no_such_helper_zzz(1)"))
+    FileUtils.mkdir_p("sig")
+    File.write(File.join("sig", "collides.rbs"), rbs)
+
+    expect(undefined_method_messages).to include(a_string_matching(/undefined method `no_such_helper_zzz'/))
+  end
+end

--- a/spec/rigor/inference/scope_indexer_spec.rb
+++ b/spec/rigor/inference/scope_indexer_spec.rb
@@ -790,6 +790,88 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
     end
   end
 
+  # #239 — the `discovered_methods` table is keyed by method NAME, so a class that defines one name on both sides
+  # (`def helper` plus a `class << self` twin) used to record whichever `def` the walk reached last and lose the
+  # other. `Scope#discovered_method?` then answered false for a method the source plainly defines, and the
+  # undefined-method rule fired on correct Ruby.
+  describe "a name defined on both the instance and singleton side" do
+    let(:tmpdir) { Dir.mktmpdir }
+
+    after { FileUtils.remove_entry(tmpdir) }
+
+    def write(name, body)
+      path = File.join(tmpdir, name)
+      File.write(path, body)
+      path
+    end
+
+    it "records both kinds for a `class << self` twin, whichever order they appear in" do
+      %w[singleton_first instance_first].each do |order|
+        singleton = "class << self\n    def helper(value) = value\n  end"
+        instance = "def helper(value) = value"
+        body = order == "singleton_first" ? [singleton, instance] : [instance, singleton]
+        program = parse("class Collides\n  #{body.join("\n  ")}\nend\n")
+        scope = described_class.index(program, default_scope: default_scope)[program]
+
+        expect(scope.discovered_method?("Collides", :helper, :instance)).to be(true), order
+        expect(scope.discovered_method?("Collides", :helper, :singleton)).to be(true), order
+      end
+    end
+
+    it "records both kinds for a `def self.` twin" do
+      program = parse(<<~RUBY)
+        class Collides
+          def helper(value) = value
+          def self.helper(value) = value
+        end
+      RUBY
+      scope = described_class.index(program, default_scope: default_scope)[program]
+
+      expect(scope.discovered_method?("Collides", :helper, :instance)).to be(true)
+      expect(scope.discovered_method?("Collides", :helper, :singleton)).to be(true)
+    end
+
+    it "records both kinds when an attr_accessor collides with a singleton def of the same name" do
+      program = parse(<<~RUBY)
+        class Collides
+          attr_accessor :helper
+          def self.helper = 1
+        end
+      RUBY
+      scope = described_class.index(program, default_scope: default_scope)[program]
+
+      expect(scope.discovered_method?("Collides", :helper, :instance)).to be(true)
+      expect(scope.discovered_method?("Collides", :helper, :singleton)).to be(true)
+    end
+
+    it "keeps a single kind for a name defined on one side only" do
+      program = parse("class Solo\n  def helper(value) = value\nend\n")
+      scope = described_class.index(program, default_scope: default_scope)[program]
+
+      expect(scope.discovered_method?("Solo", :helper, :instance)).to be(true)
+      expect(scope.discovered_method?("Solo", :helper, :singleton)).to be(false)
+    end
+
+    it "unions the two kinds across files in the cross-file index" do
+      # The cross-file table subtracts names that have an instance `def` (the ADR-17 monkey-patch contract), but the
+      # singleton half comes from a definition that rule never covered, so it must survive the subtraction.
+      paths = [
+        write("a.rb", "class Cross\n  def helper(value) = value\nend\n"),
+        write("b.rb", "class Cross\n  class << self\n    def helper(value) = value\n  end\nend\n")
+      ]
+      index = described_class.discovered_project_index_for_paths(paths)
+
+      expect(index[:def_index][:methods]["Cross"][:helper]).to eq(:singleton)
+    end
+
+    it "drops an instance-only name from the cross-file index, as before" do
+      paths = [write("a.rb", "class Solo\n  def helper(value) = value\nend\n")]
+      index = described_class.discovered_project_index_for_paths(paths)
+
+      expect(index[:def_index][:methods]["Solo"]).to be_nil
+    end
+  end
+
   describe "alias discovery" do
     it "registers the aliased name in discovered_methods" do
       program = parse(<<~RUBY)

--- a/spec/rigor/reflection_spec.rb
+++ b/spec/rigor/reflection_spec.rb
@@ -226,5 +226,18 @@ RSpec.describe Rigor::Reflection do
       expect(described_class.discovered_method?("MyClass", :do_thing, scope: scope)).to be(true)
       expect(described_class.discovered_method?("MyClass", :unknown_method, scope: scope)).to be(false)
     end
+
+    it "reports a both-sides method under either kind (#239)" do
+      # One name may be defined on both sides of a class, and the table holds one value per name — so the writers
+      # record METHOD_KIND_BOTH instead of letting the second definition erase the first's kind.
+      index = Rigor::Scope::DiscoveryIndex::EMPTY.with(
+        discovered_methods: { "MyClass" => { helper: Rigor::Scope::DiscoveryIndex::METHOD_KIND_BOTH } }
+      )
+      both = Rigor::Scope.empty.with_discovery(index)
+
+      expect(described_class.discovered_method?("MyClass", :helper, kind: :instance, scope: both)).to be(true)
+      expect(described_class.discovered_method?("MyClass", :helper, kind: :singleton, scope: both)).to be(true)
+      expect(described_class.discovered_method?("MyClass", :other, kind: :singleton, scope: both)).to be(false)
+    end
   end
 end


### PR DESCRIPTION
Closes #239.

## The defect

`Scope`'s in-source method table is `{class_name => {method_name => kind}}` — one kind per **name**. Every recorder assigned into it directly, so a class defining `def helper` beside a `class << self` twin kept whichever definition the walk reached last. `Scope#discovered_method?` then answered `false` for the other side, and on an **RBS-known** class whose `sig/` omits the method — where existence falls to this table — `self.class.helper(1)` drew `call.undefined-method` on code that runs fine.

Found by Rigor's own `make check` on `RbsLoader.entry_declarations` while landing #207, which renamed its way around the symptom before the cause was understood.

## The fix

- An entry can hold `Scope::DiscoveryIndex::METHOD_KIND_BOTH`; `discovered_method?` matches either kind against it.
- One shared `record_method_kind` write path promotes instead of clobbering, for `def`, `define_method`, `attr_*`, aliases and Data/Struct members.
- The two cross-file folds union kinds the same way.
- `subtract_def_methods` keeps the **singleton half** of a both-sides name. It subtracts names that have an instance `def` node (the ADR-17 monkey-patch contract), a rule that never covered the singleton side, so dropping the entry whole reintroduced the same false positive across files.

## It is not only our own tree

`rigor check --no-cache` over the eight RBS-shipping survey projects (rigor `lib`, textbringer, herb, haml, kramdown, rgl, binpacker, conference-app): **one diagnostic lost, zero gained.**

```
- haml/lib/haml/compiler/script_compiler.rb:71:32: error: call.undefined-method:
    undefined method `find_and_preserve' …
```

`Haml::Compiler::ScriptCompiler` declares `def self.find_and_preserve` at line 9 and `def find_and_preserve` at line 105 — exactly the shape, in a production gem, and the call at line 71 goes through the class-side one.

## Specs

Five behavioural examples that fail without the change (both `class << self` orders, the `def self.` twin, an `attr_accessor` colliding with a singleton def, and the cross-file union), plus the two that must keep behaving as they did (single-kind name; instance-only name still subtracted from the cross-file table). End-to-end, `spec/integration/singleton_instance_name_collision_spec.rb` checks the real diagnostic stream with a byte-identical `Alone` control class and a second example that must still report a genuinely absent name — so the silence is not vacuous.

Verified in reverse: reverting only `lib/` fails 5 of the new examples and the integration one.

## Gates

`make verify` green (13 groups, 0 failures; rubocop clean; `check` / `check-plugins` clean), `make docs-check` green (324). `make bench-perf` inside the band: 15,884,630 ≤ 16,557,991 against the freshly refreshed baseline. `docs/internal-spec/reflection.md` records the both-sides contract in the same commit.
