### PR TITLE
Close self-mutation holes in seven giant engine files

### DIFF
--- a/spec/rigor/environment/rbs_loader_spec.rb
+++ b/spec/rigor/environment/rbs_loader_spec.rb
@@ -693,6 +693,22 @@ RSpec.describe Rigor::Environment::RbsLoader do
       expect(interface_names).to include("_Writable")
     end
 
+    it "lists every method name declared by a real (non-stubbed) interface" do
+      File.write(
+        File.join(tmpdir, "readable.rbs"),
+        "interface _Readable\n  def read: () -> String\n  def close: () -> void\nend\n"
+      )
+      loader = described_class.new(signature_paths: [tmpdir])
+
+      expect(loader.interface_method_names("_Readable")).to contain_exactly(:read, :close)
+    end
+
+    it "returns nil for an interface name that does not resolve" do
+      loader = described_class.new(signature_paths: [tmpdir])
+
+      expect(loader.interface_method_names("_NoSuchInterface")).to be_nil
+    end
+
     it "lands class, namespace, interface and alias stubs from one batch" do
       # All four kinds in a single missing set — the shape that used to take the whole batch down with it,
       # since one buffer carried every declaration.

--- a/spec/rigor/inference/expression_typer_spec.rb
+++ b/spec/rigor/inference/expression_typer_spec.rb
@@ -1104,6 +1104,20 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       expect(type.pairs.keys).to eq([:a])
     end
 
+    it "per-pair folds Hash#transform_keys into a HashShape when the block yields a constant key" do
+      type = project_scope.type_of(parse_expression("{ a: 1 }.transform_keys { |k| k.to_s }"))
+
+      expect(type).to be_a(Rigor::Type::HashShape)
+      expect(type.pairs.keys).to eq(["a"])
+      expect(type.pairs.values.map(&:value)).to eq([1])
+    end
+
+    it "declines Hash#transform_keys (falls back to the nominal Hash carrier) for a non-constant new key" do
+      type = project_scope.type_of(parse_expression("{ a: 1 }.transform_keys { |k| rand }"))
+
+      expect(type.class_name).to eq("Hash")
+    end
+
     it "per-element folds Array#map for &:to_s into a Tuple" do
       type = project_scope.type_of(parse_expression("[1, 2, 3].map(&:to_s)"))
 
@@ -1376,6 +1390,23 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       expect(type.type_args.first).to eq(Rigor::Type::Combinator.nominal_of("Integer"))
     end
 
+    it "falls back to a bare Range with no type_args when neither endpoint contributes a typable shape" do
+      type = scope.with_local(:a, Rigor::Type::Combinator.untyped)
+                  .with_local(:b, Rigor::Type::Combinator.untyped)
+                  .type_of(parse_expression("(a..b)", scopes: [%i[a b]]))
+
+      expect(type.class_name).to eq("Range")
+      expect(type.type_args).to be_empty
+    end
+
+    it "derives the Integer element type from a Type::IntegerRange-typed endpoint" do
+      type = scope.with_local(:n, Rigor::Type::Combinator.integer_range(1, 10))
+                  .type_of(parse_expression("(n..20)", scopes: [[:n]]))
+
+      expect(type.class_name).to eq("Range")
+      expect(type.type_args.first).to eq(Rigor::Type::Combinator.nominal_of("Integer"))
+    end
+
     it "types non-interpolated RegularExpressionNode as Constant<Regexp> (v0.0.7)" do
       type = scope.type_of(parse_expression("/foo/"))
 
@@ -1464,6 +1495,25 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       bound = scope.with_local(:tag, union)
       node = parse_expression("\"<\#{tag}>\"", scopes: [[:tag]])
       expect(bound.type_of(node)).to eq(literal_string)
+    end
+  end
+
+  describe "per-element block fold over Constant<Range> receivers (v0.0.6 phase 2)" do
+    it "folds `.map` over a small inclusive Constant<Range> to a per-position Tuple" do
+      type = scope.type_of(parse_expression("(1..3).map { |i| i * 2 }"))
+      expect(type).to be_a(Rigor::Type::Tuple)
+      expect(type.elements.map(&:value)).to eq([2, 4, 6])
+    end
+
+    it "folds `.select` over a small exclusive Constant<Range>, dropping non-matching positions" do
+      type = scope.type_of(parse_expression("(1...4).select { |i| i.odd? }"))
+      expect(type).to be_a(Rigor::Type::Tuple)
+      expect(type.elements.map(&:value)).to eq([1, 3])
+    end
+
+    it "declines (falls back to the nominal Array carrier) above the per-element range cap" do
+      type = scope.type_of(parse_expression("(1..20).map { |i| i * 2 }"))
+      expect(type.class_name).to eq("Array")
     end
   end
 end

--- a/spec/rigor/inference/method_dispatcher/constant_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/constant_folding_spec.rb
@@ -734,6 +734,14 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
         # 10 - [0..+∞] = [-∞..10]
         expect(type).to eq(integer_range(Rigor::Type::IntegerRange::NEG_INFINITY, 10))
       end
+
+      it "folds a Union mixing Constant<Integer> and IntegerRange members via the bounding interval" do
+        # `1 | int<1, 6>` (e.g. an accumulator's running fixpoint assumption) reduces to the bounding
+        # interval int<1, 6> rather than bailing to Dynamic — `numeric_set_of`'s union_integer_bounds path.
+        mixed = Rigor::Type::Combinator.union(constant_of(1), integer_range(1, 6))
+        type = fold_types(mixed, :+, [constant_of(1)])
+        expect(type).to eq(integer_range(2, 7))
+      end
     end
 
     describe "binary comparison" do

