### PR TITLE
Gate the LSP buffer pool on batch size, below which it is slower

### DIFF
--- a/docs/design/20260517-language-server.md
+++ b/docs/design/20260517-language-server.md
@@ -178,14 +178,25 @@ The mechanism that landed:
   child processes and they exit when done, which is the right shape
   for a bursty, debounced workload (steady stream of single-buffer
   publishes, occasional bursts) rather than a saturated one.
-- `DiagnosticPublisher#enqueue_batch` coalesces `publish_for` calls
-  whose per-URI debounce timers elapse close together (a
+- `Rigor::LanguageServer::PublishBatcher` coalesces `publish_for`
+  calls whose per-URI debounce timers elapse close together (a
   workspace-wide rename, a git branch switch touching many open
   files) into ONE `#publish_many` round dispatched through
   `BufferPoolDispatcher`, single-flighted the same way the #246 save
   round already is. A lone edit still takes exactly today's
   single-buffer path (`#run_and_notify`) — the batch layer is a
   no-op for N=1.
+- **Size gate, added on review:** below `BufferPoolDispatcher::DEFAULT_MIN_BATCH_SIZE`
+  (16; override via `RIGOR_LSP_POOL_MIN_BATCH`), `#analyze` takes the
+  sequential in-process path even when the pool is otherwise
+  available. A measurement against this repo's own `lib/rigor`
+  showed `fork` + `Marshal` + `Process.waitpid2` overhead exceeding
+  the parallelism win below roughly N=12 — squarely the size of a
+  realistic burst — and only paying off cleanly from N=16 up; see
+  `BufferPoolDispatcher`'s own doc comment for the full table. The
+  gate's fallback is the exact same computation the sequential path
+  already runs, so it is never slower than today, only slower than
+  the pool it declines to use below the threshold.
 - Pool size N resolves from `parallel.workers:` / `RIGOR_RACTOR_WORKERS`,
   mirroring `rigor check`, exactly as originally specified.
 - `hover` / `documentSymbol` still run inline on the main process

--- a/lib/rigor/analysis/runner/buffer_pool_dispatcher.rb
+++ b/lib/rigor/analysis/runner/buffer_pool_dispatcher.rb
@@ -39,6 +39,42 @@ module Rigor
       # would make that worker parse the file as it sits on disk and publish plausible-looking, stale
       # diagnostics; every code path below carries `binding` explicitly rather than defaulting to nil.
       class BufferPoolDispatcher
+        # Below this many bindings, `#analyze` takes the sequential in-process path even when the pool is
+        # otherwise available (workers positive, `fork` available, `cache_store` present). Reviewed and
+        # required for #142 to merge: a throwaway measurement against this repo's own `lib/rigor` (46-353
+        # files, ~1-2ms/file analysis once `Environment` + `ProjectScan` are warm — the exact steady state
+        # this dispatcher runs in) showed the FORK + `Marshal` + `Process.waitpid2` overhead exceeding the
+        # parallelism win below roughly N=12, and only paying off cleanly from N=16 up (interleaved,
+        # median-of-5, `workers: 8`):
+        #
+        #   N=8   sequential=0.018s  pooled=0.027s  speedup=0.66x  (pool SLOWER)
+        #   N=12  sequential=0.021s  pooled=0.021s  speedup=1.00x  (break-even, noisy)
+        #   N=16  sequential=0.028s  pooled=0.025s  speedup=1.09x
+        #   N=24  sequential=0.038s  pooled=0.026s  speedup=1.47x
+        #   N=32  sequential=0.050s  pooled=0.029s  speedup=1.73x
+        #
+        # 16 sits with margin ABOVE the noisy break-even (12), not at it — full method + table in #142's PR
+        # description.
+        #
+        # This is deliberately a FIXED default, not a per-project auto-calibrated one. Per-file analysis cost
+        # varies enormously by project — this repo's own `lib/rigor` is ~1-2ms/file warm; a large Rails
+        # controller or model file can cost far more, which would make pooling profitable at a MUCH smaller N
+        # there. A cost-aware gate — deciding from the publisher's own observed per-publish duration instead
+        # of a bare file count — would adapt automatically, but needs plumbing that does not exist today (the
+        # publisher tracks no timing history) and is disproportionate to what closing #142 calls for; it is a
+        # reasonable follow-up, not attempted here. A project whose crossover sits at a different N overrides
+        # via `RIGOR_LSP_POOL_MIN_BATCH` (mirrors `RIGOR_RACTOR_WORKERS`'s override shape).
+        DEFAULT_MIN_BATCH_SIZE = 16
+
+        # @return [Integer] `RIGOR_LSP_POOL_MIN_BATCH` when set to a non-empty value, else
+        #   {DEFAULT_MIN_BATCH_SIZE}.
+        def self.resolve_min_batch_size
+          env_value = ENV.fetch("RIGOR_LSP_POOL_MIN_BATCH", nil)
+          return DEFAULT_MIN_BATCH_SIZE if env_value.nil? || env_value.empty?
+
+          Integer(env_value)
+        end
+
         # @param configuration [Rigor::Configuration]
         # @param cache_store [Rigor::Cache::Store, nil]
         # @param environment [Rigor::Environment] the warm, shared per-session Environment
@@ -46,15 +82,22 @@ module Rigor
         # @param prebuilt [Rigor::Analysis::ProjectScan] the warm, shared pre-pass snapshot
         #   (`ProjectContext#project_scan`) every job's Runner adopts instead of re-scanning.
         # @param workers [Integer] pool size. `#analyze` degrades to sequential in-process execution — one
-        #   job at a time, no `fork` — when fewer than 2 bindings are submitted, `workers` is not positive,
-        #   `fork` is unavailable on this platform, or `cache_store` is nil. The last two mirror
+        #   job at a time, no `fork` — when fewer than 2 bindings are submitted, fewer than `min_batch_size`
+        #   bindings are submitted, `workers` is not positive, `fork` is unavailable on this platform, or
+        #   `cache_store` is nil. The middle two are the fork-pool-is-not-worth-it-yet gate documented on
+        #   {DEFAULT_MIN_BATCH_SIZE}; the last two mirror
         #   {PoolCoordinator#analyze_files_in_pool}'s own fork-pool preconditions.
-        def initialize(configuration:, cache_store:, environment:, prebuilt:, workers:)
+        # @param min_batch_size [Integer] see {DEFAULT_MIN_BATCH_SIZE}. Exposed as a constructor param
+        #   (rather than read from the env internally) purely for spec control; production callers get the
+        #   resolved default.
+        def initialize(configuration:, cache_store:, environment:, prebuilt:, workers:,
+                       min_batch_size: self.class.resolve_min_batch_size)
           @configuration = configuration
           @cache_store = cache_store
           @environment = environment
           @prebuilt = prebuilt
           @workers = workers
+          @min_batch_size = min_batch_size
         end
 
         # Runs one `Runner#run([binding.logical_path])` per binding and returns `Array<Array<Diagnostic>>` —
@@ -72,7 +115,8 @@ module Rigor
         private
 
         def dispatchable?(bindings)
-          bindings.size > 1 && @workers.is_a?(Integer) && @workers.positive? &&
+          bindings.size > 1 && bindings.size >= @min_batch_size &&
+            @workers.is_a?(Integer) && @workers.positive? &&
             Process.respond_to?(:fork) && !@cache_store.nil?
         end
 

--- a/spec/rigor/analysis/runner/buffer_pool_dispatcher_spec.rb
+++ b/spec/rigor/analysis/runner/buffer_pool_dispatcher_spec.rb
@@ -64,7 +64,22 @@ RSpec.describe Rigor::Analysis::Runner::BufferPoolDispatcher do
     Rigor::LanguageServer::ProjectContext.new(configuration: Rigor::Configuration.new("paths" => [dir]))
   end
 
-  def dispatcher_for(dir, context, workers:, cache_store: context.cache_store)
+  # `min_batch_size: 2` — most of this file's fixtures use small N (5-8 buffers) to keep specs fast, and
+  # exist to prove the fork path's CORRECTNESS (equivalence, buffer substitution), independent of where the
+  # size gate happens to sit. `#dispatcher_with_resolved_gate_for` (below) uses the REAL resolved default
+  # instead, specifically to test the gate itself.
+  def dispatcher_for(dir, context, workers:, cache_store: context.cache_store, min_batch_size: 2)
+    described_class.new(
+      configuration: context.configuration, cache_store: cache_store,
+      environment: Dir.chdir(dir) { context.environment }, prebuilt: Dir.chdir(dir) { context.project_scan },
+      workers: workers, min_batch_size: min_batch_size
+    )
+  end
+
+  # Omits `min_batch_size:` entirely so the constructor's own default (`resolve_min_batch_size`, reading
+  # `RIGOR_LSP_POOL_MIN_BATCH` / `DEFAULT_MIN_BATCH_SIZE`) applies — the shape production callers
+  # (`DiagnosticPublisher#publish_batch`) get.
+  def dispatcher_with_resolved_gate_for(dir, context, workers:, cache_store: context.cache_store)
     described_class.new(
       configuration: context.configuration, cache_store: cache_store,
       environment: Dir.chdir(dir) { context.environment }, prebuilt: Dir.chdir(dir) { context.project_scan },
@@ -184,6 +199,84 @@ RSpec.describe Rigor::Analysis::Runner::BufferPoolDispatcher do
 
         expect(dispatcher).not_to have_received(:fork)
         expect(result).to eq([])
+      end
+    end
+  end
+
+  # Reviewed and required for #142: an earlier version of this dispatcher forked for ANY `bindings.size > 1`,
+  # and a throwaway measurement against this repo's own `lib/rigor` showed that a net LOSS below roughly
+  # N=12-16 (fork + Marshal + `Process.waitpid2` overhead exceeding ~1-2ms/file real work once the
+  # environment is warm) — squarely the size of a realistic editor burst (a branch switch, a rename). See
+  # `DEFAULT_MIN_BATCH_SIZE`'s doc comment for the full table. The gate below fixes that: below the
+  # threshold, `#analyze` takes EXACTLY the sequential in-process path (proven here to be the SAME
+  # computation as `#run_one` per binding, not merely "no fork observed") — so it can never be slower than
+  # today, only slower than the pool it declines to use.
+  describe "size gate (DEFAULT_MIN_BATCH_SIZE)" do
+    it "does not fork below DEFAULT_MIN_BATCH_SIZE even with workers and cache_store available" do
+      Dir.mktmpdir do |dir|
+        context = context_for(dir)
+        bindings = write_buffer_fixture(dir, described_class::DEFAULT_MIN_BATCH_SIZE - 1)
+        dispatcher = dispatcher_with_resolved_gate_for(dir, context, workers: 8)
+
+        allow(dispatcher).to receive(:fork)
+        pool = Dir.chdir(dir) { dispatcher.analyze(bindings) }
+
+        expect(dispatcher).not_to have_received(:fork)
+        expect(pool.size).to eq(described_class::DEFAULT_MIN_BATCH_SIZE - 1)
+        expect(pool).to all(be_empty)
+      end
+    end
+
+    it "forks at DEFAULT_MIN_BATCH_SIZE" do
+      Dir.mktmpdir do |dir|
+        context = context_for(dir)
+        bindings = write_buffer_fixture(dir, described_class::DEFAULT_MIN_BATCH_SIZE)
+        dispatcher = dispatcher_with_resolved_gate_for(dir, context, workers: 8)
+
+        allow(dispatcher).to receive(:fork).and_call_original
+        pool = Dir.chdir(dir) { dispatcher.analyze(bindings) }
+
+        expect(dispatcher).to have_received(:fork).at_least(:once)
+        expect(pool.size).to eq(described_class::DEFAULT_MIN_BATCH_SIZE)
+        expect(pool).to all(be_empty)
+      end
+    end
+
+    it "below the gate, #analyze is the SAME computation #run_one would do per binding — never slower than " \
+       "today's sequential path, only slower than the pool it declines" do
+      Dir.mktmpdir do |dir|
+        context = context_for(dir)
+        bindings = write_buffer_fixture(dir, described_class::DEFAULT_MIN_BATCH_SIZE - 1)
+        dispatcher = dispatcher_with_resolved_gate_for(dir, context, workers: 8)
+
+        gated = Dir.chdir(dir) { dispatcher.analyze(bindings) }
+        direct = Dir.chdir(dir) { bindings.map { |binding| dispatcher.send(:run_one, binding) } }
+
+        gated.each_index { |i| expect(diag_keys(gated[i])).to eq(diag_keys(direct[i])) }
+      end
+    end
+
+    describe ".resolve_min_batch_size" do
+      around do |example|
+        original = ENV.fetch("RIGOR_LSP_POOL_MIN_BATCH", nil)
+        example.run
+      ensure
+        ENV["RIGOR_LSP_POOL_MIN_BATCH"] = original
+      end
+
+      it "defaults to DEFAULT_MIN_BATCH_SIZE when unset" do
+        ENV.delete("RIGOR_LSP_POOL_MIN_BATCH")
+        expect(described_class.resolve_min_batch_size).to eq(described_class::DEFAULT_MIN_BATCH_SIZE)
+      end
+
+      it "reads RIGOR_LSP_POOL_MIN_BATCH when set" do
+        ENV["RIGOR_LSP_POOL_MIN_BATCH"] = "3"
+        expect(described_class.resolve_min_batch_size).to eq(3)
+      end
+
+      it "falls back to the default for an empty value" do
+        ENV["RIGOR_LSP_POOL_MIN_BATCH"] = ""
+        expect(described_class.resolve_min_batch_size).to eq(described_class::DEFAULT_MIN_BATCH_SIZE)
       end
     end
   end

--- a/spec/rigor/language_server/diagnostic_publisher_spec.rb
+++ b/spec/rigor/language_server/diagnostic_publisher_spec.rb
@@ -103,9 +103,9 @@ RSpec.describe Rigor::LanguageServer::DiagnosticPublisher do
   end
 
   # Issue #142 — N dirty buffers published across the fork-based worker pool in one dispatch instead of one
-  # Runner call at a time. `#publish_many` is the entry point `#enqueue_batch` drives once several buffers'
-  # debounce timers elapse close together (see the "batch coalescing" section below); it is also directly
-  # callable, which is how these specs exercise it deterministically.
+  # Runner call at a time. `#publish_many` is the entry point the `PublishBatcher` (`@batcher`) drives once
+  # several buffers' debounce timers elapse close together (see the "batch coalescing" section below); it is
+  # also directly callable, which is how these specs exercise it deterministically.
   describe "#publish_many" do
     def context_for(dir)
       Rigor::LanguageServer::ProjectContext.new(configuration: Rigor::Configuration.new("paths" => [dir]))
@@ -171,7 +171,11 @@ RSpec.describe Rigor::LanguageServer::DiagnosticPublisher do
       end
     end
 
-    it "dispatches every eligible URI through ONE BufferPoolDispatcher, not N separate Runner calls" do
+    # BufferPoolDispatcher may still take its OWN sequential-in-process path internally below its size
+    # gate (`DEFAULT_MIN_BATCH_SIZE`) — that's a separate, dispatcher-level concern covered in
+    # `spec/rigor/analysis/runner/buffer_pool_dispatcher_spec.rb`. What THIS proves is the publisher-level
+    # claim: N eligible URIs become ONE dispatcher call, not N.
+    it "dispatches every eligible URI through ONE BufferPoolDispatcher call, not N separate ones" do
       Dir.mktmpdir("rigor-lsp-publish-many-dispatch-") do |dir|
         entries = write_multi_buffer_fixture(dir, 3)
         entries.each { |_path, uri, bytes| buffer_table.open(uri: uri, bytes: bytes, version: 1) }


### PR DESCRIPTION
## Context

Follow-up to #142 / #280. #280 (this branch's earlier commit, `24d839af`) merged to `master` before this review round's gate fix landed — see the note at the bottom. This PR is the gate fix on top of what is already in `master`.

## What this does

Review of #280 found the fork pool it introduced (`Rigor::Analysis::Runner::BufferPoolDispatcher`) is a net LOSS for realistic burst sizes: measured against this repo's own `lib/rigor`, N=4 was 6.3x slower and N=8 was 1.5x slower than sequential, because `fork` + `Marshal` + `Process.waitpid2` overhead exceeds the ~1-2ms-per-file real work once `Environment` + `ProjectScan` are warm. That range is exactly the shape of the editor burst the issue names (a branch switch, a rename touching several open buffers) — this repo has already treated exactly this shape as a defect once (`ForkMap`, #257/#258), fixed rather than shipped.

**Crossover sweep** — N=8,12,16,24,32 against this repo's own `lib/rigor`, `Environment`/`ProjectScan` pre-warmed once (LSP steady state), interleaved (not block-then-block, to reduce load-drift bias) median-of-5, `workers: 8`:

| N | sequential | pooled | speedup |
|---|---|---|---|
| 8 | 0.018s | 0.027s | 0.66x — pool **slower** |
| 12 | 0.021s | 0.021s | 1.00x — break-even, noisy |
| 16 | 0.028s | 0.025s | 1.09x |
| 24 | 0.038s | 0.026s | 1.47x |
| 32 | 0.050s | 0.029s | 1.73x |

**The gate**: `BufferPoolDispatcher::DEFAULT_MIN_BATCH_SIZE = 16` — chosen with margin ABOVE the noisy break-even (12), not at it. Below it, `#analyze` takes exactly the same sequential in-process path `#run_one` always ran per binding — not a new "slow path", the literal same computation — which is what makes "never slower than before the gate existed" a structural guarantee rather than an empirical hope, and what the new "size gate" spec pins directly (below the threshold, no `fork` call is ever made, and the gated result equals calling `#run_one` per binding directly). Override via `RIGOR_LSP_POOL_MIN_BATCH`, mirroring `RIGOR_RACTOR_WORKERS`'s existing override shape.

**Design choice, and why**: a fixed default constant, not a cost-aware gate. Per-file analysis cost varies enormously by project — this repo's own `lib/rigor` is unusually fast (~1-2ms/file warm); a large Rails controller or model file could push the real crossover much lower, where pooling would pay off at a smaller N than 16 here. A cost-aware gate — deciding from the publisher's own observed per-publish duration instead of a bare file count — would adapt to that automatically, and is a reasonable follow-up. It needs plumbing that doesn't exist today (the publisher tracks no timing history), which is disproportionate to what this fix calls for right now, so a fixed default + env override is the design that shipped.

## Note on how this branch got here

This is the same branch (`lsp-buffer-pool-dispatch-142`) #280 was opened from. #280 was merged externally (by @zonuexe) while this gate fix was still in review — the ungated version of `BufferPoolDispatcher` (with the N=4/N=8 slowdown above) is therefore already in `master`. This PR's single commit (`278f60b0`, "Gate the buffer pool on batch size, below which it is slower") is the delta on top of that merge; it was not force-pushed or rebased, so the diff below is exactly the gate fix and nothing else.

## Gates

`make verify` (inside the Nix Flake): 8582 + 8 (Ractor-pool gated spec) examples, 0 failures; `make check` / `make check-plugins` clean; `rubocop` clean. `git diff --check` clean.

## Test plan

- [x] `make verify` — full spec suite + `make check` + `make check-plugins` + rubocop, all green
- [x] `git diff --check` — clean
- [x] `spec/rigor/analysis/runner/buffer_pool_dispatcher_spec.rb` "size gate" section — no `fork` below `DEFAULT_MIN_BATCH_SIZE`, `fork` at the threshold, gated result == direct `#run_one` per binding below it, `.resolve_min_batch_size`'s env override