### PR TITLE
Widen every variable a mutation receiver can select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** Filling a collection through a receiver that *selects* between variables — `(kind == :required ? required : optional)[key] = value`, an `if`/`else`, or a `||` — now widens every variable the receiver can be, so a later `.empty?` on one of them no longer draws a false `flow.always-truthy-condition` ([#277](https://github.com/rigortype/rigor/issues/277)).
 - **[engine]** A nested `Result = Data.define(...)` (or `Struct.new(...)`) constant is now visible across files, so a call on a factory's return no longer draws a false `call.undefined-method` attributed to a same-named class in the parent namespace ([#271](https://github.com/rigortype/rigor/issues/271)).
 - **[engine]** A class that defines the same method name on both sides — `def helper` plus a `class << self` (or `def self.helper`) twin — no longer draws a false `call.undefined-method` on the class-side call ([#239](https://github.com/rigortype/rigor/issues/239)).
   - The in-source method table records one kind per name, so the second definition erased the first and the method Rigor could see in the source read as missing. It now records both, including when the two definitions live in different files. Real instance: `Haml::Compiler::ScriptCompiler.find_and_preserve` on the `haml` gem, which declares that name as both a class method and an instance method.

--- a/lib/rigor/inference/mutation_widening.rb
+++ b/lib/rigor/inference/mutation_widening.rb
@@ -2,6 +2,7 @@
 
 require_relative "../type"
 require_relative "../source/node_children"
+require_relative "receiver_alias"
 
 module Rigor
   module Inference
@@ -45,6 +46,10 @@ module Rigor
     #
     # - `arr.<mutator>(...)` where `arr` is a local variable.
     # - `@arr.<mutator>(...)` where `@arr` is an instance variable.
+    # - a receiver that *selects* among such variables rather than naming one —
+    #   `(kind == :required ? required : optional)[key] = info`, an `if`/`else`, `||` / `&&`. Every
+    #   variable the expression can evaluate to is a possible mutation target, so every one widens
+    #   (issue #277). See {ReceiverAlias}.
     #
     # Out of scope (left for a separate cycle):
     #
@@ -100,10 +105,10 @@ module Rigor
         PURE_SELF_RETURNERS.include?(method_name)
       end
 
-      # Returns a scope with the call's receiver widened, when the receiver is a
-      # local-/instance-variable read whose current binding is a literal-shape carrier
+      # Returns a scope with the call's receiver widened, for every variable the receiver expression
+      # can evaluate to ({ReceiverAlias.candidates}) whose current binding is a literal-shape carrier
       # (`Tuple` / `HashShape`) or an empty-witness refinement (`non-empty-array` /
-      # `non-empty-hash`) AND the call name is a known in-place mutator for that shape.
+      # `non-empty-hash`) AND whose call name is a known in-place mutator for that shape.
       # Returns `current_scope` unchanged otherwise.
       #
       # @param call_node     [Prism::CallNode]
@@ -115,13 +120,8 @@ module Rigor
         receiver = call_node.receiver
         return current_scope if receiver.nil?
 
-        case receiver
-        when Prism::LocalVariableReadNode
-          widen_local(call_node.name, receiver.name, current_scope)
-        when Prism::InstanceVariableReadNode
-          widen_ivar(call_node.name, receiver.name, current_scope)
-        else
-          current_scope
+        ReceiverAlias.candidates(receiver).reduce(current_scope) do |acc, read|
+          widen_alias_read(call_node.name, read, acc)
         end
       end
 
@@ -130,13 +130,13 @@ module Rigor
       # LOCALS are otherwise invisible to the post-call outer scope (ivars are handled correctly
       # already because they live in the method-body scope, not the block-local scope).
       #
-      # Walks the block AST for `<receiver>.<method>(...)` calls whose receiver is either a
-      # `LocalVariableReadNode` with `depth > 0` (a captured outer local — Prism's `depth`
-      # counts scope hops outward; `depth == 0` means a block-local) or an
-      # `InstanceVariableReadNode` (always method-scope), and applies `widen_after_call` for
-      # each one against the outer scope. The widening is always safe — it can only LOSE
-      # precision — so blindly propagating is sound regardless of whether the block actually
-      # runs.
+      # Walks the block AST for `<receiver>.<method>(...)` calls, resolves the receiver expression
+      # to the variables it can evaluate to ({ReceiverAlias.candidates}), and widens each one
+      # against the outer scope. A `LocalVariableReadNode` with `depth == 0` is skipped — Prism's
+      # `depth` counts scope hops outward, so `0` means a block-local, not a capture; an
+      # `InstanceVariableReadNode` is always method-scope and always applies. The widening is
+      # always safe — it can only LOSE precision — so blindly propagating is sound regardless of
+      # whether the block actually runs.
       #
       # Recurses into nested expression nodes so chained / nested forms (`arr << f(x); arr <<
       # g(y)`, `arr.push(x) if cond`) are all caught. Does NOT recurse into nested
@@ -174,15 +174,20 @@ module Rigor
         receiver = call_node.receiver
         return scope if receiver.nil?
 
-        case receiver
-        when Prism::LocalVariableReadNode
-          return scope if receiver.depth.zero?
+        ReceiverAlias.candidates(receiver).reduce(scope) do |acc, read|
+          # A block-local read (`depth == 0`) is not a capture of the outer scope, so widening its
+          # name against the OUTER scope would hit an unrelated same-named binding.
+          next acc if read.is_a?(Prism::LocalVariableReadNode) && read.depth.zero?
 
-          widen_local(call_node.name, receiver.name, scope)
-        when Prism::InstanceVariableReadNode
-          widen_ivar(call_node.name, receiver.name, scope)
-        else
-          scope
+          widen_alias_read(call_node.name, read, acc)
+        end
+      end
+
+      def widen_alias_read(method_name, read, scope)
+        case read
+        when Prism::LocalVariableReadNode then widen_local(method_name, read.name, scope)
+        when Prism::InstanceVariableReadNode then widen_ivar(method_name, read.name, scope)
+        else scope
         end
       end
 

--- a/lib/rigor/inference/receiver_alias.rb
+++ b/lib/rigor/inference/receiver_alias.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "prism"
+
+module Rigor
+  module Inference
+    # Which variables can a receiver EXPRESSION evaluate to?
+    #
+    # A receiver-fact invalidation (see {MutationWidening}) has to name the binding it invalidates,
+    # and the overwhelmingly common receiver — a bare `arr` / `@arr` read — names exactly one. But a
+    # receiver may also *select* among variables without naming any of them:
+    #
+    #     (kind == :required ? required : optional)[key] = info
+    #
+    # The mutation lands on whichever of `required` / `optional` the ternary picked, so BOTH are
+    # possible targets and both must forget their literal shape. Reading only the syntactic head
+    # left both hashes carrying the empty `HashShape` the literal `{}` wrote, and a downstream
+    # `.empty?` then constant-folded into a false `flow.always-truthy-condition`
+    # ([#277](https://github.com/rigortype/rigor/issues/277)).
+    #
+    # The recursion covers only the forms whose value IS one of the sub-expressions: `if` / `unless`
+    # (including the ternary spelling), the short-circuit operators, and the transparent wrappers.
+    # Anything else — an index read (`declared[kind] << key`), a call result, a literal — names an
+    # object no binding can be attributed to and yields `[]`, which is what every receiver form
+    # outside the single-read case already contributed. The walk is depth-capped so a pathological
+    # nest cannot make receiver classification unbounded.
+    module ReceiverAlias
+      # Deep enough for any hand-written selection; a nest beyond it degrades to "names no binding".
+      WALK_DEPTH_CAP = 6
+
+      module_function
+
+      # @param node  [Prism::Node, nil] the receiver expression.
+      # @param depth [Integer] recursion depth, internal.
+      # @return [Array<Prism::LocalVariableReadNode, Prism::InstanceVariableReadNode>] every variable
+      #   read the expression can evaluate to; empty when it can evaluate to none.
+      def candidates(node, depth = 0)
+        return [] if node.nil? || depth > WALK_DEPTH_CAP
+
+        case node
+        when Prism::LocalVariableReadNode, Prism::InstanceVariableReadNode then [node]
+        when Prism::ParenthesesNode then candidates(node.body, depth + 1)
+        when Prism::StatementsNode then candidates(node.body.last, depth + 1)
+        when Prism::ElseNode then candidates(node.statements, depth + 1)
+        when Prism::IfNode then branches(node.statements, node.subsequent, depth)
+        when Prism::UnlessNode then branches(node.statements, node.else_clause, depth)
+        when Prism::OrNode, Prism::AndNode then branches(node.left, node.right, depth)
+        else []
+        end
+      end
+
+      def branches(first, second, depth)
+        candidates(first, depth + 1) + candidates(second, depth + 1)
+      end
+    end
+  end
+end

--- a/spec/integration/fixtures/aliased_mutation_receiver.rb
+++ b/spec/integration/fixtures/aliased_mutation_receiver.rb
@@ -1,0 +1,83 @@
+require "rigor/testing"
+include Rigor::Testing
+
+# Issue #277 — a mutation whose receiver is a *selection over variables* rather
+# than a bare variable read.
+#
+# `(kind == :required ? required : optional)[key] = info` mutates whichever of
+# the two hashes the ternary picked, but the receiver-widening walk only
+# recognised a bare `LocalVariableReadNode` / `InstanceVariableReadNode`
+# receiver, so BOTH hashes kept the empty `HashShape` seed the literal `{}`
+# wrote. `collect`'s return then read as the fully value-pinned
+# `{ required: {}, optional: {} }`, and the caller's
+# `shape[:required].empty? && shape[:optional].empty?` folded to
+# `Constant[true]` — a `flow.always-truthy-condition` on a condition that is
+# false for every input carrying a row.
+#
+# Reduced from `Rigor::Plugin::DrySchema::SchemaScanner.collect_schema_shape`,
+# where the FP fired on `each_block_type_info`'s emptiness check. Two features
+# of that shape are load-bearing and are both preserved here:
+#
+#   1. the block is handed to a user-defined method that FORWARDS it, so the
+#      engine cannot classify the call as `:non_escaping` and the ADR-56
+#      captured-writeback path does not run — post-call widening is the only
+#      thing standing between the seed and the caller;
+#   2. `collect` is self-recursive through `element_info`, so its return type is
+#      decided by the ADR-55 fixpoint. The fixpoint faithfully reproduces
+#      whatever the body computes: with the seed left un-widened it converged on
+#      the pinned empty shape and handed the caller a statically decided
+#      condition. The recursion is what SURFACED the defect (without it the
+#      cycle guard masked the body's result behind `Dynamic[top]`); the mutation
+#      receiver is what CAUSED it.
+#
+# The union across the recursive edge must stay open: `required` / `optional`
+# are `Hash`, never the empty `HashShape`.
+module SchemaWalk
+  module_function
+
+  # `rows` is `[[kind, key, nested_rows_or_nil], ...]`.
+  def collect(rows)
+    required = {}
+    optional = {}
+    declared = { required: [], optional: [] }
+    each_row(rows) do |kind, key, nested|
+      declared[kind] << key
+      info = element_info(nested)
+      (kind == :required ? required : optional)[key] = info if info
+    end
+    { required: required.freeze, optional: optional.freeze, declared: declared }.freeze
+  end
+
+  def each_row(rows, &)
+    forward(rows, &)
+  end
+
+  def forward(rows, &block)
+    rows.each { |kind, key, nested| block.call(kind, key, nested) }
+  end
+
+  # The self-recursive edge: a nested row's element info is the collector's own
+  # result, so `collect` is inferred through a cycle.
+  def element_info(nested)
+    return nil if nested.nil?
+
+    shape = collect(nested)
+    return nil if shape[:required].empty? && shape[:optional].empty?
+
+    { nested: shape }
+  end
+end
+
+shape = SchemaWalk.collect([[:required, :email, nil], [:optional, :tags, [[:required, :id, nil]]]])
+
+# `required` / `optional` are `Hash`, not the empty `HashShape` seed — the union
+# across the recursive edge stays open and `element_info`'s emptiness guard is
+# not statically decided.
+#
+# `declared` is a KNOWN, deliberate residual and marks the boundary of the fix:
+# `declared[kind] << key` mutates the array an INDEX READ returned, and an index
+# read names an object no binding can be attributed to, so the widening declines
+# rather than guessing which entry moved. It folds no condition here, so it is
+# not a false-positive source; tightening it would need element-level tracking
+# inside a `HashShape`, which is a separate feature.
+assert_type("{ required: Hash, optional: Hash, declared: { required: [], optional: [] } }", shape)

--- a/spec/integration/snapshots/aliased_mutation_receiver.yml
+++ b/spec/integration/snapshots/aliased_mutation_receiver.yml
@@ -1,0 +1,3 @@
+---
+locals:
+  shape: Dynamic[top]

--- a/spec/integration/type_construction_spec.rb
+++ b/spec/integration/type_construction_spec.rb
@@ -179,6 +179,25 @@ RSpec.describe "Rigor type construction (integration)" do
     end
   end
 
+  describe "fixtures/aliased_mutation_receiver.rb — issue #277 selection-receiver mutation widening" do
+    let(:harness) { harness_for("aliased_mutation_receiver") }
+
+    # `(kind == :required ? required : optional)[key] = info` mutates whichever hash the ternary picked, so
+    # BOTH forget their empty-`HashShape` seed. The recursive collector's return union therefore stays open
+    # across the recursive edge (`required` / `optional` are `Hash`, not `{}`).
+    it "keeps the recursive return union open across the recursive edge" do
+      mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
+      expect(mismatches).to be_empty
+    end
+
+    # The caller's `shape[:required].empty? && shape[:optional].empty?` is live for every input carrying a
+    # row; before the fix it folded to `Constant[true]` and fired a `flow.always-truthy-condition`.
+    it "fires no flow.always-truthy-condition on the recursive collector's emptiness guard" do
+      flow_constants = harness.diagnostics.select { |d| d.rule == "flow.always-truthy-condition" }
+      expect(flow_constants).to be_empty
+    end
+  end
+
   describe "fixtures/is_a_narrowing.rb — String | nil narrowing" do
     let(:harness) { harness_for("is_a_narrowing") }
 

--- a/spec/rigor/inference/mutation_widening_spec.rb
+++ b/spec/rigor/inference/mutation_widening_spec.rb
@@ -226,6 +226,41 @@ RSpec.describe Rigor::Inference::MutationWidening do
                                          "expected #{meth} not to widen the HashShape, but it did"
       end
     end
+
+    # Issue #277 — the receiver may SELECT among variables instead of naming one. Every candidate the
+    # expression can evaluate to is the mutation's possible target, so every candidate must widen.
+    it "widens both arms of a ternary receiver under `[]=`" do
+      shape = Rigor::Type::HashShape.new(a: Rigor::Type::Combinator.nominal_of("Integer"))
+      seeded = scope.with_local(:required, shape).with_local(:optional, shape)
+      call = parse_call("required = {}; optional = {}; (flag ? required : optional)[key] = value")
+      result = described_class.widen_after_call(call_node: call, current_scope: seeded)
+
+      expect(result.local(:required).class_name).to eq("Hash")
+      expect(result.local(:optional).class_name).to eq("Hash")
+    end
+
+    it "widens both arms of an `if`/`else` receiver and of a short-circuit receiver" do
+      tuple = Rigor::Type::Combinator.tuple_of(Rigor::Type::Combinator.nominal_of("String"))
+      seeded = scope.with_local(:head, tuple).with_local(:tail, tuple)
+
+      if_call = parse_call("head = []; tail = []; (if flag then head else tail end) << x")
+      if_result = described_class.widen_after_call(call_node: if_call, current_scope: seeded)
+      expect(if_result.local(:head).class_name).to eq("Array")
+      expect(if_result.local(:tail).class_name).to eq("Array")
+
+      or_call = parse_call("head = []; tail = []; (head || tail) << x")
+      or_result = described_class.widen_after_call(call_node: or_call, current_scope: seeded)
+      expect(or_result.local(:head).class_name).to eq("Array")
+      expect(or_result.local(:tail).class_name).to eq("Array")
+    end
+
+    it "declines for a receiver that names no binding — an index read is not an alias" do
+      shape = Rigor::Type::HashShape.new(required: Rigor::Type::Combinator.tuple_of)
+      seeded = scope.with_local(:declared, shape)
+      call = parse_call("declared = {}; declared[kind] << key")
+
+      expect(described_class.widen_after_call(call_node: call, current_scope: seeded)).to equal(seeded)
+    end
   end
 
   describe ".widen_after_block" do
@@ -326,6 +361,40 @@ RSpec.describe Rigor::Inference::MutationWidening do
       seeded = Rigor::Scope.empty.with_local(:arr, tuple)
       result = described_class.widen_after_block(call_node: call, outer_scope: seeded)
       expect(result.local(:arr)).to equal(tuple)
+    end
+
+    # Issue #277's exact shape: the block routes the mutation through a ternary over two captured hashes.
+    it "widens every captured arm of a selection receiver inside a block body" do
+      call = parse_each_call(<<~RUBY)
+        required = {}
+        optional = {}
+        rows.each do |kind, key, info|
+          (kind == :required ? required : optional)[key] = info
+        end
+      RUBY
+      shape = Rigor::Type::HashShape.new(a: Rigor::Type::Combinator.nominal_of("Integer"))
+      seeded = Rigor::Scope.empty.with_local(:required, shape).with_local(:optional, shape)
+      result = described_class.widen_after_block(call_node: call, outer_scope: seeded)
+
+      expect(result.local(:required).class_name).to eq("Hash")
+      expect(result.local(:optional).class_name).to eq("Hash")
+    end
+
+    # The depth-0 skip applies per candidate, not per receiver expression: a selection mixing an outer capture
+    # with a block-local shadow widens only the capture.
+    it "skips a block-local arm of a selection receiver while widening the captured arm" do
+      call = parse_each_call(<<~RUBY)
+        arr = [1]
+        other = [1]
+        items.each do |arr|
+          (flag ? arr : other) << 1
+        end
+      RUBY
+      seeded = Rigor::Scope.empty.with_local(:arr, tuple).with_local(:other, tuple)
+      result = described_class.widen_after_block(call_node: call, outer_scope: seeded)
+
+      expect(result.local(:arr)).to equal(tuple)
+      expect(result.local(:other).class_name).to eq("Array")
     end
   end
 


### PR DESCRIPTION
Closes #277.

## Root cause — not the recursion

`Rigor::Inference::MutationWidening` read only the syntactic head of a mutator call's receiver: `lib/rigor/inference/mutation_widening.rb:118` (`widen_after_call`) and `:177` (`widen_for_outer_receiver`, the ADR-56 block path) each ran a `case receiver` that widened a bare `LocalVariableReadNode` / `InstanceVariableReadNode` and returned the scope untouched for everything else. A receiver may also *select* among variables without naming one:

```ruby
(kind == :required ? required : optional)[key] = info
```

The mutation lands on whichever hash the ternary picked, so both are possible targets and both must forget their literal shape. Neither did, so both kept the empty `HashShape` the literal `{}` wrote, and a later `.empty?` on either folded to `Constant[true]`.

In `plugins/rigor-dry-schema/.../schema_scanner.rb` that stale seed rode out on `collect_schema_shape`'s return value, and `each_block_type_info`'s `nested_shape[:required].empty? && nested_shape[:optional].empty?` guard drew `flow.always-truthy-condition` on a condition that is false for every input carrying a row.

**The self-recursion surfaced the defect; it did not cause it.** With the `nested:` workaround reverted locally, `rigor type-of` at the guard reads `{ required: {}, optional: {}, ... }` — the fully value-pinned body result the ADR-55 fixpoint converged on. With the workaround in place the same position reads `Dynamic[top]`: the cycle guard masked the identical wrong body result behind `untyped`. The fixpoint reproduced exactly what the body computed, which is its contract. Reduced to a 12-line non-recursive function with a ternary mutation target, the same false positive fires — a recursive edge is not needed to trigger it.

## The fix

The receiver expression now resolves to the *set* of variables it can evaluate to (new `Rigor::Inference::ReceiverAlias`) — through `if` / `unless` including the ternary spelling, the short-circuit operators, and the transparent wrappers — and each candidate widens. Anything whose value is not one of its own sub-expressions (an index read `declared[kind] << key`, a call result, a literal) still yields the empty set, so no receiver form that declined before starts widening now. The walk is depth-capped at 6. Inside a block the `depth == 0` block-local skip applies per candidate, so a selection mixing a capture with a shadow widens only the capture.

This is a widening — it forgets a literal-shape fact the mutation no longer justifies and never adds one. It is a pure bug fix against an existing normative MUST: `docs/type-specification/control-flow-analysis.md:69` already requires that an in-place mutator invalidate a receiver refinement, with no qualification on how the receiver is spelled. No documented contract moves, so no spec-corpus change.

## FP gate

| Corpus | Before | After |
| --- | --- | --- |
| `lib` (`make check`) | 0 | 0 |
| `plugins/*/lib examples/*/lib` (`make check-plugins`) | 0 | 0 |
| `plugins/*/lib examples/*/lib`, `nested:` workaround reverted locally | 1 (`flow.always-truthy-condition`) | 0 |
| Mastodon `app` + `lib` | 313 | 313, byte-identical |
| `spec/integration/snapshots/` (all fixtures, regenerated) | — | zero movement outside the new fixture |

`make verify` exits 0; `git diff --check` exits 0.

## Regression spec

`spec/integration/fixtures/aliased_mutation_receiver.rb` is reduced from the real `collect_schema_shape` shape rather than invented minimal — per #271's lesson — and keeps both load-bearing features: the block is handed to a user method that *forwards* it (so the call cannot classify as `:non_escaping` and the ADR-56 captured-writeback path does not run), and the collector is self-recursive so its return is decided by the ADR-55 fixpoint. It pins the return union staying open across the recursive edge (`required` / `optional` are `Hash`, never `{}`) and asserts no `flow.always-truthy-condition` fires. Verified RED on master: `assert_type mismatch: expected "{ required: Hash, optional: Hash, ... }", got "{ required: {}, optional: {}, ... }"` plus the always-truthy warning at the guard. Unit coverage for the primitive lands in `spec/rigor/inference/mutation_widening_spec.rb`, including the negative — an index read is not an alias and must not widen.

## Known residual, deliberately out of scope

`declared[kind] << key` mutates the array an *index read* returned. An index read names an object no binding can be attributed to, so the widening declines rather than guessing which entry moved, and `declared` keeps `{ required: [], optional: [] }`. It folds no condition in the real plugin, so it is not a false-positive source today; tightening it needs element-level tracking inside a `HashShape`, which is a separate feature. The fixture asserts this residual explicitly so it stays visible.

## The `nested:` workaround should stay

PR #276's `nested:` flag earns its place on design merit independently of this fix: issue #137 deliberately caps `each do ... end` recursion at one level (doubly-nested arrays-of-arrays are not modelled), and threading the flag expresses that cap by construction instead of by depth-counting. Removing it would change the plugin's modelling decision, not just its inference workaround. The claim that the engine no longer needs it is proved by the scratch reproduction above, not by deleting it.