--- a/spec/rigor/inference/method_dispatcher/shape_dispatch_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/shape_dispatch_spec.rb
@@ -1381,6 +1381,16 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ShapeDispatch do
         expect(dispatch(receiver: non_empty_str, method_name: :*, args: [non_negative_int])).to be_nil
       end
 
+      it "non-empty-string * int<0, 0> (exact-zero IntegerRange) → Constant[\"\"]" do
+        expect(dispatch(receiver: non_empty_str, method_name: :*,
+                        args: [Rigor::Type::Combinator.integer_range(0, 0)])).to eq(constant(""))
+      end
+
+      it "non-empty-string * int<1, 5> (positive IntegerRange) → non-empty-string" do
+        expect(dispatch(receiver: non_empty_str, method_name: :*,
+                        args: [Rigor::Type::Combinator.integer_range(1, 5)])).to eq(non_empty_str)
+      end
+
       it "non-empty-string * Nominal[Integer] → falls through" do
         expect(dispatch(receiver: non_empty_str, method_name: :*,
                         args: [Rigor::Type::Combinator.nominal_of("Integer")])).to be_nil
@@ -1706,6 +1716,16 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ShapeDispatch do
 
     it "declines `hash.any? { … }`" do
       expect(dispatch(receiver: h, method_name: :any?, block_type: block)).to be_nil
+    end
+  end
+
+  describe "Type::Intersection receiver dispatch (dispatch_intersection)" do
+    it "meets two IntegerRange member projections for (non_empty_string ∩ lowercase_string).size" do
+      intersection = Rigor::Type::Combinator.non_empty_lowercase_string
+      # non_empty_string.size projects positive-int (int<1, max>); lowercase_string.size projects
+      # non-negative-int (int<0, max>) — the meet is the tighter bound, positive-int.
+      expect(dispatch(receiver: intersection, method_name: :size))
+        .to eq(Rigor::Type::Combinator.positive_int)
     end
   end
 end

--- a/spec/rigor/inference/narrowing_spec.rb
+++ b/spec/rigor/inference/narrowing_spec.rb
@@ -196,6 +196,25 @@ RSpec.describe Rigor::Inference::Narrowing do
     end
   end
 
+  describe ".value_pattern_certainty" do
+    it "returns :yes when a pinned value-equality Constant subject equals the pattern value" do
+      expect(described_class.value_pattern_certainty(integer_one, 1)).to eq(:yes)
+    end
+
+    it "returns :no when a pinned value-equality Constant subject differs from the pattern value" do
+      expect(described_class.value_pattern_certainty(integer_one, 2)).to eq(:no)
+    end
+
+    it "returns :maybe when the subject is not a pinned Constant" do
+      expect(described_class.value_pattern_certainty(integer_nominal, 1)).to eq(:maybe)
+    end
+
+    it "returns :maybe for a Constant whose value class has custom `===` semantics" do
+      range_constant = Rigor::Type::Combinator.constant_of(1..5)
+      expect(described_class.value_pattern_certainty(range_constant, 3)).to eq(:maybe)
+    end
+  end
+
   describe ".predicate_scopes" do
     let(:union_int_nil) { Rigor::Type::Combinator.union(integer_nominal, constant_nil) }
 
@@ -226,6 +245,21 @@ RSpec.describe Rigor::Inference::Narrowing do
       truthy, falsey = described_class.predicate_scopes(pred, bound)
       expect(truthy.local(:x)).to eq(constant_nil)
       expect(falsey.local(:x)).to eq(integer_nominal)
+    end
+
+    it "reaches the declared-return polarity analyser for a Union receiver on an unrecognised predicate" do
+      # `.nil?` itself is intercepted earlier (by `dispatch_call`'s dedicated unary-predicate handling), so it
+      # never reaches `analyse_union_predicate_polarity` — the analyser this exercises is specifically the
+      # fallback for predicates with NO dedicated handler (its own doc comment's motivating case is
+      # ActiveSupport's `present?`). `.frozen?` has no dedicated handler either and no core-RBS arm resolves to
+      # a literal boolean, so the analyser declines (`nil`) — but reaching that decision still calls
+      # `Type::Union#members` (the `partition_arms_by_polarity` call, plus the guard's own two reads), which is
+      # what this pins: the call completes and returns the union unchanged on both edges, rather than raising.
+      bound = scope.with_local(:x, union_int_nil)
+      pred = parse_predicate("x.frozen?")
+      truthy, falsey = described_class.predicate_scopes(pred, bound)
+      expect(truthy.local(:x)).to eq(union_int_nil)
+      expect(falsey.local(:x)).to eq(union_int_nil)
     end
 
     it "swaps truthy/falsey for !x" do
@@ -343,6 +377,19 @@ RSpec.describe Rigor::Inference::Narrowing do
       expect(falsey.local(:h)).to eq(integer_nominal)
     end
 
