### PR TITLE
Preserve structured fields through the severity re-stamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 - **[engine]** A generic method whose signature passes an argument straight through, such as `Ractor.make_shareable(obj)` typed `[T] (T) -> T`, now comes back as the argument's own type rather than untyped, and carries that type into a generic return like `Array[T]` — with the binding deliberately declined wherever a method you defined yourself shadows the signature that resolved, so an imprecise answer never becomes a confidently wrong one ([#303](https://github.com/rigortype/rigor/issues/303)).
 - **[engine]** `Array#inspect` / `#to_s` and `Hash#inspect` / `#to_s` now fold to the exact `Constant[String]` when every element (or, for a Hash, every value of a fully-known shape) is a constant, and `Array#*` now folds both its join-alias string form and its repetition integer form to a precise result ([#121](https://github.com/rigortype/rigor/issues/121)).
+
+### Fixed
+
+- **[rigor check]** A diagnostic whose severity the configured profile re-stamps (for example `def.return-type-mismatch` under the default `balanced` profile) no longer loses its structured `method_name`, `receiver_type`, and `project_definition_site` fields in JSON output and `rigor triage`.
 ## [0.3.2] - 2026-08-08
 
 v0.3.2 makes the mutation tier of `rigor coverage` practical on a whole project: each file's measurement is cached, the run forks across workers, and two opt-in bleeding-edge features let it choose sites and judge kills with the same cross-file knowledge `rigor check` already has. The editor surface widens in the same direction, so a save, an in-flight buffer, and a batch of open buffers are all now answered against the whole project rather than one file at a time. The `dry-schema` and `dry-validation` plugins type a Contract's own result shape, and a batch of engine fixes retires false positives on correct code. The largest correctness fix is the least visible: Rigor's own bundled signatures collided with the ones the `rbs` gem ships, silently disabling type checking for `Gem::Specification`, `Time`, `Bundler` and six more classes.

--- a/lib/rigor/analysis/severity_stamp.rb
+++ b/lib/rigor/analysis/severity_stamp.rb
@@ -35,7 +35,8 @@ module Rigor
         Diagnostic.new(
           path: diagnostic.path, line: diagnostic.line, column: diagnostic.column,
           message: diagnostic.message, severity: resolved, rule: diagnostic.rule,
-          source_family: diagnostic.source_family
+          source_family: diagnostic.source_family, receiver_type: diagnostic.receiver_type,
+          method_name: diagnostic.method_name, project_definition_site: diagnostic.project_definition_site
         )
       end
     end

--- a/spec/rigor/analysis/runner/diagnostic_aggregator_spec.rb
+++ b/spec/rigor/analysis/runner/diagnostic_aggregator_spec.rb
@@ -615,5 +615,23 @@ RSpec.describe Rigor::Analysis::Runner::DiagnosticAggregator do
 
       expect(result.map(&:rule)).to eq(["kept.rule"])
     end
+
+    it "preserves the structured fields when the profile re-stamps a diagnostic's severity" do
+      # `def.return-type-mismatch` is authored :error and the default balanced profile resolves it to
+      # :warning, so this exercises SeverityStamp's rebuild path — the one that must carry
+      # receiver_type / method_name / project_definition_site through, not just the positional fields.
+      diagnostic = Rigor::Analysis::Diagnostic.new(
+        path: "a.rb", line: 3, column: 1, message: "return-type mismatch on `to_s'",
+        severity: :error, rule: "def.return-type-mismatch",
+        receiver_type: "String", method_name: "to_s", project_definition_site: "a.rb:3"
+      )
+
+      result = build_aggregator.apply_severity_profile([diagnostic]).first
+
+      expect(result.severity).to eq(:warning)
+      expect(result.method_name).to eq("to_s")
+      expect(result.receiver_type).to eq("String")
+      expect(result.project_definition_site).to eq("a.rb:3")
+    end
   end
 end


### PR DESCRIPTION
SeverityStamp.stamp rebuilds a Diagnostic when the profile-resolved severity differs from the authored severity, but the rebuild forwarded only path/line/column/message/severity/rule/source_family — silently dropping `receiver_type`, `method_name`, and `project_definition_site`.

The impact was an arbitrary asymmetry across rules of the same family: `def.return-type-mismatch` is authored `:error` and the default `balanced` profile resolves it to `:warning`, so every such diagnostic reached `rigor check --format json` with `method_name` null even though `build_return_type_mismatch_diagnostic` explicitly sets it. The ADR-35 override rules are authored `:warning` and resolve to `:warning`, so they skipped the rebuild and kept their fields. Any rule whose authored severity differs from its resolved severity was affected, and `rigor triage`'s heuristic recognisers (ADR-23 WD3) read these fields directly.

The fix forwards the three missing keyword arguments in the rebuild. A new aggregator example pins the round-trip: it feeds a re-stamped diagnostic carrying all three fields through `apply_severity_profile` and asserts they survive; it fails against the unfixed code.

`make verify` and `git diff --check` are clean.