### PR TITLE
Ship the deferred rigor-dry-schema / rigor-dry-validation ceiling slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Added
 
+- **[plugins]** `rigor-dry-validation` now refines `Contract.new.call(input).to_h` from the generic `Hash[Symbol, untyped]` RBS overlay to the Contract's own schema shape, for a Contract whose `params { ... }` or `json { ... }` block is a plain dry-schema declaration and `rigor-dry-schema` is also loaded ([#137](https://github.com/rigortype/rigor/issues/137)).
 - **[plugins]** `rigor-dry-schema` now recurses `required(:key).each do ... end` into a nested `HashShape` (an array of a nested schema, not just an array of a scalar) and reports `dry-schema.unknown-type` (info) when a `filled`/`value`/`maybe`/`each` predicate's Symbol argument isn't a recognised dry-schema type ([#137](https://github.com/rigortype/rigor/issues/137)).
 - **[engine]** `Array#first(n)` and `Array#last(n)` on a literal array now fold to the precise sub-array element types instead of the widened `Array[Elem]`, closing the last gap in the `take`/`drop`/`first`/`last` family ([#121](https://github.com/rigortype/rigor/issues/121)).
 - **[engine]** `Regexp.compile` on a constant pattern now folds to the precise `Constant[Regexp]` the same way `Regexp.new` already does, since it is a documented alias of the same C entry point ([#121](https://github.com/rigortype/rigor/issues/121)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Added
 
+- **[plugins]** `rigor-dry-validation` now reports `dry-validation.rule-key-mismatch` (error) when a `rule(:key)` call references a key absent from the Contract's own `params`/`json` schema, gated hard on both the schema and the `rule()` call being statically fully resolvable ([#137](https://github.com/rigortype/rigor/issues/137)).
 - **[plugins]** `rigor-dry-validation` now refines `Contract.new.call(input).to_h` from the generic `Hash[Symbol, untyped]` RBS overlay to the Contract's own schema shape, for a Contract whose `params { ... }` or `json { ... }` block is a plain dry-schema declaration and `rigor-dry-schema` is also loaded ([#137](https://github.com/rigortype/rigor/issues/137)).
 - **[plugins]** `rigor-dry-schema` now recurses `required(:key).each do ... end` into a nested `HashShape` (an array of a nested schema, not just an array of a scalar) and reports `dry-schema.unknown-type` (info) when a `filled`/`value`/`maybe`/`each` predicate's Symbol argument isn't a recognised dry-schema type ([#137](https://github.com/rigortype/rigor/issues/137)).
 - **[engine]** `Array#first(n)` and `Array#last(n)` on a literal array now fold to the precise sub-array element types instead of the widened `Array[Elem]`, closing the last gap in the `take`/`drop`/`first`/`last` family ([#121](https://github.com/rigortype/rigor/issues/121)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Added
 
+- **[plugins]** `rigor-dry-schema` now recurses `required(:key).each do ... end` into a nested `HashShape` (an array of a nested schema, not just an array of a scalar) and reports `dry-schema.unknown-type` (info) when a `filled`/`value`/`maybe`/`each` predicate's Symbol argument isn't a recognised dry-schema type ([#137](https://github.com/rigortype/rigor/issues/137)).
 - **[engine]** `Array#first(n)` and `Array#last(n)` on a literal array now fold to the precise sub-array element types instead of the widened `Array[Elem]`, closing the last gap in the `take`/`drop`/`first`/`last` family ([#121](https://github.com/rigortype/rigor/issues/121)).
 - **[engine]** `Regexp.compile` on a constant pattern now folds to the precise `Constant[Regexp]` the same way `Regexp.new` already does, since it is a documented alias of the same C entry point ([#121](https://github.com/rigortype/rigor/issues/121)).
 - **[engine]** `Integer#rationalize` (no-argument form) and `Integer#abs2` / `Float#abs2` on a constant receiver now fold to the exact `Rational` / squared-magnitude result instead of the widened class, closing two more small gaps in the deterministic builtin-fold backlog ([#121](https://github.com/rigortype/rigor/issues/121)).

--- a/plugins/rigor-dry-schema/README.md
+++ b/plugins/rigor-dry-schema/README.md
@@ -87,8 +87,58 @@ end
 three type-bearing predicates (`filled` / `value` / `maybe`)
 yield `list: false`. The `list:` slot is symmetric with
 `rigor-graphql`'s field-table shape so downstream cross-plugin
-consumers (a future `rigor-dry-validation` plugin) can reason
-about list-vs-scalar fields uniformly.
+consumers (`rigor-dry-validation`) can reason about
+list-vs-scalar fields uniformly.
+
+## `each do ... end` element-type recursion
+
+`each` also accepts a block instead of a type symbol, declaring
+an array of a NESTED schema rather than an array of a scalar:
+
+```ruby
+OrderSchema = Dry::Schema.Params do
+  required(:items).each do
+    required(:sku).filled(:string)
+    optional(:qty).value(:integer)
+  end
+end
+```
+
+The block is walked with the same required/optional algorithm a
+top-level `Dry::Schema.X { ... }` body uses (predicate
+vocabulary, cross-plugin alias resolution, the untyped-row
+fallback all apply identically at the nested level), and the
+row's `type:` slot becomes a nested shape rather than a class
+name:
+
+```ruby
+{
+  "OrderSchema" => {
+    required: {
+      items: {
+        type: { nested: { required: { sku: { type: "String", list: false } },
+                           optional: { qty: { type: "Integer", list: false } },
+                           unmodelled: { required: [], optional: [] } } },
+        list: true
+      }
+    },
+    optional: {}
+  }
+}
+```
+
+`each do schema do ... end end` — dry-schema's other spelling for
+the identical declaration — is recognised too; both unwrap to the
+same nested shape. `OrderSchema.call(input).to_h[:items]` types as
+`Array[{ sku: String, ?qty: Integer, ... }]`.
+
+The recursion caps at ONE level: an `each do ... end` found
+INSIDE another `each do ... end` is not modelled (the outer key
+falls back to `untyped`, the scanner's standard "declined, not
+wrong" posture for anything outside its recognised vocabulary).
+A block with no recognisable `required`/`optional` row at all — a
+bare per-element predicate like `each { int? }` — declines the
+same way.
 
 ## Predicate type recognition
 
@@ -152,23 +202,37 @@ The slice-1 deliverable is the **floor**:
   alias resolution.
 - Publishes the table; no user-facing diagnostics yet.
 
-**Landed since**: **typed `result.to_h` returns**.
-`NewUserSchema.call(input).to_h` infers
-`{ email: String, age: Integer, ?nickname: String, ... }`
-instead of an untyped hash. See § "Typed `result.to_h`" below.
+**Landed since**:
 
-The **ceiling** (future slices, demand-driven):
+- **Typed `result.to_h` returns**. `NewUserSchema.call(input).to_h`
+  infers `{ email: String, age: Integer, ?nickname: String, ... }`
+  instead of an untyped hash. See § "Typed `result.to_h`" below.
+- **`each do ... end` element-type recursion** (issue #137). See
+  § "`each do ... end` element-type recursion" above.
+- **`dry-schema.unknown-type` `:info` diagnostic** (issue #137).
+  See § "Diagnostics" below.
+- **`rigor-dry-validation` integration** (issue #137) — landed in
+  that plugin's own slices 2/3, not here: a Contract's inline
+  `params { ... }` / `json { ... }` block is walked with the
+  SAME DSL vocabulary this plugin defines, refining
+  `Contract#call(...).to_h`. See
+  [`rigor-dry-validation`'s README](../rigor-dry-validation/README.md).
 
-- **Nested schemas** (`schema(do ... end)` inside another row).
-- **`predicates(:size?)` / per-row constraint walks**.
-- **`each { ... }` element-type recursion**.
-- **Per-row diagnostics** — `dry-schema.unknown-predicate` /
-  `dry-schema.unknown-type` `:info` when a row's predicate or
-  type symbol isn't recognised.
-- **`rigor-dry-validation` integration** — Contract subclasses
-  whose `params { ... }` block delegates to a dry-schema
-  declaration would consume `:dry_schema_table` for typed
-  `Contract#call → Result` payloads.
+The **ceiling** (still open, demand-driven):
+
+- **Nested schemas outside `each`** (`required(:x).schema do ... end`
+  with no `each` in the chain) — the key stays untyped; only the
+  `each`-wrapped nested form (above) recurses.
+- **`predicates(:size?)` / other per-row constraint walks.**
+- **`dry-schema.unknown-predicate` diagnostic** — deliberately not
+  shipped. There's no reliable static signal that distinguishes a
+  genuinely-mistyped predicate name from one of dry-schema's many
+  legitimate fine-grained predicates (`size?` / `gt?` / `format?` /
+  `included_in?` / ...) this scanner doesn't model, and a bare
+  `required(:key)` with no type-bearing predicate at all is itself
+  valid dry-schema (a presence-only check). Guessing here would
+  flag correct code — the `AGENTS.md` "false positives outrank
+  worst-case reading" call, applied by declining.
 
 ## Typed `result.to_h`
 
@@ -214,9 +278,33 @@ site (`NewUserSchema.call(x).to_h`). Reached through a local or
 by a relative constant path from inside the declaring module,
 the chain contributes nothing and `to_h` types as it did before.
 
+## Diagnostics
+
+`dry-schema.unknown-type` (`:info`) fires when a type-bearing
+predicate (`filled` / `value` / `maybe` / `each`) receives a
+literal Symbol argument that is NOT one of the canonical dry-schema
+type symbols in the table above:
+
+```ruby
+Schema = Dry::Schema.Params do
+  required(:count).filled(:integr)   # typo for :integer
+end
+# → info: `count` uses `:integr`, which is not a recognised
+#   dry-schema canonical type symbol [dry-schema.unknown-type]
+```
+
+It does NOT fire for a Constant argument
+(`value(Types::Email)`) — an unresolved alias already has the
+silent fallback described above, and flagging it would misfire on
+every entirely-correct row in a project that simply doesn't have
+`rigor-dry-types` loaded. It recurses into an `each do ... end`
+nested row too, so a bad symbol on a nested key is caught at its
+own position.
+
 ## What the plugin does NOT do (yet)
 
-- Emit diagnostics for unknown predicates / types / keys.
+- Emit `dry-schema.unknown-predicate` (see § "Floor / ceiling"
+  for why) or any per-row key-existence diagnostic.
 - Round-trip the schema table through the cache descriptor —
   `prepare(services)` re-scans on every run. Add a glob-based
   `Cache::Descriptor::FileEntry` when scan cost becomes

--- a/plugins/rigor-dry-schema/demo/demo.rb
+++ b/plugins/rigor-dry-schema/demo/demo.rb
@@ -40,3 +40,21 @@ payload = NewUserSchema.call({}).to_h
 Rigor.dump_type(payload)
 Rigor.dump_type(payload[:email])
 Rigor.dump_type(payload[:nickname])
+
+# `each do ... end` element-type recursion (issue #137's ceiling): the nested block is walked with the
+# same required/optional algorithm as a top-level schema body, so `items` types as an Array of the
+# nested HashShape rather than untyped.
+OrderSchema = Dry::Schema.Params do
+  required(:items).each do
+    required(:sku).filled(:string)
+    optional(:qty).value(:integer)
+  end
+end
+
+Rigor.dump_type(OrderSchema.call({}).to_h)
+
+# `dry-schema.unknown-type` — an `:info` diagnostic for a type-bearing predicate's Symbol argument
+# outside the canonical vocabulary. A typo, most likely — `rigor check` reports it below.
+TypoSchema = Dry::Schema.Params do
+  required(:count).filled(:integr)
+end

--- a/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema.rb
+++ b/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema.rb
@@ -63,12 +63,18 @@ module Rigor
     # ADR-16 Tier C substrate the README originally projected — Tier C synthesises methods on a class
     # from a class-level DSL call, and this is a return type for a call chain off a constant.
     #
-    # The **ceiling** (slice 2+):
+    # Landed since (issue #137): `each do ... end` element-type recursion ({SchemaScanner#each_block_type_info})
+    # and the `dry-schema.unknown-type` `:info` diagnostic ({SchemaScanner#unknown_type_issues}), wired
+    # below via {.node_file_context} + {.node_rule}.
     #
-    # - Nested schemas (`schema(do ... end)` inside another row) — the key is currently kept as untyped.
-    # - `predicates(:size?)` / `each { ... }` recursion.
-    # - Per-row `dry-schema.unknown-predicate` / `dry-schema.unknown-type` `:info` diagnostics when a
-    #   row's predicate or type symbol isn't recognised.
+    # The **ceiling** (still open):
+    #
+    # - Nested schemas OUTSIDE an `each` (`required(:x).schema do ... end` with no `each` in the chain) —
+    #   the key is still kept as untyped; only the `each`-wrapped nested form recurses.
+    # - `predicates(:size?)` / other fine-grained predicate constraint walks.
+    # - `dry-schema.unknown-predicate` — deliberately NOT shipped; see {SchemaScanner.unknown_type_issues}
+    #   for why (no reliable static signal without a full predicate registry; risks flagging correct code).
+    # - `rigor-dry-validation` integration — landed separately in that plugin's own slices 2/3 (issue #137).
     class DrySchema < Rigor::Plugin::Base
       manifest(
         id: "dry-schema",
@@ -91,6 +97,32 @@ module Rigor
       # first act rejects any chain that is not `<Const>.call(...).to_h` before the table is touched.
       dynamic_return methods: [:to_h] do |call_node, _scope|
         result_shape_for(call_node)
+      end
+
+      # ADR-37 slice 1c two-pass: the "collect" half of `dry-schema.unknown-type` (issue #137's ceiling
+      # diagnostic). Walks the already-parsed file root once via {SchemaScanner.unknown_type_issues}; the
+      # `node_rule` below is the "validate" half that turns each collected issue into a Diagnostic.
+      node_file_context do |root, _scope|
+        SchemaScanner.unknown_type_issues(root)
+      end
+
+      # Fires exactly once per file: `Prism::ProgramNode` is the AST root, and the engine's node walker
+      # visits the root itself before descending (see `Source::NodeWalker#walk_with_ancestors`). Cheaper
+      # than a `Prism::CallNode` rule re-matching every call site in the file — the collect pass already
+      # did the real walk.
+      node_rule Prism::ProgramNode do |_node, _scope, path, issues|
+        next [] if issues.nil? || issues.empty?
+
+        issues.map do |issue|
+          diagnostic(
+            issue[:node],
+            path: path,
+            message: "`#{issue[:key]}` uses `:#{issue[:symbol]}`, which is not a recognised dry-schema " \
+                     "canonical type symbol (see the plugin README's predicate type table)",
+            severity: :info,
+            rule: "dry-schema.unknown-type"
+          )
+        end
       end
 
       # Walks every project file once during `prepare(services)` to build the schema table, then publishes

--- a/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema/result_shape.rb
+++ b/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema/result_shape.rb
@@ -98,10 +98,20 @@ module Rigor
         end
 
         def row_type(row)
-          element = class_type(row[:type])
+          element = element_type(row[:type])
           return nil if element.nil?
 
           row[:list] ? Rigor::Type::Combinator.nominal_of("Array", type_args: [element]) : element
+        end
+
+        # `type` is either a class-name String (the scalar case) or a `{nested: <shape>}` Hash — an
+        # `each do ... end` element-type recursion (issue #137's ceiling slice): {SchemaScanner} already
+        # collected the nested block with the same `collect_schema_shape` algorithm a top-level schema
+        # body uses, so building its HashShape is just a recursive {.build} call.
+        def element_type(type)
+          return build(type[:nested]) if type.is_a?(Hash)
+
+          class_type(type)
         end
 
         def class_type(class_name)

--- a/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema/schema_scanner.rb
+++ b/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema/schema_scanner.rb
@@ -67,6 +67,84 @@ module Rigor
         end
         private_class_method :scan_file
 
+        # Per-row `dry-schema.unknown-type` diagnostics (ceiling slice, issue #137). Walks an
+        # ALREADY-PARSED file's root node — the engine parses every analysed file once, so this reuses
+        # that AST rather than re-reading and re-parsing the file — collecting `{node:, key:, symbol:}`
+        # issues for a `required(:key).<verb>(:sym)` / `optional(:key).<verb>(:sym)` row whose
+        # type-bearing predicate (`filled` / `value` / `maybe` / `each`) receives a literal Symbol argument
+        # OUTSIDE `CANONICAL_TYPES`. Recurses into `each do ... end` nested rows (mirrors
+        # {#each_block_type_info}) so a nested row's bad symbol is caught too.
+        #
+        # A Constant argument (`value(Types::Email)`) is never flagged: an unresolved alias already has a
+        # silent, deliberate fallback (no `:dry_type_aliases` fact, or a name the fact doesn't know) per
+        # the existing slice-1 "drops constant-type references..." behaviour, and this diagnostic firing
+        # on it would misfire on every entirely-correct `value(Types::Email)` row in a project that simply
+        # doesn't have `rigor-dry-types` loaded.
+        #
+        # `dry-schema.unknown-predicate` (the OTHER ceiling diagnostic the README named) is deliberately
+        # NOT implemented: distinguishing a genuinely-unrecognised predicate NAME from one of dry-schema's
+        # many legitimate fine-grained predicates (`size?`, `gt?`, `format?`, `included_in?`, ...) that
+        # this scanner simply doesn't model would need a complete predicate registry this plugin doesn't
+        # have, and a `required(:key)` row with NO type-bearing predicate at all is itself entirely
+        # legitimate dry-schema (a presence-only check). Guessing here risks flagging correct code — the
+        # AGENTS.md "false positives outrank worst-case reading" call, applied by declining.
+        def unknown_type_issues(root)
+          issues = []
+          walk_for_unknown_type(root, issues)
+          issues
+        end
+
+        def walk_for_unknown_type(node, issues)
+          return if node.nil?
+
+          if node.is_a?(Prism::CallNode) && schema_entry_call?(node) && node.block
+            collect_row_issues(node.block, issues)
+          end
+          node.compact_child_nodes.each { |child| walk_for_unknown_type(child, issues) }
+        end
+        private_class_method :walk_for_unknown_type
+
+        def collect_row_issues(block_node, issues)
+          body = block_node.body
+          return if body.nil?
+
+          children = body.is_a?(Prism::StatementsNode) ? body.body : [body]
+          children.each { |child| visit_chain_for_issues(child, issues) }
+        end
+        private_class_method :collect_row_issues
+
+        def visit_chain_for_issues(node, issues)
+          return unless node.is_a?(Prism::CallNode)
+
+          key, = extract_key_and_kind(node)
+          return if key.nil?
+
+          current = node
+          while current.is_a?(Prism::CallNode)
+            if current.name == :each && current.block
+              collect_row_issues(nested_block_body(current.block), issues)
+              return
+            end
+            if TYPE_BEARING_PREDICATES.include?(current.name)
+              record_unknown_type_issue(current, key, issues)
+              return
+            end
+            current = current.receiver
+          end
+        end
+        private_class_method :visit_chain_for_issues
+
+        def record_unknown_type_issue(call_node, key, issues)
+          arg = call_node.arguments&.arguments&.first
+          return unless arg.is_a?(Prism::SymbolNode)
+
+          symbol = arg.unescaped.to_sym
+          return if CANONICAL_TYPES.key?(symbol)
+
+          issues << { node: call_node, key: key, symbol: symbol }
+        end
+        private_class_method :record_unknown_type_issue
+
         # Walks the AST collecting `<Const> = Dry::Schema.X { ... }` assignments at any nesting level.
         # Tracks the enclosing constant chain so a class-level `class Foo; SCHEMA = Dry::Schema.Params
         # { ... }; end` registers as `"Foo::SCHEMA"`.
@@ -102,7 +180,7 @@ module Rigor
           return {} unless rhs.is_a?(Prism::CallNode) && rhs.block
 
           schema_const = (qualified_prefix + [node.name.to_s]).join("::")
-          shape = collect_schema_shape(rhs.block, type_aliases)
+          shape = collect_schema_shape(rhs.block, type_aliases, nested: false)
           { schema_const => shape }
         end
         private_class_method :collect_schema_assignment
@@ -120,11 +198,18 @@ module Rigor
         end
         private_class_method :schema_entry_call?
 
-        def collect_schema_shape(block_node, type_aliases)
+        # `nested:` is false at the top-level `Dry::Schema.X { ... }` body and true inside an `each do
+        # ... end` row's own recursive call (see {#each_block_type_info}). It caps the recursion at ONE
+        # level deep: with `nested: true`, {#walk_predicate_chain} declines a FURTHER `each do ... end`
+        # rather than recursing again (issue #137 deliberately does not model doubly-nested arrays of
+        # arrays). This also keeps `collect_schema_shape` from calling itself — {#each_block_type_info}
+        # is the only caller that ever passes `nested: true}` — so the call graph has no cycle for the
+        # engine's return-type inference to approximate through.
+        def collect_schema_shape(block_node, type_aliases, nested:)
           required = {}
           optional = {}
           declared = { required: [], optional: [] }
-          walk_block_body(block_node) do |kind, key, type_info|
+          walk_block_body(block_node, type_aliases, nested) do |kind, key, type_info|
             declared[kind] << key
             (kind == :required ? required : optional)[key] = type_info if type_info
           end
@@ -142,13 +227,15 @@ module Rigor
 
         # Walks every top-level `required(:key).<predicate>(...)` / `optional(:key).<predicate>(...)`
         # chain in the block body. The block's body is either a `Prism::StatementsNode` (multi-statement)
-        # or a single expression node.
-        def walk_block_body(block_node, &)
+        # or a single expression node. `type_aliases` threads down to a nested `each do ... end` row's own
+        # recursive {#collect_schema_shape} call (slice 2's alias resolution applies at every nesting
+        # depth, not just the top level).
+        def walk_block_body(block_node, type_aliases, nested, &)
           body = block_node.body
           return if body.nil?
 
           children = body.is_a?(Prism::StatementsNode) ? body.body : [body]
-          children.each { |child| visit_chain(child, &) }
+          children.each { |child| visit_chain(child, type_aliases, nested, &) }
         end
         private_class_method :walk_block_body
 
@@ -157,13 +244,13 @@ module Rigor
         # the chain's tail. The `each(<Type>)` predicate yields a list-of-element type info (`{type: <T>,
         # list: true}`); other type-bearing predicates (`filled`/`value`/`maybe`) yield scalar info
         # (`{type: <T>, list: false}`).
-        def visit_chain(node, &block)
+        def visit_chain(node, type_aliases, nested, &block)
           return unless node.is_a?(Prism::CallNode)
 
           key, kind = extract_key_and_kind(node)
           return if key.nil?
 
-          type_info = walk_predicate_chain(node)
+          type_info = walk_predicate_chain(node, type_aliases, nested)
           block.call(kind, key, type_info)
         end
         private_class_method :visit_chain
@@ -189,9 +276,19 @@ module Rigor
         # Walks the call chain finding the first type-bearing predicate (`filled` / `value` / `maybe` /
         # `each`) and extracts its argument type. Returns a `{type:, list:}` tuple (`each` is the only
         # verb that produces a list) or nil when no recognisable type sits on the chain.
-        def walk_predicate_chain(node)
+        #
+        # `each do ... end` (a block instead of a type-symbol argument) is the ceiling's element-type
+        # recursion (issue #137): the block is itself a nested schema declaration, walked with the SAME
+        # algorithm as a top-level `Dry::Schema.X { ... }` body via {#each_block_type_info}. Already
+        # `nested` (i.e. this chain is itself inside another `each do ... end`) declines a FURTHER each —
+        # see {#collect_schema_shape}'s `nested:` doc for why the recursion caps at one level.
+        def walk_predicate_chain(node, type_aliases, nested)
           current = node
           while current.is_a?(Prism::CallNode)
+            if current.name == :each && current.block
+              return nested ? nil : each_block_type_info(current.block, type_aliases)
+            end
+
             if TYPE_BEARING_PREDICATES.include?(current.name)
               underlying = extract_type_from_predicate(current)
               return { type: underlying, list: current.name == :each } if underlying
@@ -201,6 +298,40 @@ module Rigor
           nil
         end
         private_class_method :walk_predicate_chain
+
+        # `required(:key).each do ... end` — recurses into the each-block using {#collect_schema_shape},
+        # the identical row-collection algorithm a top-level schema body uses, so a nested `required` /
+        # `optional` row gets the same predicate vocabulary, alias resolution, and untyped-row fallback as
+        # the outer schema. Two spellings are recognised: the bare `each do required(:x)...; end` form, and
+        # `each do schema do required(:x)...; end end` (dry-schema's alternate nested-hash spelling) via
+        # {#nested_block_body}.
+        #
+        # A block that yields no row at all — a bare per-element predicate like `each { int? }`, which
+        # this scanner does not model — declines (nil) rather than returning an empty nested shape: the key
+        # falls through to {#unmodelled_keys} and renders `untyped`, the same "declined, not wrong" posture
+        # every other unresolvable row already gets.
+        def each_block_type_info(each_block, type_aliases)
+          nested_shape = collect_schema_shape(nested_block_body(each_block), type_aliases, nested: true)
+          return nil if nested_shape[:required].empty? && nested_shape[:optional].empty?
+
+          { type: { nested: nested_shape }, list: true }
+        end
+        private_class_method :each_block_type_info
+
+        # Unwraps the `each do schema do ... end end` spelling to the inner `schema` block; the bare
+        # `each do required(...); ...; end` spelling passes the each-block through unchanged. Both declare
+        # the same nested key set, just at a different literal nesting depth.
+        def nested_block_body(each_block)
+          body = each_block.body
+          return each_block if body.nil?
+
+          children = body.is_a?(Prism::StatementsNode) ? body.body : [body]
+          return each_block unless children.size == 1
+
+          single = children.first
+          single.is_a?(Prism::CallNode) && single.name == :schema && single.block ? single.block : each_block
+        end
+        private_class_method :nested_block_body
 
         # Reads the first positional argument of a `filled(:string)` / `value(:integer)` /
         # `maybe(Types::Email)` call. Returns either the canonical-type-symbol's underlying class
@@ -240,11 +371,15 @@ module Rigor
         # (e.g. `"Types::Email"`) gets resolved through the type_aliases fact. Unresolvable values drop
         # from the bucket (no fact contribution rather than misleading data). The `list:` slot rides along
         # unchanged.
+        #
+        # A nested-shape row (`type: {nested: {...}}`, from an `each do ... end` element-type recursion)
+        # is already fully resolved by its own recursive {#collect_schema_shape} call — its `type:` slot is
+        # a Hash, not a class-name String, and is skipped here rather than treated as an unresolvable alias.
         def remap_aliases!(bucket, type_aliases)
           canonical_set = CANONICAL_TYPES.values.to_set
           bucket.each_pair.to_a.each do |key, info|
             type_name = info.fetch(:type)
-            next if canonical_set.include?(type_name)
+            next if type_name.is_a?(Hash) || canonical_set.include?(type_name)
 
             resolved = type_aliases[type_name]
             if resolved

--- a/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema/schema_scanner.rb
+++ b/plugins/rigor-dry-schema/lib/rigor/plugin/dry_schema/schema_scanner.rb
@@ -198,6 +198,14 @@ module Rigor
         end
         private_class_method :schema_entry_call?
 
+        # PUBLIC reuse surface (issue #137 slices 2/3): `rigor-dry-validation`'s `params { ... }` /
+        # `json { ... }` block body is the SAME dry-schema DSL a top-level `Dry::Schema.X { ... }` body
+        # is, so that plugin delegates here instead of duplicating the required/optional walk — the
+        # `docs/design/20260517-dry-validation-slicing.md` slicing note's own "delegate to
+        # rigor-dry-schema's walker" option. Only reachable from another plugin when `rigor-dry-schema`
+        # is registered (the caller checks `Rigor::Plugin.registered_for("dry-schema")` first — that is
+        # also what makes THIS class already loaded/defined for the caller to reference).
+        #
         # `nested:` is false at the top-level `Dry::Schema.X { ... }` body and true inside an `each do
         # ... end` row's own recursive call (see {#each_block_type_info}). It caps the recursion at ONE
         # level deep: with `nested: true`, {#walk_predicate_chain} declines a FURTHER `each do ... end`
@@ -223,7 +231,6 @@ module Rigor
             unmodelled: unmodelled_keys(declared, required, optional)
           }.freeze
         end
-        private_class_method :collect_schema_shape
 
         # Walks every top-level `required(:key).<predicate>(...)` / `optional(:key).<predicate>(...)`
         # chain in the block body. The block's body is either a `Prism::StatementsNode` (multi-statement)

--- a/plugins/rigor-dry-validation/README.md
+++ b/plugins/rigor-dry-validation/README.md
@@ -11,6 +11,12 @@ cross-plugin fact. Ships an RBS overlay typing
 `Contract#call` / `Result#success?` / `Result#failure?` /
 `Result#to_h` / `Result#errors` / `Result#[]`.
 
+With `rigor-dry-schema` also loaded, a Contract's `params { ... }` /
+`json { ... }` block — the SAME dry-schema DSL a top-level
+`Dry::Schema.X { ... }` body uses — refines `result.to_h` from the
+RBS overlay's generic `Hash[Symbol, untyped]` to the schema-typed
+`HashShape`. See § "params / json integration" below.
+
 > **Using this plugin?** The user guide lives in the manual at
 > [docs/manual/plugins/rigor-dry-validation.md](../../docs/manual/plugins/rigor-dry-validation.md).
 > This README covers the plugin's internals.
@@ -71,13 +77,76 @@ With the overlay loaded:
 ```ruby
 result = NewUserContract.new.call(input)  # Dry::Validation::Result
 result.success?                            # bool
-result.to_h                                # Hash[Symbol, untyped]
-result.errors                              # untyped (refined in slice 2)
+result.to_h                                # Hash[Symbol, untyped] — refined below, with rigor-dry-schema
+result.errors                              # untyped (still — no ceiling slice targets this)
 ```
+
+## `params` / `json` integration (slices 2/3)
+
+With `rigor-dry-schema` also loaded, `prepare(services)` walks
+every recognised Contract's class body for a TOP-LEVEL, bare
+`params do ... end` and/or `json do ... end` call — a direct
+class-body statement, no receiver, no positional/keyword
+arguments, exactly one block. The block is the SAME dry-schema
+DSL a top-level `Dry::Schema.X { ... }` body uses (`required` /
+`optional` / `filled` / `value` / `maybe` / `each`), so this
+plugin delegates the actual walk to
+`Rigor::Plugin::DrySchema::SchemaScanner.collect_schema_shape`
+rather than duplicating it — the
+[slicing plan](../../docs/design/20260517-dry-validation-slicing.md)'s
+own "delegate to rigor-dry-schema's walker" option.
+
+```ruby
+class NewUserContract < Dry::Validation::Contract
+  params do
+    required(:email).filled(:string)
+    required(:age).value(:integer)
+  end
+end
+```
+
+publishes the `:dry_validation_params` fact:
+
+```ruby
+{
+  "NewUserContract" => {
+    params: {
+      required: { email: { type: "String", list: false },
+                  age:   { type: "Integer", list: false } },
+      optional: {},
+      unmodelled: { required: [], optional: [] }
+    }
+  }
+}
+```
+
+and refines `NewUserContract.new.call(input).to_h` from the RBS
+overlay's generic `Hash[Symbol, untyped]` to
+`{ email: String, age: Integer, ... }` — the identical
+required/optional-preserving, open-shape HashShape build
+rigor-dry-schema's own `ResultShape.build` uses (delegated to,
+not duplicated). `json { ... }` works identically under a
+`json:` key; a Contract with BOTH blocks (unusual) prefers
+`params` for the `to_h` refinement.
+
+The chain recognised is `<Const>.new.call(...).to_h` — the
+Contract must be named by a constant as written at the call
+site, matching rigor-dry-schema's own floor for `SomeSchema.call(x).to_h`.
+Reached through a local, the chain contributes nothing and
+`to_h` types per the RBS overlay as before.
+
+A `params { ... }` / `json { ... }` call that ISN'T a bare,
+top-level class-body statement — wrapped in a conditional, built
+via a method call, given positional arguments — is not
+recognised; the Contract simply has no entry in
+`:dry_validation_params` and `to_h` keeps the generic overlay
+shape. Without `rigor-dry-schema` loaded at all, this whole
+section is inert: the plugin ships no required/optional walker
+of its own.
 
 ## Floor / ceiling
 
-Slice 1 ships the **floor**:
+Slice 1 shipped the **floor**:
 
 - Contract subclass recognition (full-path
   `Dry::Validation::Contract` AND lexical-Dry path
@@ -88,34 +157,34 @@ Slice 1 ships the **floor**:
   `Result#to_h` returns `Hash[Symbol, untyped]`.
 - No user-facing diagnostics yet.
 
-The **ceiling** (deferred to demand):
+**Landed since** (issue #137): **slices 2/3** — `params { ... }` /
+`json { ... }` integration with `rigor-dry-schema`, refining
+`result.to_h` per-Contract. See § "`params` / `json` integration"
+above.
 
-- **Slice 2 — params block integration with dry-schema.**
-  When `rigor-dry-schema` is loaded and a Contract's
-  `params { ... }` block delegates to a schema, refine
-  `result.to_h` to the typed `HashShape[{email: String,
-  age: Integer}]` per the schema's published fact
-  (`:dry_schema_table`). Today's RBS overlay's generic
-  `Hash[Symbol, untyped]` becomes the schema-typed shape.
-- **Slice 3 — `json { ... }` adapter parity.** Same shape as
-  slice 2 but for the `json` block adapter.
+The **ceiling** (still open):
+
 - **Per-Contract diagnostics.** E.g. `rule(:nonexistent_key)`
   references a key not in the `params { ... }` schema → emit
   `dry-validation.rule-key-mismatch`.
 
 ## What the plugin does NOT do (yet)
 
-- Synthesise typed `result.to_h` shapes per Contract
-  (deferred to slice 2; needs dry-schema integration).
-- Recognise `rule { ... }` blocks for key validation.
-- Emit `dry-validation.*` diagnostics.
-- Round-trip the contract list through the cache descriptor —
+- Recognise `rule { ... }` blocks for key validation, or emit
+  any `dry-validation.*` diagnostic (see § "Floor / ceiling").
+- Refine `result.errors` — it stays `untyped` regardless of
+  whether `rigor-dry-schema` is loaded.
+- Recognise a `params(SomeSchema)` / `json(SomeSchema)` form
+  that delegates to an EXTERNALLY-declared schema by reference
+  — only the inline block form is recognised.
+- Round-trip either fact through the cache descriptor —
   `prepare(services)` re-scans on every run.
 
 ## Configuration
 
 ```yaml
 plugins:
+  - rigor-dry-schema       # optional; enables the params/json → to_h refinement
   - rigor-dry-validation
 ```
 
@@ -136,7 +205,8 @@ entry's `.rb` files looking for the Contract subclass shape.
 - [`rigor-dry-types`](../rigor-dry-types/) — Tier A foundation
   publishing `:dry_type_aliases`.
 - [`rigor-dry-schema`](../rigor-dry-schema/) — Tier A publishing
-  `:dry_schema_table`; future consumer for slice 2's per-Contract
-  `result.to_h` typing.
+  `:dry_schema_table`; slices 2/3 delegate to its
+  `SchemaScanner.collect_schema_shape` / `ResultShape.build` for
+  the per-Contract `result.to_h` typing above.
 - [`rigor-dry-struct`](../rigor-dry-struct/) — the first dry-rb
   consumer plugin (Tier C macro substrate).

--- a/plugins/rigor-dry-validation/README.md
+++ b/plugins/rigor-dry-validation/README.md
@@ -15,7 +15,9 @@ With `rigor-dry-schema` also loaded, a Contract's `params { ... }` /
 `json { ... }` block — the SAME dry-schema DSL a top-level
 `Dry::Schema.X { ... }` body uses — refines `result.to_h` from the
 RBS overlay's generic `Hash[Symbol, untyped]` to the schema-typed
-`HashShape`. See § "params / json integration" below.
+`HashShape`, and a `rule(:key)` referencing a key absent from that
+schema draws `dry-validation.rule-key-mismatch`. See §§ "params /
+json integration" and "Diagnostics" below.
 
 > **Using this plugin?** The user guide lives in the manual at
 > [docs/manual/plugins/rigor-dry-validation.md](../../docs/manual/plugins/rigor-dry-validation.md).
@@ -144,6 +146,49 @@ shape. Without `rigor-dry-schema` loaded at all, this whole
 section is inert: the plugin ships no required/optional walker
 of its own.
 
+## Diagnostics
+
+`dry-validation.rule-key-mismatch` (`:error`) fires when a
+`rule(:key, ...) do ... end` call references a key the Contract's
+own `params`/`json` schema never declares:
+
+```ruby
+class NewUserContract < Dry::Validation::Contract
+  params do
+    required(:email).filled(:string)
+  end
+
+  rule(:handle) do   # :handle isn't a params key — typo for :email?
+    key.failure("nope")
+  end
+end
+# → error: rule(:handle) references a key not declared by
+#   `NewUserContract`'s params/json schema (did you mean `:email`?)
+#   [dry-validation.rule-key-mismatch]
+```
+
+It requires TWO independent all-or-nothing checks to pass before
+it fires at all, either of which silently declines the WHOLE
+Contract (not just the ambiguous part) rather than risk a false
+positive:
+
+1. **The Contract's key universe must be cleanly resolved.** Every
+   top-level statement in every `params`/`json` block must be a
+   recognised `required`/`optional` row (typed or not — an
+   unmodelled row is still a DECLARED key) or the inert
+   `config.<x> = <literal>` idiom. A loop building keys
+   dynamically, a splat, an `include`, or anything else the scanner
+   doesn't recognise makes the Contract's ENTIRE key set
+   untrustworthy, and no `rule()` call in it is checked.
+2. **The `rule(...)` call's own arguments must all be literal
+   Symbols.** A splat (`rule(*keys)`), a String, a local variable,
+   or the nested-key Hash form (`rule(user: [:name])`) makes that
+   WHOLE call unresolvable, and it is skipped rather than partially
+   validated.
+
+Without `rigor-dry-schema` loaded, this diagnostic never fires —
+there is no key universe to check a `rule()` call against.
+
 ## Floor / ceiling
 
 Slice 1 shipped the **floor**:
@@ -157,21 +202,22 @@ Slice 1 shipped the **floor**:
   `Result#to_h` returns `Hash[Symbol, untyped]`.
 - No user-facing diagnostics yet.
 
-**Landed since** (issue #137): **slices 2/3** — `params { ... }` /
-`json { ... }` integration with `rigor-dry-schema`, refining
-`result.to_h` per-Contract. See § "`params` / `json` integration"
-above.
+**Landed since** (issue #137):
 
-The **ceiling** (still open):
+- **Slices 2/3** — `params { ... }` / `json { ... }` integration
+  with `rigor-dry-schema`, refining `result.to_h` per-Contract.
+  See § "`params` / `json` integration" above.
+- **`dry-validation.rule-key-mismatch`.** See § "Diagnostics"
+  above.
 
-- **Per-Contract diagnostics.** E.g. `rule(:nonexistent_key)`
-  references a key not in the `params { ... }` schema → emit
-  `dry-validation.rule-key-mismatch`.
+This closes every checkbox issue #137 opened for this plugin; the
+ceiling is empty pending fresh demand.
 
-## What the plugin does NOT do (yet)
+## What the plugin does NOT do
 
-- Recognise `rule { ... }` blocks for key validation, or emit
-  any `dry-validation.*` diagnostic (see § "Floor / ceiling").
+- Recognise `rule { ... }` blocks for anything beyond the
+  flat-Symbol-arguments key-existence check above — no nested-key
+  form, no cross-rule reasoning, no business-logic evaluation.
 - Refine `result.errors` — it stays `untyped` regardless of
   whether `rigor-dry-schema` is loaded.
 - Recognise a `params(SomeSchema)` / `json(SomeSchema)` form

--- a/plugins/rigor-dry-validation/demo/.rigor.dist.yml
+++ b/plugins/rigor-dry-validation/demo/.rigor.dist.yml
@@ -2,6 +2,7 @@ paths:
   - demo.rb
 
 plugins:
+  - rigor-dry-schema
   - rigor-dry-validation
 
 signature_paths:

--- a/plugins/rigor-dry-validation/demo/demo.rb
+++ b/plugins/rigor-dry-validation/demo/demo.rb
@@ -3,7 +3,7 @@
 # rigor-dry-validation demo. Run from this directory:
 #
 #   cp .rigor.dist.yml .rigor.yml
-#   RUBYLIB=$PWD/../lib bundle exec rigor check
+#   RUBYLIB=$PWD/../lib:$PWD/../../rigor-dry-schema/lib bundle exec rigor check
 #
 # The canonical Dry::Validation::Contract subclass shapes: fully-qualified and lexical-Dry-nested. With
 # the plugin enabled, rigor's `prepare(services)` hook scans this file, sees both subclasses, and
@@ -12,6 +12,10 @@
 # The shipped RBS overlay (sig/dry_validation.rbs, wired via the `signature_paths:` config) types
 # `contract.call(input)` as returning `Dry::Validation::Result`, so the chained `.success?` / `.to_h`
 # queries below resolve cleanly.
+#
+# With rigor-dry-schema ALSO loaded (this demo's `.rigor.dist.yml` lists both), slices 2/3 (issue #137)
+# refine `result.to_h` further: instead of the RBS overlay's generic `Hash[Symbol, untyped]`, it types
+# per this Contract's own `params { ... }` block.
 
 class NewUserContract < Dry::Validation::Contract
   params do
@@ -41,3 +45,8 @@ if result.success?
 else
   puts result.errors.inspect
 end
+
+# Slices 2/3 (issue #137): `Rigor.dump_type` shows the refined shape —
+#   { email: String, age: Integer, ... }
+# instead of the RBS overlay's generic `Hash[Symbol, untyped]`.
+Rigor.dump_type(NewUserContract.new.call(email: "alice@example.com", age: 17).to_h)

--- a/plugins/rigor-dry-validation/demo/demo.rb
+++ b/plugins/rigor-dry-validation/demo/demo.rb
@@ -50,3 +50,15 @@ end
 #   { email: String, age: Integer, ... }
 # instead of the RBS overlay's generic `Hash[Symbol, untyped]`.
 Rigor.dump_type(NewUserContract.new.call(email: "alice@example.com", age: 17).to_h)
+
+# dry-validation.rule-key-mismatch (issue #137): `rule(:handle)` references a key that
+# NewUserContract's own `params { ... }` block never declares — `rigor check` reports it below.
+class TypoContract < Dry::Validation::Contract
+  params do
+    required(:email).filled(:string)
+  end
+
+  rule(:handle) do
+    key.failure("nope")
+  end
+end

--- a/plugins/rigor-dry-validation/lib/rigor/plugin/dry_validation.rb
+++ b/plugins/rigor-dry-validation/lib/rigor/plugin/dry_validation.rb
@@ -5,6 +5,7 @@ require "prism"
 require "rigor/plugin"
 
 require_relative "dry_validation/contract_scanner"
+require_relative "dry_validation/params_shape"
 
 module Rigor
   module Plugin
@@ -21,13 +22,20 @@ module Rigor
     #   Result) and `Dry::Validation::Result#{success?, failure?, to_h}`. The manifest's
     #   `signature_paths: ["sig"]` auto-contributes the overlay (ADR-25) — no project-side wiring needed.
     #
-    # Slice 2 (deferred, per design note):
+    # Landed since (issue #137):
     #
-    # - Integrate with `:dry_schema_table` (published by `rigor-dry-schema`) so the `params { ... }`
-    #   block inside a Contract contributes a typed `result.to_h` shape per the schema. Until this lands,
-    #   `result.to_h` types as `Hash[Symbol, untyped]` (the generic RBS overlay shape).
+    # - **Slice 2** — when `rigor-dry-schema` is loaded, a Contract's `params { ... }` block (the SAME
+    #   dry-schema DSL a top-level `Dry::Schema.X { ... }` body uses) refines
+    #   `NewUserContract.new.call(input).to_h` from the RBS overlay's generic `Hash[Symbol, untyped]` to
+    #   the schema-typed `HashShape`. See {ContractScanner.scan_schema_blocks} + {ParamsShape}.
+    # - **Slice 3** — `json { ... }` adapter parity with `params { ... }`. Same mechanism, same fact.
     #
-    # Slice 3 (deferred): `json { ... }` adapter parity with `params { ... }`. Same shape as slice 2.
+    # Without `rigor-dry-schema` loaded, `result.to_h` still types per the RBS overlay's generic
+    # `Hash[Symbol, untyped]` — this plugin ships no required/optional walker of its own; it delegates to
+    # dry-schema's (see {ContractScanner}'s module doc for why that is a deliberate hard precondition, not
+    # a degrade-gracefully fallback).
+    #
+    # The next ceiling item — per-Contract `rule(:key)` diagnostics — is issue #137's remaining checkbox.
     #
     # No ADR-3 amendment is needed for the validation surface itself; `Dry::Validation::Result` is a
     # generic class, not a sum type (the `success?` / `failure?` predicates narrow via existing bool flow
@@ -36,30 +44,70 @@ module Rigor
       manifest(
         id: "dry-validation",
         version: "0.1.0",
-        description: "Recognises `class T < Dry::Validation::Contract` subclasses and " \
-                     "publishes the contract FQN set.",
-        produces: [:dry_validation_contracts],
+        description: "Recognises `class T < Dry::Validation::Contract` subclasses, publishes the " \
+                     "contract FQN set, and (with rigor-dry-schema loaded) refines each contract's " \
+                     "`result.to_h` to its `params`/`json` schema shape.",
+        produces: %i[dry_validation_contracts dry_validation_params],
+        consumes: [{ plugin_id: "dry-types", name: :dry_type_aliases, optional: true }],
         # Auto-contribute the bundled RBS overlay (Contract#call -> Result, Result#success?/#to_h/...)
         # per ADR-25, so no project-side signature_paths wiring is needed.
         signature_paths: ["sig"]
       )
 
+      # ADR-37 dynamic return — refines `NewUserContract.new.call(input).to_h` to the per-contract
+      # `HashShape` when {#result_shape_for} finds one. Gated on the method name alone (mirrors
+      # rigor-dry-schema's own `.to_h` rule): the RBS overlay types `Contract#call`'s return as the
+      # generic `Result`, but that alone can't select a PER-CONTRACT shape, so the block does its own
+      # syntactic chain match via {ParamsShape.contract_name} before touching the table. When
+      # rigor-dry-schema isn't loaded, or the chain isn't a Contract call, this returns nil and the RBS
+      # overlay's generic `Hash[Symbol, untyped]` stands.
+      dynamic_return methods: [:to_h] do |call_node, _scope|
+        result_shape_for(call_node)
+      end
+
       def prepare(services)
         contracts = ContractScanner.scan(paths: scannable_paths(services))
-        return if contracts.empty?
+        unless contracts.empty?
+          services.fact_store.publish(
+            plugin_id: manifest.id,
+            name: :dry_validation_contracts,
+            value: contracts
+          )
+        end
+
+        type_aliases = services.fact_store.read(plugin_id: "dry-types", name: :dry_type_aliases) || {}
+        params_table = ContractScanner.scan_schema_blocks(paths: scannable_paths(services), type_aliases: type_aliases)
+        return if params_table.empty?
 
         services.fact_store.publish(
           plugin_id: manifest.id,
-          name: :dry_validation_contracts,
-          value: contracts
+          name: :dry_validation_params,
+          value: params_table
         )
       end
 
       def init(_services)
         @scannable_paths = nil
+        @params_shapes = {}
       end
 
       private
+
+      # The HashShape for a `<Const>.new.call(...).to_h` chain, or nil when the chain isn't that shape,
+      # names no contract in the table, or the contract's `params`/`json` shape declares no key.
+      # `params` wins over `json` when (unusually) a Contract declares both — mirrors dry-schema's own
+      # per-name memoisation, including nil, for the same reason: the miss is the common case.
+      def result_shape_for(call_node)
+        name = ParamsShape.contract_name(call_node)
+        return nil if name.nil?
+
+        shapes = (@params_shapes ||= {})
+        return shapes[name] if shapes.key?(name)
+
+        entry = read_fact(plugin_id: manifest.id, name: :dry_validation_params)&.[](name)
+        row = entry && (entry[:params] || entry[:json])
+        shapes[name] = row.nil? ? nil : ParamsShape.build(row)
+      end
 
       def scannable_paths(services)
         @scannable_paths ||= services.configuration.paths.flat_map do |entry|

--- a/plugins/rigor-dry-validation/lib/rigor/plugin/dry_validation.rb
+++ b/plugins/rigor-dry-validation/lib/rigor/plugin/dry_validation.rb
@@ -29,13 +29,14 @@ module Rigor
     #   `NewUserContract.new.call(input).to_h` from the RBS overlay's generic `Hash[Symbol, untyped]` to
     #   the schema-typed `HashShape`. See {ContractScanner.scan_schema_blocks} + {ParamsShape}.
     # - **Slice 3** — `json { ... }` adapter parity with `params { ... }`. Same mechanism, same fact.
+    # - **`dry-validation.rule-key-mismatch`** — a `rule(:key)` referencing a key absent from the
+    #   Contract's own `params`/`json` block. Hard-gated: see {ContractScanner.rule_key_issues}'s doc for
+    #   the two all-or-nothing checks that keep it silent on anything not statically resolvable.
     #
     # Without `rigor-dry-schema` loaded, `result.to_h` still types per the RBS overlay's generic
-    # `Hash[Symbol, untyped]` — this plugin ships no required/optional walker of its own; it delegates to
-    # dry-schema's (see {ContractScanner}'s module doc for why that is a deliberate hard precondition, not
-    # a degrade-gracefully fallback).
-    #
-    # The next ceiling item — per-Contract `rule(:key)` diagnostics — is issue #137's remaining checkbox.
+    # `Hash[Symbol, untyped]` and `rule-key-mismatch` never fires — this plugin ships no required/optional
+    # walker of its own; it delegates to dry-schema's (see {ContractScanner}'s module doc for why that is
+    # a deliberate hard precondition, not a degrade-gracefully fallback).
     #
     # No ADR-3 amendment is needed for the validation surface itself; `Dry::Validation::Result` is a
     # generic class, not a sum type (the `success?` / `failure?` predicates narrow via existing bool flow
@@ -63,6 +64,33 @@ module Rigor
       # overlay's generic `Hash[Symbol, untyped]` stands.
       dynamic_return methods: [:to_h] do |call_node, _scope|
         result_shape_for(call_node)
+      end
+
+      # ADR-37 slice 1c two-pass — the "collect" half of `dry-validation.rule-key-mismatch`. Reads the
+      # SAME `:dry_type_aliases` fact `#prepare` does (a plain `services.fact_store.read`, not
+      # `#read_fact`'s memoised wrapper — `services` at collect time is the run-wide instance, so an
+      # in-block memo isn't needed here the way it is across many per-call `dynamic_return` invocations).
+      node_file_context do |root, _scope|
+        type_aliases = services.fact_store.read(plugin_id: "dry-types", name: :dry_type_aliases) || {}
+        ContractScanner.rule_key_issues(root, type_aliases)
+      end
+
+      # Fires once per file (see rigor-dry-schema's identical `Prism::ProgramNode` rule for why).
+      node_rule Prism::ProgramNode do |_node, _scope, path, issues|
+        next [] if issues.nil? || issues.empty?
+
+        issues.map do |issue|
+          hint = Rigor::Plugin::Base.suggest(issue[:key], issue[:known_keys])
+          suffix = hint ? " (did you mean `:#{hint}`?)" : ""
+          diagnostic(
+            issue[:node],
+            path: path,
+            message: "rule(:#{issue[:key]}) references a key not declared by " \
+                     "`#{issue[:contract_fqn]}`'s params/json schema#{suffix}",
+            severity: :error,
+            rule: "dry-validation.rule-key-mismatch"
+          )
+        end
       end
 
       def prepare(services)

--- a/plugins/rigor-dry-validation/lib/rigor/plugin/dry_validation/contract_scanner.rb
+++ b/plugins/rigor-dry-validation/lib/rigor/plugin/dry_validation/contract_scanner.rb
@@ -41,6 +41,105 @@ module Rigor
         end
         private_class_method :scan_file
 
+        # Issue #137 slices 2/3 — per-Contract `params { ... }` / `json { ... }` shapes, delegating the
+        # actual required/optional walk to `rigor-dry-schema`'s {DrySchema::SchemaScanner.collect_schema_shape}
+        # (the SAME dry-schema DSL, just under a bare `params`/`json` call instead of
+        # `Dry::Schema.Params { ... }`). Returns `{}` immediately, without touching a single file, when
+        # `rigor-dry-schema` isn't loaded — the companion plugin's absence is a hard precondition here,
+        # not a degrade-gracefully fallback, because this plugin ships no required/optional walker of
+        # its own.
+        #
+        # @return [Hash{String => Hash{Symbol => Hash}}] contract FQN => `{params: <shape>}` and/or
+        #   `{json: <shape>}` (only the recognised key(s) are present; a contract with neither present
+        #   contributes nothing). Each `<shape>` is exactly {DrySchema::SchemaScanner.collect_schema_shape}'s
+        #   `{required:, optional:, unmodelled:}` return.
+        def scan_schema_blocks(paths:, type_aliases: {})
+          return {} unless Rigor::Plugin.registered_for("dry-schema")
+
+          table = {}
+          paths.each do |path|
+            scan_file_schema_blocks(path, type_aliases).each do |fqn, shapes|
+              table[fqn] ||= shapes
+            end
+          end
+          table.freeze
+        end
+
+        def scan_file_schema_blocks(path, type_aliases)
+          source = File.read(path)
+          parse_result = Prism.parse(source, filepath: path)
+          return {} unless parse_result.errors.empty?
+
+          collect_params_blocks(parse_result.value, [], type_aliases)
+        rescue StandardError
+          {}
+        end
+        private_class_method :scan_file_schema_blocks
+
+        # Mirrors {#collect_contracts}'s recursive shape, additionally capturing each recognised
+        # Contract's own `params { ... }` / `json { ... }` shape.
+        def collect_params_blocks(node, qualified_prefix, type_aliases)
+          return {} if node.nil?
+
+          case node
+          when Prism::ClassNode
+            collect_class_params_blocks(node, qualified_prefix, type_aliases)
+          when Prism::ModuleNode
+            inner_name = constant_name_for(node.constant_path)
+            return {} if inner_name.nil?
+
+            collect_params_blocks(node.body, qualified_prefix + [inner_name], type_aliases)
+          else
+            node.compact_child_nodes.each_with_object({}) do |child, acc|
+              collect_params_blocks(child, qualified_prefix, type_aliases).each { |k, v| acc[k] ||= v }
+            end
+          end
+        end
+        private_class_method :collect_params_blocks
+
+        def collect_class_params_blocks(node, qualified_prefix, type_aliases)
+          inner_name = constant_name_for(node.constant_path)
+          return {} if inner_name.nil?
+
+          new_prefix = qualified_prefix + [inner_name]
+          inner = collect_params_blocks(node.body, new_prefix, type_aliases)
+
+          if contract_subclass?(node)
+            shapes = class_body_schema_shapes(node.body, type_aliases)
+            inner[new_prefix.join("::")] = shapes unless shapes.empty?
+          end
+          inner
+        end
+        private_class_method :collect_class_params_blocks
+
+        # ONLY a top-level `params do ... end` / `json do ... end` call directly inside the Contract's
+        # class body — a bare call, no receiver, no positional/keyword arguments, exactly one block.
+        # A call nested inside a conditional, a method def, or wrapped in any other construct is NOT
+        # this floor; it's indistinguishable here from a dynamically-built or externally-shared schema,
+        # and the conservative read is to contribute nothing rather than guess.
+        def class_body_schema_shapes(body, type_aliases)
+          return {} if body.nil?
+
+          children = body.is_a?(Prism::StatementsNode) ? body.body : [body]
+          shapes = {}
+          children.each do |child|
+            next unless bare_block_call?(child)
+
+            case child.name
+            when :params then shapes[:params] ||= DrySchema::SchemaScanner.collect_schema_shape(child.block, type_aliases, nested: false)
+            when :json then shapes[:json] ||= DrySchema::SchemaScanner.collect_schema_shape(child.block, type_aliases, nested: false)
+            end
+          end
+          shapes
+        end
+        private_class_method :class_body_schema_shapes
+
+        def bare_block_call?(node)
+          node.is_a?(Prism::CallNode) && node.receiver.nil? && node.arguments.nil? &&
+            node.block.is_a?(Prism::BlockNode)
+        end
+        private_class_method :bare_block_call?
+
         def collect_contracts(node, qualified_prefix)
           return [] if node.nil?
 

--- a/plugins/rigor-dry-validation/lib/rigor/plugin/dry_validation/contract_scanner.rb
+++ b/plugins/rigor-dry-validation/lib/rigor/plugin/dry_validation/contract_scanner.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "prism"
+require "rigor/source/literals"
 
 module Rigor
   module Plugin
@@ -139,6 +140,163 @@ module Rigor
             node.block.is_a?(Prism::BlockNode)
         end
         private_class_method :bare_block_call?
+
+        # `dry-validation.rule-key-mismatch` (issue #137's remaining ceiling checkbox) — walks an
+        # ALREADY-PARSED file's root node collecting `{node:, key:, contract_fqn:}` issues for a
+        # `rule(:sym, ...) do ... end` call whose Symbol argument names a key that is NOT in the
+        # Contract's OWN, cleanly-recognised `params`/`json` key set.
+        #
+        # FP-gated hard, per two independent all-or-nothing checks:
+        #
+        # - {#clean_known_keys} — the Contract's key universe is trusted ONLY when EVERY top-level
+        #   statement in EVERY `params`/`json` block is a recognised `required`/`optional` row (typed or
+        #   not — an unmodelled row is still a DECLARED key) or the inert `config.<x> = <literal>` idiom.
+        #   A loop building keys dynamically, a splat, an `include`, a nested schema merge, or a
+        #   `params`/`json(SomeSchema)` delegating to an externally-shared schema — ANY of these makes
+        #   the WHOLE Contract's key universe untrustworthy, not just the offending row, and the
+        #   Contract is skipped outright (no diagnostic against any of its `rule()` calls).
+        # - {#rule_arguments_or_nil} — a `rule(...)` call is checked ONLY when EVERY argument is a
+        #   literal Symbol. A splat (`rule(*keys)`), a String, a local variable, or a Hash (the
+        #   nested-key form `rule(user: [:name])`) makes the WHOLE call unresolvable, not just that one
+        #   argument, and it is skipped rather than partially validated.
+        #
+        # Returns `[]` immediately, without touching a single file, when `rigor-dry-schema` isn't loaded
+        # — there is no key universe to check a `rule()` call against without it.
+        def rule_key_issues(root, type_aliases)
+          return [] unless Rigor::Plugin.registered_for("dry-schema")
+
+          issues = []
+          walk_for_rule_issues(root, [], type_aliases, issues)
+          issues
+        end
+
+        def walk_for_rule_issues(node, qualified_prefix, type_aliases, issues)
+          return if node.nil?
+
+          case node
+          when Prism::ClassNode
+            inner_name = constant_name_for(node.constant_path)
+            return if inner_name.nil?
+
+            new_prefix = qualified_prefix + [inner_name]
+            check_contract_rules(node, new_prefix.join("::"), type_aliases, issues) if contract_subclass?(node)
+            walk_for_rule_issues(node.body, new_prefix, type_aliases, issues)
+          when Prism::ModuleNode
+            inner_name = constant_name_for(node.constant_path)
+            return if inner_name.nil?
+
+            walk_for_rule_issues(node.body, qualified_prefix + [inner_name], type_aliases, issues)
+          else
+            node.compact_child_nodes.each { |child| walk_for_rule_issues(child, qualified_prefix, type_aliases, issues) }
+          end
+        end
+        private_class_method :walk_for_rule_issues
+
+        def check_contract_rules(class_node, contract_fqn, type_aliases, issues)
+          body = class_node.body
+          return if body.nil?
+
+          children = body.is_a?(Prism::StatementsNode) ? body.body : [body]
+          known_keys = clean_known_keys(children, type_aliases)
+          return if known_keys.nil?
+
+          children.each do |child|
+            next unless rule_call?(child)
+
+            check_rule_call(child, contract_fqn, known_keys, issues)
+          end
+        end
+        private_class_method :check_contract_rules
+
+        # The Contract's full declared key set (required + optional + unmodelled, across BOTH `params`
+        # and `json` if both are present — a Contract having both is unusual, so the conservative read
+        # is the union rather than guessing which one a given `rule()` targets), or nil when the
+        # Contract has no `params`/`json` block at all OR either block fails {#clean_schema_block?}.
+        def clean_known_keys(children, type_aliases)
+          blocks = children.select { |c| bare_block_call?(c) && %i[params json].include?(c.name) }
+          return nil if blocks.empty?
+
+          keys = Set.new
+          blocks.each do |block_call|
+            return nil unless clean_schema_block?(block_call.block)
+
+            shape = DrySchema::SchemaScanner.collect_schema_shape(block_call.block, type_aliases, nested: false)
+            keys.merge(shape[:required].keys)
+            keys.merge(shape[:optional].keys)
+            keys.merge(shape[:unmodelled][:required])
+            keys.merge(shape[:unmodelled][:optional])
+          end
+          keys
+        end
+        private_class_method :clean_known_keys
+
+        def clean_schema_block?(block_node)
+          body = block_node.body
+          return true if body.nil? # empty block — vacuously clean, contributes no keys
+
+          children = body.is_a?(Prism::StatementsNode) ? body.body : [body]
+          children.all? { |child| required_or_optional_row?(child) || inert_config_assignment?(child) }
+        end
+        private_class_method :clean_schema_block?
+
+        # A `required(:key)...` / `optional(:key)...` chain, ANY predicate suffix (even one this
+        # scanner can't type — an unmodelled row is still a row that DECLARES the key, which is all
+        # {#clean_known_keys} needs).
+        def required_or_optional_row?(node)
+          return false unless node.is_a?(Prism::CallNode)
+
+          current = node
+          while current.is_a?(Prism::CallNode)
+            if %i[required optional].include?(current.name)
+              return !Rigor::Source::Literals.symbol(current.arguments&.arguments&.first).nil?
+            end
+
+            current = current.receiver
+          end
+          false
+        end
+        private_class_method :required_or_optional_row?
+
+        # `config.validate_keys = true` and similar — dry-schema's own `config.<x> = <literal>` idiom.
+        # Declares no key, so it's safe to ignore rather than treat as "unrecognised" (over-declining a
+        # perfectly common line would silently drop valid diagnostics, not risk a false positive, but
+        # there's no reason to pay that cost).
+        def inert_config_assignment?(node)
+          node.is_a?(Prism::CallNode) && node.name.end_with?("=") &&
+            node.receiver.is_a?(Prism::CallNode) && node.receiver.name == :config && node.receiver.receiver.nil?
+        end
+        private_class_method :inert_config_assignment?
+
+        def rule_call?(node)
+          node.is_a?(Prism::CallNode) && node.name == :rule && node.receiver.nil? && node.block.is_a?(Prism::BlockNode)
+        end
+        private_class_method :rule_call?
+
+        def check_rule_call(rule_node, contract_fqn, known_keys, issues)
+          symbols = rule_arguments_or_nil(rule_node)
+          return if symbols.nil?
+
+          symbols.each do |arg|
+            key = arg.unescaped.to_sym
+            next if known_keys.include?(key)
+
+            issues << { node: arg, key: key, contract_fqn: contract_fqn, known_keys: known_keys }
+          end
+        end
+        private_class_method :check_rule_call
+
+        # Every positional argument of `rule(...)`, as `Prism::SymbolNode`s, or nil when there are none,
+        # or ANY of them isn't a literal Symbol (a splat, a String, a local variable, or a Hash — the
+        # `rule(user: [:name])` nested-key form). One non-Symbol argument makes the WHOLE call
+        # unresolvable, not just that argument.
+        def rule_arguments_or_nil(rule_node)
+          args = rule_node.arguments&.arguments
+          return nil if args.nil? || args.empty?
+          return nil unless args.all?(Prism::SymbolNode)
+
+          args
+        end
+        private_class_method :rule_arguments_or_nil
 
         def collect_contracts(node, qualified_prefix)
           return [] if node.nil?

--- a/plugins/rigor-dry-validation/lib/rigor/plugin/dry_validation/params_shape.rb
+++ b/plugins/rigor-dry-validation/lib/rigor/plugin/dry_validation/params_shape.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "prism"
+
+module Rigor
+  module Plugin
+    class DryValidation < Rigor::Plugin::Base
+      # Issue #137 slices 2/3 — recognises the `<Const>.new.call(...).to_h` call chain and builds the
+      # per-contract `HashShape` from the entry {ContractScanner.scan_schema_blocks} collected.
+      module ParamsShape
+        module_function
+
+        # The Contract constant `to_h_node`'s receiver chain, or nil when the chain isn't the recognised
+        # `<Const>.new.call(...).to_h` form.
+        #
+        # Mirrors rigor-dry-schema's `ResultShape.schema_name` with one extra hop: a schema's `.call` is a
+        # bare class method on the schema constant itself, but a Contract's `.call` is an INSTANCE method
+        # (`NewUserContract.new.call(input)`), so the chain has to walk through `.new` first. Floor,
+        # matching dry-schema's own posture: the contract must be named by a constant as written at the
+        # call site. Reached through a local (`c = NewUserContract.new; c.call(x).to_h`) or a relative
+        # constant path, the chain contributes nothing and `to_h` types per the RBS overlay's generic
+        # `Hash[Symbol, untyped]` as it did before.
+        def contract_name(to_h_node)
+          return nil unless to_h_node.is_a?(Prism::CallNode) && to_h_node.name == :to_h
+          return nil unless to_h_node.arguments.nil? && to_h_node.block.nil?
+
+          call_node = to_h_node.receiver
+          return nil unless call_node.is_a?(Prism::CallNode) && call_node.name == :call
+
+          new_node = call_node.receiver
+          return nil unless new_node.is_a?(Prism::CallNode) && new_node.name == :new
+          return nil unless new_node.arguments.nil? && new_node.block.nil?
+
+          constant_name(new_node.receiver)
+        end
+
+        # Delegates the entry -> HashShape build to rigor-dry-schema's own
+        # {DrySchema::ResultShape.build} — the identical algorithm the entry was collected with (via
+        # {ContractScanner.scan_schema_blocks}, which itself delegates to
+        # {DrySchema::SchemaScanner.collect_schema_shape}). Only ever called once the caller has already
+        # confirmed rigor-dry-schema is loaded.
+        def build(entry)
+          DrySchema::ResultShape.build(entry)
+        end
+
+        # Renders `Foo` / `Foo::Bar` / `::Foo::Bar` as the `::`-joined String {ContractScanner}'s table is
+        # keyed by. Duplicated from rigor-dry-schema's identical helper rather than shared — five lines,
+        # no dependency on anything ELSE in that plugin, and reusing it would need a `registered_for`
+        # guard here too even though this leaf never touches dry-schema's own type/alias machinery.
+        def constant_name(node)
+          case node
+          when Prism::ConstantReadNode then node.name.to_s
+          when Prism::ConstantPathNode then constant_path_name(node)
+          end
+        end
+
+        def constant_path_name(node)
+          parent = node.parent
+          name = node.name&.to_s
+          return nil if name.nil?
+          return name if parent.nil? # `::Foo` — the table keys are unrooted, so drop the leading `::`
+
+          prefix = constant_name(parent)
+          prefix.nil? ? nil : "#{prefix}::#{name}"
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/plugins/dry_schema_plugin_spec.rb
+++ b/spec/integration/plugins/dry_schema_plugin_spec.rb
@@ -177,6 +177,139 @@ RSpec.describe "rigor-dry-schema integration" do
     expect(shape.fetch(:optional)).to eq(authors: { type: "String", list: true })
   end
 
+  # `each do ... end` element-type recursion — the ceiling slice issue #137 named for rigor-dry-schema.
+  describe "`each do ... end` element-type recursion" do
+    it "recurses a bare nested block into a nested required/optional shape" do
+      demo = <<~RUBY
+        Schema = Dry::Schema.Params do
+          required(:items).each do
+            required(:sku).filled(:string)
+            optional(:qty).value(:integer)
+          end
+        end
+      RUBY
+      shape = run_and_read_fact(demo: demo).fetch("Schema")
+      row = shape.fetch(:required).fetch(:items)
+      expect(row.fetch(:list)).to be(true)
+      nested = row.fetch(:type).fetch(:nested)
+      expect(nested.fetch(:required)).to eq(sku: { type: "String", list: false })
+      expect(nested.fetch(:optional)).to eq(qty: { type: "Integer", list: false })
+    end
+
+    it "recurses the `each do schema do ... end end` spelling identically" do
+      demo = <<~RUBY
+        Schema = Dry::Schema.Params do
+          required(:items).each do
+            schema do
+              required(:sku).filled(:string)
+            end
+          end
+        end
+      RUBY
+      shape = run_and_read_fact(demo: demo).fetch("Schema")
+      nested = shape.fetch(:required).fetch(:items).fetch(:type).fetch(:nested)
+      expect(nested.fetch(:required)).to eq(sku: { type: "String", list: false })
+    end
+
+    it "declines (untyped) a block with no recognisable required/optional row" do
+      demo = <<~RUBY
+        Schema = Dry::Schema.Params do
+          required(:known).filled(:string)
+          required(:tags).each do
+            int?
+          end
+        end
+      RUBY
+      shape = run_and_read_fact(demo: demo).fetch("Schema")
+      expect(shape.fetch(:required)).to eq(known: { type: "String", list: false })
+      expect(shape.fetch(:unmodelled)).to eq(required: [:tags], optional: [])
+    end
+
+    it "types `Schema.call(input).to_h` with a nested HashShape wrapped in Array" do
+      dump = dump_types(<<~RUBY).first
+        Schema = Dry::Schema.Params do
+          required(:items).each do
+            required(:sku).filled(:string)
+          end
+        end
+
+        Rigor.dump_type(Schema.call({}).to_h)
+      RUBY
+      expect(dump).to include("items", "Array", "sku", "String")
+    end
+
+    it "resolves a nested row's constant type reference through :dry_type_aliases too" do
+      demo = <<~RUBY
+        module Types
+          include Dry.Types()
+
+          Email = String.constrained(format: /@/)
+        end
+
+        ContactBook = Dry::Schema.Params do
+          required(:contacts).each do
+            required(:email).value(Types::Email)
+          end
+        end
+      RUBY
+      shape = run_and_read_fact(demo: demo, with_dry_types: true).fetch("ContactBook")
+      nested = shape.fetch(:required).fetch(:contacts).fetch(:type).fetch(:nested)
+      expect(nested.fetch(:required)).to eq(email: { type: "String", list: false })
+    end
+  end
+
+  # The `dry-schema.unknown-type` per-row diagnostic — the other ceiling slice issue #137 named.
+  describe "`dry-schema.unknown-type` diagnostic" do
+    it "fires :info for a type-bearing predicate's unrecognised Symbol argument" do
+      demo = <<~RUBY
+        Schema = Dry::Schema.Params do
+          required(:known).filled(:string)
+          required(:bogus).filled(:not_a_type)
+        end
+      RUBY
+      result = run_demo(demo)
+      issue = result.diagnostics.find { |d| d.rule == "dry-schema.unknown-type" }
+      expect(issue).not_to be_nil
+      expect(issue.severity).to eq(:info)
+      expect(issue.message).to include("bogus").or include(":not_a_type")
+    end
+
+    it "does NOT fire for a Constant argument even when rigor-dry-types isn't loaded" do
+      demo = <<~RUBY
+        Schema = Dry::Schema.Params do
+          required(:email).value(Types::Email)
+        end
+      RUBY
+      result = run_demo(demo)
+      expect(result.diagnostics.select { |d| d.rule == "dry-schema.unknown-type" }).to be_empty
+    end
+
+    it "does NOT fire for a recognised canonical type symbol" do
+      demo = <<~RUBY
+        Schema = Dry::Schema.Params do
+          required(:email).filled(:string)
+          required(:age).value(:integer)
+        end
+      RUBY
+      result = run_demo(demo)
+      expect(result.diagnostics.select { |d| d.rule == "dry-schema.unknown-type" }).to be_empty
+    end
+
+    it "recurses into an `each do ... end` nested row's own bad symbol" do
+      demo = <<~RUBY
+        Schema = Dry::Schema.Params do
+          required(:items).each do
+            required(:sku).filled(:not_a_type_either)
+          end
+        end
+      RUBY
+      result = run_demo(demo)
+      issue = result.diagnostics.find { |d| d.rule == "dry-schema.unknown-type" }
+      expect(issue).not_to be_nil
+      expect(issue.message).to include("not_a_type_either")
+    end
+  end
+
   it "does NOT publish the fact when no `Dry::Schema.X` declaration is present" do
     demo = <<~RUBY
       class Foo

--- a/spec/integration/plugins/dry_validation_plugin_spec.rb
+++ b/spec/integration/plugins/dry_validation_plugin_spec.rb
@@ -9,6 +9,16 @@ DRY_VALIDATION_PLUGIN_LIB = File.expand_path("../../../plugins/rigor-dry-validat
 $LOAD_PATH.unshift(DRY_VALIDATION_PLUGIN_LIB) unless $LOAD_PATH.include?(DRY_VALIDATION_PLUGIN_LIB)
 require "rigor-dry-validation"
 
+DRY_SCHEMA_PLUGIN_LIB_FOR_VALIDATION = File.expand_path("../../../plugins/rigor-dry-schema/lib", __dir__)
+unless $LOAD_PATH.include?(DRY_SCHEMA_PLUGIN_LIB_FOR_VALIDATION)
+  $LOAD_PATH.unshift(DRY_SCHEMA_PLUGIN_LIB_FOR_VALIDATION)
+end
+require "rigor-dry-schema"
+
+DRY_TYPES_PLUGIN_LIB_FOR_VALIDATION = File.expand_path("../../../plugins/rigor-dry-types/lib", __dir__)
+$LOAD_PATH.unshift(DRY_TYPES_PLUGIN_LIB_FOR_VALIDATION) unless $LOAD_PATH.include?(DRY_TYPES_PLUGIN_LIB_FOR_VALIDATION)
+require "rigor-dry-types"
+
 RSpec.describe "rigor-dry-validation integration" do
   let(:plugin_class) { Rigor::Plugin::DryValidation }
 
@@ -119,6 +129,205 @@ RSpec.describe "rigor-dry-validation integration" do
       expect(contents).to include("def call:")
       expect(contents).to include("class Result")
       expect(contents).to include("def to_h:")
+    end
+  end
+
+  # Slices 2/3 (issue #137) — `params { ... }` / `json { ... }` integration with rigor-dry-schema.
+  describe "params/json schema integration (slices 2/3)" do
+    it "publishes :dry_validation_params for a Contract's `params { ... }` block" do
+      demo = <<~RUBY
+        class NewUserContract < Dry::Validation::Contract
+          params do
+            required(:email).filled(:string)
+            required(:age).value(:integer)
+          end
+        end
+      RUBY
+      table = run_and_read_params_fact(demo: demo)
+      entry = table.fetch("NewUserContract")
+      expect(entry.fetch(:params).fetch(:required)).to eq(
+        email: { type: "String", list: false },
+        age: { type: "Integer", list: false }
+      )
+    end
+
+    it "publishes :dry_validation_params for a Contract's `json { ... }` block" do
+      demo = <<~RUBY
+        class ImportContract < Dry::Validation::Contract
+          json do
+            required(:sku).filled(:string)
+          end
+        end
+      RUBY
+      table = run_and_read_params_fact(demo: demo)
+      expect(table.fetch("ImportContract").fetch(:json).fetch(:required)).to eq(
+        sku: { type: "String", list: false }
+      )
+    end
+
+    it "does NOT publish :dry_validation_params when rigor-dry-schema isn't loaded" do
+      demo = <<~RUBY
+        class NewUserContract < Dry::Validation::Contract
+          params do
+            required(:email).filled(:string)
+          end
+        end
+      RUBY
+      expect(run_and_read_params_fact(demo: demo, with_dry_schema: false)).to be_nil
+    end
+
+    it "does NOT capture a `params { ... }` call that isn't a direct top-level class-body statement" do
+      demo = <<~RUBY
+        class ConditionalContract < Dry::Validation::Contract
+          if true
+            params do
+              required(:email).filled(:string)
+            end
+          end
+        end
+      RUBY
+      expect(run_and_read_params_fact(demo: demo)).to be_nil
+    end
+
+    it "refines `Contract.new.call(input).to_h` to the params schema's HashShape" do
+      dump = dump_types(<<~RUBY).first
+        class NewUserContract < Dry::Validation::Contract
+          params do
+            required(:email).filled(:string)
+            required(:age).value(:integer)
+          end
+        end
+
+        Rigor.dump_type(NewUserContract.new.call({}).to_h)
+      RUBY
+      expect(dump).to include("email", "String", "age", "Integer")
+    end
+
+    it "refines `Contract.new.call(input).to_h` to the json schema's HashShape" do
+      dump = dump_types(<<~RUBY).first
+        class ImportContract < Dry::Validation::Contract
+          json do
+            required(:sku).filled(:string)
+          end
+        end
+
+        Rigor.dump_type(ImportContract.new.call({}).to_h)
+      RUBY
+      expect(dump).to include("sku", "String")
+    end
+
+    it "keeps the generic Hash[Symbol, untyped] shape when rigor-dry-schema isn't loaded" do
+      dump = dump_types(<<~RUBY, with_dry_schema: false).first
+        class NewUserContract < Dry::Validation::Contract
+          params do
+            required(:email).filled(:string)
+          end
+        end
+
+        Rigor.dump_type(NewUserContract.new.call({}).to_h)
+      RUBY
+      expect(dump).not_to include("email")
+    end
+
+    it "contributes nothing for a Contract with no params/json block at all" do
+      dumps = dump_types(<<~RUBY)
+        class EmptyContract < Dry::Validation::Contract
+        end
+
+        Rigor.dump_type(EmptyContract.new.call({}).to_h)
+      RUBY
+      expect(dumps.first).not_to include("=>")
+    end
+
+    it "resolves a params row's constant type reference through :dry_type_aliases too" do
+      demo = <<~RUBY
+        module Types
+          include Dry.Types()
+
+          Email = String.constrained(format: /@/)
+        end
+
+        class NewUserContract < Dry::Validation::Contract
+          params do
+            required(:email).value(Types::Email)
+          end
+        end
+      RUBY
+      table = run_and_read_params_fact(demo: demo, with_dry_types: true)
+      expect(table.fetch("NewUserContract").fetch(:params).fetch(:required)).to eq(
+        email: { type: "String", list: false }
+      )
+    end
+  end
+
+  # Runs the plugin(s) against a single-file project and returns the `dump.type` messages, in source order.
+  def dump_types(demo, with_dry_schema: true)
+    run_demo(demo, with_dry_schema: with_dry_schema).diagnostics.select { |d| d.rule == "dump.type" }.map(&:message)
+  end
+
+  def run_demo(demo, with_dry_schema: true, with_dry_types: false)
+    plugin_entries = ["rigor-dry-validation"]
+    plugin_entries << "rigor-dry-schema" if with_dry_schema
+    plugin_entries << "rigor-dry-types" if with_dry_types
+
+    Rigor::Plugin.unregister!
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "contracts.rb"), demo)
+      FileUtils.mkdir_p(File.join(dir, "sig"))
+      File.write(File.join(dir, "sig", "dry_validation.rbs"), dry_validation_rbs)
+      run_analysis(dir: dir, plugin_entries: plugin_entries)
+    end
+  end
+
+  # Runs the plugin(s) against a single-file project and returns the `:dry_validation_params` fact value.
+  def run_and_read_params_fact(demo:, with_dry_schema: true, with_dry_types: false)
+    plugin_entries = ["rigor-dry-validation"]
+    plugin_entries << "rigor-dry-schema" if with_dry_schema
+    plugin_entries << "rigor-dry-types" if with_dry_types
+
+    Rigor::Plugin.unregister!
+    captured_store = capture_fact_store!
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "contracts.rb"), demo)
+      FileUtils.mkdir_p(File.join(dir, "sig"))
+      File.write(File.join(dir, "sig", "dry_validation.rbs"), dry_validation_rbs)
+      run_analysis(dir: dir, plugin_entries: plugin_entries)
+    end
+    captured_store.call&.read(plugin_id: "dry-validation", name: :dry_validation_params)
+  end
+
+  def capture_fact_store!
+    captured = nil
+    allow(Rigor::Plugin::Services).to receive(:new).and_wrap_original do |original, **kwargs|
+      services = original.call(**kwargs)
+      captured = services.fact_store
+      services
+    end
+    -> { captured }
+  end
+
+  def run_analysis(dir:, plugin_entries:)
+    configuration = Rigor::Configuration.new(
+      Rigor::Configuration::DEFAULTS.merge(
+        "paths" => [File.join(dir, "contracts.rb")],
+        "plugins" => plugin_entries
+      )
+    )
+
+    Dir.chdir(dir) do
+      Rigor::Analysis::Runner.new(
+        configuration: configuration, cache_store: nil,
+        plugin_requirer: lambda do |name|
+          # #194 slice 2 — a bundled plugin arrives as its engine-anchored absolute path; basename
+          # recovers the gem name (a bare name passes through unchanged).
+          case File.basename(name, ".rb")
+          when "rigor-dry-types" then Rigor::Plugin.register(Rigor::Plugin::DryTypes)
+          when "rigor-dry-schema" then Rigor::Plugin.register(Rigor::Plugin::DrySchema)
+          when "rigor-dry-validation" then Rigor::Plugin.register(Rigor::Plugin::DryValidation)
+          end
+          true
+        end
+      ).run
     end
   end
 

--- a/spec/integration/plugins/dry_validation_plugin_spec.rb
+++ b/spec/integration/plugins/dry_validation_plugin_spec.rb
@@ -260,6 +260,158 @@ RSpec.describe "rigor-dry-validation integration" do
     end
   end
 
+  # Per-Contract diagnostics (issue #137's remaining checkbox) — `dry-validation.rule-key-mismatch`.
+  describe "`dry-validation.rule-key-mismatch` diagnostic" do
+    it "fires when rule(:key) references a key absent from the Contract's params schema" do
+      demo = <<~RUBY
+        class NewUserContract < Dry::Validation::Contract
+          params do
+            required(:email).filled(:string)
+          end
+
+          rule(:nonexistent_key) do
+            key.failure("nope")
+          end
+        end
+      RUBY
+      result = run_demo(demo)
+      issue = result.diagnostics.find { |d| d.rule == "dry-validation.rule-key-mismatch" }
+      expect(issue).not_to be_nil
+      expect(issue.severity).to eq(:error)
+      expect(issue.message).to include("nonexistent_key").and include("NewUserContract")
+    end
+
+    it "does NOT fire when every rule() key is declared" do
+      demo = <<~RUBY
+        class NewUserContract < Dry::Validation::Contract
+          params do
+            required(:email).filled(:string)
+            required(:age).value(:integer)
+          end
+
+          rule(:email, :age) do
+            key.failure("nope")
+          end
+        end
+      RUBY
+      result = run_demo(demo)
+      expect(result.diagnostics.select { |d| d.rule == "dry-validation.rule-key-mismatch" }).to be_empty
+    end
+
+    it "does NOT fire for an unmodelled (untyped-but-declared) key" do
+      demo = <<~RUBY
+        class NewUserContract < Dry::Validation::Contract
+          params do
+            required(:email).filled(:string)
+            required(:weird).filled(:not_a_type)
+          end
+
+          rule(:weird) do
+            key.failure("nope")
+          end
+        end
+      RUBY
+      result = run_demo(demo)
+      expect(result.diagnostics.select { |d| d.rule == "dry-validation.rule-key-mismatch" }).to be_empty
+    end
+
+    it "declines the WHOLE Contract when the params block has an unrecognised statement" do
+      demo = <<~RUBY
+        class NewUserContract < Dry::Validation::Contract
+          params do
+            required(:email).filled(:string)
+            %i[extra_a extra_b].each { |k| required(k).filled(:string) }
+          end
+
+          rule(:nonexistent_key) do
+            key.failure("nope")
+          end
+        end
+      RUBY
+      result = run_demo(demo)
+      expect(result.diagnostics.select { |d| d.rule == "dry-validation.rule-key-mismatch" }).to be_empty
+    end
+
+    it "declines a rule() call with a splat argument" do
+      demo = <<~RUBY
+        class NewUserContract < Dry::Validation::Contract
+          params do
+            required(:email).filled(:string)
+          end
+
+          KEYS = [:nonexistent_key].freeze
+
+          rule(*KEYS) do
+            key.failure("nope")
+          end
+        end
+      RUBY
+      result = run_demo(demo)
+      expect(result.diagnostics.select { |d| d.rule == "dry-validation.rule-key-mismatch" }).to be_empty
+    end
+
+    it "declines a rule() call with the nested-key Hash form" do
+      demo = <<~RUBY
+        class NewUserContract < Dry::Validation::Contract
+          params do
+            required(:user).filled(:hash)
+          end
+
+          rule(user: [:nonexistent_key]) do
+            key.failure("nope")
+          end
+        end
+      RUBY
+      result = run_demo(demo)
+      expect(result.diagnostics.select { |d| d.rule == "dry-validation.rule-key-mismatch" }).to be_empty
+    end
+
+    it "does NOT fire when rigor-dry-schema isn't loaded" do
+      demo = <<~RUBY
+        class NewUserContract < Dry::Validation::Contract
+          params do
+            required(:email).filled(:string)
+          end
+
+          rule(:nonexistent_key) do
+            key.failure("nope")
+          end
+        end
+      RUBY
+      result = run_demo(demo, with_dry_schema: false)
+      expect(result.diagnostics.select { |d| d.rule == "dry-validation.rule-key-mismatch" }).to be_empty
+    end
+
+    it "does NOT fire for a Contract with no params/json block at all" do
+      demo = <<~RUBY
+        class NewUserContract < Dry::Validation::Contract
+          rule(:nonexistent_key) do
+            key.failure("nope")
+          end
+        end
+      RUBY
+      result = run_demo(demo)
+      expect(result.diagnostics.select { |d| d.rule == "dry-validation.rule-key-mismatch" }).to be_empty
+    end
+
+    it "includes a did-you-mean suggestion for a close typo" do
+      demo = <<~RUBY
+        class NewUserContract < Dry::Validation::Contract
+          params do
+            required(:email).filled(:string)
+          end
+
+          rule(:emial) do
+            key.failure("nope")
+          end
+        end
+      RUBY
+      result = run_demo(demo)
+      issue = result.diagnostics.find { |d| d.rule == "dry-validation.rule-key-mismatch" }
+      expect(issue.message).to include("did you mean `:email`?")
+    end
+  end
+
   # Runs the plugin(s) against a single-file project and returns the `dump.type` messages, in source order.
   def dump_types(demo, with_dry_schema: true)
     run_demo(demo, with_dry_schema: with_dry_schema).diagnostics.select { |d| d.rule == "dump.type" }.map(&:message)


### PR DESCRIPTION
## Summary

Closes #137 — all four checkboxes shipped.

- **rigor-dry-schema ceiling**: `required(:key).each do ... end` now recurses into a nested `HashShape` (an array of a nested schema, not just an array of a scalar), and a new `dry-schema.unknown-type` (`:info`) diagnostic fires when a `filled`/`value`/`maybe`/`each` predicate's Symbol argument isn't in the canonical dry-schema type vocabulary. The typed-`result.to_h` headline deliverable had already landed in an earlier commit (via `dynamic_return`, not the ADR-16 Tier C substrate the README originally projected) — see "Contradictions found" below.
- **rigor-dry-validation slice 2**: with `rigor-dry-schema` also loaded, a Contract's top-level, bare `params { ... }` block is walked with rigor-dry-schema's own `SchemaScanner.collect_schema_shape` (not a duplicated walker) and refines `Contract.new.call(input).to_h` from the RBS overlay's generic `Hash[Symbol, untyped]` to the schema-typed `HashShape`, via rigor-dry-schema's own `ResultShape.build`.
- **rigor-dry-validation slice 3**: `json { ... }` parity with slice 2, same mechanism.
- **Per-Contract diagnostics**: `rule(:key)` referencing a key absent from the Contract's own `params`/`json` schema now draws `dry-validation.rule-key-mismatch` (`:error`, with a did-you-mean suggestion). Hard FP-gated: the whole Contract is skipped if any statement in its params/json block isn't a recognised `required`/`optional` row (or the inert `config.<x> = <literal>` idiom), and the whole `rule()` call is skipped if any argument isn't a literal Symbol (declines splats, Strings, locals, and the nested-key Hash form).

## Contradictions found (reported, not silently redesigned)

- Issue #137's checkbox 1 describes typed `result.to_h` as still-to-build "via the ADR-16 Tier C synthetic-method mechanism." That headline deliverable was **already shipped** in a prior commit, via `dynamic_return` (ADR-37) instead — the README's own "Landed since" note already explains why Tier C didn't fit (Tier C synthesises methods from a class-level DSL call; this is a return type for a call chain off a constant). This PR's actual scope for checkbox 1 was therefore narrower than the issue text: just the two remaining ceiling items the README named (`each { ... }` recursion, per-row diagnostics).
- `dry-schema.unknown-predicate` (the sibling diagnostic the README also named) is **deliberately not implemented**. There is no reliable static signal that distinguishes a genuinely mistyped predicate name from one of dry-schema's many legitimate fine-grained predicates (`size?` / `gt?` / `format?` / `included_in?` / ...) this scanner doesn't model, and a bare `required(:key)` with no type-bearing predicate at all is itself valid dry-schema (a presence-only check). Guessing here would flag correct code, so it's declined per `AGENTS.md`'s "false positives outrank worst-case reading."
- No boundary into `lib/rigor/` was needed — all four checkboxes stayed within `plugins/rigor-dry-schema/` and `plugins/rigor-dry-validation/`. One incidental engine-adjacent finding: the `each{}` recursion's first draft made `collect_schema_shape` call itself, and Rigor's own `make check` self-check then reported "condition is always truthy" on the empty-shape guard — a genuine return-type-inference imprecision for recursive methods, not a bug in the new code (verified: the check evaluates correctly at runtime in both branches; the spec covering the non-empty case passes). Rather than touch the engine, the recursion was restructured with a `nested:` flag so `collect_schema_shape` never calls itself (a `nested: true` call declines a further `each` rather than recursing again) — this also matches the deliberate "cap at one level of nesting" scope decision, so it wasn't a workaround so much as the right shape anyway.

## Test plan

- [x] `make verify` (parallel rspec, rubocop, `rigor check lib`, `rigor check plugins/*/lib examples/*/lib`) green after each of the three commits.
- [x] `git diff --check` clean.
- [x] New integration specs in `spec/integration/plugins/dry_schema_plugin_spec.rb` and `spec/integration/plugins/dry_validation_plugin_spec.rb` cover: each-block recursion (both spellings, the declines-when-unrecognised case, alias resolution), the unknown-type diagnostic (fires / doesn't fire on a Constant arg / recurses into nested rows), params/json → to_h refinement (both adapters, the "rigor-dry-schema not loaded" fallback, the "not a bare top-level statement" decline), and rule-key-mismatch (fires, doesn't fire on a declared or unmodelled key, declines on an unrecognised schema statement / splat / nested-key Hash / rigor-dry-schema absent).
- [x] Both plugins' `demo/` directories updated and manually run end-to-end (`rigor check` against each) to confirm the new diagnostics and refined types actually appear in real CLI output, not just in specs.
- [x] READMEs' inventory/ceiling sections updated to reflect what shipped; CHANGELOG `[Unreleased]` carries one `**[plugins]**` bullet per landed item.