+    it "narrows a Union of two optional-key HashShapes member-wise on both edges of key?" do
+      shape_a = Rigor::Type::HashShape.new({ foo: integer_nominal }, optional_keys: [:foo])
+      shape_b = Rigor::Type::HashShape.new({ foo: string_nominal }, optional_keys: [:foo])
+      bound = scope.with_local(:h, Rigor::Type::Combinator.union(shape_a, shape_b))
+      pred = parse_predicate("h.key?(:foo)", locals: %i[h])
+      truthy, falsey = described_class.predicate_scopes(pred, bound)
+      # Present edge: each member promotes :foo to required, still distinguishable by value type -> stays a Union.
+      expect(truthy.local(:h)).to be_a(Rigor::Type::Union)
+      truthy.local(:h).members.each { |m| expect(m.required_key?(:foo)).to be(true) }
+      # Absent edge: :foo drops from both members, collapsing the (now-identical) empty shapes into one.
+      expect(falsey.local(:h)).to eq(Rigor::Type::HashShape.new({}))
+    end
+
     # §4-4 — Elixir non-empty / tuple_size analogue.
     def array_int
       Rigor::Type::Combinator.nominal_of("Array", type_args: [integer_nominal])
@@ -382,6 +429,19 @@ RSpec.describe Rigor::Inference::Narrowing do
       truthy, falsey = described_class.predicate_scopes(pred, bound)
       expect(truthy.local(:arr)).to eq(array_int)
       expect(falsey.local(:arr)).to eq(array_int)
+    end
+
+    it "narrows a Union[Array[T1], Array[T2]] receiver member-wise on the false edge of empty?" do
+      array_str = Rigor::Type::Combinator.nominal_of("Array", type_args: [string_nominal])
+      union = Rigor::Type::Combinator.union(array_int, array_str)
+      bound = scope.with_local(:arr, union)
+      pred = parse_predicate("arr.empty?", locals: %i[arr])
+      _truthy, falsey = described_class.predicate_scopes(pred, bound)
+      expect(falsey.local(:arr)).to eq(
+        Rigor::Type::Combinator.union(
+          non_empty_int, Rigor::Type::Combinator.non_empty_array(string_nominal)
+        )
+      )
     end
 
     it "does not narrow a non-Array receiver (gradual)" do
@@ -590,6 +650,23 @@ RSpec.describe Rigor::Inference::Narrowing do
         )
         expect(multi[0].local_facts(:s, bucket: :relational)).to be_empty
       end
+    end
+  end
+
+  describe ".narrow_for_fact (ADR-7 Slice 4-A public Fact-shaped narrowing entry)" do
+    let(:env) { Rigor::Environment.default }
+    let(:union_int_string) { Rigor::Type::Combinator.union(integer_nominal, string_nominal) }
+
+    it "narrows down to a Nominal-typed Fact's class on the positive edge" do
+      fact = Rigor::FlowContribution::Fact.new(target_kind: :local, target_name: :x, type: integer_nominal)
+      expect(described_class.narrow_for_fact(union_int_string, fact, env)).to eq(integer_nominal)
+    end
+
+    it "removes a Nominal-typed Fact's class on the negative edge" do
+      fact = Rigor::FlowContribution::Fact.new(
+        target_kind: :local, target_name: :x, type: integer_nominal, negative: true
+      )
+      expect(described_class.narrow_for_fact(union_int_string, fact, env)).to eq(string_nominal)
     end
   end
 
@@ -924,6 +1001,12 @@ RSpec.describe Rigor::Inference::Narrowing do
         .to eq(Rigor::Type::Combinator.constant_of(0))
     end
 
+    it "narrows each member of a Union receiver independently via narrow_integer_equal" do
+      union = Rigor::Type::Combinator.union(integer_nominal, Rigor::Type::Combinator.integer_range(-5, 5))
+      expect(described_class.narrow_integer_equal(union, 0))
+        .to eq(Rigor::Type::Combinator.constant_of(0))
+    end
+
     it "drops the value at a range endpoint via not_equal" do
       # int<0, 10> != 0  → int<1, 10>
       range = Rigor::Type::Combinator.integer_range(0, 10)
@@ -945,6 +1028,21 @@ RSpec.describe Rigor::Inference::Narrowing do
       # int<-5, 5> != 0 cannot be expressed precisely as a single range.
       range = Rigor::Type::Combinator.integer_range(-5, 5)
       expect(described_class.narrow_integer_not_equal(range, 0)).to eq(range)
+    end
+
+    it "drops a Constant equal to the value to Bot, preserves a different one" do
+      expect(described_class.narrow_integer_not_equal(Rigor::Type::Combinator.constant_of(0), 0))
+        .to be_a(Rigor::Type::Bot)
+      expect(described_class.narrow_integer_not_equal(Rigor::Type::Combinator.constant_of(5), 0))
+        .to eq(Rigor::Type::Combinator.constant_of(5))
+    end
+
+    it "narrows each Union member independently via not_equal" do
+      union = Rigor::Type::Combinator.union(
+        Rigor::Type::Combinator.constant_of(0), Rigor::Type::Combinator.constant_of(5)
+      )
+      expect(described_class.narrow_integer_not_equal(union, 0))
+        .to eq(Rigor::Type::Combinator.constant_of(5))
     end
   end
 
@@ -1164,6 +1262,30 @@ RSpec.describe Rigor::Inference::Narrowing do
       # `Nominal[String]` is not integer-rooted; the existing class-narrowing path runs and produces
       # `narrow_class(String, "Numeric")`, which collapses to Bot since String is disjoint from Numeric.
       expect(body.local(:n)).to be_a(Rigor::Type::Bot)
