### PR TITLE
Give editor mode whole-project scope with `--incremental`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 - **[rigor-rbs-inline]** An inline-RBS annotation that Rigor parses but does not honour is now reported as `plugin.rbs-inline.source-rbs-annotation-not-honoured` (info) instead of being dropped in silence ([#229](https://github.com/rigortype/rigor/issues/229)).
   - There are two inline-RBS implementations, and they spell `module-self` differently: Rigor reads `# @rbs module-self Foo`, while `rbs`'s own inline documentation shows `# @rbs module-self: Foo`. The second form previously contributed nothing, with the annotation comment still echoed into the generated RBS — so the omission was invisible. The rest of the file's annotations are unaffected, and the diagnostic says so.
   - The manual chapter now states which dialect Rigor reads and what differs.
+- **[rigor check]** Editor mode gains whole-project scope: `--tmp-file` / `--instead-of` **with `--incremental`** analyses the whole project with the unsaved buffer substituted, so an in-flight edit surfaces in the files that depend on it and not only in the file being edited ([#146](https://github.com/rigortype/rigor/issues/146)).
+  - The edited file and its dependents are re-analysed; every other file is served from the incremental snapshot. It needs a snapshot to reuse — run `rigor check --incremental` once — and says so on stderr when there is none, analysing the buffer alone as before.
+  - An editor-mode run never writes the snapshot, so the bytes in your editor can never be mistaken for the state of the file on disk.
+- **[rigor check]** `--verify-incremental` now refuses an editor buffer instead of silently comparing it against a full analysis of the files on disk.
 
 ### Changed
 

--- a/docs/design/20260516-editor-mode.md
+++ b/docs/design/20260516-editor-mode.md
@@ -162,9 +162,29 @@ Three viable shapes:
   the buffer's public surface (return type, constant value, exported
   module).
 
-**v1 ships (A).** It's the smallest cut that delivers the speed
+**v1 shipped (A).** It's the smallest cut that delivers the speed
 target, and it composes forward: when a per-file diagnostic cache
 exists, the same CLI shape upgrades to (B) with no flag rename.
+
+**(B) shipped in #146**, on ADR-46's snapshot: `--tmp-file` /
+`--instead-of` **plus `--incremental`**. The composition, rather than
+an automatic upgrade, is deliberate — silently widening scope when a
+snapshot happens to exist would make the same command emit different
+diagnostics on different machines. Three properties fix the design:
+
+- **The buffer is a changed file by definition.** Its recorded stat
+  entry describes the file on disk, so the logical path is never
+  stat-fresh and always re-analyses.
+- **The closure must be computed from the buffer's bytes.** The
+  symbol-fingerprint scan that decides which dependents re-analyse
+  reads through the binding; reading the logical path from disk
+  compares the snapshot against bytes the user already edited away,
+  and serves every dependent of the unsaved change from cache.
+- **The session never saves.** Its per-file cache and digests describe
+  bytes that exist only in the editor. That is also why a snapshot it
+  cannot reuse falls back to (A) rather than running a baseline: the
+  baseline could not be persisted, so it would repeat on every
+  keystroke.
 
 The editor extension can layer (C) on top of (A) by issuing multiple
 single-file invocations (one per affected file). Rigor doesn't owe

--- a/docs/manual/02-cli-reference.md
+++ b/docs/manual/02-cli-reference.md
@@ -48,10 +48,37 @@ the `paths:` list from the configuration file.
 | `--treat-all-as-inline-rbs` | Force-load `rigor-rbs-inline` with `require_magic_comment: false`, so every analysed file is treated as inline-RBS without the `# rbs_inline: enabled` comment (ADR-32). |
 | `--bleeding-edge[=ids]` | Adopt the bleeding-edge overlay for this run, overriding the configured [`bleeding_edge:`](03-configuration.md) selection (ADR-50 § WD2). Bare adopts every queued feature; `--bleeding-edge=a,b` adopts only the named feature ids. Inspect it with [`rigor show-bleedingedge`](#rigor-show-bleedingedge). |
 | `--no-bleeding-edge` | Ignore any configured `bleeding_edge:` selection for this run (adopt none). |
-| `--tmp-file=PATH --instead-of=PATH` | Editor mode: analyse `PATH` using the buffer in `--tmp-file`. Both required together. |
+| `--tmp-file=PATH --instead-of=PATH` | Editor mode: analyse `PATH` using the buffer in `--tmp-file`. Both required together. Alone, only the buffer's own file produces diagnostics; add `--incremental` for whole-project scope (see below). |
 
 Exit `0` when no error-severity diagnostics remain, `1` when
 any are reported, `64` on a usage error.
+
+### Editor mode scope
+
+`--tmp-file` / `--instead-of` on their own analyse **only** the
+buffer's file: fast, and blind to what the unsaved edit does to the
+rest of the project.
+
+Adding `--incremental` analyses the **whole project with the buffer
+substituted** — the edited file and the files that depend on it are
+re-analysed, everything else is served from the incremental snapshot.
+An unsaved change to a method's return type therefore surfaces in its
+callers, not just in the file being edited.
+
+Two things to know:
+
+- It needs a snapshot to reuse. Run `rigor check --incremental` once
+  (it is also what a normal terminal check should use) and every later
+  editor invocation gets whole-project scope. Without one, Rigor says
+  so on stderr and analyses the buffer alone.
+- An editor-mode run never writes the snapshot — the buffer's bytes
+  exist only in your editor, and recording them would make the next
+  ordinary run believe it had already analysed a file in a state it
+  was never in.
+
+`--verify-incremental` refuses a buffer: it compares against a full
+analysis of the files on disk, which a buffer contradicts by
+construction.
 
 ## `rigor init`
 

--- a/lib/rigor/analysis/incremental_session.rb
+++ b/lib/rigor/analysis/incremental_session.rb
@@ -62,9 +62,14 @@ module Rigor
       #   pool records each worker's cross-file reads and marshals them back (PoolCoordinator), so the
       #   dependency graph a pooled recheck rebuilds equals the sequential one.
       def initialize(configuration:, paths: nil, environment: nil, cache_store: nil, plugin_requirer: nil,
-                     workers: 0)
+                     workers: 0, buffer: nil)
         @configuration = configuration
         @paths = paths
+        # Editor mode option B (#146) — the in-flight buffer, threaded into every internal Runner so the
+        # pre-passes and the closure re-analysis read the editor's bytes at the logical path. A session
+        # holding one MUST NOT persist its snapshot: its `@digests` and `@cache` describe bytes that exist
+        # only in the editor. {#run_buffer_recheck} is the only entry that honours that.
+        @buffer = buffer
         @environment = environment
         @cache_store = cache_store
         @plugin_requirer = plugin_requirer
@@ -166,6 +171,32 @@ module Rigor
                     removed: removed.to_set, affected: affected, reused: reused.to_set)
       end
 
+      # Editor mode option B (#146) — a whole-project recheck with the editor's buffer substituted for one
+      # file, for the CLI's `--incremental --tmp-file=X --instead-of=Y`. Returns the {Recheck} when the
+      # snapshot could be reused, or nil when it could not — the caller then falls back to option A
+      # (single-file scope) rather than paying a full baseline, because that baseline would repeat on every
+      # keystroke: this session MUST NOT save, so nothing it computes can warm the next invocation.
+      #
+      # Not saving is the whole safety story. `@digests` and `@cache` here describe the buffer's bytes, which
+      # exist only in the editor; persisting them would make the next `rigor check --incremental` believe the
+      # on-disk file was already analysed in a state it was never in.
+      def run_buffer_recheck(snapshot:, fingerprint:)
+        Cache::FileDigest.with_run(strict: @configuration.cache_validation_strict?) do
+          restored = fingerprint && snapshot.load(fingerprint: fingerprint)
+          break nil unless restored
+
+          restore(restored)
+          result = recheck
+          adopt_plugin_fact_fingerprint
+          # The ADR-88 gate applies unchanged: if the plugin fact surface moved, the cache-served files may be
+          # stale. A full baseline is the sound answer for `--incremental`, but in editor mode it is also the
+          # latency this mode exists to avoid, so decline and let the caller drop to single-file scope.
+          break nil unless @plugin_fact_reusable.reusable_against?(restored.plugin_fact_digest)
+
+          result
+        end
+      end
+
       # The frozen set of files a #recheck must re-analyse: the symbol/ancestry-granularity closure of the
       # changed files (slice 4), the added files themselves, the consumers of any symbol / class that
       # *appeared* in a changed OR added file (slice 3 — a now-defined `call.unresolved-toplevel` target or
@@ -185,7 +216,12 @@ module Rigor
         # ADR-89 WD1 declaration signatures. They were separate `discovered_def_index_for_paths` passes over
         # the same `scan` set — a duplicate re-parse of every changed file each recheck (recon §2 / the P6
         # recheck-floor audit).
-        summary = scan.empty? ? nil : Inference::ScopeIndexer.scan_summary_for_paths(scan)
+        # `buffer:` is load-bearing for editor mode option B (#146), not an optimisation: this scan decides
+        # the closure, so reading the buffer's logical path from DISK would compare the snapshot's symbol
+        # fingerprints against bytes the user has already edited away — every dependent of the unsaved change
+        # would then be served from cache, which is the stale answer whole-project editor scope exists to
+        # avoid. `ScopeIndexer.scan_summary_for_paths` resolves each path through the binding.
+        summary = scan.empty? ? nil : Inference::ScopeIndexer.scan_summary_for_paths(scan, buffer: @buffer)
         scan_index = summary && summary[:def_index]
         declaration_signatures = (summary && summary[:declaration_signatures]) || {}
         new_fps = symbol_fingerprints_from_index(scan_index)
@@ -764,7 +800,7 @@ module Rigor
         Runner.new(
           configuration: @configuration, cache_store: @cache_store, environment: @environment,
           plugin_requirer: @plugin_requirer, seed_bundles: @seed_bundles, collect_seed_bundles: true,
-          workers: @workers, **
+          workers: @workers, buffer: @buffer, **
         )
       end
 
@@ -791,10 +827,19 @@ module Rigor
         candidates.reject { |path| stat_fresh?(path) }
       end
 
+      # A bound buffer's logical path is never fresh: the bytes to analyse live in the editor's temp file, and
+      # the recorded entry describes the file on disk. Re-analysing it when the two happen to agree costs one
+      # file; trusting the stat tuple would serve the editor its own stale diagnostics.
+      def buffer_path?(path)
+        !@buffer.nil? && path == @buffer.logical_path
+      end
+
       # True when `path`'s recorded stat entry proves it unchanged since the last analysis. Any stat / parse
       # failure (missing entry, unreadable / vanished file) reads as NOT fresh (→ re-analyse), preserving the
       # prior `digest(path) != recorded` "changed" semantics for a file that cannot be validated.
       def stat_fresh?(path)
+        return false if buffer_path?(path)
+
         entry = @digests[path]
         return false if entry.nil?
 

--- a/lib/rigor/analysis/runner.rb
+++ b/lib/rigor/analysis/runner.rb
@@ -794,11 +794,18 @@ module Rigor
       def target_files(expansion)
         files = expansion.fetch(:files)
         # ADR-46 slice 2 — restrict the analyzed set to the affected closure while the pre-pass (run
-        # separately over `expansion`'s full file list) keeps the cross-file index complete. Buffer mode
-        # takes precedence — its single logical path is the analyzed set.
-        files = files.select { |path| @analyze_only.include?(path) } if @analyze_only
+        # separately over `expansion`'s full file list) keeps the cross-file index complete.
+        if @analyze_only
+          # Editor mode option B (#146) — with BOTH set, the closure wins and the buffer is one member of it.
+          # The logical path joins even when it is not on disk under `paths:` (design § "Failure envelope"),
+          # the same allowance option A makes below.
+          files = files.select { |path| @analyze_only.include?(path) }
+          files |= [@buffer.logical_path] if @buffer && @analyze_only.include?(@buffer.logical_path)
+          return files
+        end
         return files if @buffer.nil?
 
+        # Editor mode option A — no closure, so the buffer's single logical path IS the analyzed set.
         [@buffer.logical_path]
       end
 

--- a/lib/rigor/cli/check_command.rb
+++ b/lib/rigor/cli/check_command.rb
@@ -59,7 +59,7 @@ module Rigor
         return finalize_cache_hit(probed, configuration, options, config_warnings) unless probed.nil?
 
         load_check_dependencies
-        special = dispatch_special_check_mode(configuration, options, cache_root)
+        special = dispatch_special_check_mode(configuration, options, cache_root, buffer)
         return special unless special.nil?
 
         invocation = invoke_check(
@@ -142,9 +142,22 @@ module Rigor
 
       # ADR-46 — the two incremental-analysis check modes both fully handle the run and return an exit code (so `run`
       # short-circuits); returns nil for an ordinary check.
-      def dispatch_special_check_mode(configuration, options, cache_root)
-        return run_verify_incremental(configuration, options, cache_root) if options.fetch(:verify_incremental)
-        return run_incremental_check(configuration, options, cache_root) if options.fetch(:incremental)
+      # A nil return means "not a special mode" — `run` continues with the ordinary check. Editor mode option B
+      # also returns nil when it declines (no reusable snapshot), so the run falls back to single-file scope.
+      def dispatch_special_check_mode(configuration, options, cache_root, buffer)
+        if options.fetch(:verify_incremental)
+          # The gate compares an incremental recheck against a full-run oracle, and a buffer makes the two
+          # disagree by construction (the oracle reads the file on disk). Refusing beats the silent wrong
+          # answer both incremental modes gave a buffer before #146.
+          if buffer
+            @err.puts("rigor: --verify-incremental cannot run against an editor buffer " \
+                      "(--tmp-file / --instead-of); it compares against a full analysis of the files on disk.")
+            return CLI::EXIT_USAGE
+          end
+
+          return run_verify_incremental(configuration, options, cache_root)
+        end
+        return run_incremental_check(configuration, options, cache_root, buffer) if options.fetch(:incremental)
 
         nil
       end
@@ -190,7 +203,7 @@ module Rigor
       # run (plus their dependents), serving the rest from the snapshot; on a miss runs a full baseline. Persists the
       # updated snapshot for the next invocation. Diagnostics are identical to a full run (the `--verify-incremental`
       # gate enforces this); the win is skipping per-file inference for unchanged files.
-      def run_incremental_check(configuration, options, cache_root)
+      def run_incremental_check(configuration, options, cache_root, buffer = nil)
         require_relative "check_runner_factory"
         paths = @argv.empty? ? nil : @argv
         fingerprint = Cache::IncrementalSnapshot.fingerprint(
@@ -204,8 +217,11 @@ module Rigor
           # ADR-46 — thread the same worker-count precedence the standard `check` path uses
           # (CLI `--workers` > `RIGOR_RACTOR_WORKERS` > `parallel.workers:` > 0) so the recheck's closure
           # re-analysis parallelises; the fork pool marshals dependency records back so the graph is sound.
-          workers: CheckRunnerFactory.resolve_workers(options, configuration)
+          workers: CheckRunnerFactory.resolve_workers(options, configuration),
+          buffer: buffer
         )
+
+        return run_editor_mode_option_b(session, snapshot, fingerprint, configuration, options) if buffer
 
         diagnostics, warm = session.run_incremental(snapshot: snapshot, fingerprint: fingerprint)
         # The banner's file count comes from the session's analyzed set (cold analyses all; a warm recheck's
@@ -220,6 +236,33 @@ module Rigor
                                        options)
         write_result(result, options.fetch(:format))
         result.success? ? 0 : 1
+      end
+
+      # Editor mode option B (#146) — `--incremental` plus an editor buffer. The whole project is in scope with
+      # the buffer substituted for one file: the buffer's logical path and its dependents re-analyse, every
+      # other file is served from the snapshot. Before this, the two flags together silently ignored the
+      # buffer and analysed the file on disk, which is a wrong answer rather than a missing feature.
+      #
+      # The session never saves — the buffer's bytes exist only in the editor — so there is no warm state to
+      # build up. That is why a snapshot it cannot reuse means falling back to option A (single-file scope,
+      # the pre-#146 behaviour) instead of running a baseline that would repeat on the next keystroke. The
+      # note tells the user how to get option B: warm the snapshot with a plain `rigor check --incremental`.
+      def run_editor_mode_option_b(session, snapshot, fingerprint, configuration, options)
+        result = session.run_buffer_recheck(snapshot: snapshot, fingerprint: fingerprint)
+        if result.nil?
+          @err.puts("rigor: --incremental has no reusable snapshot for this project; analysing the buffer " \
+                    "alone (run `rigor check --incremental` once to enable whole-project editor mode).")
+          return nil
+        end
+
+        @err.puts("rigor: --incremental editor mode — re-analysed #{result.affected.size} file(s), " \
+                  "#{result.reused.size} served from cache")
+        emit_incremental_fact_surface_notes(session)
+        filtered = apply_baseline_filter(
+          Analysis::Result.new(diagnostics: result.diagnostics, stats: nil), configuration, options
+        )
+        write_result(filtered, options.fetch(:format))
+        filtered.success? ? 0 : 1
       end
 
       # ADR-88 WD1 — a one-line stderr note when the plugin fact surface (an ADR-9 fact, an ADR-60 producer

--- a/spec/rigor/analysis/incremental_session_spec.rb
+++ b/spec/rigor/analysis/incremental_session_spec.rb
@@ -467,6 +467,143 @@ RSpec.describe Rigor::Analysis::IncrementalSession do
   # faithful simulation of two `rigor check --incremental` processes, the established pundit /
   # cache-producer cross-process pattern: a fresh `Store` has an empty in-memory memo, so a hit is a real
   # disk read.
+  # #146 — editor mode option B: whole-project scope with the editor's buffer substituted for one file. Before
+  # this, `--incremental` plus a buffer silently analysed the file on disk.
+  describe "#run_buffer_recheck (editor mode option B)" do
+    # `other.rb` reads `Widget#name`'s return type, so a buffer that changes it must light up the DEPENDENT —
+    # the thing option A (single-file scope) structurally cannot report.
+    # The editor's temp file lives OUTSIDE the analysed tree, as a real editor's does — inside it, the buffer
+    # would be analysed as a second project file declaring the same class.
+    def write_editor_project(dir)
+      FileUtils.mkdir_p(File.join(dir, "lib"))
+      File.write(File.join(dir, "lib", "widget.rb"), "class Widget\n  def name\n    \"w\"\n  end\nend\n")
+      File.write(File.join(dir, "lib", "other.rb"),
+                 "class Other\n  def go\n    Widget.new.name.upcase\n  end\nend\n")
+      buffer = File.join(dir, "buffer_widget.rb")
+      File.write(buffer, "class Widget\n  def name\n    1\n  end\nend\n")
+      Rigor::Analysis::BufferBinding.new(
+        logical_path: File.join(dir, "lib", "widget.rb"), physical_path: buffer
+      )
+    end
+
+    def analysis_root(dir)
+      File.join(dir, "lib")
+    end
+
+    # The run-level gem-RBS info diagnostic is keyed on `.rigor.yml` and recomputed every run; it is not a
+    # per-file result and says nothing about scope.
+    def project_diagnostics(diagnostics)
+      diagnostics.reject { |diagnostic| diagnostic.path.to_s.end_with?(".rigor.yml") }
+    end
+
+    def buffer_session(config, dir, buffer)
+      described_class.new(configuration: config, paths: [analysis_root(dir)],
+                          environment: shared_environment, buffer: buffer)
+    end
+
+    def editor_config(dir)
+      Rigor::Configuration.new("paths" => [analysis_root(dir)])
+    end
+
+    def warm_snapshot(config, dir, snapshot, fingerprint)
+      session_for(config, paths: [analysis_root(dir)]).run_incremental(snapshot: snapshot, fingerprint: fingerprint)
+    end
+
+    it "reports a dependent's diagnostic caused by the unsaved buffer, and serves the rest from the snapshot" do
+      Dir.mktmpdir do |dir|
+        buffer = write_editor_project(dir)
+        config = editor_config(dir)
+        snapshot = Rigor::Cache::IncrementalSnapshot.new(root: File.join(dir, ".cache"))
+        fp = fingerprint(config, analysis_root(dir))
+
+        # Warm the snapshot from the files on disk: clean.
+        warm_snapshot(config, dir, snapshot, fp)
+        expect(project_diagnostics(full_run(analysis_root(dir)))).to be_empty
+
+        result = buffer_session(config, dir, buffer).run_buffer_recheck(snapshot: snapshot, fingerprint: fp)
+
+        expect(result.diagnostics.map(&:message)).to include(a_string_matching(/undefined method `upcase' for 1/))
+        # The diagnostic is attributed to the DEPENDENT, not the buffer, and the buffer reports under its
+        # logical path so the editor highlights the file the user is looking at.
+        expect(result.diagnostics.map(&:path)).to all(satisfy { |path| !path.to_s.include?("buffer_widget") })
+        expect(result.affected).to include(File.join(dir, "lib", "widget.rb"), File.join(dir, "lib", "other.rb"))
+      end
+    end
+
+    it "never persists the buffer's state — the next on-disk recheck is unaffected" do
+      Dir.mktmpdir do |dir|
+        buffer = write_editor_project(dir)
+        config = editor_config(dir)
+        snapshot = Rigor::Cache::IncrementalSnapshot.new(root: File.join(dir, ".cache"))
+        fp = fingerprint(config, analysis_root(dir))
+        warm_snapshot(config, dir, snapshot, fp)
+        before = File.binread(snapshot.path)
+
+        buffer_session(config, dir, buffer).run_buffer_recheck(snapshot: snapshot, fingerprint: fp)
+
+        expect(File.binread(snapshot.path)).to eq(before)
+        # And the on-disk truth is still what a full run says.
+        diags, warm = warm_snapshot(config, dir, snapshot, fp)
+        expect(warm).to be(true)
+        expect(sorted(diags)).to eq(sorted(full_run(analysis_root(dir))))
+      end
+    end
+
+    # The closure decision reads the CHANGED files to fingerprint their symbols. Reading the buffer's logical
+    # path from disk there looks harmless — the run itself substitutes correctly — but it compares the
+    # snapshot against bytes the user already edited away, so every dependent of the unsaved change is served
+    # from cache. Caught by this example while building #146; the CLI-level smoke test had passed by luck.
+    it "puts the dependents of the UNSAVED change in the closure, not just the buffer's own file" do
+      Dir.mktmpdir do |dir|
+        buffer = write_editor_project(dir)
+        config = editor_config(dir)
+        snapshot = Rigor::Cache::IncrementalSnapshot.new(root: File.join(dir, ".cache"))
+        fp = fingerprint(config, analysis_root(dir))
+        warm_snapshot(config, dir, snapshot, fp)
+
+        result = buffer_session(config, dir, buffer).run_buffer_recheck(snapshot: snapshot, fingerprint: fp)
+
+        expect(result.affected).to include(File.join(dir, "lib", "other.rb"))
+        expect(result.reused).not_to include(File.join(dir, "lib", "other.rb"))
+      end
+    end
+
+    it "declines (nil) when there is no reusable snapshot, so the caller can fall back to single-file scope" do
+      Dir.mktmpdir do |dir|
+        buffer = write_editor_project(dir)
+        config = editor_config(dir)
+        snapshot = Rigor::Cache::IncrementalSnapshot.new(root: File.join(dir, ".cache"))
+
+        # Nothing written yet: a baseline here would repeat on every keystroke, since this session cannot save.
+        expect(buffer_session(config, dir, buffer)
+                 .run_buffer_recheck(snapshot: snapshot, fingerprint: fingerprint(config,
+                                                                                  analysis_root(dir)))).to be_nil
+      end
+    end
+
+    it "re-analyses the buffer even when its bytes match the file on disk" do
+      Dir.mktmpdir do |dir|
+        write_editor_project(dir)
+        config = editor_config(dir)
+        snapshot = Rigor::Cache::IncrementalSnapshot.new(root: File.join(dir, ".cache"))
+        fp = fingerprint(config, analysis_root(dir))
+        warm_snapshot(config, dir, snapshot, fp)
+
+        identical = File.join(dir, "identical_buffer.rb")
+        File.write(identical, File.read(File.join(dir, "lib", "widget.rb")))
+        binding_to_identical = Rigor::Analysis::BufferBinding.new(
+          logical_path: File.join(dir, "lib", "widget.rb"), physical_path: identical
+        )
+        result = buffer_session(config, dir, binding_to_identical)
+                 .run_buffer_recheck(snapshot: snapshot, fingerprint: fp)
+
+        # The stat tuple of the temp file says nothing about the logical path, so the buffer is always re-read.
+        expect(result.affected).to include(File.join(dir, "lib", "widget.rb"))
+        expect(project_diagnostics(result.diagnostics)).to be_empty
+      end
+    end
+  end
+
   describe "#run_incremental plugin-producer cache reuse (WD1)" do
     let(:probe_producer_id) { "plugin.wd1-cache-probe.probe" }
 

--- a/spec/rigor/cli/check_command_spec.rb
+++ b/spec/rigor/cli/check_command_spec.rb
@@ -63,6 +63,71 @@ RSpec.describe Rigor::CLI::CheckCommand do
     expect(warm_out).to include("No diagnostics")
   end
 
+  # #146 — editor mode option B. `--incremental` plus a buffer used to ignore the buffer entirely and analyse
+  # the file on disk: a wrong answer, not a missing feature. It now analyses the whole project with the buffer
+  # substituted, and declines to single-file scope when there is no snapshot to reuse.
+  describe "editor mode with --incremental (option B)" do
+    def write_editor_project
+      FileUtils.mkdir_p("lib")
+      File.write(File.join("lib", "widget.rb"), "class Widget\n  def name\n    \"w\"\n  end\nend\n")
+      File.write(File.join("lib", "other.rb"), "class Other\n  def go\n    Widget.new.name.upcase\n  end\nend\n")
+      File.write("buffer_widget.rb", "class Widget\n  def name\n    1\n  end\nend\n")
+    end
+
+    def editor_argv
+      ["--no-ci-detect", "--no-stats", "--incremental",
+       "--tmp-file=buffer_widget.rb", "--instead-of=lib/widget.rb", "lib"]
+    end
+
+    it "falls back to single-file scope, with a note, when no snapshot exists yet" do
+      write_editor_project
+
+      status, out, err = run(editor_argv)
+
+      expect(err).to include("no reusable snapshot")
+      expect(err).to include("rigor check --incremental")
+      # Option A's answer: the buffer alone, so the dependent's diagnostic is absent.
+      expect(out).not_to include("lib/other.rb")
+      expect(status).to eq(0)
+    end
+
+    it "reports the unsaved buffer's effect on a dependent once a snapshot exists" do
+      write_editor_project
+      run(["--no-ci-detect", "--no-stats", "--incremental", "lib"]) # warm the snapshot from disk
+
+      status, out, err = run(editor_argv)
+
+      expect(err).to include("--incremental editor mode")
+      expect(out).to include("lib/other.rb")
+      expect(out).to include("undefined method `upcase'")
+      expect(status).to eq(1)
+    end
+
+    it "leaves the snapshot untouched, so the next on-disk run is unaffected" do
+      write_editor_project
+      run(["--no-ci-detect", "--no-stats", "--incremental", "lib"])
+      snapshot = File.join(".rigor", "cache", "incremental", "snapshot.bin")
+      before = File.binread(snapshot)
+
+      run(editor_argv)
+
+      expect(File.binread(snapshot)).to eq(before)
+      status, out, = run(["--no-ci-detect", "--no-stats", "--incremental", "lib"])
+      expect(out).to include("No diagnostics")
+      expect(status).to eq(0)
+    end
+
+    it "refuses --verify-incremental against a buffer instead of comparing against the wrong oracle" do
+      write_editor_project
+
+      status, _out, err = run(["--no-ci-detect", "--no-stats", "--verify-incremental",
+                               "--tmp-file=buffer_widget.rb", "--instead-of=lib/widget.rb", "lib"])
+
+      expect(status).to eq(Rigor::CLI::EXIT_USAGE)
+      expect(err).to include("--verify-incremental cannot run against an editor buffer")
+    end
+  end
+
   it "allows parameter_inference: on a full (non-incremental) check" do
     File.write(".rigor.yml", "paths:\n  - clean.rb\nparameter_inference: true\n")
     File.write("clean.rb", "x = 1\n")


### PR DESCRIPTION
Closes #146 — editor mode option B, per `docs/design/20260516-editor-mode.md` § "Scope choice".

## Before

`--tmp-file` / `--instead-of` analysed **only** the buffer's own file (option A), so an unsaved edit's effect on the rest of the project stayed invisible until you saved and re-ran.

And the two flag sets already composed — into the wrong answer:

```console
$ rigor check --incremental --tmp-file=/tmp/buf.rb --instead-of=lib/widget.rb lib
rigor: --incremental cold — full analysis (2 files)
lib/other.rb:3:21: error: undefined method `no_such_zzz' for "w"
```

The buffer was ignored entirely and the file on disk analysed instead — output identical to a plain check, with nothing saying so.

## After

```console
$ rigor check --incremental lib            # once, to warm the snapshot
$ rigor check --incremental --tmp-file=/tmp/buf.rb --instead-of=lib/widget.rb lib
rigor: --incremental editor mode — re-analysed 2 file(s), 0 served from cache
lib/other.rb:3:21: error: undefined method `upcase' for 1
```

`lib/widget.rb` is untouched on disk; the buffer changes `#name` from `String` to `Integer`, and the diagnostic lands in its **caller**. Option A reports nothing here.

No snapshot yet:

```
rigor: --incremental has no reusable snapshot for this project; analysing the buffer alone
  (run `rigor check --incremental` once to enable whole-project editor mode).
```

## Design

Composition rather than an automatic upgrade is deliberate: scope that widens whenever a snapshot happens to exist would make the same command emit different diagnostics on different machines.

Three properties carry it:

1. **The buffer is a changed file by definition** — its recorded stat entry describes the file on disk, so its logical path is never stat-fresh.
2. **The closure is computed from the buffer's bytes.** `ScopeIndexer.scan_summary_for_paths` already took `buffer:`; the session now passes it. Without that, the symbol fingerprints come from disk, the snapshot compares equal, and every dependent of the unsaved change is served from cache — the stale answer this mode exists to avoid. A spec pins it; the CLI smoke test had passed by luck before I wrote it.
3. **The session never saves.** Its per-file cache and digests describe bytes that exist only in the editor. That is also why an unusable snapshot falls back to option A rather than running a baseline — the baseline could not be persisted, so it would repeat on the next keystroke.

`--verify-incremental` now refuses a buffer (exit 64): it compares against a full analysis of the files on disk, which a buffer contradicts by construction.

## Specs

Session level (`incremental_session_spec.rb`): the dependent's diagnostic appears; the dependent is in the closure and not in `reused`; the snapshot file is byte-identical after a buffer run and the next on-disk recheck is unaffected; a buffer identical to disk still re-analyses; no snapshot → `nil`. Two of them fail if the closure scan loses `buffer:`.

CLI level (`check_command_spec.rb`): the fallback note, the whole-project result, snapshot immutability across a buffer run, and the `--verify-incremental` refusal.

## Gates

`make verify` green (13 groups, 0 failures; rubocop clean over 688 files; `check` / `check-plugins` clean), `make docs-check` green (324). Manual § "Editor mode scope" and the design doc's scope-choice section updated in the same commit.
