### PR TITLE
Fork-map the Tier 2 mutation file loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Changed
 
+- **[rigor coverage]** `--workers=N` now applies to the mutation tier (`--protection --mutation`), forking the per-file measurement across worker processes — Rigor's own `lib/rigor/analysis` falls from 35s to 23s at eight workers on a 12-core machine, with byte-identical output ([#134](https://github.com/rigortype/rigor/issues/134)).
+  - The flag was already accepted and documented on that path, but silently ignored; it now resolves the same way it does for `rigor check` (`--workers` › `RIGOR_RACTOR_WORKERS` › `parallel.workers:` › `0`). The whole-project pre-pass is still paid once, on the parent.
+  - The fused `--with-tests` tier deliberately stays sequential — its test hook shells out to your test runner, and concurrent runs would race over one working tree — and an explicit `--workers` there is now reported as ignored on stderr instead of being dropped.
+  - Any fork-parallel coverage scan also gets faster, `--protection` included: workers now re-arm deferred YJIT, which `fork` does not carry into a child. Without it a long parallel run was *slower* than the sequential one it replaced.
 - **[rigor check]** A cold run on a project that ships RBS spends roughly a third fewer allocations: the signature scan that looks for references to undeclared types no longer builds every class in the project to find them ([#207](https://github.com/rigortype/rigor/issues/207)).
   - It reads the declarations instead, applying the same membership test RBS itself applies, so the same names are found. On Rigor's own `lib` that scan falls from 7.84M allocations to 25k — 33% of the run to 0.15% — and on a Rails-shaped project the whole run drops 84%. Diagnostics are unchanged across the eight RBS-shipping projects the change was measured on.
 

--- a/docs/manual/02-cli-reference.md
+++ b/docs/manual/02-cli-reference.md
@@ -360,7 +360,10 @@ the effectiveness ratio and `--format=json` carries `mode`,
 `killed`, `survived`, `effectiveness_ratio`, per-file rows, and
 `add_a_type_here`. It is the truth tier behind the static
 `--protection` proxy, at the cost of many analyses — an opt-in CI
-deep-dive, not an interactive check.
+deep-dive, not an interactive check. `--workers=N` fork-parallelizes
+this tier too (the whole-project pre-pass is paid once on the parent
+and the per-file measurement is spread across workers), with the
+same precedence chain and the same byte-identical output.
 
 ```sh
 rigor coverage --protection --mutation [paths]
@@ -379,7 +382,10 @@ cost is proportional to the protection hole. `--format=json`
 carries `mode` (`protection-fused`), `type_killed`,
 `test_killed`, `unprotected`, `protected_ratio`, per-file rows,
 and `add_protection_here`; `--threshold` gates on the fused
-ratio.
+ratio. This tier is always sequential — the suite hook shells out
+to your test runner, and concurrent runs would race over one
+working tree — so `--workers` does not apply and an explicit one
+is reported as ignored on stderr.
 
 `--test-command=CMD` is the runner hook (default
 `bundle exec rake`). The suite must pass on clean code first, or

--- a/docs/manual/15-type-protection-coverage.md
+++ b/docs/manual/15-type-protection-coverage.md
@@ -74,7 +74,13 @@ real "add a type here" site, surfaced with no guesswork.
 
 It runs many analyses, so it defaults to the **git-changed** `.rb`
 files (pass explicit paths to widen — whole-project is minutes) and
-is an opt-in CI deep-dive, not an interactive check. The framing is
+is an opt-in CI deep-dive, not an interactive check. `--workers=N`
+applies here too, and it is the main lever on a wide run: the
+whole-project pre-pass is paid once, then the per-file measurement —
+which is nearly all of the wall time — is fork-mapped across
+workers, byte-identically to a sequential run.
+
+The framing is
 always *effectiveness / where to add a type*, never "your code is
 broken": a surviving breakage at a `Dynamic` site is a place
 the type net does not reach.
@@ -236,6 +242,10 @@ them as a deep-dive, not a per-keystroke check:
   (suite runtime)`. A fast, well-scoped test command is the biggest
   lever.
 - **Cap with `--limit`** on `--include-dynamic` or large files.
+- **Spread with `--workers=N`** on `--mutation` (and Tier 1). The
+  fused `--with-tests` tier stays sequential — the suite hook shells
+  out, and concurrent runs would race — so widen it with scope and
+  `--limit` instead.
 
 ## In CI
 

--- a/lib/rigor/cli/coverage_command.rb
+++ b/lib/rigor/cli/coverage_command.rb
@@ -27,6 +27,7 @@ require_relative "fused_protection_report"
 require_relative "fused_protection_renderer"
 require_relative "coverage_mutation"
 require_relative "protection_fork_scan"
+require_relative "mutation_fork_scan"
 require_relative "check_runner_factory"
 require_relative "command"
 
@@ -103,7 +104,8 @@ module Rigor
           options[:protection] = true
         end
         define_mutation_options(opts, options)
-        opts.on("--workers=N", Integer, "With --protection: fork N workers over the scanned files " \
+        opts.on("--workers=N", Integer, "With --protection (with or without --mutation, but not --with-tests, " \
+                                        "which must stay sequential): fork N workers over the scanned files " \
                                         "(default: config parallel.workers / RIGOR_RACTOR_WORKERS / 0)") do |v|
           options[:workers] = v
         end

--- a/lib/rigor/cli/coverage_mutation.rb
+++ b/lib/rigor/cli/coverage_mutation.rb
@@ -26,6 +26,8 @@ module Rigor
         end
 
         note_sampling(options)
+        # `--with-tests` deliberately does NOT take the fork path below: {Protection::TestSuiteOracle} shells
+        # out to the project's test runner, and concurrent suite invocations would race over one working tree.
         return run_fused_protection(target_files, options) if options[:with_tests]
 
         report = scan_mutation_protection(target_files, options)
@@ -49,6 +51,7 @@ module Rigor
       # mutant survived" is meaningless — abort with a clear message if not.
       def run_fused_protection(paths, options)
         configuration = Configuration.load(options.fetch(:config))
+        warn_workers_ignored_under_tests(options)
         test_oracle = Protection::TestSuiteOracle.new(command: options.fetch(:test_command))
         return suite_not_green_error(options) unless test_oracle.green?
 
@@ -63,6 +66,18 @@ module Rigor
         report = accumulator.to_report
         FusedProtectionRenderer.new(out: @out).render(report, format: options.fetch(:format))
         determine_protection_exit(report, options)
+      end
+
+      # An explicit `--workers=N` on the fused path cannot be honoured, so say so rather than repeat the bug
+      # this slice fixed (a flag accepted and silently dropped). Only the explicit flag warns — a project-wide
+      # `parallel.workers:` or `RIGOR_RACTOR_WORKERS` default is not a request about *this* run.
+      def warn_workers_ignored_under_tests(options)
+        return unless options[:workers].to_i > 1
+
+        @err.puts(
+          "coverage: --workers is ignored with --with-tests — the test-suite oracle shells out to " \
+          "#{options.fetch(:test_command).join(' ')}, and parallel runs would race."
+        )
       end
 
       def scan_fused_one(path, scanner, accumulator, test_oracle, configuration)
@@ -89,6 +104,10 @@ module Rigor
         1
       end
 
+      # Builds the RBS environment + whole-project pre-pass ONCE (≈6% of a 45-file run), then fork-maps the
+      # per-file measurement — the ≈94% that is `Σ(1 + N_f)` single-file analyses — across the resolved worker
+      # count (#134 slice 1). {MutationForkScan} returns `{path => result}` and the parent absorbs in `paths`
+      # order, so the report is byte-identical to a sequential run whatever order the workers finished in.
       def scan_mutation_protection(paths, options)
         configuration = Configuration.load(options.fetch(:config))
         context = LanguageServer::ProjectContext.new(configuration: configuration)
@@ -98,19 +117,22 @@ module Rigor
         )
         accumulator = MutationProtectionAccumulator.new
 
-        paths.each { |path| scan_mutation_one(path, scanner, accumulator, configuration) }
+        results = MutationForkScan.run(
+          paths: paths, scanner: scanner, environment: context.environment,
+          configuration: configuration, workers: CheckRunnerFactory.resolve_workers(options, configuration)
+        )
+        # `fetch`, never `[]`: a worker that died mid-slice must abort the run rather than quietly drop files
+        # out of a ratio that `--threshold` gates CI on.
+        paths.each { |path| absorb_mutation_result(accumulator, path, results.fetch(path)) }
         accumulator.to_report
       end
 
-      def scan_mutation_one(path, scanner, accumulator, configuration)
-        source = File.read(path)
-        parse_result = Prism.parse(source, filepath: path, version: configuration.target_ruby)
-        if parse_result.errors.any?
-          accumulator.record_parse_error(path, parse_result.errors)
-          return
+      def absorb_mutation_result(accumulator, path, result)
+        if result.is_a?(MutationForkScan::ParseError)
+          accumulator.record_parse_error_count(path, result.count)
+        else
+          accumulator.absorb(result)
         end
-
-        accumulator.absorb(scanner.scan_file(path, source: source))
       end
 
       # The git-changed (modified / added / untracked) `.rb` files that exist on disk — the default Tier 2 scope.

--- a/lib/rigor/cli/mutation_fork_scan.rb
+++ b/lib/rigor/cli/mutation_fork_scan.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "prism"
+
+require_relative "../inference/fork_map"
+
+module Rigor
+  class CLI
+    # Fork-pool for the `rigor coverage --protection --mutation` scan (#134 slice 1) — the Tier-2 analogue of
+    # {ProtectionForkScan}. The expensive shared state is built ONCE on the parent (the RBS environment, the
+    # plugin registry, and the whole-project pre-pass {Analysis::ProjectScan}, all held by the
+    # {Protection::MutationScanner}'s oracle) and children copy-on-write inherit it via {Inference::ForkMap},
+    # each measuring a contiguous slice of paths.
+    #
+    # Why this is safe to parallelise where Tier 1 already is: a Tier-2 per-file measurement is pure-read
+    # against that shared state — every mutant is analysed through `Runner.new(prebuilt:)#run_source`, an
+    # in-memory overlay that writes nothing to disk and, because `prebuilt:` disables the run-result cache, has
+    # no cache store to race on. The returned {Protection::MutationScanner::FileResult} is a Data of primitives
+    # (and `SurvivingSite` likewise), so it marshals back verbatim.
+    #
+    # Determinism: {MutationProtectionAccumulator#absorb} is order-dependent (the per-file list and the
+    # "add a type here" example paths follow absorption order), so the parent MUST iterate the original `paths`
+    # and `fetch` each result rather than consume completion order. A missing key then raises instead of
+    # silently under-reporting an effectiveness ratio a `--threshold` gate reads.
+    #
+    # NOT used by the fused `--with-tests` path: {Protection::TestSuiteOracle} shells out to the project's test
+    # runner, and concurrent suite invocations would race over the same working tree.
+    module MutationForkScan
+      module_function
+
+      # A parse failure for one file, carrying only the marshalable error count (Prism error objects are not
+      # reliably marshalable, and the accumulator only needs the count).
+      ParseError = Data.define(:count)
+
+      # @param paths [Array<String>] the files to measure, in caller order.
+      # @param scanner [Protection::MutationScanner] built on the parent; COW-inherited by workers.
+      # @param environment [Rigor::Environment] the scanner's environment, prewarmed here before forking.
+      # @param configuration [Rigor::Configuration] for the Prism `target_ruby` version.
+      # @param workers [Integer] resolved worker count (≤1 → sequential).
+      # @return [Hash{String => Protection::MutationScanner::FileResult, ParseError}] one entry per path.
+      def run(paths:, scanner:, environment:, configuration:, workers:)
+        # Force the full RBS load on the parent so children copy-on-write inherit a warm environment rather
+        # than each rebuilding it after the fork. A no-op on the sequential path but cheap.
+        environment.rbs_loader&.prewarm if Inference::ForkMap.parallel?([workers, paths.size].min)
+
+        payloads = Inference::ForkMap.call(items: paths, workers: workers) do |slice|
+          slice.to_h { |path| [path, scan_path(path, scanner, configuration)] }
+        end
+        payloads.each_with_object({}) { |slice_results, merged| merged.merge!(slice_results) }
+      end
+
+      # Measures one file and returns the scanner's {Protection::MutationScanner::FileResult}, or a
+      # {ParseError} when the source does not parse — the same read → parse → guard → scan order the sequential
+      # loop used, so a broken file is reported identically either side of the fork.
+      def scan_path(path, scanner, configuration)
+        source = File.read(path)
+        parse_result = Prism.parse(source, filepath: path, version: configuration.target_ruby)
+        return ParseError.new(count: parse_result.errors.size) if parse_result.errors.any?
+
+        scanner.scan_file(path, source: source)
+      end
+    end
+  end
+end

--- a/lib/rigor/cli/mutation_protection_report.rb
+++ b/lib/rigor/cli/mutation_protection_report.rb
@@ -56,7 +56,13 @@ module Rigor
       end
 
       def record_parse_error(path, errors)
-        @parse_errors << { "path" => path, "errors" => errors.size }
+        record_parse_error_count(path, errors.size)
+      end
+
+      # Count-based variant for the fork-pool path, where a worker carries only the marshalable error count
+      # (see {MutationForkScan::ParseError}), not the Prism error objects.
+      def record_parse_error_count(path, count)
+        @parse_errors << { "path" => path, "errors" => count }
       end
 
       def to_report

--- a/lib/rigor/inference/fork_map.rb
+++ b/lib/rigor/inference/fork_map.rb
@@ -2,6 +2,8 @@
 
 require "tmpdir"
 
+require_relative "../runtime/jit"
+
 module Rigor
   module Inference
     # Generic fork-over-slices map for the embarrassingly-parallel per-file passes of the
@@ -56,6 +58,15 @@ module Rigor
       # (skipping `at_exit` / stdio flush — the payload is durable on disk). Any failure exits non-zero so
       # the parent re-runs the slice in-process.
       def run_worker(slice, block, out_path)
+        # Re-arm deferred YJIT in the child, exactly as the check fork pool does
+        # ({Analysis::Runner::PoolCoordinator#run_fork_worker}). The CLI armed `enable_after` on a background
+        # thread, but `fork` copies only the calling thread, so the sleeping deadline never fires in a worker
+        # — every child would run its whole slice un-JITted however long it takes, while the parent JITs the
+        # tail it no longer runs. Without this the pool is a *pessimization* on long runs: `coverage
+        # --protection --mutation lib/rigor/analysis` measured 37s sequential against 67s at eight workers,
+        # versus 42s at eight workers with YJIT off on both sides. A child forked after the parent already
+        # enabled YJIT inherits the enabled state and this is a no-op.
+        Runtime::Jit.enable_after(Runtime::Jit.deadline_seconds)
         File.binwrite(out_path, Marshal.dump(block.call(slice)))
         exit!(0)
       rescue StandardError

--- a/spec/rigor/cli/coverage_command_spec.rb
+++ b/spec/rigor/cli/coverage_command_spec.rb
@@ -53,6 +53,20 @@ RSpec.describe Rigor::CLI::CoverageCommand do
     expect(payload["killed"]).to be >= 1
   end
 
+  # Issue #134 slice 1 — the Tier 2 fork pool is a pure performance change, exactly as P3-10 was for Tier 1:
+  # the accumulator's per-file list and per-method examples are absorption-ordered, so the parent absorbs in
+  # original `paths` order and the JSON must come out byte-identical.
+  it "produces byte-identical mutation JSON under --workers as sequential (multi-file)" do
+    FileUtils.mkdir_p("lib")
+    4.times { |i| File.write("lib/f#{i}.rb", %(def m#{i}(x)\n  "hello#{i}".upcase\n  x.thing#{i}\nend\n)) }
+
+    _, sequential, = run(["--protection", "--mutation", "--workers", "0", "--format", "json", "lib"])
+    _, forked, = run(["--protection", "--mutation", "--workers", "4", "--format", "json", "lib"])
+
+    expect(JSON.parse(sequential)["killed"]).to be >= 1
+    expect(forked).to eq(sequential)
+  end
+
   it "reports nothing to measure when no paths are given and nothing changed" do
     # An empty git work tree → no changed Ruby files → vacuous success.
     system("git", "init", "--quiet", out: File::NULL, err: File::NULL)
@@ -210,6 +224,19 @@ RSpec.describe Rigor::CLI::CoverageCommand do
       expect(payload["mode"]).to eq("protection-fused")
       expect(payload).to have_key("protected_ratio")
       expect(payload["unprotected"]).to be >= 1
+    end
+
+    # Issue #134 slice 1 — the fused tier stays sequential (the suite oracle shells out; parallel runs would
+    # race), so an explicit --workers is announced as ignored rather than silently dropped.
+    it "keeps the fused path sequential and says so when --workers is given explicitly" do
+      File.write("joins.rb", %(def j\n  File.join("a", "b")\nend\n))
+      stub_oracle(green: true, kills: true)
+      allow(Rigor::CLI::MutationForkScan).to receive(:run).and_raise("the fused path must not fork")
+
+      status, _out, err = run(["--protection", "--mutation", "--with-tests", "--workers", "4", "joins.rb"])
+
+      expect(status).to eq(0)
+      expect(err).to include("--workers is ignored with --with-tests")
     end
 
     it "rejects --include-dynamic without --with-tests (usage error)" do

--- a/spec/rigor/cli/mutation_fork_scan_spec.rb
+++ b/spec/rigor/cli/mutation_fork_scan_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+require "rigor/cli/mutation_fork_scan"
+require "rigor/configuration"
+require "rigor/language_server/project_context"
+require "rigor/protection/mutation_scanner"
+
+# Issue #134 slice 1 — direct coverage of the ADR-63 Tier 2 fork pool: sequential/fork result equivalence,
+# parse-error sentinel handling, and one entry per path. Mirrors `protection_fork_scan_spec.rb`, the Tier 1
+# proof of the same contract.
+RSpec.describe Rigor::CLI::MutationForkScan do
+  let(:configuration) { Rigor::Configuration.new({}) }
+  let(:context) { Rigor::LanguageServer::ProjectContext.new(configuration: configuration) }
+  let(:scanner) do
+    Rigor::Protection::MutationScanner.new(
+      configuration: configuration, environment: context.environment, project_scan: context.project_scan
+    )
+  end
+
+  around { |example| Dir.mktmpdir { |dir| Dir.chdir(dir) { example.run } } }
+
+  # Writes `count` measurable source files into the (chdir'd) tmpdir and returns their paths. Each carries a
+  # concrete-receiver dispatch site, so the biteable filter keeps at least one mutation per file.
+  def write_sources(count)
+    Array.new(count) do |i|
+      path = "f#{i}.rb"
+      File.write(path, %(def m#{i}\n  "hello#{i}".upcase\nend\n))
+      path
+    end
+  end
+
+  def run(paths, workers)
+    described_class.run(paths: paths, scanner: scanner, environment: context.environment,
+                        configuration: configuration, workers: workers)
+  end
+
+  it "returns one entry per path, keyed by path" do
+    paths = write_sources(3)
+    results = run(paths, 0)
+
+    expect(results.keys).to match_array(paths)
+    expect(results.values).to all(be_a(Rigor::Protection::MutationScanner::FileResult))
+  end
+
+  it "produces the same results forked as sequential" do
+    skip "fork unavailable on this platform" unless Process.respond_to?(:fork)
+
+    paths = write_sources(4)
+    expect(run(paths, 3)).to eq(run(paths, 0))
+  end
+
+  it "measures something — the equivalence assertion would be vacuous over empty results" do
+    results = run(write_sources(1), 0)
+
+    expect(results.fetch("f0.rb").total).to be >= 1
+  end
+
+  it "records a parse error as a marshalable ParseError sentinel (forked and sequential agree)" do
+    paths = write_sources(3)
+    File.write("broken.rb", "def oops(\n")
+    paths << "broken.rb"
+
+    sequential = run(paths, 0)
+    expect(sequential["broken.rb"]).to be_a(described_class::ParseError)
+    expect(sequential["broken.rb"].count).to be >= 1
+
+    expect(run(paths, 4)).to eq(sequential) if Process.respond_to?(:fork)
+  end
+end

--- a/spec/rigor/inference/fork_map_spec.rb
+++ b/spec/rigor/inference/fork_map_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "tmpdir"
+
 require "rigor/inference/fork_map"
 
 # P3-10 — the generic fork-over-slices map behind the coverage-protection scan and the parameter-inference rounds.
@@ -45,5 +47,25 @@ RSpec.describe Rigor::Inference::ForkMap do
 
   it "handles empty items without forking" do
     expect(described_class.call(items: [], workers: 4) { |slice| slice }).to eq([[]])
+  end
+
+  # `fork` copies only the calling thread, so the CLI's `Runtime::Jit.enable_after` sleeper never fires in a
+  # worker: without re-arming, every child runs its whole slice interpreted while the parent JITs work it no
+  # longer does, and the pool becomes SLOWER than sequential on a long run (`coverage --protection --mutation
+  # lib/rigor/analysis`: 37s sequential vs 67s at eight workers, fixed to 23s). Driven in-process with `exit!`
+  # stubbed, exactly as the check pool's equivalent is — a spy in the parent cannot observe a real child.
+  describe "deferred YJIT in the fork worker" do
+    it "re-arms deferred YJIT before running its slice" do
+      Dir.mktmpdir do |dir|
+        out_path = File.join(dir, "payload")
+        allow(described_class).to receive(:exit!) # keep the worker body in-process
+        allow(Rigor::Runtime::Jit).to receive(:enable_after)
+
+        described_class.run_worker([1, 2], ->(slice) { slice }, out_path)
+
+        expect(Rigor::Runtime::Jit)
+          .to have_received(:enable_after).with(Rigor::Runtime::Jit.deadline_seconds)
+      end
+    end
   end
 end


### PR DESCRIPTION
Slice 1 of #134. Implementation delegated to a subagent in an isolated worktree against the rewritten issue; reviewed and gate-rerun on the main tree before push.

`rigor coverage --protection --mutation` is dominated by its per-file loop: the whole-project pre-pass is paid once (~6% of a 45-file run) and the remaining ~94% is `Σ(1 + N_f)` independent single-file analyses. Tier 1 has fork-mapped that shape since P3-10; Tier 2 never did — and `--workers` was parsed, documented, and then silently dropped on this path because `run` returns for `options[:mutation]` before the only call to `resolve_workers`.

`MutationForkScan` is the Tier 2 analogue of `ProtectionForkScan`, on the contract that module already proves. The parent absorbs `results.fetch(path)` in original `paths` order — `fetch`, never `[]`, so a worker dying mid-slice aborts the run rather than quietly shrinking a ratio `--threshold` gates CI on. `--with-tests` stays sequential (its oracle shells out to the project's test runner) and now *says so* on an explicit `--workers` instead of repeating the silently-dropped-flag bug; a config/env default does not warn, because it is not a statement about this run.

## The bigger find: ForkMap was a pessimization on long runs

The first measurement showed the pool making things **worse**: 37.2s sequential vs **67.4s at 8 workers**. `fork` copies only the calling thread, so the CLI's deferred-YJIT deadline sleeper (`Runtime::Jit.enable_after`) never fires in a `ForkMap` child — every worker ran its entire slice interpreted while the parent JITted work it no longer did. `PoolCoordinator#run_fork_worker` has re-armed YJIT in its children since it was written; `ForkMap` never learned to. Confirmed by A/B: with YJIT disabled on both sides the pool behaved (69.9s → 41.8s); with YJIT force-enabled from boot, 23.2s.

Re-arming in `ForkMap.run_worker` fixes every `ForkMap` caller at once — **the Tier-1 protection scan and the parameter-inference rounds had the same latent deficit**.

## Measured (`lib/rigor/analysis`, 45 files / 916 mutants, warm, 12 cores)

| workers | before the YJIT fix | after |
|---|---|---|
| 0 | 37.2s | 35.1s |
| 2 | 48.0s | 27.8s |
| 4 | 43.6s | 26.7s |
| 8 | 67.4s | **23.2s** |

`--format=json` **byte-identical at every worker count** (same SHA-256 across 0/2/4/8, both before and after the fix). 23.2s equals the YJIT-forced-from-boot ceiling, so the JIT deficit is fully closed; the distance to linear is the ~2.3s fixed cost, per-worker JIT warm-up, and contiguous slices of uneven mutant count.

## Verification

`make verify`, `make docs-check`, `git diff --check` all exit 0 — in the implementing worktree AND rerun independently on the main tree at this commit. New specs: fork/sequential equivalence with a non-vacuity guard, the parse-error sentinel across the marshal boundary, command-level byte-identity at `--workers 0` vs `4`, a spec that the fused path structurally cannot fork (stub raises), and the ForkMap YJIT re-arm.

## Follow-ups surfaced, not taken here

- A `Jit.rearm_after_fork` carrying the *remaining* deadline (children currently restart the full 5s window, matching the `PoolCoordinator` precedent) would shave high-worker-count warm-up, for this pool and the check pool both.
- The Tier-1 P3-10 numbers (`61s → 43s`) were measured with the latent ForkMap deficit in place; a Mastodon-scale re-measure would likely improve them.