+    end
+
+    it "treats a pinned Constant[Integer] subject as integer-rooted" do
+      bound = scope.with_local(:n, Rigor::Type::Combinator.constant_of(5))
+      case_node = parse_case_of_n(<<~RUBY)
+        case n
+        when 1..10 then n
+        end
+      RUBY
+      body = first_when_body_scope(case_node, bound)
+      expect(body.local(:n)).to eq(Rigor::Type::Combinator.constant_of(5))
+    end
+
+    it "treats a Union of integer-rooted members as integer-rooted (member-wise range intersect)" do
+      bound = scope.with_local(
+        :n, Rigor::Type::Combinator.union(integer_nominal, Rigor::Type::Combinator.integer_range(-10, 10))
+      )
+      case_node = parse_case_of_n(<<~RUBY)
+        case n
+        when 1..10 then n
+        end
+      RUBY
+      body = first_when_body_scope(case_node, bound)
+      expect(body.local(:n)).to eq(Rigor::Type::Combinator.integer_range(1, 10))
     end
   end
 

--- a/spec/rigor/inference/scope_indexer_spec.rb
+++ b/spec/rigor/inference/scope_indexer_spec.rb
@@ -71,6 +71,18 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
       expect(idx[receiver].local(:x)).to eq(Rigor::Type::Combinator.constant_of(1))
     end
 
+    it "materialises program-wide globals directly into the top-level seeded scope (Slice 7 phase 6)" do
+      # Distinct from a read reached VIA the `program_globals` accumulator (a def body's entry scope): this pins the
+      # top-level seeded scope's OWN `.global` map, which top-level / CLI-probe reads consult directly without going
+      # through the accumulator.
+      program, idx = index_for(<<~RUBY)
+        $verbose = true
+        $verbose
+      RUBY
+
+      expect(idx[program].global(:$verbose)).to eq(Rigor::Type::Combinator.constant_of(true))
+    end
+
     it "shows branch-internal bindings inside their branch only" do
       program, idx = index_for(<<~RUBY)
         if cond
@@ -653,6 +665,71 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
     end
   end
 
+  describe "declaration_signature parts (ADR-89 WD1)" do
+    let(:tmpdir) { Dir.mktmpdir }
+
+    after { FileUtils.remove_entry(tmpdir) }
+
+    def write(name, body)
+      path = File.join(tmpdir, name)
+      File.write(path, body)
+      path
+    end
+
+    it "joins a multi-module include list with a comma (append_ancestry_signature)" do
+      path = write("a.rb", <<~RUBY)
+        module ModA; end
+        module ModB; end
+
+        class Foo
+          include ModA
+          include ModB
+        end
+      RUBY
+      file_index = described_class.discovered_project_index_for_paths([path]).fetch(:def_index)
+      parts = []
+      described_class.append_ancestry_signature(parts, file_index)
+      expect(parts).to include("i:Foo=ModA,ModB")
+    end
+
+    it "joins a multi-parameter signature with a comma (parameter_signature)" do
+      path = write("a.rb", <<~RUBY)
+        class Foo
+          def bar(x, y:, z: 1)
+            x
+          end
+        end
+      RUBY
+      program = parse(File.read(path))
+      idx = described_class.index(program, default_scope: default_scope)
+      def_node = idx[program].user_def_for("Foo", :bar)
+      expect(described_class.parameter_signature(def_node)).to eq("(r:x,kr:y,ko:z)")
+    end
+  end
+
+  describe ".discovered_project_index_incremental (ADR-85 WD2 fold path)" do
+    let(:tmpdir) { Dir.mktmpdir }
+
+    after { FileUtils.remove_entry(tmpdir) }
+
+    def write(name, body)
+      path = File.join(tmpdir, name)
+      File.write(path, body)
+      path
+    end
+
+    it "Set-unions class_sources across files that reopen the same class (fold_ancestry_tables)" do
+      a = write("a.rb", "class Shared\n  include Comparable\nend\n")
+      b = write("b.rb", "class Shared\n  include Enumerable\nend\n")
+
+      combined = described_class.discovered_project_index_incremental([a, b], seed_bundles: {})
+      di = combined.fetch(:def_index)
+
+      expect(di[:class_sources]["Shared"]).to eq(Set[a, b])
+      expect(di[:includes]["Shared"]).to contain_exactly("Comparable", "Enumerable")
+    end
+  end
+
   describe "declaration overrides (Slice A-declarations)" do
     it "annotates the constant_path of `module Foo` with Singleton[Foo]" do
       program = parse("module Foo\nend")
@@ -982,6 +1059,31 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
         type = outer.class_ivars_for("Pure")[:@struct]
         # `.last` is NOT a mutator, so no widening fires; the seed precision is preserved.
         expect(type).to be_a(Rigor::Type::Tuple)
+      end
+
+      it "widens only the Tuple member of a Union-seeded ivar (sibling writes of different shapes)" do
+        program = parse(<<~RUBY)
+          class Multi
+            def initialize
+              @data = [1]
+            end
+
+            def reset
+              @data = "x"
+            end
+
+            def push!
+              @data << 2
+            end
+          end
+        RUBY
+        idx = described_class.index(program, default_scope: default_scope)
+        outer = idx[program]
+        type = outer.class_ivars_for("Multi")[:@data]
+        expect(type).to be_a(Rigor::Type::Union)
+        array_member = type.members.grep(Rigor::Type::Nominal).find { |m| m.class_name == "Array" }
+        expect(array_member.type_args.first).to be_a(Rigor::Type::Dynamic)
+        expect(type.members).to include(Rigor::Type::Combinator.constant_of("x"))
       end
     end
 

