### PR TITLE
Fold the Tuple carrier's set operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
   - The edited file and its dependents are re-analysed; every other file is served from the incremental snapshot. It needs a snapshot to reuse — run `rigor check --incremental` once — and says so on stderr when there is none, analysing the buffer alone as before.
   - An editor-mode run never writes the snapshot, so the bytes in your editor can never be mistaken for the state of the file on disk.
 - **[rigor check]** `--verify-incremental` now refuses an editor buffer instead of silently comparing it against a full analysis of the files on disk.
+- **[inference]** Set operations on an array of known values now keep their precision: `%w[a b] & allowed`, `|`, `-`, `intersection`, `union`, `difference`, `intersect?`, plus `at(i)`, `one?` and `deconstruct` ([#121](https://github.com/rigortype/rigor/issues/121)).
+  - Each is evaluated with Ruby's own operator, so `eql?` membership decides exactly as it does at runtime — `[1] & [1.0]` folds to the empty array, not to `[1]`.
 
 ### Changed
 

--- a/docs/notes/20260522-type-method-coverage.md
+++ b/docs/notes/20260522-type-method-coverage.md
@@ -351,11 +351,19 @@ IntegerRange 向け専用ハンドラ群は別途 `shape_dispatch.rb` に存在�
 
 ### 5-1. メソッド一覧
 
+> **2026-07-31 の再スイープ**: この文書の 🔲 は実装より古く、過大報告する（カタログの純粋関数経路が
+> 多くを自動的に畳むため）。`dispatch_precise_tiers` を直接叩く経験的スイープで String / Array / Hash /
+> Integer / Float / Symbol を再確認し、残っていた真の欠落は本節の集合演算群のみだった。以降この文書を
+> 実装の根拠にする前に、必ず同じ経験的プローブで確認すること。
+
 | メソッド | 状態 | 備考 |
 |----------|------|------|
 | `[]` / `fetch` | ✅ | `tuple_lookup` / `tuple_fetch` — 整数インデックスで位置別型を返す。 |
 | `+` (連結) | ✅ | `Tuple + Tuple` → 新しい Tuple。**高優先度。** `tuple_concat` 実装。 |
-| `-` (差集合) | 🔲 | 差集合 → 型が複雑。低優先度。 |
+| `at` | ✅ | `tuple_at` — 単一 Integer 形式のみ。`[]` / `slice` と違い範囲外は畳まず RBS に委ねる（証明された nil は新規診断を生むため、#121 の対象外）。 |
+| `intersect?` | ✅ | `tuple_intersect?` — `Constant[bool]`（#121, 2026-07-31）。 |
+| `one?`（ブロックなし） | ✅ | `tuple_one?` — 全要素 Constant なら真偽が決定可能（#121, 2026-07-31）。 |
+| `-` (差集合) | ✅ | `tuple_difference` — 全要素 Constant の Tuple 同士で Ruby の `-` を実行して畳む（#121, 2026-07-31）。 |
 | `*` (繰り返し) | 🔲 | `Tuple * n` → 繰り返し Tuple。低優先度。 |
 | `<<` / `push` / `append` | 🚫 | 破壊的変更（形状変化）。 |
 | `<=>` | 🔷 | RBS `Integer?` で十分。 |
@@ -370,7 +378,7 @@ IntegerRange 向け専用ハンドラ群は別途 `shape_dispatch.rb` に存在�
 | `compact` | ✅ | `Constant[nil]` エントリを除去した Tuple。**高優先度。** `tuple_compact` 実装。 |
 | `count` | ✅ | `tuple_count` — ブロックなしで `Constant[Integer]`。 |
 | `cycle` | 🚫 | Enumerable。 |
-| `deconstruct` | 🔲 | パターンマッチ用 — `to_a` と等価。低優先度。 |
+| `deconstruct` | ✅ | `shape_self` — レシーバの Tuple をそのまま返す（#121, 2026-07-31）。 |
 | `delete` / `delete_at` / `delete_if` | 🚫 | 破壊的変更。 |
 | `detect` / `find` | ✅ | `PER_ELEMENT_TUPLE_METHODS` — ブロック毎要素で要素型を返す。 |
 | `dig` | ✅ | `tuple_dig` — 入れ子 Tuple / HashShape を掘る。 |
@@ -389,7 +397,7 @@ IntegerRange 向け専用ハンドラ群は別途 `shape_dispatch.rb` に存在�
 | `include?` | ✅ | `tuple_include?` → `Constant[bool]`（Constant 引数のとき）。 |
 | `index` / `find_index` | ✅ | `PER_ELEMENT_TUPLE_METHODS` → `Constant[Integer\|nil]`。 |
 | `insert` | 🚫 | 破壊的変更。 |
-| `intersection` | 🔲 | 集合交差。低優先度。 |
+| `intersection` / `&` | ✅ | `tuple_intersection` — `eql?` 意味論を保つため Ruby の `&` をそのまま実行（#121, 2026-07-31）。 |
 | `join` | ✅ | `tuple_join` — すべて Constant のとき `Constant[String]`。全要素が `Constant[String]` かつセパレータが Constant/省略の場合は `LiteralStringFolding` が精密フォールドに道を譲る（2026-07-18）。 |
 | `keep_if` | 🚫 | 破壊的変更。 |
 | `last` | ✅ | `tuple_last` → 末尾 n 要素。 |
@@ -420,7 +428,7 @@ IntegerRange 向け専用ハンドラ群は別途 `shape_dispatch.rb` に存在�
 | `to_a` | ✅ | `tuple_to_a` → self。 |
 | `to_h` | ✅ | `tuple_to_h` → HashShape（`Tuple[Tuple[K,V]…]` 形式）。 |
 | `transpose` | 🔲 | 2 次元 Tuple の行列転置。低優先度。 |
-| `union` | 🔲 | 集合和（dedup）。低優先度。 |
+| `union` / `\|` | ✅ | `tuple_union` — `tuple_intersection` と同じ経路（#121, 2026-07-31）。 |
 | `uniq` | ✅ | `tuple_uniq` → Constant 要素の重複除去 Tuple。 |
 | `values_at` | ✅ | `values_at(*indices)` → 位置指定 Tuple。**高優先度。** `tuple_values_at` 実装。 |
 | `zip` | ✅ | `tuple_zip` → 要素ペア Tuple。 |

--- a/lib/rigor/inference/method_dispatcher/shape_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/shape_dispatch.rb
@@ -82,6 +82,16 @@ module Rigor
           drop: :tuple_drop,
           rotate: :tuple_rotate,
           uniq: :tuple_uniq,
+          at: :tuple_at,
+          :& => :tuple_intersection,
+          intersection: :tuple_intersection,
+          :| => :tuple_union,
+          union: :tuple_union,
+          :- => :tuple_difference,
+          difference: :tuple_difference,
+          intersect?: :tuple_intersect?,
+          one?: :tuple_one?,
+          deconstruct: :shape_self,
           index: :tuple_find_index,
           find_index: :tuple_find_index,
           rindex: :tuple_rindex,
@@ -957,6 +967,88 @@ module Rigor
 
           # `tuple + other` — concatenates two Tuples. Both sides must be `Type::Tuple`. Returns a new
           # Tuple whose elements are those of the receiver followed by those of the argument.
+          # `at(n)` — the strict single-Integer accessor. Deliberately NOT an alias of {#tuple_index}: `[]`
+          # and `slice` accept a Range or a `(start, length)` pair, while `Array#at` raises `ArgumentError`
+          # on anything but one Integer, and a fold must never invent a value for a call that raises.
+          #
+          # An out-of-range index declines rather than folding to `Constant[nil]`, matching {#tuple_index}.
+          # Ruby really does return nil there, so the fold would be correct — but it would also turn a
+          # receiver the RBS tier types as `Elem?` into a proven nil, newly surfacing diagnostics on code
+          # that may be guarded in ways a shape cannot see. Precision that fires a new diagnostic is a
+          # separate decision from precision that removes a `Dynamic` (#121).
+          def tuple_at(tuple, _method_name, args)
+            return nil unless args.size == 1
+            return nil unless args.first.is_a?(Type::Constant) && args.first.value.is_a?(Integer)
+
+            tuple.elements[args.first.value]
+          end
+
+          # `a & b` / `a.intersection(b, ...)`, `a | b` / `a.union(...)`, `a - b` / `a.difference(...)`.
+          # Every set operation is evaluated by running Ruby's own operator over the unwrapped values, which
+          # is the only way to reproduce its `eql?` / `hash` semantics exactly — `[1] & [1.0]` is empty even
+          # though `1 == 1.0`, so an equality-based reimplementation would fold the wrong answer.
+          def tuple_intersection(tuple, _method_name, args)
+            set_operation(tuple, args) { |values, others| others.reduce(values, :&) }
+          end
+
+          def tuple_union(tuple, _method_name, args)
+            set_operation(tuple, args) { |values, others| others.reduce(values, :|) }
+          end
+
+          def tuple_difference(tuple, _method_name, args)
+            set_operation(tuple, args) { |values, others| others.reduce(values, :-) }
+          end
+
+          # `a.intersect?(b)` — the predicate form, `Constant[bool]`. `nil` is the decline signal every
+          # handler shares, not a boolean answer, so the predicate-return cop is disabled as it is for the
+          # other `?`-named handlers above.
+          # rubocop:disable Style/ReturnNilInPredicateMethodDefinition
+          def tuple_intersect?(tuple, _method_name, args)
+            result = set_operation(tuple, args) { |values, others| others.reduce(values, :&) }
+            return nil if result.nil?
+
+            Type::Combinator.constant_of(!result.elements.empty?)
+          end
+
+          # Shared body for the set operations: unwrap the receiver and every Tuple argument, hand the raw
+          # values to `block`, and lift the result back. Declines unless every element on both sides is a
+          # `Constant` (an unknown element makes membership undecidable) and every argument is a `Tuple` —
+          # `Array#&` also accepts anything that responds to `to_ary`, which a shape cannot prove.
+          def set_operation(tuple, args)
+            return nil if args.empty? || args.size > MAX_SET_OPERATION_ARITY
+
+            values = constant_values(tuple.elements)
+            return nil if values.nil?
+
+            others = args.map do |arg|
+              return nil unless arg.is_a?(Type::Tuple)
+
+              constant_values(arg.elements) || (return nil)
+            end
+            result = yield(values, others)
+            return nil if result.size > MAX_SET_OPERATION_SIZE
+
+            Type::Combinator.tuple_of(*result.map { |value| Type::Combinator.constant_of(value) })
+          end
+
+          # An argument list longer than this, or a result wider than this, declines to the RBS tier rather
+          # than materialising an unbounded Tuple — the same discipline as {MAX_ZIP_ARITY} / the join cap.
+          MAX_SET_OPERATION_ARITY = 8
+          MAX_SET_OPERATION_SIZE = 64
+          private_constant :MAX_SET_OPERATION_ARITY, :MAX_SET_OPERATION_SIZE
+
+          # `one?` with no block and no pattern — `Constant[bool]` of "exactly one truthy element". Only
+          # `Constant` elements have decidable truthiness, and the block / pattern forms defer.
+          def tuple_one?(tuple, _method_name, args)
+            return nil unless args.empty?
+
+            values = constant_values(tuple.elements)
+            return nil if values.nil?
+
+            Type::Combinator.constant_of(values.one? { |value| value })
+          end
+          # rubocop:enable Style/ReturnNilInPredicateMethodDefinition
+
           def tuple_concat(tuple, _method_name, args)
             return nil unless args.size == 1
 

--- a/spec/integration/fixtures/tuple_access.rb
+++ b/spec/integration/fixtures/tuple_access.rb
@@ -40,3 +40,22 @@ assert_type("[10, 30]", xs.minmax)
 # `min(n)` ascending, `max(n)` descending.
 assert_type("[10, 20]", xs.min(2))
 assert_type("[30, 20]", xs.max(2))
+
+# Set operations over all-Constant tuples fold to sub-Tuples. Each is
+# evaluated with Ruby's own operator, so `eql?` membership (not `==`)
+# decides: `[1] & [1.0]` is empty.
+assert_type("[20, 30]", xs & [20, 30, 40])
+assert_type("[10, 20, 30, 40]", xs | [30, 40])
+assert_type("[10, 30]", xs - [20])
+assert_type("[]", [1] & [1.0])
+assert_type("[20]", xs.intersection([10, 20], [20, 30]))
+assert_type("[20]", xs.difference([10], [30]))
+assert_type("[10, 20, 30, 40]", xs.union([40]))
+assert_type("true", xs.intersect?([30]))
+assert_type("false", xs.intersect?([99]))
+
+# `at` folds the single-index form; `one?` counts truthy slots.
+assert_type("20", xs.at(1))
+assert_type("30", xs.at(-1))
+assert_type("false", xs.one?)
+assert_type("true", [nil, 1, false].one?)

--- a/spec/rigor/inference/method_dispatcher/shape_dispatch_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/shape_dispatch_spec.rb
@@ -1501,6 +1501,77 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ShapeDispatch do
     end
   end
 
+  # #121 — the Tuple carrier's set operations. Every one is evaluated by running Ruby's own operator over
+  # the unwrapped values, because `Array#&` / `#|` / `#-` use `eql?` / `hash` rather than `==`: `[1] & [1.0]`
+  # is empty though `1 == 1.0`, and an equality-based reimplementation folds the wrong answer.
+  describe "Tuple set operations (#121)" do
+    let(:t) { tuple(constant(1), constant(2), constant(3)) }
+
+    it "folds & / intersection, | / union, and - / difference" do
+      expect(dispatch(receiver: t, method_name: :&, args: [tuple(constant(2), constant(3), constant(4))]))
+        .to eq(tuple(constant(2), constant(3)))
+      expect(dispatch(receiver: t, method_name: :|, args: [tuple(constant(3), constant(4))]))
+        .to eq(tuple(constant(1), constant(2), constant(3), constant(4)))
+      expect(dispatch(receiver: t, method_name: :-, args: [tuple(constant(2))]))
+        .to eq(tuple(constant(1), constant(3)))
+      expect(dispatch(receiver: t, method_name: :intersection,
+                      args: [tuple(constant(1), constant(2)), tuple(constant(2), constant(3))]))
+        .to eq(tuple(constant(2)))
+      expect(dispatch(receiver: t, method_name: :difference,
+                      args: [tuple(constant(1)), tuple(constant(3))]))
+        .to eq(tuple(constant(2)))
+      expect(dispatch(receiver: t, method_name: :union, args: [tuple(constant(4))]))
+        .to eq(tuple(constant(1), constant(2), constant(3), constant(4)))
+    end
+
+    it "reproduces Ruby's eql? membership, not ==" do
+      expect(dispatch(receiver: tuple(constant(1)), method_name: :&, args: [tuple(constant(1.0))]))
+        .to eq(tuple)
+      expect([1] & [1.0]).to eq([])
+    end
+
+    it "folds intersect? and the no-block one?" do
+      expect(dispatch(receiver: t, method_name: :intersect?, args: [tuple(constant(2))])).to eq(constant(true))
+      expect(dispatch(receiver: t, method_name: :intersect?, args: [tuple(constant(9))])).to eq(constant(false))
+      expect(dispatch(receiver: t, method_name: :one?)).to eq(constant(false))
+      expect(dispatch(receiver: tuple(constant(1), constant(nil), constant(false)), method_name: :one?))
+        .to eq(constant(true))
+    end
+
+    it "declines when membership is undecidable or the argument is not a shape" do
+      opaque = tuple(constant(1), Rigor::Type::Combinator.nominal_of("Object"))
+      expect(dispatch(receiver: opaque, method_name: :&, args: [tuple(constant(1))])).to be_nil
+      expect(dispatch(receiver: t, method_name: :&, args: [tuple(constant(1), Rigor::Type::Combinator.nominal_of("Object"))])).to be_nil
+      # `Array#&` accepts anything with `to_ary`, which a non-Tuple shape cannot prove.
+      expect(dispatch(receiver: t, method_name: :&, args: [Rigor::Type::Combinator.nominal_of("Array")])).to be_nil
+      expect(dispatch(receiver: t, method_name: :&)).to be_nil
+      expect(dispatch(receiver: t, method_name: :one?, args: [constant(1)])).to be_nil
+    end
+  end
+
+  describe "Tuple#at (#121)" do
+    let(:t) { tuple(constant(1), constant(2), constant(3)) }
+
+    it "folds a single static index, including a negative one" do
+      expect(dispatch(receiver: t, method_name: :at, args: [constant(0)])).to eq(constant(1))
+      expect(dispatch(receiver: t, method_name: :at, args: [constant(-1)])).to eq(constant(3))
+    end
+
+    it "declines out of range, like `[]`, rather than proving a nil the RBS tier only calls optional" do
+      expect(dispatch(receiver: t, method_name: :at, args: [constant(3)])).to be_nil
+      expect(dispatch(receiver: t, method_name: :at, args: [constant(-4)])).to be_nil
+    end
+
+    it "declines the arities `Array#at` itself rejects, so no fold stands in for an ArgumentError" do
+      expect(dispatch(receiver: t, method_name: :at)).to be_nil
+      expect(dispatch(receiver: t, method_name: :at, args: [constant(0), constant(1)])).to be_nil
+      expect { [1, 2, 3].at(0, 1) }.to raise_error(ArgumentError)
+      # `[]` and `slice` DO take that pair, which is why `at` is not an alias of them.
+      expect(dispatch(receiver: t, method_name: :slice, args: [constant(0), constant(2)]))
+        .to eq(tuple(constant(1), constant(2)))
+    end
+  end
+
   describe "ADR-76 WD2 / ADR-78 WD3 — pure self-returners preserve the shape carrier" do
     let(:t) { tuple(constant(1), constant(2), constant(3)) }
     let(:h) { hash_shape(reason: constant("boom")) }

--- a/spec/rigor/inference/method_dispatcher/shape_dispatch_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/shape_dispatch_spec.rb
@@ -1541,7 +1541,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ShapeDispatch do
     it "declines when membership is undecidable or the argument is not a shape" do
       opaque = tuple(constant(1), Rigor::Type::Combinator.nominal_of("Object"))
       expect(dispatch(receiver: opaque, method_name: :&, args: [tuple(constant(1))])).to be_nil
-      expect(dispatch(receiver: t, method_name: :&, args: [tuple(constant(1), Rigor::Type::Combinator.nominal_of("Object"))])).to be_nil
+      opaque_arg = tuple(constant(1), Rigor::Type::Combinator.nominal_of("Object"))
+      expect(dispatch(receiver: t, method_name: :&, args: [opaque_arg])).to be_nil
       # `Array#&` accepts anything with `to_ary`, which a non-Tuple shape cannot prove.
       expect(dispatch(receiver: t, method_name: :&, args: [Rigor::Type::Combinator.nominal_of("Array")])).to be_nil
       expect(dispatch(receiver: t, method_name: :&)).to be_nil


### PR DESCRIPTION
Part of #121 (ongoing FP-safe precision folds), via the `rigor-type-coverage-uplift` workflow.

## The gap

An array of statically known values keeps its precision through concatenation, slicing, `uniq`, `min`/`max` — and then loses it at the first set operation:

```ruby
ALLOWED = %w[read write]
ALLOWED & requested_keys      # was Array[String], now folds when both sides are known
```

Now folding: `&` / `intersection`, `|` / `union`, `-` / `difference`, `intersect?`, plus `at(i)`, the no-block `one?`, and `deconstruct`.

## Ruby's own operator, not a reimplementation

`Array#&` decides membership with `eql?` / `hash`, not `==`. So `[1] & [1.0]` is **empty** even though `1 == 1.0`. Every set fold therefore unwraps both sides and runs the real operator, which is the only way to reproduce that; a hand-written equality loop folds the wrong answer for exactly the mixed-numeric case that makes the distinction matter. A spec asserts the fold and the real Ruby result side by side.

Declines when membership is undecidable (any non-`Constant` element on either side), when the argument is not a Tuple (`Array#&` accepts anything with `to_ary`, which a shape cannot prove), beyond 8 arguments, or when the result would exceed 64 elements.

## `at` is not an alias of `[]`

Two deliberate differences, both encoded as specs:

- `Array#at` raises `ArgumentError` on the `(start, length)` pair `[]` and `slice` accept, so `at` declines those arities — a fold must not stand in for a raise.
- An out-of-range index **declines** rather than folding to the nil Ruby really returns. The fold would be correct, but it turns a receiver the RBS tier types as `Elem?` into a proven nil and can surface new diagnostics — which #121 explicitly scopes out ("declining any fold that would newly surface a diagnostic"). Same choice `tuple_index` already makes.

## On the audit doc

`docs/notes/20260522-type-method-coverage.md` lists many 🔲 that are already implemented — its entries predate the catalog's purity path. I re-swept empirically instead: enumerate each class's own methods, invoke the real method to learn the true result, dispatch the same call through `dispatch_precise_tiers`, and flag any case where the real result is foldable but dispatch declines. Across String, Array, Hash, Integer, Float and Symbol these set operations were the only genuine remaining gaps. The doc's rows are updated and it now carries a note saying it must not be trusted without that probe.

## Gates

- Corpus FP diff — `rigor check --no-cache --format json` over the eight RBS-shipping survey projects (rigor `lib`, textbringer, herb, haml, kramdown, rgl, binpacker, conference-app): **diagnostic-identical, zero new firings**.
- `make coverage`: 55.8% precise on `lib` against the 43% floor.
- `make verify` green (13 groups, rubocop clean, `check` / `check-plugins` clean); `make docs-check` green.
- Unit specs in `shape_dispatch_spec.rb`, integration `assert_type` lines in `fixtures/tuple_access.rb` (whose harness has a "no assert_type mismatches" example — verified it fails when an expectation is wrong, so the additions are not vacuous).

