### PR TITLE
Record Data/Struct constant declarations cross-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** A nested `Result = Data.define(...)` (or `Struct.new(...)`) constant is now visible across files, so a call on a factory's return no longer draws a false `call.undefined-method` attributed to a same-named class in the parent namespace ([#271](https://github.com/rigortype/rigor/issues/271)).
 - **[engine]** A class that defines the same method name on both sides — `def helper` plus a `class << self` (or `def self.helper`) twin — no longer draws a false `call.undefined-method` on the class-side call ([#239](https://github.com/rigortype/rigor/issues/239)).
   - The in-source method table records one kind per name, so the second definition erased the first and the method Rigor could see in the source read as missing. It now records both, including when the two definitions live in different files. Real instance: `Haml::Compiler::ScriptCompiler.find_and_preserve` on the `haml` gem, which declares that name as both a class method and an instance method.
 - **[inference]** Under the opt-in `parameter_inference:`, `call.argument-type-mismatch` no longer fires when the *receiver's* type came from call-site parameter inference ([#205](https://github.com/rigortype/rigor/issues/205)).

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -2598,24 +2598,47 @@ module Rigor
         node.rigor_each_child { |child| collect_class_decls(child, qualified_prefix, accumulator) }
       end
 
-      # T1 (template-corpora survey) — record a `Const = Class.new(Super)` (and the bare `Class.new` / `Module.new`)
-      # class-creating constant in the cross-file discovery table so a reference to `Const` from ANOTHER file under the
-      # same namespace resolves to the project class instead of falling through to a core same-named class
+      # T1 (template-corpora survey) — record a class-creating constant write (`Const = Class.new(Super)`, the bare
+      # `Class.new` / `Module.new`, and the `Data.define(*sym)` / `Struct.new(*sym)` forms, each with or without a
+      # block) in the cross-file discovery table so a reference to `Const` from ANOTHER file under the same namespace
+      # resolves to the project class instead of falling through to a same-named class elsewhere
       # (`Liquid::SyntaxError = Class.new(Error)` referenced in a sibling file's `rescue SyntaxError => e`, which
       # otherwise resolved to core `::SyntaxError`). Mirrors the single-file `in_source_constants` answer, which types
-      # `Class.new(Super)` as `Singleton[Super]` (the constructed class answers method lookups through Super's chain).
-      # The superclass name is resolved lexically against the enclosing prefix; a bare `Class.new` with no superclass
-      # (or `Module.new`) types as `Singleton[Const]` itself. The block form is left to the existing
-      # `meta_new_block_body` machinery — only the plain `Class.new(Super)` constant (the namespaced-sibling-error
-      # idiom) is added here.
+      # `Class.new(Super)` as `Singleton[Super]` (the constructed class answers method lookups through Super's chain)
+      # and every other recognised form as `Singleton[Const]`.
+      #
+      # #271 — the Data/Struct forms are here because their absence was an ACTIVE false positive, not merely a missed
+      # resolution: a nested `Const = Data.define(...)` invisible cross-file lets Ruby's lexical walk continue to the
+      # PARENT namespace's same-named sibling, so `Analysis::PluginFactFingerprint.from_registry(...).opaque?` typed
+      # its receiver as the unrelated `Rigor::Analysis::Result` and reported `call.undefined-method` on correct code.
+      # Nested `Result` / `Entry` / `Config` Data constants shadowing a sibling are ordinary Ruby, and only the
+      # DEFINING file's `in_source_constants` (never part of the project seed) knew about them.
       def record_class_new_constant_decl(node, qualified_prefix, accumulator)
         rvalue = node.value
-        return unless class_new_call?(rvalue) || module_new_call?(rvalue)
-        return if rvalue.block # block form: handled by meta_new_block_body walks
+        return unless meta_new_constant_rvalue?(rvalue)
 
         full = (qualified_prefix + [node.name.to_s]).join("::")
-        super_name = class_new_superclass_name(rvalue, qualified_prefix, accumulator)
-        accumulator[full] = Type::Combinator.singleton_of(super_name || full)
+        accumulator[full] = Type::Combinator.singleton_of(
+          meta_new_constant_decl_name(rvalue, full, qualified_prefix, accumulator)
+        )
+      end
+
+      # The four recognised class-creating rvalue shapes at constant-write position — the same set
+      # {#meta_new_block_body} recognises, so the cross-file table and the per-file block-as-method walk agree on what
+      # counts as a declaration.
+      def meta_new_constant_rvalue?(rvalue)
+        class_new_call?(rvalue) || module_new_call?(rvalue) ||
+          data_define_call?(rvalue) || struct_new_call?(rvalue)
+      end
+
+      # The name the constant's `Singleton[...]` carries. Only a block-less `Class.new(Super)` borrows its superclass's
+      # name (the constructed class answers lookups through `Super`'s chain and declares nothing of its own); every
+      # other form — Data/Struct members, any block body — owns methods under its OWN qualified name, which is exactly
+      # what the per-file `meta_new_constant_type` answers.
+      def meta_new_constant_decl_name(rvalue, full, qualified_prefix, accumulator)
+        return full if rvalue.block || data_define_call?(rvalue) || struct_new_call?(rvalue)
+
+        class_new_superclass_name(rvalue, qualified_prefix, accumulator) || full
       end
 
       # Lexically-qualified name of a `Class.new(Super)` superclass argument, or nil when there is no positional

--- a/spec/rigor/analysis/nested_data_constant_cross_file_spec.rb
+++ b/spec/rigor/analysis/nested_data_constant_cross_file_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+
+# Issue #271 — a nested `Const = Data.define(...)` must win Ruby's lexical constant lookup over a SAME-NAMED sibling in
+# the parent namespace, from a consumer in another file.
+#
+# The cross-file discovery table (`ScopeIndexer.collect_class_decls`) recorded `class` / `module` declarations and
+# `Const = Class.new(...)`, but not the Data/Struct constant-write forms; only the DEFINING file's `in_source_constants`
+# knew about those, and that table is not part of the project seed. So when a consumer in another file adopted the
+# inferred return of a factory defined here, `Result` inside the callee's body fell through the nested candidate to the
+# parent namespace's sibling — and because that sibling is RBS-known (closed world), `call.undefined-method` fired on
+# correct code with a receiver from an unrelated class.
+#
+# The RBS-known sibling is load-bearing, not decoration: without it the whole chain degrades to `Dynamic` and nothing
+# fires, which is why the issue's first minimal repro came back clean.
+RSpec.describe "cross-file nested Data constant resolution" do
+  let(:sibling_rbs) do
+    <<~RBS
+      module M
+        class Result
+          attr_reader diagnostics: Array[untyped]
+          def initialize: (?diagnostics: Array[untyped]) -> void
+          def success?: () -> bool
+        end
+      end
+    RBS
+  end
+
+  let(:defining_file) do
+    <<~RUBY
+      module M
+        class Result
+          attr_reader :diagnostics
+
+          def initialize(diagnostics: [])
+            @diagnostics = diagnostics
+          end
+
+          def success?
+            diagnostics.empty?
+          end
+        end
+
+        class Factory
+          Result = Data.define(:digest) do
+            def opaque?
+              digest.nil?
+            end
+          end
+
+          def self.build
+            new.compute
+          end
+
+          def compute
+            Result.new(digest: "x")
+          end
+        end
+      end
+    RUBY
+  end
+
+  # Runs a two-file project (the defining file plus `consumer`) with the sibling's RBS on `signature_paths:`.
+  def undefined_method_messages(consumer)
+    Dir.mktmpdir do |dir|
+      lib = File.join(dir, "lib")
+      sig = File.join(dir, "sig")
+      FileUtils.mkdir_p([lib, sig])
+      File.write(File.join(lib, "a.rb"), defining_file)
+      File.write(File.join(lib, "b.rb"), consumer)
+      File.write(File.join(sig, "m.rbs"), sibling_rbs)
+      result = Rigor::Analysis::Runner.new(
+        configuration: Rigor::Configuration.new("paths" => [lib], "signature_paths" => [sig]),
+        cache_store: nil
+      ).run
+      result.diagnostics.select { |d| d.rule == "call.undefined-method" }.map(&:message)
+    end
+  end
+
+  it "does not attribute a two-hop factory return to the parent namespace's sibling" do
+    expect(undefined_method_messages(<<~RUBY)).to be_empty
+      module M
+        class Consumer
+          def run
+            M::Factory.build.opaque?
+          end
+        end
+      end
+    RUBY
+  end
+
+  it "does not attribute a one-hop instance-method return to the sibling either" do
+    expect(undefined_method_messages(<<~RUBY)).to be_empty
+      module M
+        class Consumer
+          def run
+            M::Factory.new.compute.opaque?
+          end
+        end
+      end
+    RUBY
+  end
+
+  # The harness must be able to say "yes": the sibling is genuinely closed, so a real typo on IT still fires. Without
+  # this the two examples above would pass on a build that had simply stopped analysing the file.
+  it "still reports a genuine undefined method on the sibling itself" do
+    expect(undefined_method_messages(<<~RUBY)).to include(a_string_matching(/M::Result/))
+      module M
+        class Consumer
+          def run
+            M::Result.new.zzz_undefined
+          end
+        end
+      end
+    RUBY
+  end
+end

--- a/spec/rigor/inference/scope_indexer_spec.rb
+++ b/spec/rigor/inference/scope_indexer_spec.rb
@@ -1691,10 +1691,47 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
       end
     end
 
-    it "leaves the block form to the existing meta-new machinery (no flat record)" do
+    it "records the block form under the constant's OWN name, not its superclass's" do
       with_files({ "a.rb" => "module M\n  Blk = Class.new(Object) do\n    def x; end\n  end\nend\n" }) do |discovered|
-        # block form is not flat-recorded here; it does not type as Singleton[Object]
-        expect(discovered["M::Blk"]).not_to eq(Rigor::Type::Combinator.singleton_of("Object"))
+        # A block body declares methods of its own, so the constant cannot borrow `Object`'s identity the way a
+        # block-less `Class.new(Super)` does — the same answer the per-file `meta_new_constant_type` gives.
+        expect(discovered["M::Blk"]).to eq(Rigor::Type::Combinator.singleton_of("M::Blk"))
+      end
+    end
+
+    # Issue #271 — the Data/Struct constant-write forms belong in the SAME table. Left out, a nested `Result` was
+    # invisible cross-file and Ruby's lexical walk continued to the parent namespace's same-named sibling, which is a
+    # `call.undefined-method` false positive when that sibling is RBS-known (see
+    # spec/rigor/analysis/nested_data_constant_cross_file_spec.rb).
+    it "records a Const = Data.define(*sym) under its own qualified name" do
+      with_files({ "a.rb" => "module M\n  class F\n    Result = Data.define(:digest)\n  end\nend\n" }) do |discovered|
+        expect(discovered["M::F::Result"]).to eq(Rigor::Type::Combinator.singleton_of("M::F::Result"))
+      end
+    end
+
+    it "records the Data.define block form, so a nested Result outranks a parent-namespace sibling" do
+      files = {
+        "a.rb" => <<~RUBY
+          module M
+            class Result; end
+
+            class F
+              Result = Data.define(:digest) do
+                def opaque? = digest.nil?
+              end
+            end
+          end
+        RUBY
+      }
+      with_files(files) do |discovered|
+        expect(discovered["M::F::Result"]).to eq(Rigor::Type::Combinator.singleton_of("M::F::Result"))
+        expect(discovered["M::Result"]).to eq(Rigor::Type::Combinator.singleton_of("M::Result"))
+      end
+    end
+
+    it "records a Const = Struct.new(*sym) under its own qualified name" do
+      with_files({ "a.rb" => "module M\n  Row = Struct.new(:a, :b)\nend\n" }) do |discovered|
+        expect(discovered["M::Row"]).to eq(Rigor::Type::Combinator.singleton_of("M::Row"))
       end
     end
   end


### PR DESCRIPTION
Fixes #271.

## Root cause

`ScopeIndexer.collect_class_decls` — the cross-file discovered-classes pre-pass — recorded `class` / `module` declarations and `Const = Class.new(Super)`, but **not** `Const = Data.define(*sym)` / `Const = Struct.new(*sym)`, nor any block form. Those are known only to the DEFINING file's `in_source_constants` table, and that table is not part of `Runner#project_scope_seed_tables`.

So when a consumer in another file adopts the inferred return of a factory, the callee's body is re-typed against a scope carrying the CONSUMER's discovery index. `Result` inside `PluginFactFingerprint#digest_registry` then walks `Reflection.lexical_constant_candidates`: the nested `Rigor::Analysis::PluginFactFingerprint::Result` misses every table, and the walk continues to `Rigor::Analysis::Result` — a real class **with an RBS declaration in `sig/rigor.rbs`** — which hits. A closed receiver plus a method it does not have is `call.undefined-method` on correct code.

The RBS-known sibling is why the issue's first minimal repro came back clean: with an in-source-only sibling nothing is closed, the chain degrades to `Dynamic`, and no rule fires. Reproducing needs three ingredients together — a nested Data constant, a same-named sibling in the parent namespace, and RBS for that sibling.

## The fix

`record_class_new_constant_decl` now recognises all four class-creating rvalue shapes (the same set `meta_new_block_body` recognises) and records each under its qualified name. Only a block-less `Class.new(Super)` still borrows its superclass's name — every other form, Data/Struct members or any block body, owns methods under its own name, which is exactly what the per-file `meta_new_constant_type` answers. The cross-file table now agrees with the per-file one at the site where they were always meant to.

This is a pure bug fix restoring intended behaviour: no documented type-model or analyzer-internal contract states which constant-write forms enter `discovered_classes`, so no spec-corpus change.

## FP safety

The change only ever replaces a *wrong* name with the *right* one or with nothing — it cannot widen a diagnostic's firing surface. A Data/Struct class discovered in source but absent from RBS is not closed, so resolving to it makes the receiver un-checkable rather than newly checkable.

Measured, not argued: `rigor check --no-cache --no-ci-detect --format=json lib` and the same over `plugins/*/lib examples/*/lib` are byte-identical before and after, modulo `wall_seconds` / `peak_rss_bytes`. Delta on `lib`: **0** (the two target FPs are currently masked by #270's `key_digest` workaround).

## Acceptance

Reverting the `key_digest` indirection locally and restoring the pre-workaround `from_registry(...).opaque?` / `.digest` call shape in `lib/rigor/protection/mutation_cache.rb`: 2 errors before the fix, **clean** after. The workaround is kept — it earns its place on its own terms, centralising the opaque⇒decline rule so a future consumer cannot key on `digest` while forgetting that an opaque surface makes it meaningless (PR #270's argument). It is no longer load-bearing.

## Specs

- `spec/rigor/analysis/nested_data_constant_cross_file_spec.rb` — a distilled two-file project with the sibling's RBS on `signature_paths:`, pinning both the two-hop factory return and the one-hop instance return. Red on master (2 failures, both `undefined method 'opaque?' for M::Result`), green here. The third example is the harness's positive control: a genuine typo on the sibling still fires, so an empty result cannot come from the analysis having quietly stopped.
- Four examples in `spec/rigor/inference/scope_indexer_spec.rb` pinning the table itself. The existing "leaves the block form to the existing meta-new machinery" example is rewritten — its assertion (`not_to eq Singleton[Object]`) still held, but its name no longer described the behaviour.

## Gates

`make verify` 0 · `git diff --check` 0 · `make docs-check` 0.
