### PR TITLE
Key the analysis-result caches on the engine's own source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[cache]** Running Rigor from a git checkout — a working copy you are patching, or `gem "rigor", github:` tracking a branch — now keys the caches that hold analysis results (`rigor check`'s run cache and `rigor coverage --protection --mutation`'s per-file cache) on the content of Rigor's own source, so editing the analyzer and re-running recomputes instead of replaying the previous answer; a released gem is unaffected, since its version already identifies its code exactly ([#285](https://github.com/rigortype/rigor/issues/285)).
 - **[engine]** Filling a collection through a receiver that *selects* between variables — `(kind == :required ? required : optional)[key] = value`, an `if`/`else`, or a `||` — now widens every variable the receiver can be, so a later `.empty?` on one of them no longer draws a false `flow.always-truthy-condition` ([#277](https://github.com/rigortype/rigor/issues/277)).
 - **[engine]** A nested `Result = Data.define(...)` (or `Struct.new(...)`) constant is now visible across files, so a call on a factory's return no longer draws a false `call.undefined-method` attributed to a same-named class in the parent namespace ([#271](https://github.com/rigortype/rigor/issues/271)).
 - **[engine]** A class that defines the same method name on both sides — `def helper` plus a `class << self` (or `def self.helper`) twin — no longer draws a false `call.undefined-method` on the class-side call ([#239](https://github.com/rigortype/rigor/issues/239)).

--- a/docs/internal-spec/cache.md
+++ b/docs/internal-spec/cache.md
@@ -280,6 +280,40 @@ run's diagnostics without loading the inference engine at all. It records
 a hit (so `--cache-stats` still balances) but never a miss — a probe miss
 hands off to the full path, which records its own.
 
+### Engine identity in a computed-value key
+
+A cache whose value is a function of what the analyzer *computes* —
+`analysis.run-diagnostics` and `protection.mutation-file-result` — MUST
+key on the engine's source, not only on `Rigor::VERSION`. The version
+pins the bytes for a gem installed from RubyGems and for nothing else,
+so on an edited working tree a warm run replays pre-edit diagnostics and
+a before/after measurement of an engine change reports a zero it did not
+earn ([#285](https://github.com/rigortype/rigor/issues/285)).
+
+`Cache::EngineSource.identity` supplies the slot, in two regimes:
+
+- **Version-pinned** — the tree sits at `<gem_home>/gems/rigortype-<VERSION>`
+  and holds no `.git`. Answers `nil`; the caller adds **no** config entry,
+  so a released gem's key is byte-identical to the pre-#285 one and costs
+  nothing to compute. The predicate is positive about being pinned, so
+  every unrecognised layout falls to the mutable side.
+- **Mutable** — anything else (a checkout, a `bundle add rigor, github:`
+  clone, a `path:` gem). The caller adds an `engine-source` config entry
+  holding a SHA-256 over every `.rb` under the gem root's `lib/` and
+  `plugins/`, each contributing its **root-relative path** and its
+  **content**. Content, not a stat tuple: a stat tuple is barred from a
+  cache KEY (see `FileEntry`), and a path-relative content digest is what
+  makes the key survive a re-clone or a fresh CI checkout of the same
+  commit.
+
+A mutable tree whose source cannot be read raises
+`EngineSource::Unavailable`, which both callers turn into "no cache for
+this run". Falling back to the version-only key is forbidden: it restores
+exactly the blind spot the slot exists to close.
+
+`IncrementalSnapshot.fingerprint` does **not** carry the slot yet, so
+`rigor check --incremental` retains the same blind spot.
+
 ### Read fault tolerance
 
 A read encountering any of the following silently returns a

--- a/docs/manual/12-caching.md
+++ b/docs/manual/12-caching.md
@@ -28,11 +28,22 @@ on:
 - the **content** of the source and `.rbs` files that fed it,
 - the **gems** in play, by name and locked version,
 - the active **plugins**, by ID and version,
-- the relevant **configuration**.
+- the relevant **configuration**,
+- **Rigor itself**, by version.
 
 Change any of those and the dependent entries are recomputed
 automatically. A corrupt or unreadable entry is treated as a
 miss and overwritten — bad cache state cannot wedge a run.
+
+Rigor's version identifies its own code only for a released gem.
+If you run Rigor from a git checkout — a working copy you are
+patching, or `gem "rigor", github:` tracking a branch, where two
+commits share one version number — the entries that hold
+analysis results are keyed on the content of Rigor's own source
+as well, so editing the analyzer and re-running recomputes
+instead of replaying the previous answer. That costs one pass
+over Rigor's source per run (about 20 ms); an installed gem
+neither pays it nor needs it.
 
 The cache is also schema-versioned: after a Rigor upgrade that
 changes the cache format, the stale cache is purged on the

--- a/lib/rigor/analysis/run_cache_key.rb
+++ b/lib/rigor/analysis/run_cache_key.rb
@@ -13,6 +13,7 @@ end
 
 require_relative "../version"
 require_relative "../cache/descriptor"
+require_relative "../cache/engine_source"
 require_relative "../cache/rbs_descriptor"
 require_relative "../environment/default_libraries"
 
@@ -51,7 +52,7 @@ module Rigor
       def descriptor(configuration:, files:, explain:, rbs_config_entries:)
         Cache::Descriptor.new(
           gems: [Cache::RbsDescriptor.rbs_gem_entry],
-          configs: rbs_config_entries + [
+          configs: rbs_config_entries + engine_source_entries + [
             config_entry("configuration", Marshal.dump(configuration.to_h)),
             config_entry("engine",
                          "#{Rigor::VERSION}:#{Cache::Descriptor::SCHEMA_VERSION}:#{explain}"),
@@ -60,6 +61,21 @@ module Rigor
         )
       rescue StandardError
         nil
+      end
+
+      # Issue #285 — the `engine` slot above pins the engine by VERSION, which identifies the source only
+      # for a released gem. A checkout (a contributor's, or a `bundle add rigor, github:` clone) gets one
+      # extra slot carrying a digest of the engine's own source, so editing `lib/rigor/inference/*.rb` no
+      # longer replays the pre-edit diagnostics out of a warm cache. A released install adds NO entry, so
+      # its key — and its hit rate — are exactly what they were.
+      #
+      # {Cache::EngineSource::Unavailable} is left to propagate into `descriptor`'s rescue, which disables
+      # the cache for the run: an engine we cannot identify must not be keyed by its version alone.
+      def engine_source_entries
+        identity = Cache::EngineSource.identity
+        return [] if identity.nil?
+
+        [config_entry("engine-source", identity)]
       end
 
       def config_entry(key, payload)

--- a/lib/rigor/cache/engine_source.rb
+++ b/lib/rigor/cache/engine_source.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "digest"
+
+require_relative "../version"
+
+module Rigor
+  module Cache
+    # Issue #285 — the identity of the ENGINE'S OWN SOURCE, as a cache-key slot.
+    #
+    # Every Rigor cache whose value is a function of what the analyzer COMPUTES (the ADR-45 run-result
+    # cache, the #134 mutation-result cache) keys on `Rigor::VERSION`. For a gem installed from RubyGems
+    # that is exact — the version pins the bytes. For anyone running an edited working tree it is not, and
+    # the failure is invisible: a warm `rigor check` replays the pre-edit diagnostics verbatim, so a
+    # before/after measurement of an engine change reports `0 new, 0 gone` no matter what the change does.
+    # That shape of false zero survived into #152's FP evaluation before it was caught.
+    #
+    # ## The two regimes
+    #
+    # {.identity} answers `nil` for a tree whose identity `Rigor::VERSION` already fixes — a RubyGems
+    # install, recognised by its `<gem_home>/gems/rigortype-<VERSION>` directory layout. The caller then
+    # adds NO slot, so a released gem's cache key is byte-identical to the one it had before this module
+    # existed and pays not one syscall for it. Everything else — a contributor's checkout, a `bundle add
+    # rigor, github:` clone (where two commits share one `Rigor::VERSION`), a `path:` gem — is treated as
+    # mutable and gets a content digest of the engine's source tree.
+    #
+    # The predicate is deliberately POSITIVE about being pinned, so every case it fails to recognise lands
+    # on the safe side: an unrecognised release pays one directory walk and one extra cache generation,
+    # while an unrecognised checkout would have served a stale answer.
+    #
+    # ## Why a content digest and not a stat tuple
+    #
+    # A `(size, mtime, ctime, inode)` walk is ~3× cheaper (measured: 5.4 ms vs 17 ms over this repo's 539
+    # engine files), and ADR-87 WD1 trusts exactly that tuple for FRESHNESS. It cannot be used here:
+    # {Descriptor::FileEntry} states the rule directly — a stat tuple carries machine-local, per-run
+    # nondeterministic data and MUST NOT enter a descriptor used as a cache KEY. On the freshness side a
+    # moved tuple falls back to the recorded digest, so a fresh checkout of unchanged content still
+    # validates; a KEY has no such fallback, so keying on stat would make every CI run and every branch
+    # switch a total miss for the `github:`-tracking users this module exists to protect.
+    #
+    # ## Never a wrong hit
+    #
+    # A mutable tree whose digest cannot be computed raises {Unavailable} rather than answering `nil`.
+    # Both callers already rescue a malformed key into "no cache for this run", which is the only sound
+    # reading: falling back to the version-only key would restore precisely the blind spot being fixed.
+    module EngineSource
+      # Raised when the tree is not version-pinned AND its source cannot be digested. Deliberately not
+      # rescued in this module — see the class doc's last paragraph.
+      class Unavailable < StandardError; end
+
+      # The RubyGems package name. `<name>-<version>` is the install directory layout {.version_pinned?}
+      # recognises; the constant is not read from the gemspec because this file loads on the boot-slimming
+      # probe path, which must not touch RubyGems' specification machinery.
+      GEM_NAME = "rigortype"
+
+      # Engine source, relative to the gem root. `plugins/` ships inside the same gem and its recognisers
+      # move diagnostics exactly as `lib/` does, so an edit there must invalidate too; `examples/`,
+      # `apps/` and `tool/` are not loaded by an analysis and stay out.
+      SOURCE_DIRECTORIES = %w[lib plugins].freeze
+
+      # The one directory whose absence means "this is not an engine tree". `plugins/` may legitimately be
+      # missing (a slimmed install contributes nothing); a missing `lib/` would silently shrink the digest
+      # to whatever else happened to be there, which is exactly the weakening this module forbids.
+      REQUIRED_DIRECTORY = "lib"
+
+      module_function
+
+      # @return [String] the gem root — the directory holding `lib/`, three levels above this file.
+      def root
+        @root ||= File.expand_path("../../..", __dir__)
+      end
+
+      # @param root [String] the gem root, defaulted through {.root} so a spec can relocate the tree.
+      # @return [String, nil] a digest identifying the engine's current source, or nil when the tree is
+      #   version-pinned and the caller should add no slot at all.
+      # @raise [Unavailable] when a mutable tree's source cannot be read.
+      def identity(root = self.root)
+        return nil if version_pinned?(root)
+
+        digest_tree(root)
+      end
+
+      # True when `Rigor::VERSION` already pins this tree's bytes: an immutable RubyGems install, laid out
+      # as `…/gems/rigortype-<VERSION>`. The `.git` probe is the belt to that braces — a working tree that
+      # somehow occupies a release-shaped path is still a working tree.
+      def version_pinned?(root)
+        return false unless File.basename(root) == "#{GEM_NAME}-#{Rigor::VERSION}"
+        return false unless File.basename(File.dirname(root)) == "gems"
+
+        !File.exist?(File.join(root, ".git"))
+      end
+
+      # A SHA-256 over every engine `.rb` file: its ROOT-RELATIVE path (so the digest survives moving or
+      # re-cloning the checkout) followed by its bytes, in sorted path order.
+      #
+      # Not memoised: {Analysis::RunCacheKey.descriptor} is reached at most twice per process (the
+      # boot-slimming probe, then the runner on a miss), so a memo would save one walk on the path that
+      # already pays for a full analysis while adding state that a fork-pool worker would inherit.
+      def digest_tree(root)
+        unless File.directory?(File.join(root, REQUIRED_DIRECTORY))
+          raise Unavailable, "#{root} has no #{REQUIRED_DIRECTORY}/ to identify the engine by"
+        end
+
+        digest = Digest::SHA256.new
+        prefix = "#{root}#{File::SEPARATOR}"
+        count = 0
+        source_files(root).each do |path|
+          digest << path.delete_prefix(prefix) << "\0"
+          digest.file(path)
+          count += 1
+        end
+        raise Unavailable, "no engine source found under #{root}" if count.zero?
+
+        digest.hexdigest
+      rescue SystemCallError, IOError => e
+        raise Unavailable, "engine source under #{root} could not be read: #{e.message}"
+      end
+
+      # Sorted absolute paths of every engine `.rb` file, across the directories that exist.
+      def source_files(root)
+        SOURCE_DIRECTORIES.flat_map do |relative|
+          directory = File.join(root, relative)
+          File.directory?(directory) ? Dir.glob(File.join(directory, "**", "*.rb")) : []
+        end.sort
+      end
+    end
+  end
+end

--- a/lib/rigor/protection/mutation_cache.rb
+++ b/lib/rigor/protection/mutation_cache.rb
@@ -5,6 +5,7 @@ require "json"
 
 require_relative "../analysis/plugin_fact_fingerprint"
 require_relative "../cache/descriptor"
+require_relative "../cache/engine_source"
 require_relative "../cache/file_digest"
 require_relative "../cache/incremental_snapshot"
 require_relative "../cache/store"
@@ -25,7 +26,10 @@ module Rigor
     # The KEY carries the inputs that are known before the measurement and are not files:
     #
     # - `Rigor::VERSION` + this class's {SCHEMA} + the {Cache::Descriptor} schema — an engine upgrade is an ABI
-    #   boundary for a Marshal'd `FileResult` and a measurement-semantics boundary for everything else.
+    #   boundary for a Marshal'd `FileResult` and a measurement-semantics boundary for everything else. A
+    #   VERSION pins the engine's bytes only for a RELEASED gem, so a checkout adds {Cache::EngineSource}'s
+    #   source digest alongside it (#285) — without it, editing the analyzer and re-measuring serves the
+    #   pre-edit kill counts back, which is the exact failure a mutation score exists to detect.
     # - The {Cache::IncrementalSnapshot} fingerprint the dependency edges came from — itself a digest of the
     #   resolved configuration, the analysis roots, `Gemfile.lock`, `rbs_collection.lock.yaml`, and the
     #   project's own `sig/` contents. This is how a config or `sig/` edit invalidates the measurement.
@@ -79,6 +83,7 @@ module Rigor
       NO_SNAPSHOT = "no reusable `rigor check --incremental` snapshot"
       OPAQUE_PLUGIN = "a plugin contributes types with no incremental fingerprint surface"
       UNDIGESTIBLE = "the project-scan tables could not be digested"
+      UNIDENTIFIED_ENGINE = "the engine's own source tree could not be digested"
 
       class << self
         # @param configuration [Rigor::Configuration]
@@ -154,7 +159,7 @@ module Rigor
           tables = table_digest(project_scan)
           return UNDIGESTIBLE if tables.nil?
 
-          [
+          (engine_source_entries + [
             config_entry("engine", "#{Rigor::VERSION}:#{SCHEMA}:#{Cache::Descriptor::SCHEMA_VERSION}"),
             config_entry("snapshot", fingerprint),
             config_entry("sampling", sampling.to_h.sort.map { |k, v| "#{k}=#{v.inspect}" }.join(" ")),
@@ -162,9 +167,21 @@ module Rigor
             config_entry("project-tables", tables),
             config_entry("plugin-facts", facts),
             config_entry("discovery-seed", seed_digest(seed_inputs))
-          ].freeze
+          ]).freeze
+        rescue Cache::EngineSource::Unavailable
+          UNIDENTIFIED_ENGINE
         rescue StandardError
           UNDIGESTIBLE
+        end
+
+        # Issue #285 — one extra slot pinning the ENGINE'S OWN SOURCE when `Rigor::VERSION` does not (a
+        # checkout rather than a released gem). Empty for a released install, so its key composition is
+        # unchanged and {SCHEMA} needs no bump; an engine that cannot be identified raises through to the
+        # `Unavailable` rescue above and disables the cache, which is the only sound reading of a key slot
+        # that could not be computed.
+        def engine_source_entries
+          identity = Cache::EngineSource.identity
+          identity.nil? ? [] : [config_entry("engine-source", identity)]
         end
 
         def config_entry(key, payload)

--- a/spec/rigor/cache/engine_source_spec.rb
+++ b/spec/rigor/cache/engine_source_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "tmpdir"
+
+require "rigor/cache/engine_source"
+
+# Issue #285 — the engine's own source as a cache-key slot. Two regimes, and the whole design rests on
+# getting the boundary between them right: a released gem must be untouched (`nil`, no walk), a working
+# tree must be identified by its bytes, and anything that cannot be identified must raise so the caller
+# disables the cache rather than falling back to the version-only key.
+RSpec.describe Rigor::Cache::EngineSource do
+  # A stand-in engine tree, so an example can EDIT engine source without touching this checkout.
+  def write_engine(root, body)
+    FileUtils.mkdir_p(File.join(root, "lib", "rigor", "inference"))
+    File.write(File.join(root, "lib", "rigor", "inference", "narrowing.rb"), body)
+    root
+  end
+
+  describe ".version_pinned?" do
+    it "recognises a RubyGems install, where VERSION already pins the bytes" do
+      expect(described_class.version_pinned?("/gems/#{described_class::GEM_NAME}-#{Rigor::VERSION}"))
+        .to be(true)
+    end
+
+    it "rejects an install of a DIFFERENT version, and a directory that is not a gem install" do
+      expect(described_class.version_pinned?("/gems/#{described_class::GEM_NAME}-9.9.9")).to be(false)
+      expect(described_class.version_pinned?("/src/#{described_class::GEM_NAME}-#{Rigor::VERSION}"))
+        .to be(false)
+    end
+
+    # `bundle add rigor, github:` checks out to `bundler/gems/<repo>-<sha>`: the parent is `gems`, so only
+    # the basename tells a tracked branch from a release. Two commits share one Rigor::VERSION there.
+    it "rejects a Bundler git checkout living under a `gems` parent" do
+      expect(described_class.version_pinned?("/bundler/gems/rigor-0123456789ab")).to be(false)
+    end
+
+    # Contrived, but the predicate is the only thing standing between a working tree and a stale serve.
+    it "rejects a release-shaped path that is actually a working tree" do
+      Dir.mktmpdir("rigor-engine-source-") do |dir|
+        root = File.join(dir, "gems", "#{described_class::GEM_NAME}-#{Rigor::VERSION}")
+        FileUtils.mkdir_p(File.join(root, ".git"))
+
+        expect(described_class.version_pinned?(root)).to be(false)
+      end
+    end
+  end
+
+  describe ".identity" do
+    it "answers nil for a version-pinned tree, so a released gem's key gains no slot at all" do
+      Dir.mktmpdir("rigor-engine-source-") do |dir|
+        root = write_engine(File.join(dir, "gems", "#{described_class::GEM_NAME}-#{Rigor::VERSION}"), "# v1\n")
+
+        expect(described_class.identity(root)).to be_nil
+      end
+    end
+
+    it "is stable across calls when nothing moved, and changes when engine source is edited" do
+      Dir.mktmpdir("rigor-engine-source-") do |dir|
+        root = write_engine(File.join(dir, "checkout"), "# v1\n")
+        before = described_class.identity(root)
+
+        expect(described_class.identity(root)).to eq(before)
+
+        File.write(File.join(root, "lib", "rigor", "inference", "narrowing.rb"), "# v2\n")
+        expect(described_class.identity(root)).not_to eq(before)
+      end
+    end
+
+    it "sees a NEW engine file and a deleted one, not only an edit to a known one" do
+      Dir.mktmpdir("rigor-engine-source-") do |dir|
+        root = write_engine(File.join(dir, "checkout"), "# v1\n")
+        before = described_class.identity(root)
+
+        added = File.join(root, "lib", "rigor", "inference", "extra.rb")
+        File.write(added, "# added\n")
+        expect(described_class.identity(root)).not_to eq(before)
+
+        FileUtils.rm(added)
+        expect(described_class.identity(root)).to eq(before)
+      end
+    end
+
+    it "covers `plugins/` as well as `lib/` — a recogniser edit moves diagnostics too" do
+      Dir.mktmpdir("rigor-engine-source-") do |dir|
+        root = write_engine(File.join(dir, "checkout"), "# v1\n")
+        plugin = File.join(root, "plugins", "rigor-units", "lib")
+        FileUtils.mkdir_p(plugin)
+        File.write(File.join(plugin, "units.rb"), "# p1\n")
+        before = described_class.identity(root)
+
+        File.write(File.join(plugin, "units.rb"), "# p2\n")
+        expect(described_class.identity(root)).not_to eq(before)
+      end
+    end
+
+    # The digest keys on ROOT-RELATIVE paths, so re-cloning or moving a checkout — and, more to the point,
+    # a fresh CI checkout of the same commit — keeps the same identity. A stat tuple could not do this,
+    # which is why {Descriptor::FileEntry} bars stat data from a cache KEY.
+    it "is independent of where the checkout lives" do
+      Dir.mktmpdir("rigor-engine-source-") do |dir|
+        here = write_engine(File.join(dir, "here"), "# v1\n")
+        there = write_engine(File.join(dir, "somewhere", "else"), "# v1\n")
+
+        expect(described_class.identity(there)).to eq(described_class.identity(here))
+      end
+    end
+
+    it "raises rather than answering a weaker key when there is no engine source to read" do
+      Dir.mktmpdir("rigor-engine-source-") do |dir|
+        expect { described_class.identity(File.join(dir, "nowhere")) }
+          .to raise_error(described_class::Unavailable)
+
+        empty = File.join(dir, "empty")
+        FileUtils.mkdir_p(File.join(empty, "lib"))
+        expect { described_class.identity(empty) }.to raise_error(described_class::Unavailable)
+      end
+    end
+  end
+
+  # The examples above all relocate the tree; this one pins the DEFAULT, so the seam they use cannot hide a
+  # root that points somewhere absurd.
+  it "identifies this checkout by its source, since a checkout is not version-pinned" do
+    expect(described_class.root).to eq(File.expand_path("../../..", __dir__))
+    expect(described_class.version_pinned?(described_class.root)).to be(false)
+    expect(described_class.identity).to match(/\A[0-9a-f]{64}\z/)
+  end
+end

--- a/spec/rigor/cache/run_cache_engine_source_spec.rb
+++ b/spec/rigor/cache/run_cache_engine_source_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fileutils"
+require "tmpdir"
+
+require "rigor/analysis/run_cache_key"
+require "rigor/analysis/runner"
+require "rigor/cache/engine_source"
+require "rigor/cache/store"
+require "rigor/configuration"
+
+# Issue #285, acceptance — the defect was not "the key string omits a slot", it was that a warm
+# `rigor check` REPLAYS pre-edit diagnostics after an engine edit, which is what makes a before/after
+# measurement of an engine change report a fabricated zero. So every example here drives the real
+# {Analysis::Runner} against a real on-disk {Cache::Store} and asserts on whether the analysis actually
+# RAN, using the cross-file discovery pass the warm path is known to skip (the same observable
+# `runner_lazy_prepass_spec` uses).
+#
+# The engine tree is relocated to a temporary directory for the duration, because the alternative is
+# editing this checkout's own `lib/` from a spec. `engine_source_spec.rb` pins the un-relocated default.
+RSpec.describe "run-result cache invalidation on an engine-source edit" do
+  # The engine file an example edits — the very path whose edits used to be invisible.
+  def engine_source(root)
+    File.join(root, "lib", "rigor", "inference", "narrowing.rb")
+  end
+
+  def write_engine(dir, body)
+    root = File.join(dir, "engine")
+    FileUtils.mkdir_p(File.dirname(engine_source(root)))
+    File.write(engine_source(root), body)
+    allow(Rigor::Cache::EngineSource).to receive(:root).and_return(root)
+    root
+  end
+
+  def edit_engine(root, body)
+    File.write(engine_source(root), body)
+  end
+
+  # Two files, so cross-file discovery genuinely runs on a miss.
+  def write_project(dir)
+    lib = File.join(dir, "project", "lib")
+    FileUtils.mkdir_p(lib)
+    File.write(File.join(lib, "a.rb"), "class Widget\n  def price\n    10\n  end\nend\n")
+    File.write(File.join(lib, "b.rb"), "class Shop\n  def total\n    Widget.new.price\n  end\nend\n")
+    lib
+  end
+
+  # A FRESH Runner and a FRESH Store every time, so a hit has to come off disk rather than out of the
+  # Store's in-process memo — which is what the next `rigor check` process would face.
+  def analyse(dir, lib, cache_root)
+    Dir.chdir(dir) do
+      Rigor::Analysis::Runner.new(
+        configuration: Rigor::Configuration.new("paths" => [lib]),
+        cache_store: Rigor::Cache::Store.new(root: cache_root), collect_stats: false
+      ).run
+    end
+  end
+
+  before do
+    allow(Rigor::Inference::ScopeIndexer)
+      .to receive(:discovered_project_index_for_paths).and_call_original
+  end
+
+  it "RECOMPUTES a warm run after an engine-source edit, instead of replaying the stale diagnostics" do
+    Dir.mktmpdir("rigor-engine-source-run-") do |dir|
+      lib = write_project(dir)
+      engine = write_engine(dir, "# v1\n")
+      cache_root = File.join(dir, ".rigor", "cache")
+
+      cold = analyse(dir, lib, cache_root)
+      expect(Rigor::Inference::ScopeIndexer).to have_received(:discovered_project_index_for_paths).once
+
+      # No edit: the cache is useful — the second run is SERVED, not recomputed.
+      warm = analyse(dir, lib, cache_root)
+      expect(Rigor::Inference::ScopeIndexer).to have_received(:discovered_project_index_for_paths).once
+      expect(warm.diagnostics.map(&:to_h)).to eq(cold.diagnostics.map(&:to_h))
+
+      # The acceptance criterion: an engine edit alone — no project file, no config, no `sig/` moved —
+      # makes the next warm run analyse again.
+      edit_engine(engine, "# v2\n")
+      after = analyse(dir, lib, cache_root)
+      expect(Rigor::Inference::ScopeIndexer).to have_received(:discovered_project_index_for_paths).twice
+      expect(after.diagnostics.map(&:to_h)).to eq(cold.diagnostics.map(&:to_h))
+
+      # And the post-edit result is itself cacheable: the key moved, it did not stop working.
+      analyse(dir, lib, cache_root)
+      expect(Rigor::Inference::ScopeIndexer).to have_received(:discovered_project_index_for_paths).twice
+    end
+  end
+
+  it "DISABLES the cache when the engine cannot be identified, rather than weakening the key" do
+    Dir.mktmpdir("rigor-engine-source-run-") do |dir|
+      lib = write_project(dir)
+      cache_root = File.join(dir, ".rigor", "cache")
+      allow(Rigor::Cache::EngineSource)
+        .to receive(:identity).and_raise(Rigor::Cache::EngineSource::Unavailable)
+
+      2.times { analyse(dir, lib, cache_root) }
+
+      # Neither run was served: an unidentifiable engine means no cache, never a version-only fallback.
+      expect(Rigor::Inference::ScopeIndexer).to have_received(:discovered_project_index_for_paths).twice
+      expect(
+        Rigor::Analysis::RunCacheKey.descriptor(
+          configuration: Rigor::Configuration.new("paths" => [lib]), files: [], explain: false,
+          rbs_config_entries: []
+        )
+      ).to be_nil
+    end
+  end
+
+  it "leaves a released gem's key composition exactly as it was" do
+    configuration = Rigor::Configuration.new({})
+    args = { configuration: configuration, files: ["a.rb"], explain: false, rbs_config_entries: [] }
+
+    checkout = Rigor::Analysis::RunCacheKey.descriptor(**args)
+    allow(Rigor::Cache::EngineSource).to receive(:identity).and_return(nil)
+    released = Rigor::Analysis::RunCacheKey.descriptor(**args)
+
+    expect(released.configs.map(&:key)).to contain_exactly("configuration", "engine", "paths")
+    expect(checkout.configs.map(&:key)).to include("engine-source")
+    expect(released.to_canonical_hash).not_to eq(checkout.to_canonical_hash)
+  end
+end

--- a/spec/rigor/protection/mutation_cache_spec.rb
+++ b/spec/rigor/protection/mutation_cache_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require "fileutils"
 require "tmpdir"
 
 require "rigor/analysis/project_scan"
+require "rigor/cache/engine_source"
 require "rigor/cache/incremental_snapshot"
 require "rigor/configuration"
 require "rigor/inference/project_patched_methods"
@@ -179,6 +181,47 @@ RSpec.describe Rigor::Protection::MutationCache do
     # including one whose own `deps` never named it.
     File.write("dep.rb", "class Dep\n  def extra = 2\nend\n")
     expect(cache(feature_ids: ids, seed_inputs: seed_inputs).fetch("a.rb")).to be_nil
+  end
+
+  # #285 — `Rigor::VERSION` identifies the engine's bytes only for a released gem, and a mutation score is
+  # measured almost exclusively FROM a checkout, by someone who just changed the analyzer. Serving the
+  # pre-edit kill counts back would invert the exact signal the measurement exists to produce.
+  describe "the engine's own source" do
+    def with_engine_tree(body)
+      root = File.join(Dir.pwd, "engine")
+      FileUtils.mkdir_p(File.join(root, "lib"))
+      File.write(File.join(root, "lib", "narrowing.rb"), body)
+      allow(Rigor::Cache::EngineSource).to receive(:root).and_return(root)
+      root
+    end
+
+    it "misses after the engine is edited, with every other input unmoved" do
+      write_project
+      root = with_engine_tree("# v1\n")
+      store_result
+      expect(cache.fetch("a.rb")).to eq(result)
+
+      File.write(File.join(root, "lib", "narrowing.rb"), "# v2\n")
+      expect(cache.fetch("a.rb")).to be_nil
+    end
+
+    it "disables itself when the engine cannot be identified, rather than keying on VERSION alone" do
+      write_project
+      allow(Rigor::Cache::EngineSource)
+        .to receive(:identity).and_raise(Rigor::Cache::EngineSource::Unavailable)
+      cold = cache
+
+      expect(cold.enabled?).to be(false)
+      expect(cold.reason).to eq(described_class::UNIDENTIFIED_ENGINE)
+      expect(cold.store("a.rb", result)).to be(false)
+      expect(cold.fetch("a.rb")).to be_nil
+    end
+
+    it "adds no slot for a released gem, leaving its key composition unchanged" do
+      allow(Rigor::Cache::EngineSource).to receive(:identity).and_return(nil)
+
+      expect(described_class.engine_source_entries).to eq([])
+    end
   end
 
   # #254 — the dependent-closure oracle makes a file's verdict depend on its DEPENDENTS' diagnostics, which


### PR DESCRIPTION
Closes #285.

## The defect

`Analysis::RunCacheKey.descriptor` built its engine slot as `"#{Rigor::VERSION}:#{Cache::Descriptor::SCHEMA_VERSION}:#{explain}"`. Nothing in the key is derived from the engine's SOURCE, and `Rigor::VERSION` pins the source only for a gem installed from RubyGems. On an edited working tree a warm `rigor check` replays the pre-edit diagnostics verbatim, so a before/after corpus diff of an engine change reports `0 new, 0 gone` regardless of what the change does — indistinguishable from a clean result. #152's FP evaluation hit exactly this. `Protection::MutationCache` (#270) had the same blind spot, and it matters more there: a mutation score is measured almost exclusively from a checkout, by someone who just changed the analyzer.

## Which candidate, and the measurement that decided it

The issue offered (1) a source digest and (2) `git rev-parse HEAD` plus a dirty-tree marker. **(1) wins, on cost and on soundness.** All timings on this repo (539 engine `.rb` files, warm FS, Ruby 4.0.5 under the Flake):

| candidate | measured |
| --- | --- |
| source content digest over `lib/` + `plugins/` | **17 ms** |
| source stat walk (size+mtime+ctime+inode) | 5.4 ms |
| `git rev-parse HEAD` | 25–47 ms |
| `git status --porcelain` (the dirty marker) | **306–647 ms** |
| `git diff HEAD -- lib plugins` | 20 ms |

Candidate (2)'s dirty marker alone costs more than the entire run it is protecting: a warm boot-slimmed `rigor check lib` is ~260 ms, so `git status --porcelain` would more than double it. **And the literal form of (2) is unsound** — a dirty-tree *marker* does not distinguish two successive edits to the same file: both render as `M lib/rigor/inference/narrowing.rb`, the key does not move, and the second edit is served stale. Making it sound requires hashing the diff, i.e. re-deriving candidate (1) by a slower route that additionally cannot see an untracked new engine file (`git diff HEAD` does not list them; only the 310 ms `git status` does).

**Content digest, not the 3× cheaper stat walk.** `Descriptor::FileEntry` already states the rule: a stat tuple carries machine-local, per-run-nondeterministic data and MUST NOT enter a descriptor used as a cache KEY. That rule is right here for a concrete reason — on the *freshness* side a moved stat tuple falls back to the recorded digest, so a fresh CI checkout of unchanged content still validates; a KEY has no such fallback, so keying on stat would make every CI run and every branch switch a total miss for precisely the `bundle add rigor, github:` users this change exists to protect. The digest keys on each file's **root-relative** path plus its content, so it survives moving or re-cloning the checkout.

## Cost, and who pays it

Warm `rigor check lib` (a boot-slimming `RunCacheProbe` hit), n=15 each, same machine, back to back:

| | min | p50 | p90 |
| --- | --- | --- | --- |
| before | 245 ms | **261 ms** | 277 ms |
| after | 259 ms | **280 ms** | 308 ms |

≈ **+19 ms (+7%)**, consistent with the 17 ms isolated digest. Not negligible, so per the "prefer the design that is free for released-gem users" rule the slot is gated: `EngineSource.identity` answers `nil` for a version-pinned tree — one sitting at `<gem_home>/gems/rigortype-<VERSION>` with no `.git` — and the caller then adds **no config entry at all**. A released gem's key is byte-identical to the pre-#285 key, its hit rate is unchanged, and it does not pay one syscall for the check. **Released-gem behaviour does not change.**

The predicate is deliberately *positive* about being pinned, so every layout it fails to recognise (a `path:` gem, an unusual install) lands on the safe side: one extra directory walk, never a stale serve.

## Never a wrong hit

A mutable tree whose source cannot be digested raises `EngineSource::Unavailable` rather than answering `nil`. `RunCacheKey.descriptor`'s existing rescue turns that into "no cache for this run"; `MutationCache` turns it into a disabled cache carrying the new `UNIDENTIFIED_ENGINE` reason, which the caller already prints on stderr. Falling back to the version-only key would restore exactly the blind spot being closed. A missing `lib/`, or a tree with no `.rb` files at all, raises rather than digesting to a constant that would silently agree with every other broken tree.

`MutationCache::SCHEMA` is **not** bumped: for a released gem the key composition is unchanged, and for a checkout the new slot moves the canonical hash on its own, so old entries already read as misses. Bumping would needlessly invalidate released users' entries.

## Tests

The acceptance test is end-to-end, not a unit test of the key string: `spec/rigor/cache/run_cache_engine_source_spec.rb` drives the real `Analysis::Runner` against a real on-disk `Cache::Store` and asserts whether the analysis actually RAN, using the cross-file discovery pass the warm path is known to skip (the observable `runner_lazy_prepass_spec` already uses). It covers all three required properties — served on a re-run with no edit, RECOMPUTED after an engine-source edit with every other input unmoved, and cache disabled (not weakened) when the engine cannot be identified. Verified red before the fix: all three examples fail with the slot removed. The engine tree is relocated to a temp directory for those examples, since the alternative is a spec editing this checkout's own `lib/`; `spec/rigor/cache/engine_source_spec.rb` pins the un-relocated default (this checkout is not version-pinned and yields a digest). `mutation_cache_spec.rb` gets the same three properties against the real `Cache::Store` and a real ADR-46 snapshot.

`--no-cache` is untouched and stays documented in `docs/manual/12-caching.md` and `docs/manual/02-cli-reference.md`.

## Known remaining gap

`Cache::IncrementalSnapshot.fingerprint` has the identical defect — it is a SHA-256 over the engine VERSION plus config, roots and lockfiles — so `rigor check --incremental` still serves per-file diagnostics computed by a pre-edit engine. It is out of #285's stated scope, it is on a path that computes the fingerprint up to four times per mutation run (so it wants the memoisation this change deliberately omits), and it deserves its own change. `docs/internal-spec/cache.md` records the gap explicitly rather than leaving it implied.

## Gates

`make verify` exit 0 · `make docs-check` exit 0 · `git diff --check` exit 0.