--- a/spec/rigor/inference/statement_evaluator_spec.rb
+++ b/spec/rigor/inference/statement_evaluator_spec.rb
@@ -253,6 +253,102 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     end
   end
 
+  describe "RSpec matcher narrowing (`expect(x)...`, v0.0.3)" do
+    # The AST-shape-matched fallback: `expect(<local>)` followed by `not_to`/`to_not(be_nil)` or
+    # `to(be_a/be_kind_of/be_an_instance_of/be_instance_of(C))` narrows the named local downstream. No RBS for RSpec
+    # is required — the shape is recognised purely from the call nodes.
+    it "narrows a local away from NilClass after `not_to be_nil`" do
+      _, post = evaluate(<<~RUBY)
+        x = rand < 0.5 ? Array.new : nil
+        expect(x).not_to be_nil
+        x
+      RUBY
+      expect(post.local(:x)).to eq(Rigor::Type::Combinator.nominal_of("Array"))
+    end
+
+    it "narrows a local away from NilClass after `to_not be_nil`" do
+      _, post = evaluate(<<~RUBY)
+        x = rand < 0.5 ? Array.new : nil
+        expect(x).to_not be_nil
+        x
+      RUBY
+      expect(post.local(:x)).to eq(Rigor::Type::Combinator.nominal_of("Array"))
+    end
+
+    it "does NOT narrow when `be_nil` carries a stray argument (defensive arity guard)" do
+      # `be_nil` takes no arguments; Prism only allocates an `ArgumentsNode` when there is at least one argument
+      # (`be_nil()` and bare `be_nil` both parse with `arguments: nil`), so `matcher.arguments.arguments.empty?`
+      # is reachable ONLY when the matcher is (mis)written with a stray argument like `be_nil(1)`. This proves the
+      # arity guard is live: without it, `not_to be_nil(1)` would incorrectly narrow `x` away from nil.
+      _, post = evaluate(<<~RUBY)
+        x = rand < 0.5 ? Array.new : nil
+        expect(x).not_to be_nil(1)
+        x
+      RUBY
+      expect(post.local(:x)).to eq(
+        Rigor::Type::Combinator.union(
+          Rigor::Type::Combinator.nominal_of("Array"), Rigor::Type::Combinator.constant_of(nil)
+        )
+      )
+    end
+
+    it "narrows a local to the named class after `to be_a(C)`" do
+      _, post = evaluate(<<~RUBY)
+        x = rand < 0.5 ? Array.new : "str"
+        expect(x).to be_a(Array)
+        x
+      RUBY
+      expect(post.local(:x)).to eq(Rigor::Type::Combinator.nominal_of("Array"))
+    end
+
+    it "narrows a local to the named class after `to be_kind_of(C)`" do
+      _, post = evaluate(<<~RUBY)
+        x = rand < 0.5 ? Array.new : "str"
+        expect(x).to be_kind_of(Array)
+        x
+      RUBY
+      expect(post.local(:x)).to eq(Rigor::Type::Combinator.nominal_of("Array"))
+    end
+
+    it "narrows a local to the named class after `to be_an_instance_of(C)` (exact)" do
+      _, post = evaluate(<<~RUBY)
+        x = rand < 0.5 ? Array.new : "str"
+        expect(x).to be_an_instance_of(Array)
+        x
+      RUBY
+      expect(post.local(:x)).to eq(Rigor::Type::Combinator.nominal_of("Array"))
+    end
+
+    it "narrows a local to the named class after `to be_instance_of(C)` (exact)" do
+      _, post = evaluate(<<~RUBY)
+        x = rand < 0.5 ? Array.new : "str"
+        expect(x).to be_instance_of(Array)
+        x
+      RUBY
+      expect(post.local(:x)).to eq(Rigor::Type::Combinator.nominal_of("Array"))
+    end
+
+    it "leaves the local's type unchanged for an unrecognised matcher (`eq`)" do
+      _, post = evaluate(<<~RUBY)
+        x = rand < 0.5 ? Array.new : "str"
+        expect(x).to eq("str")
+        x
+      RUBY
+      expect(post.local(:x).members.map { |m| m.respond_to?(:class_name) ? m.class_name : m.value })
+        .to contain_exactly("Array", "str")
+    end
+
+    it "leaves the local's type unchanged when the `expect(...)` target is not a bare local" do
+      _, post = evaluate(<<~RUBY)
+        x = rand < 0.5 ? Array.new : "str"
+        expect(x.itself).to be_a(Array)
+        x
+      RUBY
+      expect(post.local(:x).members.map { |m| m.respond_to?(:class_name) ? m.class_name : m.value })
+        .to contain_exactly("Array", "str")
+    end
+  end
+
   describe "loop-exit predicate-assignment narrowing" do
     it "narrows an `until x = expr` target non-nil after the loop" do
       _, post = evaluate(<<~RUBY)
@@ -567,6 +663,22 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     it "for-loop over an Integer Range literal binds the index to Integer" do
       _, post = evaluate(<<~RUBY)
         for i in (1..10)
