### PR TITLE
Return the schema's own shape from a dry-schema result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
   - The edited file and its dependents are re-analysed; every other file is served from the incremental snapshot. It needs a snapshot to reuse — run `rigor check --incremental` once — and says so on stderr when there is none, analysing the buffer alone as before.
   - An editor-mode run never writes the snapshot, so the bytes in your editor can never be mistaken for the state of the file on disk.
 - **[rigor check]** `--verify-incremental` now refuses an editor buffer instead of silently comparing it against a full analysis of the files on disk.
+- **[rigor-dry-schema]** `SomeSchema.call(input).to_h` now returns the schema's own hash shape — `{ email: String, age: Integer, ?nickname: String, ... }` — instead of an untyped hash, so reading a key gives you the type the schema declares for it ([#137](https://github.com/rigortype/rigor/issues/137)).
+  - A `required` row becomes a required key and an `optional` row an optional one, following the declaration's own vocabulary rather than `to_h`'s worst case: a failed validation can drop a required key too, but typing every key as possibly-absent would put a nil error inside an `if result.success?` branch, on correct code.
+  - A key the plugin cannot type — a predicate outside the canonical vocabulary, a nested `schema do ... end` row, an alias no `rigor-dry-types` table resolves — stays in the shape as untyped rather than being dropped, because a key missing from a hash shape reads as `nil`.
+  - The schema must be named by a constant as written at the call site; reached through a local variable, the chain types as it did before.
 - **[inference]** Set operations on an array of known values now keep their precision: `%w[a b] & allowed`, `|`, `-`, `intersection`, `union`, `difference`, `intersect?`, plus `at(i)`, `one?` and `deconstruct` ([#121](https://github.com/rigortype/rigor/issues/121)).
   - Each is evaluated with Ruby's own operator, so `eql?` membership decides exactly as it does at runtime — `[1] & [1.0]` folds to the empty array, not to `[1]`.
 

--- a/plugins/rigor-dry-schema/README.md
+++ b/plugins/rigor-dry-schema/README.md
@@ -152,12 +152,13 @@ The slice-1 deliverable is the **floor**:
   alias resolution.
 - Publishes the table; no user-facing diagnostics yet.
 
+**Landed since**: **typed `result.to_h` returns**.
+`NewUserSchema.call(input).to_h` infers
+`{ email: String, age: Integer, ?nickname: String, ... }`
+instead of an untyped hash. See § "Typed `result.to_h`" below.
+
 The **ceiling** (future slices, demand-driven):
 
-- **Synthesise typed `result.to_h` returns** from each schema
-  via ADR-16 Tier C heredoc-template substrate — promotes
-  `NewUserSchema.call(input).to_h` from `Hash[Symbol, untyped]`
-  to `HashShape[{email: String, age: Integer}]`.
 - **Nested schemas** (`schema(do ... end)` inside another row).
 - **`predicates(:size?)` / per-row constraint walks**.
 - **`each { ... }` element-type recursion**.
@@ -169,10 +170,43 @@ The **ceiling** (future slices, demand-driven):
   declaration would consume `:dry_schema_table` for typed
   `Contract#call → Result` payloads.
 
+## Typed `result.to_h`
+
+`SomeSchema.call(input).to_h` returns the schema's own hash
+shape:
+
+```ruby
+payload = NewUserSchema.call(input).to_h
+#=> { email: String, age: Integer, ?nickname: String, ... }
+
+payload[:email]     #=> String
+payload[:nickname]  #=> String?
+```
+
+A `required` row becomes a required key and an `optional` row an
+optional one — the declaration's own vocabulary. That is
+deliberately *not* the worst case: `Result#to_h` returns the
+coerced input, so a failed validation can drop a required key
+too. Modelling that would type `payload[:email]` as `String?`
+even inside an `if result.success?` branch, and a false positive
+on correct code costs more here than a worst-case reading buys
+(`AGENTS.md` § Implementation Guidelines).
+
+The shape is **open**, and a key the scanner cannot type — a
+predicate outside the canonical vocabulary, a nested
+`schema do ... end` row, an unresolved alias — stays in the
+shape as `untyped` rather than being dropped. Dropping it would
+be worse than useless: a key absent from a hash shape reads as
+`nil`, so a *declared* key would type as nil for whoever reads
+it.
+
+The schema must be named by a constant as written at the call
+site (`NewUserSchema.call(x).to_h`). Reached through a local or
+by a relative constant path from inside the declaring module,
+the chain contributes nothing and `to_h` types as it did before.
+
 ## What the plugin does NOT do (yet)
 
-- Synthesise typed return shapes for schema-bearing methods
-  (`NewUserSchema.call(...)` is still `untyped` at this slice).
 - Emit diagnostics for unknown predicates / types / keys.
 - Round-trip the schema table through the cache descriptor —
   `prepare(services)` re-scans on every run. Add a glob-based

--- a/plugins/rigor-dry-schema/demo/demo.rb
+++ b/plugins/rigor-dry-schema/demo/demo.rb
@@ -10,9 +10,9 @@
 # publishes the `:dry_schema_table` fact mapping each schema constant to its `{required: {...},
 # optional: {...}}` typed-key shape.
 #
-# At slice 1 the observable change is fact-publication only; the downstream uplift (typed `Contract#call
-# → Result.to_h` returns through rigor-dry-validation) lands in a later slice per
-# docs/design/20260517-dry-validation-slicing.md.
+# The table also backs the typed `SomeSchema.call(input).to_h` return the consumer below exercises. The
+# remaining uplift (typed `Contract#call → Result` payloads through rigor-dry-validation) lands in a
+# later slice per docs/design/20260517-dry-validation-slicing.md.
 
 module Types
   include Dry.Types()
@@ -30,3 +30,13 @@ ProductJSON = Dry::Schema.JSON do
   required(:sku).filled(:string)
   required(:price).value(:decimal)
 end
+
+# The typed `to_h` return. `Rigor.dump_type` prints the inferred type at each site:
+#
+#   { email: String, age: Integer, ?nickname: String, ... }
+#   String
+#   String?
+payload = NewUserSchema.call({}).to_h
+Rigor.dump_type(payload)
+Rigor.dump_type(payload[:email])
+Rigor.dump_type(payload[:nickname])

--- a/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema.rb
+++ b/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema.rb
@@ -5,6 +5,7 @@ require "prism"
 require "rigor/plugin"
 
 require_relative "dry_schema/schema_scanner"
+require_relative "dry_schema/result_shape"
 
 module Rigor
   module Plugin
@@ -58,11 +59,13 @@ module Rigor
     #   above.
     # - Publishes the table; no user-facing diagnostics yet.
     #
+    # Landed since: typed `result.to_h` returns, via the {.dynamic_return} rule below rather than the
+    # ADR-16 Tier C substrate the README originally projected — Tier C synthesises methods on a class
+    # from a class-level DSL call, and this is a return type for a call chain off a constant.
+    #
     # The **ceiling** (slice 2+):
     #
-    # - Synthesise typed `result.to_h` returns from each schema via ADR-16 Tier C heredoc-template
-    #   substrate.
-    # - Nested schemas (`schema(do ... end)` inside another row).
+    # - Nested schemas (`schema(do ... end)` inside another row) — the key is currently kept as untyped.
     # - `predicates(:size?)` / `each { ... }` recursion.
     # - Per-row `dry-schema.unknown-predicate` / `dry-schema.unknown-type` `:info` diagnostics when a
     #   row's predicate or type symbol isn't recognised.
@@ -75,6 +78,20 @@ module Rigor
         produces: [:dry_schema_table],
         consumes: [{ plugin_id: "dry-types", name: :dry_type_aliases, optional: true }]
       )
+
+      # ADR-37 dynamic return — `NewUserSchema.call(input).to_h` yields the schema's own
+      # `HashShape[{email: String, ?nickname: String}]` instead of the untyped hash the DSL's boundary
+      # otherwise leaves behind. The shape's required/optional split and its open extra-key policy are
+      # argued in {ResultShape}.
+      #
+      # Gated on the method name alone, not on a `Dry::Schema::Result` receiver: this plugin ships no RBS
+      # overlay for dry-schema, so in an ordinary project the receiver of `.to_h` is untyped and a
+      # `receivers:` gate would never fire. The cost of the wider gate is bounded — the engine compiles
+      # `methods:` into its registry name gate, so the block is consulted only for `.to_h` calls, and its
+      # first act rejects any chain that is not `<Const>.call(...).to_h` before the table is touched.
+      dynamic_return methods: [:to_h] do |call_node, _scope|
+        result_shape_for(call_node)
+      end
 
       # Walks every project file once during `prepare(services)` to build the schema table, then publishes
       # via the ADR-9 fact store. Mirrors the rigor-dry-types `#prepare` shape — the walk is bounded by
@@ -93,9 +110,27 @@ module Rigor
 
       def init(_services)
         @scannable_paths = nil
+        @result_shapes = {}
       end
 
       private
+
+      # The HashShape for a `<Const>.call(...).to_h` chain, or nil when the chain isn't that shape, names
+      # no schema in the table, or names one that declares no key.
+      # Memoised per schema name INCLUDING nil: a carrier is a value object, and the miss is the common
+      # case on any project that calls `to_h` on something that isn't a schema result.
+      def result_shape_for(call_node)
+        name = ResultShape.schema_name(call_node)
+        return nil if name.nil?
+
+        # `||=` rather than a plain read of an `init`-assigned ivar: `dynamic_return_type` rescues every
+        # StandardError to nil, so a NoMethodError here would turn the whole feature off in silence.
+        shapes = (@result_shapes ||= {})
+        return shapes[name] if shapes.key?(name)
+
+        entry = read_fact(plugin_id: manifest.id, name: :dry_schema_table)&.[](name)
+        shapes[name] = entry.nil? ? nil : ResultShape.build(entry)
+      end
 
       def scannable_paths(services)
         @scannable_paths ||= services.configuration.paths.flat_map do |entry|

--- a/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema/result_shape.rb
+++ b/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema/result_shape.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "prism"
+
+module Rigor
+  module Plugin
+    class DrySchema < Rigor::Plugin::Base
+      # Translates one `:dry_schema_table` entry into the `Rigor::Type::HashShape` that
+      # `SomeSchema.call(input).to_h` returns, and recognises the call chain that earns it.
+      #
+      # The table entry is the shape {SchemaScanner} publishes:
+      #
+      #     { required: { email: { type: "String", list: false } },
+      #       optional: { nickname: { type: "String", list: true } } }
+      #
+      # ## Why the shape mirrors the declaration's own vocabulary
+      #
+      # `Dry::Schema::Result#to_h` returns the *coerced input*, so on a failed validation a
+      # `required(:email)` key can be absent. Modelling that worst case — every key optional — would be
+      # the sound reading and the wrong one: the idiomatic consumer checks `success?` first, and typing
+      # `result.to_h[:age]` as `Integer?` inside that branch draws a nil diagnostic on correct code.
+      # Rigor weighs a false positive above a worst-case static reading (AGENTS.md § Implementation
+      # Guidelines), and already took the same call for RBS's `%a{implicitly-returns-nil}`.
+      #
+      # So `required` rows become required keys and `optional` rows become optional keys — the schema's
+      # own words. A reader who wrote `optional(:nickname)` is not surprised that the key reads as
+      # possibly-absent, and one who wrote `required(:email)` is not surprised that it does not.
+      #
+      # The shape is **open**: dry-schema's key map only emits declared keys, but a closed shape would
+      # turn any read of an undeclared key into a diagnostic, and being wrong there costs more than the
+      # extra precision buys.
+      module ResultShape
+        # `:bool` rows land in the published fact as "TrueClass" — the fact's vocabulary names one
+        # underlying class per row and has no union slot. A hash value typed `TrueClass` would false-fire
+        # on every `false`, so the shape widens it back to the two-class union here rather than in the
+        # fact, whose consumers (rigor-dry-struct, rigor-dry-validation) read it for a class name.
+        BOOL_CLASSES = %w[TrueClass FalseClass].freeze
+
+        module_function
+
+        # The schema constant `to_h_node`'s receiver chain names, or nil when the chain isn't the
+        # recognised `<Const>.call(...).to_h` form.
+        #
+        # Floor: the schema must be named by a constant *as written* at the call site, because the FQN is
+        # matched against the table's keys verbatim. A schema referenced through a local
+        # (`schema = NewUserSchema; schema.call(x).to_h`) or by a relative constant path from inside the
+        # declaring module resolves to no entry and contributes nothing — the pre-slice behaviour.
+        def schema_name(to_h_node)
+          return nil unless to_h_node.is_a?(Prism::CallNode) && to_h_node.name == :to_h
+          return nil unless to_h_node.arguments.nil? && to_h_node.block.nil?
+
+          inner = to_h_node.receiver
+          return nil unless inner.is_a?(Prism::CallNode) && inner.name == :call
+
+          constant_name(inner.receiver)
+        end
+
+        # The HashShape for one table entry, or nil when the schema declares no key at all. An empty shape
+        # is worse than no contribution: since a key outside a shape reads as `nil`, `{}` would type every
+        # read of that hash as nil.
+        def build(entry)
+          unmodelled = entry[:unmodelled] || {}
+          required = pairs_for(entry[:required]).merge(untyped_pairs(unmodelled[:required]))
+          optional = pairs_for(entry[:optional]).merge(untyped_pairs(unmodelled[:optional]))
+          return nil if required.empty? && optional.empty?
+
+          Rigor::Type::Combinator.hash_shape_of(
+            required.merge(optional),
+            required_keys: required.keys,
+            optional_keys: optional.keys,
+            extra_keys: :open
+          )
+        end
+
+        # A key the schema declares but the scanner could not type still belongs in the shape, as
+        # `untyped`. Leaving it out is not neutral: a key absent from a HashShape reads as `nil`, so
+        # dropping `required(:address).schema { … }` would type `payload[:address]` as nil and put a
+        # `call.undefined-method` on the next line of correct code.
+        def untyped_pairs(keys)
+          (keys || []).to_h { |key| [key, Rigor::Type::Combinator.untyped] }
+        end
+
+        def pairs_for(rows)
+          (rows || {}).each_with_object({}) do |(key, row), pairs|
+            type = row_type(row)
+            pairs[key] = type unless type.nil?
+          end
+        end
+
+        def row_type(row)
+          element = class_type(row[:type])
+          return nil if element.nil?
+
+          row[:list] ? Rigor::Type::Combinator.nominal_of("Array", type_args: [element]) : element
+        end
+
+        def class_type(class_name)
+          return nil if class_name.nil? || class_name.empty?
+          return Rigor::Type::Combinator.union(*BOOL_CLASSES.map { |c| Rigor::Type::Combinator.nominal_of(c) }) \
+            if class_name == "TrueClass"
+
+          Rigor::Type::Combinator.nominal_of(class_name)
+        end
+
+        # Renders `Foo` / `Foo::Bar` / `::Foo::Bar` as the `::`-joined String the table is keyed by.
+        # Mirrors the helper rigor-sorbet's TypeTranslator and rigor-activerecord's ModelDiscoverer use.
+        def constant_name(node)
+          case node
+          when Prism::ConstantReadNode then node.name.to_s
+          when Prism::ConstantPathNode then constant_path_name(node)
+          end
+        end
+
+        def constant_path_name(node)
+          parent = node.parent
+          name = node.name&.to_s
+          return nil if name.nil?
+          return name if parent.nil? # `::Foo` — the table keys are unrooted, so drop the leading `::`
+
+          prefix = constant_name(parent)
+          prefix.nil? ? nil : "#{prefix}::#{name}"
+        end
+      end
+    end
+  end
+end

--- a/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema/schema_scanner.rb
+++ b/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema/schema_scanner.rb
@@ -123,14 +123,20 @@ module Rigor
         def collect_schema_shape(block_node, type_aliases)
           required = {}
           optional = {}
+          declared = { required: [], optional: [] }
           walk_block_body(block_node) do |kind, key, type_info|
+            declared[kind] << key
             (kind == :required ? required : optional)[key] = type_info if type_info
           end
 
           remap_aliases!(required, type_aliases)
           remap_aliases!(optional, type_aliases)
 
-          { required: required.freeze, optional: optional.freeze }.freeze
+          {
+            required: required.freeze,
+            optional: optional.freeze,
+            unmodelled: unmodelled_keys(declared, required, optional)
+          }.freeze
         end
         private_class_method :collect_schema_shape
 
@@ -212,6 +218,22 @@ module Rigor
           end
         end
         private_class_method :extract_type_from_predicate
+
+        # Keys the schema declares that this scanner saw but could not type — a predicate outside the
+        # canonical vocabulary (`filled(:not_a_type)`), a nested `schema do … end` row, or a constant
+        # alias no `:dry_type_aliases` fact resolved.
+        #
+        # They are recorded rather than forgotten because forgetting them is not neutral downstream: a key
+        # absent from the synthesized `to_h` HashShape reads as `nil`, not as `untyped`, so a *declared*
+        # key would type as nil for anyone who reads it. {ResultShape} puts these back as untyped entries.
+        # Consumers that only want typed keys read `:required` / `:optional` and are unaffected.
+        def unmodelled_keys(declared, required, optional)
+          {
+            required: (declared[:required] - required.keys).uniq.freeze,
+            optional: (declared[:optional] - optional.keys).uniq.freeze
+          }.freeze
+        end
+        private_class_method :unmodelled_keys
 
         # In-place: any value's `type:` slot in `bucket` that doesn't already match a canonical class
         # (e.g. `"Types::Email"`) gets resolved through the type_aliases fact. Unresolvable values drop

--- a/spec/integration/plugins/dry_schema_plugin_spec.rb
+++ b/spec/integration/plugins/dry_schema_plugin_spec.rb
@@ -186,6 +186,162 @@ RSpec.describe "rigor-dry-schema integration" do
     expect(run_and_read_fact(demo: demo)).to be_nil
   end
 
+  # The typed `result.to_h` return — the first of the ceiling slices the plugin deferred to demand
+  # (issue #137, README § "Floor / ceiling").
+  describe "typed `SomeSchema.call(input).to_h`" do
+    it "yields the schema's own hash shape instead of an untyped hash" do
+      dump = dump_types(<<~RUBY).first
+        NewUserSchema = Dry::Schema.Params do
+          required(:email).filled(:string)
+          required(:age).value(:integer)
+        end
+
+        Rigor.dump_type(NewUserSchema.call({}).to_h)
+      RUBY
+      expect(dump).to include("email", "String", "age", "Integer")
+    end
+
+    it "keeps an `optional` row's key optional and a `required` row's key required" do
+      dump = dump_types(<<~RUBY).first
+        Schema = Dry::Schema.Params do
+          required(:email).filled(:string)
+          optional(:nickname).maybe(:string)
+        end
+
+        Rigor.dump_type(Schema.call({}).to_h)
+      RUBY
+      # The declaration's own vocabulary carries over: `optional` reads as possibly-absent, `required`
+      # does not. See ResultShape for why `to_h`'s worst case (a failed result drops required keys too)
+      # is deliberately not modelled.
+      expect(dump).to include("?nickname")
+      expect(dump).not_to include("?email")
+    end
+
+    it "types an `each(<Type>)` row as an Array of that type" do
+      dump = dump_types(<<~RUBY).first
+        Schema = Dry::Schema.Params do
+          required(:tags).each(:string)
+        end
+
+        Rigor.dump_type(Schema.call({}).to_h)
+      RUBY
+      expect(dump).to include("Array")
+      expect(dump).to include("String")
+    end
+
+    it "widens a `:bool` row back to the two-class union the fact cannot carry" do
+      # The published fact names one class per row, so `:bool` lands there as "TrueClass". A hash value
+      # typed TrueClass would false-fire on every `false`.
+      dump = dump_types(<<~RUBY).first
+        Schema = Dry::Schema.Params do
+          required(:admin).filled(:bool)
+        end
+
+        Rigor.dump_type(Schema.call({}).to_h)
+      RUBY
+      expect(dump).to include("FalseClass").or include("bool")
+    end
+
+    it "registers a schema declared under a namespace by its full constant path" do
+      dump = dump_types(<<~RUBY).first
+        module App
+          module Schemas
+            UserCreate = Dry::Schema.Params do
+              required(:email).filled(:string)
+            end
+          end
+        end
+
+        Rigor.dump_type(App::Schemas::UserCreate.call({}).to_h)
+      RUBY
+      expect(dump).to include("email", "String")
+    end
+
+    it "contributes nothing to a `to_h` that is not a schema-result chain" do
+      dumps = dump_types(<<~RUBY)
+        Schema = Dry::Schema.Params do
+          required(:email).filled(:string)
+        end
+
+        Rigor.dump_type(Schema.to_h)
+        Rigor.dump_type(NotASchema.call({}).to_h)
+        Rigor.dump_type({ a: 1 }.to_h)
+      RUBY
+      expect(dumps.size).to eq(3)
+      expect(dumps).to all(satisfy { |message| !message.include?("email") })
+    end
+
+    it "keeps a declared key the scanner cannot type in the shape, as untyped" do
+      # The decisive case. A key absent from a HashShape reads as `nil`, not as untyped — so dropping a
+      # row whose predicate is outside the canonical vocabulary would type `payload[:bogus]` as nil and
+      # put a diagnostic on the next line of correct code.
+      dumps = dump_types(<<~RUBY)
+        Schema = Dry::Schema.Params do
+          required(:email).filled(:string)
+          required(:bogus).filled(:not_a_type)
+          required(:address).schema do
+            required(:city).filled(:string)
+          end
+        end
+
+        payload = Schema.call({}).to_h
+        Rigor.dump_type(payload[:email])
+        Rigor.dump_type(payload[:bogus])
+        Rigor.dump_type(payload[:address])
+      RUBY
+      expect(dumps).to eq(["dump_type: String", "dump_type: Dynamic[top]", "dump_type: Dynamic[top]"])
+    end
+
+    it "contributes nothing for a schema that declares no key at all" do
+      dumps = dump_types(<<~RUBY)
+        Schema = Dry::Schema.Params do
+          config.validate_keys = true
+        end
+
+        Rigor.dump_type(Schema.call({}).to_h)
+      RUBY
+      expect(dumps.first).not_to include("=>")
+    end
+
+    it "draws no diagnostic on a consumer that reads an undeclared key" do
+      # The shape is open — dry-schema's key map only emits declared keys, but being wrong about that
+      # would turn an ordinary read into a diagnostic, and this project weighs that cost higher.
+      #
+      # Scoped to the consumer lines: the declaration block itself draws an unrelated pre-existing
+      # `required` diagnostic, because the fixture's RBS stub types the block parameter as untyped and
+      # the DSL calls read as implicit-self calls on main.
+      demo = <<~RUBY
+        Schema = Dry::Schema.Params do
+          required(:email).filled(:string)
+        end
+
+        payload = Schema.call({}).to_h
+        payload[:email]
+        payload[:undeclared]
+      RUBY
+      consumer_line = demo.lines.index { |line| line.start_with?("payload =") } + 1
+      result = run_demo(demo)
+      expect(result.diagnostics.select { |d| d.line >= consumer_line }).to be_empty
+    end
+  end
+
+  # Runs the plugin against a single-file project and returns the `dump.type` messages, in source order.
+  def dump_types(demo)
+    run_demo(demo).diagnostics.select { |d| d.rule == "dump.type" }.map(&:message)
+  end
+
+  def run_demo(demo, with_dry_types: false)
+    Rigor::Plugin.unregister!
+    plugin_entries = with_dry_types ? %w[rigor-dry-types rigor-dry-schema] : ["rigor-dry-schema"]
+
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "schema.rb"), demo)
+      FileUtils.mkdir_p(File.join(dir, "sig"))
+      File.write(File.join(dir, "sig", "dry_schema.rbs"), dry_schema_rbs)
+      run_analysis(dir: dir, plugin_entries: plugin_entries)
+    end
+  end
+
   # Runs the plugin(s) against a single-file project and returns the `:dry_schema_table` fact value. Optionally
   # also loads rigor-dry-types (for the cross-plugin fact-resolution test).
   def run_and_read_fact(demo:, with_dry_types: false)


