### PR TITLE
Add a standalone self-check job for the bleeding-edge overlay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,13 +393,49 @@ jobs:
             exit 1
           fi
 
+  # ── 6. Self-check under the bleeding-edge overlay ───────────────
+  # ADR-50 § WD2's "Rigor's own CI exercises the overlay" made real: `rigor
+  # check` under the WHOLE queued overlay (`--bleeding-edge` = adopt all)
+  # must stay clean on Rigor's own lib, because WD7 graduation flips a
+  # queued discipline default-on at a major, and lib drifting out of
+  # compliance with a queued discipline would otherwise surface only on
+  # graduation day.
+  #
+  # This exercises severity features only: a behaviour feature changes what
+  # a separate command measures, not what `check` analyses, and its on/off
+  # correctness is spec'd in the suite (byte-identity with the feature
+  # off), not exercised here.
+  #
+  # Runs cold on purpose — deterministic, no cache interplay: no cache
+  # restore and no JSON artifact, since the exit code is the whole
+  # assertion.
+  self-check-bleeding-edge:
+    name: Self-check (bleeding-edge)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0"
+          bundler-cache: true
+
+      - name: Run rigor self-check under the bleeding-edge overlay
+        run: bundle exec exe/rigor check --bleeding-edge lib
+
   # ── Fan-in: single required-check target for branch protection ───
   # Configure branch protection to require only "CI required" rather
   # than each individual job. New jobs added above are automatically
   # gated without touching protection rules.
   required:
     name: CI required
-    needs: [changes, test, rbs-compat, lint, self-check, self-check-diff]
+    needs: [changes, test, rbs-compat, lint, self-check, self-check-diff, self-check-bleeding-edge]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -411,6 +447,7 @@ jobs:
           LINT_RESULT: ${{ needs.lint.result }}
           SELF_CHECK_RESULT: ${{ needs.self-check.result }}
           SELF_CHECK_DIFF_RESULT: ${{ needs.self-check-diff.result }}
+          SELF_CHECK_BLEEDING_EDGE_RESULT: ${{ needs.self-check-bleeding-edge.result }}
         run: |
           failed=0
           # Change detection must always succeed — it is what decides
@@ -421,7 +458,7 @@ jobs:
           fi
           # A gated job that was skipped (Markdown-only PR) is acceptable;
           # only an outright failure or cancellation blocks the merge.
-          for job_result in "$TEST_RESULT" "$RBS_COMPAT_RESULT" "$LINT_RESULT" "$SELF_CHECK_RESULT" "$SELF_CHECK_DIFF_RESULT"; do
+          for job_result in "$TEST_RESULT" "$RBS_COMPAT_RESULT" "$LINT_RESULT" "$SELF_CHECK_RESULT" "$SELF_CHECK_DIFF_RESULT" "$SELF_CHECK_BLEEDING_EDGE_RESULT"; do
             if [[ "$job_result" != "success" && "$job_result" != "skipped" ]]; then
               echo "A required job did not succeed (result: $job_result)"
               failed=1


### PR DESCRIPTION
Answers the question raised when the overlay gained real consumers (#252/#255): should CI grow a bleeding-edge matrix axis? **A full axis, no — one standalone job, yes.**

## Why not a matrix axis

- `test` / `rbs-compat` / `lint` are insensitive to the `bleeding_edge:` selector — specs inject what they need via stubs and the linter never reads the config. Doubling them buys nothing.
- Per-feature on/off correctness belongs to the spec suite, not to a CI duplication: #253/#254 both carry a byte-identity-with-the-feature-off acceptance criterion, and #255 pins the selector plumbing (`with_bleeding_edge` re-derivation) in specs.

## Why one job

ADR-50 § WD2 already commits to it: a queued discipline is exercised by "early adopters + **Rigor's own CI** by id". And WD7 makes it insurance: graduation flips a queued discipline default-on at a major, so if `lib` drifts out of compliance with a queued discipline, that would otherwise surface **on graduation day** — this job surfaces it in the PR that introduces the drift.

The job runs `rigor check --bleeding-edge lib` — the whole overlay, cold on purpose (deterministic, no cache interplay; the exit code is the whole assertion) — and joins the `required` fan-in.

It exercises **severity** features only, stated honestly in the job comment: a behaviour feature changes what a separate command measures, not what `check` analyses. Relatedly, PR #255 gained a documented constraint out of this investigation: a behaviour feature must not change `check` analysis output unless its id enters the cache identity, because severity is stamped post-cache (`Analysis::SeverityStamp`, ADR-87 WD4) but the selector is not part of the cache key.

## Verification

- YAML loads (`ruby -ryaml`); job comment and fan-in wiring mirror the file's existing numbered-section and `SELF_CHECK_DIFF_RESULT` patterns.
- The job's command run locally through the Flake: `bundle exec exe/rigor check --bleeding-edge --no-cache lib` → **exit 0** on current master content (347 files, no diagnostics), so the job lands green.
- Independent of #255 — `--bleeding-edge` and the two queued severity features predate it.