+        end
+      RUBY
+      nominal = post.local(:i).members.grep(Rigor::Type::Nominal)
+      expect(nominal.map(&:class_name)).to contain_exactly("Integer")
+    end
+
+    it "for-loop over a Type::IntegerRange-narrowed collection binds the index to Integer" do
+      # Distinct from the literal-Range case above: `case n; when 1..10` narrows `n` itself to a `Type::IntegerRange`
+      # carrier (not a `Constant<Range>`), so `for i in n` exercises `collection_element_type`'s `Type::IntegerRange`
+      # branch rather than `constant_element_type`'s `Range` branch.
+      _, post = evaluate(<<~RUBY)
+        n = rand(100)
+        case n
+        when 1..10
+          for i in n
+          end
         end
       RUBY
       nominal = post.local(:i).members.grep(Rigor::Type::Nominal)
@@ -1891,6 +2003,50 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     end
   end
 
+  describe "transitive callee-escape content floor (ADR-57 slice 2 self-call channel)" do
+    # An escaping block may content-mutate a captured local INDIRECTLY, by passing it as an argument to a
+    # self-dispatched helper that mutates its own parameter — `collect_content_mutations` only sees a direct
+    # `local[k] = v` / `local << x` write in the block body, so this channel is a separate resolve-the-callee path
+    # (`floor_callee_escaped_args_for_call` / `callee_content_mutated_parameters`). It needs `top_level_def_for` to
+    # resolve `helper`'s def, which requires a discovery-seeded scope — a bare `Scope.empty` never runs ScopeIndexer,
+    # so (like the cross-method ivar tests above) this goes through `ScopeIndexer.index` directly.
+    it "floors a captured local an escaping block passes to a self-call that mutates it directly" do
+      ast = parse_program(<<~RUBY)
+        def helper(arr)
+          arr << 1
+        end
+
+        data = []
+        Thread.new { helper(data) }
+        data
+      RUBY
+      index = Rigor::Inference::ScopeIndexer.index(ast, default_scope: scope)
+      _type, post = index[ast.statements].evaluate(ast.statements)
+      expect(post.local(:data)).to eq(
+        Rigor::Type::Combinator.nominal_of("Array", type_args: [Rigor::Type::Combinator.untyped])
+      )
+    end
+
+    it "floors a captured local a self-call mutates through ITS OWN nested block (the escaped, not direct, channel)" do
+      ast = parse_program(<<~RUBY)
+        def helper(h)
+          foo.bar { h[:k] = 1 }
+        end
+
+        data = {}
+        Thread.new { helper(data) }
+        data
+      RUBY
+      index = Rigor::Inference::ScopeIndexer.index(ast, default_scope: scope)
+      _type, post = index[ast.statements].evaluate(ast.statements)
+      expect(post.local(:data)).to eq(
+        Rigor::Type::Combinator.nominal_of(
+          "Hash", type_args: [Rigor::Type::Combinator.untyped, Rigor::Type::Combinator.untyped]
+        )
+      )
+    end
+  end
+
   describe "captured-local invalidation on closure escape (Slice 6 phase C sub-phase 3c)" do
     let(:default_env_scope) { Rigor::Scope.empty(environment: Rigor::Environment.default) }
 
@@ -1950,6 +2106,81 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       )
       _, post = base.evaluate(parse_program("Thread.new { x = 2 }"))
       expect(post.local_facts(:x, bucket: :local_binding)).to be_empty
+    end
+  end
+
+  describe "escaping-block collection content floor (ADR-57 slice 2)" do
+    # A content-mutating (not rebinding) escaping/unknown block cannot be joined over a bounded evidence set (it may
+    # run later, any number of times), so the sound continuation is the bare-collection floor: Array ->
+    # `Array[Dynamic[top]]`, Hash -> `Hash[untyped, untyped]`, String -> `String` unchanged. These cases exercise
+    # `content_floor_for` / `arrayish?` / `hashish?` / `stringish?` across both the direct-carrier and the
+    # nilable-union pre-state shapes.
+    it "floors a Nominal[Array] captured local to Array[Dynamic[top]]" do
+      _, post = evaluate(<<~RUBY)
+        arr = Array.new
+        Thread.new { arr << 1 }
+        arr
+      RUBY
+      expect(post.local(:arr)).to eq(
+        Rigor::Type::Combinator.nominal_of("Array", type_args: [Rigor::Type::Combinator.untyped])
+      )
+    end
+
+    it "floors a Nominal[Hash] captured local to Hash[untyped, untyped]" do
+      _, post = evaluate(<<~RUBY)
+        h = Hash.new
+        Thread.new { h[:k] = 1 }
+        h
+      RUBY
+      expect(post.local(:h)).to eq(
+        Rigor::Type::Combinator.nominal_of(
+          "Hash", type_args: [Rigor::Type::Combinator.untyped, Rigor::Type::Combinator.untyped]
+        )
+      )
+    end
+
+    it "leaves a String captured local's carrier unchanged (no element parameter)" do
+      _, post = evaluate(<<~RUBY)
+        s = ""
+        Thread.new { s << "x" }
+        s
+      RUBY
+      expect(post.local(:s)).to eq(Rigor::Type::Combinator.nominal_of("String"))
+    end
+
+    it "floors a nilable (Array | nil) captured local through the union arrayish? branch" do
+      _, post = evaluate(<<~RUBY)
+        arr = rand < 0.5 ? [] : nil
+        Thread.new { arr << 1 }
+        arr
+      RUBY
+      expect(post.local(:arr)).to eq(
+        Rigor::Type::Combinator.nominal_of("Array", type_args: [Rigor::Type::Combinator.untyped])
+      )
+    end
+
+    it "floors a nilable (Hash | nil) captured local through the union hashish? branch" do
+      _, post = evaluate(<<~RUBY)
+        h = rand < 0.5 ? {} : nil
+        Thread.new { h[:k] = 1 }
+        h
+      RUBY
+      expect(post.local(:h)).to eq(
+        Rigor::Type::Combinator.nominal_of(
+          "Hash", type_args: [Rigor::Type::Combinator.untyped, Rigor::Type::Combinator.untyped]
+        )
+      )
+    end
+
+    it "widens a String captured local to its nominal base via the non-escaping join path" do
+      # `join_content_for_param` (the slice-C non-escaping write-back join, not the escaping floor above) hits the
+      # same stringish? contract from its own call site.
+      _, post = evaluate(<<~RUBY)
+        s = ""
+        [1, 2].each { |n| s << n.to_s }
+        s
+      RUBY
+      expect(post.local(:s)).to eq(Rigor::Type::Combinator.nominal_of("String"))
     end
   end
 