### PR DESCRIPTION
First of the ceiling slices `rigor-dry-schema` deferred to demand (part of #137). `SomeSchema.call(input).to_h` was an untyped hash, so a schema that states every key's type contributed nothing to the code reading it. It now returns the schema's own `HashShape`, built from the `:dry_schema_table` the plugin already publishes.

```ruby
payload = NewUserSchema.call(input).to_h
#=> { email: String, age: Integer, ?nickname: String, ... }

payload[:email]     #=> String
payload[:nickname]  #=> String?
```

## The required/optional split is the declaration's vocabulary, not `to_h`'s worst case

`Result#to_h` returns the coerced input, so a failed validation can drop a required key too. Modelling that — every key optional — is the sound reading and the wrong one: it types `payload[:email]` as `String?` inside an `if result.success?` branch, a false positive on correct code. That cost outranks the worst-case reading here, the same call the `%a{implicitly-returns-nil}` posture already took.

Measured on the plugin's demo before deciding, via `Rigor.dump_type`: a required key reads as `String`, an optional one as `String?`. Had every key been optional, both would have read `String?`.

## The defect that measurement turned up

A key **absent** from a `HashShape` reads as `nil`, not as untyped — even when the shape is `extra_keys: :open`, because the open policy is only consulted in `Inference::Acceptance` and never on the element-read path (`rg '\.open\?' lib/` has exactly one hit).

The scanner drops any row it cannot type, so `required(:address).schema { ... }` would have typed `payload[:address]` as `nil` and put `call.undefined-method` on the next line of correct code. `SchemaScanner` now records those keys as `unmodelled:` and `ResultShape` puts them back as untyped entries, so the rows it does understand keep their precision. Verified end-to-end — that key now reads `Dynamic[top]`, not `nil`.

The engine-side question — whether an open shape should answer untyped for an unknown key — is deliberately left alone: it moves types for every open shape and wants its own corpus diff.

## Gate

`methods: [:to_h]` rather than a `Dry::Schema::Result` receiver gate. The plugin ships no RBS overlay for dry-schema, so in an ordinary project that receiver is untyped and a `receivers:` gate would never fire. The engine compiles `methods:` into its registry name gate, so the block is consulted only for `.to_h` calls, and its first act rejects any chain that is not `<Const>.call(...).to_h` before the table is touched.

## Verification

`make verify` green (exit 0) and `git diff --check` clean. Nine new integration examples cover the shape, the required/optional split, the `each(...)` list row, the `:bool` widening, the namespaced constant, the three non-matching `to_h` forms, the unmodelled-key case, and a consumer that draws no diagnostic.