--- a/spec/rigor/sig_gen/generator_spec.rb
+++ b/spec/rigor/sig_gen/generator_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe Rigor::SigGen::Generator do
         .to eq([["Widget", :n, "def n: () -> 42"]])
     end
 
+    it "resolves a directory path by recursively globbing every nested *.rb file" do
+      write_fixture("lib/a/one.rb", "class One\n  def n\n    1\n  end\nend\n")
+      write_fixture("lib/b/two.rb", "class Two\n  def n\n    2\n  end\nend\n")
+      write_fixture("lib/README.md", "not ruby")
+      lib_dir = File.join(tmpdir, "lib")
+
+      candidates = generator(paths: [lib_dir]).run
+      new_methods = candidates.select { |c| c.classification == Rigor::SigGen::Classification::NEW_METHOD }
+
+      expect(new_methods.map(&:class_name)).to contain_exactly("One", "Two")
+    end
+
     it "renders required-positional parameters as untyped per ADR-5 clause 2" do
       path = write_fixture("lib/adder.rb", <<~RUBY)
         class Adder
@@ -149,6 +161,17 @@ RSpec.describe Rigor::SigGen::Generator do
       candidate = generator(paths: [path]).run.find { |c| c.method_name == :m }
 
       expect(candidate.rbs).to start_with("def m:")
+    end
+
+    it "does not treat the named form `module_function :name` as the bare region toggle" do
+      # `module_function :go` names a SPECIFIC method rather than opening a region; this walker only tracks the
+      # bare-form region toggle, so a subsequent def is unaffected (stays a regular instance method).
+      src = "module Helper\n  module_function :go\n  def go; \"ok\"; end\nend\n"
+      path = write_fixture("lib/x.rb", src)
+
+      candidate = generator(paths: [path]).run.find { |c| c.method_name == :go }
+
+      expect(candidate.rbs).to start_with("def go:")
     end
   end
 
@@ -355,6 +378,21 @@ RSpec.describe Rigor::SigGen::Generator do
       expect(candidate.class_superclasses["Scm::Adapters::GitAdapter"]).to eq("AbstractAdapter")
     end
 
+    it "records a NAMESPACED-constant-path superclass verbatim (ConstantPathNode superclass)" do
+      # Distinct from the class's own qualified name above: here the SUPERCLASS itself is a `Foo::Bar` path
+      # (`qualified_constant_path`'s recursive `Prism::ConstantPathNode` branch).
+      src = <<~RUBY
+        class Widget < Acme::Base
+          def go; 1; end
+        end
+      RUBY
+      path = write_fixture("lib/widget.rb", src)
+
+      candidate = generator(paths: [path]).run.find { |c| c.method_name == :go }
+
+      expect(candidate.class_superclasses["Widget"]).to eq("Acme::Base")
+    end
+
     # A computed superclass is un-representable in RBS and guessing would misfold. The `Data.define` / `Struct.new`
     # pair is the exception the ADR-48 layouts let us resolve exactly (#227) — everything else stays unrecorded.
     it "does not record a computed superclass it cannot resolve" do
@@ -489,6 +527,15 @@ RSpec.describe Rigor::SigGen::Generator do
       expect(init.rbs).to eq("def initialize: () ?{ (*untyped) -> untyped } -> void")
     end
 
+    it "renders a `*args` constructor rest param as `*untyped`" do
+      src = "class Box\n  def initialize(*args)\n    @args = args\n  end\nend\n"
+      path = write_fixture("lib/box.rb", src)
+
+      init = generator(paths: [path]).run.find { |c| c.method_name == :initialize }
+
+      expect(init.rbs).to eq("def initialize: (*untyped) -> void")
+    end
+
     it "places the block suffix after a keyword-rest param (the mastodon `(**untyped) ?{ … }` shape)" do
       src = "class Box\n  def initialize(**opts, &block)\n    @opts = opts\n  end\nend\n"
       path = write_fixture("lib/box.rb", src)
@@ -551,6 +598,21 @@ RSpec.describe Rigor::SigGen::Generator do
       expect(method.classification).to eq(Rigor::SigGen::Classification::EQUIVALENT)
     end
 
+    it "refuses to classify as tighter when the declared union loses a member and the INFERRED side is ALSO a Union" do
+      # Distinct from the `String?` case above (there the inferred side is a bare Constant, never taking the
+      # `Type::Union` branch of `loses_declared_union_member?`'s inferred-side dispatch). Here both sides are
+      # Unions: declared `String | Integer | nil` vs. an inferred `String | Integer` that drops the `nil` arm.
+      write_fixture("sig/box.rbs", "class Box\n  def fetch: () -> (String | Integer | nil)\nend\n")
+      path = write_fixture(
+        "lib/box.rb", "class Box\n  def fetch\n    rand < 0.5 ? \"hi\" : 1\n  end\nend\n"
+      )
+
+      gen = generator(paths: [path], signature_paths: [File.join(tmpdir, "sig")])
+      method = gen.run.find { |c| c.method_name == :fetch }
+
+      expect(method.classification).to eq(Rigor::SigGen::Classification::EQUIVALENT)
+    end
+
     it "refuses to tighten Array[T] to a Tuple shape" do
       write_fixture("sig/box.rbs", "class Box\n  def each: () -> Array[Integer]\nend\n")
       path = write_fixture("lib/box.rb", "class Box\n  def each\n    [1, 2, 3]\n  end\nend\n")
@@ -589,6 +651,21 @@ RSpec.describe Rigor::SigGen::Generator do
 
       gen = generator(paths: [path], signature_paths: [File.join(tmpdir, "sig")])
       method = gen.run.find { |c| c.method_name == :to_h }
+
+      expect(method.classification).to eq(Rigor::SigGen::Classification::EQUIVALENT)
+    end
+
+    it "refuses to tighten when a declared Nominal `untyped` type-arg would be replaced (non-HashShape carrier)" do
+      # Distinct from the HashShape case above: `narrows_collection_to_shape?` never fires here (the inferred
+      # value is itself a `Nominal[Array, …]`, not a literal-shape carrier), so this exercises
+      # `replaces_untyped_type_arg?`'s own class_name/type_args comparison directly.
+      write_fixture("sig/box.rbs", "class Box\n  def dup_ints: (Array[Integer] arr) -> Array[untyped]\nend\n")
+      path = write_fixture(
+        "lib/box.rb", "class Box\n  def dup_ints(arr)\n    arr.map { |x| x }\n  end\nend\n"
+      )
+
+      gen = generator(paths: [path], signature_paths: [File.join(tmpdir, "sig")])
+      method = gen.run.find { |c| c.method_name == :dup_ints }
 
       expect(method.classification).to eq(Rigor::SigGen::Classification::EQUIVALENT)
     end
@@ -730,6 +807,22 @@ RSpec.describe Rigor::SigGen::Generator do
                                  .run.find { |c| c.method_name == :m }
 
       expect(candidate.rbs).to eq(%(def m: ("a" | "b") -> "r"))
+    end
+
+    it "renders multiple observed positional params comma-joined, each unioned independently" do
+      path = write_fixture("lib/box.rb", "class Box\n  def add(a, b)\n    \"x\"\n  end\nend\n")
+      observations = {
+        ["Box", :add] => [
+          [Rigor::Type::Combinator.constant_of(1), Rigor::Type::Combinator.constant_of("y")],
+          [Rigor::Type::Combinator.constant_of(2), Rigor::Type::Combinator.constant_of("z")]
+        ]
+      }
+
+      config = Rigor::Configuration.new(Rigor::Configuration::DEFAULTS)
+      candidate = described_class.new(configuration: config, paths: [path], observations: observations)
+                                 .run.find { |c| c.method_name == :add }
+
+      expect(candidate.rbs).to eq(%(def add: (1 | 2, "y" | "z") -> "x"))
     end
 
     # attr_reader + initialize-param observations


### PR DESCRIPTION
Closes checkbox 1 of #135 partially — the >300 LOC engine-file tier of the ADR-62 self-mutation sweep, up to a named boundary.

This tier was deferred as "expensive: each fused measurement is minutes-long". That changed this week: PR #257 fork-mapped the Tier-2 file loop and PR #270 added the per-file mutation-result cache (warm/cold 0.011), so the sweep is affordable for the first time.

Seven giant files swept to their equivalent-mutant floor: `statement_evaluator`, `expression_typer`, `scope_indexer`, `narrowing`, `shape_dispatch` + `constant_folding`, `rbs_loader`, `sig_gen/generator`. 642 added spec lines, no `lib/` change — every surviving mutant here was a hole in the *observation* (a branch, guard, or return no existing example watched at a TYPED site), not a defect in the engine, which is the outcome this harness is built to distinguish.

The examples pin mechanisms rather than outputs where the distinction matters. The clearest case is `narrowing_spec.rb`'s new `.frozen?` example: `.nil?` never reaches the declared-return polarity analyser (it is intercepted earlier by the dedicated unary-predicate handling), so exercising that analyser's fallback needs a predicate with no dedicated handler — the example says so in place, so a later reader does not "simplify" it back to `.nil?` and silently stop covering the path.

**Boundary, deliberately named:** `analysis/runner.rb` was the next file in the tier and was not reached — the run was cut short by an external limit, not by a finding. The next session resumes there rather than re-deriving the file list.

Gates: `make verify` exit 0, `git diff --check` exit 0, both run in the Flake on this branch.
