### PR TITLE
Anchor suppression markers to the start of the comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 ### Fixed
 
 - **[rigor check]** A diagnostic whose severity the configured profile re-stamps (for example `def.return-type-mismatch` under the default `balanced` profile) no longer loses its structured `method_name`, `receiver_type`, and `project_definition_site` fields in JSON output and `rigor triage`.
+- **[rigor check]** A `# rigor:disable` / `# rigor:disable-file` marker is now recognised only when it opens the comment, so a comment that merely quotes the syntax — documentation prose, a doc-tool `##` line, or an `=begin` block — no longer silences diagnostics and no longer warns about its own quoted examples; a whole-line or trailing directive keeps working exactly as before, including with no space after the `#` ([#306](https://github.com/rigortype/rigor/issues/306)).
+
 ## [0.3.2] - 2026-08-08
 
 v0.3.2 makes the mutation tier of `rigor coverage` practical on a whole project: each file's measurement is cached, the run forks across workers, and two opt-in bleeding-edge features let it choose sites and judge kills with the same cross-file knowledge `rigor check` already has. The editor surface widens in the same direction, so a save, an in-flight buffer, and a batch of open buffers are all now answered against the whole project rather than one file at a time. The `dry-schema` and `dry-validation` plugins type a Contract's own result shape, and a batch of engine fixes retires false positives on correct code. The largest correctness fix is the least visible: Rigor's own bundled signatures collided with the ones the `rbs` gem ships, silently disabling type checking for `Gem::Specification`, `Time`, `Bundler` and six more classes.

--- a/docs/manual/04-diagnostics.md
+++ b/docs/manual/04-diagnostics.md
@@ -225,6 +225,14 @@ on the line the diagnostic points at; there is no
 `disable-block` form, so an expression spread over several
 lines needs the comment on each line that fires.
 
+The marker has to be the **first thing in the comment** — a
+whole-line `# rigor:disable …` or a trailing
+`expr  # rigor:disable …`. A comment that merely quotes the
+syntax, as this manual does throughout, is ordinary prose: it
+suppresses nothing and warns about nothing. The same goes for a
+doubled `## rigor:disable …` and for a marker written inside an
+`=begin` / `=end` block — neither activates.
+
 A marker that cannot work is flagged rather than silently
 ignored: a token that names no known rule (a typo like
 `call.undefined-metod`) fires

--- a/docs/type-specification/diagnostic-policy.md
+++ b/docs/type-specification/diagnostic-policy.md
@@ -104,6 +104,14 @@ The rule list is comma- and/or whitespace-separated and uses the rule-ID prefixe
 
 Inline markers are applied before the configured `severity_profile:` and before the project baseline (ADR-22), which is the last suppression layer. See the User Manual § "Diagnostics" for the operational guide.
 
+### Marker position within a comment
+
+A marker is recognised **only when it opens the comment**: the implementation matches every suppression-recognition pattern anchored (`\A`) against the comment token, which begins at the `#`. Both real directive shapes have that form — the whole-line `# rigor:disable-file <rules>` and the trailing `expr # rigor:disable <rules>` — while a comment that merely *mentions* a marker has prose before the quoted `#` and MUST NOT be treated as a directive. This binds the `suppression.*` surveillance rules identically: a quoted marker is not a marker, so it fires neither `suppression.unknown-rule` nor `suppression.empty` nor `suppression.unknown-marker`. Two consequences follow from the same anchor and are normative: a doubled `##` comment (the doc-tool convention) never activates a marker, because the second `#` is neither whitespace nor the marker word; and an `=begin` / `=end` embedded-document comment never activates one either, because its token starts at `=begin`. Whitespace between the `#` and the marker word is allowed, and so is none at all (`#rigor:disable <rules>`).
+
+Position within the *file* is unconstrained and stays so — a file-level marker is honoured wherever it appears, and a line-level marker binds the physical line its comment sits on.
+
+The patterns were unanchored until issue #306, so a directive quoted anywhere inside a doc comment silently took effect — that mis-recognition suppressed every diagnostic on Rigor's own `lib/rigor/analysis/check_rules.rb`.
+
 ### Token resolution
 
 A rule token — in a `# rigor:disable[-file]` marker or in the `.rigor.yml` `disable:` list — is **expanded to a set of canonical rule ids at parse time** (`resolve_rule_token`); the per-line / per-file suppression match is then an exact membership test of the diagnostic's canonical `rule` against that set. Four token shapes are recognised:

--- a/lib/rigor/analysis/check_rules.rb
+++ b/lib/rigor/analysis/check_rules.rb
@@ -424,6 +424,12 @@ module Rigor
       #   only. `# rigor:disable all` on a line suppresses
       #   every rule on that line.
       #
+      # Both in-source forms are recognised only when the
+      # marker is the FIRST thing in the comment, so a
+      # directive quoted inside ordinary prose — as the bullets
+      # above quote it — is not a directive. See the pattern
+      # constants below.
+      #
       # Diagnostics with `rule == nil` (parse errors, path
       # errors, internal analyzer errors) are NEVER
       # suppressed — they represent failures the user cannot
@@ -443,17 +449,26 @@ module Rigor
         end
       end
 
-      LINE_SUPPRESSION_PATTERN = /#\s*rigor:disable(?!-file)\s+(?<rules>[\w.,\s-]+)/
+      # Every suppression-recognition pattern below is anchored with `\A` against the COMMENT SLICE —
+      # Prism hands us a slice that starts at the `#`, so `\A#` means "the marker is the first thing in
+      # the comment". A real directive always has that shape, in both the whole-line form and the
+      # trailing `code # rigor:disable <rule>` form; prose that merely quotes a directive
+      # (`... like `# rigor:disable-file all` ...`) has text before the inner `#` and no longer
+      # activates anything. Two consequences worth naming: a doc-tool `##` comment never activates (the
+      # second `#` is neither whitespace nor the marker word), and an `=begin`/`=end` block comment
+      # never activates either (its slice starts at `=begin`). Unanchored, these patterns silently
+      # file-suppressed this very file — see issue #306.
+      LINE_SUPPRESSION_PATTERN = /\A#\s*rigor:disable(?!-file)\s+(?<rules>[\w.,\s-]+)/
       private_constant :LINE_SUPPRESSION_PATTERN
 
-      FILE_SUPPRESSION_PATTERN = /#\s*rigor:disable-file\s+(?<rules>[\w.,\s-]+)/
+      FILE_SUPPRESSION_PATTERN = /\A#\s*rigor:disable-file\s+(?<rules>[\w.,\s-]+)/
       private_constant :FILE_SUPPRESSION_PATTERN
 
       # A `rigor:disable[-file]` marker word regardless of whether any rule tokens follow. Used only by the
       # `suppression.empty` detection — the two suppression patterns above require at least one token
       # character, so a bare `# rigor:disable` never reaches them. The lookahead keeps
       # `rigor:disable-something-else` from counting as a marker.
-      BARE_SUPPRESSION_MARKER = /#\s*rigor:disable(?<file>-file)?(?![\w-])(?<rest>.*)/
+      BARE_SUPPRESSION_MARKER = /\A#\s*rigor:disable(?<file>-file)?(?![\w-])(?<rest>.*)/
       private_constant :BARE_SUPPRESSION_MARKER
 
       # A `rigor:` marker word that is NOT part of Rigor's suppression grammar but reads like an attempted
@@ -463,7 +478,7 @@ module Rigor
       # surveillance they silently suppress nothing. Matches `disable-<suffix>` for any suffix other than
       # `file`, and `enable` with or without a suffix.
       UNKNOWN_SUPPRESSION_MARKER =
-        /#\s*rigor:(?<marker>disable-(?!file(?![\w-]))[\w-]+|enable(?:-[\w-]+)?)(?![\w-])(?<rest>.*)/
+        /\A#\s*rigor:(?<marker>disable-(?!file(?![\w-]))[\w-]+|enable(?:-[\w-]+)?)(?![\w-])(?<rest>.*)/
       private_constant :UNKNOWN_SUPPRESSION_MARKER
 
       # @return [Array<(Hash{Integer => Set}, Set)>] pair of
@@ -527,9 +542,10 @@ module Rigor
       end
 
       # A comment carrying the marker word but not the token-bearing suppression grammar. A remainder of
-      # nothing but whitespace / commas is a genuinely empty marker (`# rigor:disable`); anything else
-      # (documentation prose like "`# rigor:disable <rule>` comments") is left alone as an ordinary
-      # comment, matching the parse path, which never treats it as a suppression either.
+      # nothing but whitespace / commas is a genuinely empty marker (`# rigor:disable`); anything else is
+      # left alone as an ordinary comment, matching the parse path, which never treats it as a
+      # suppression either. Prose that merely quotes a marker is already excluded a step earlier by the
+      # `\A` anchor, since the quotation is not at the start of the comment.
       def diagnose_bare_suppression_marker(path, comment, source, diagnostics)
         bare = BARE_SUPPRESSION_MARKER.match(source)
         if bare
@@ -545,8 +561,9 @@ module Rigor
 
       # `# rigor:disable-next-line <rule>` / `# rigor:enable <rule>` — a marker word Rigor's grammar does
       # not recognise but that reads as an attempted suppression (the RuboCop reflex). Fires only when the
-      # remainder is empty or looks like a rule list, so prose mentioning the spelling in backticks stays
-      # an ordinary comment — the same escape the empty-marker detection observes.
+      # marker opens the comment and the remainder is empty or looks like a rule list, so prose mentioning
+      # the spelling in backticks stays an ordinary comment — the same escape the empty-marker detection
+      # observes.
       def diagnose_unknown_suppression_marker(path, comment, source, diagnostics)
         unknown = UNKNOWN_SUPPRESSION_MARKER.match(source)
         return if unknown.nil?
@@ -2720,10 +2737,20 @@ module Rigor
 
         # Returns true when `override_visibility` is strictly more restrictive than `parent_visibility`
         # under the public > protected > private ordering.
+        #
+        # The nil guard below is defence, not dead code. `VISIBILITY_RANK` is a closed literal hash read
+        # with a dynamic key, so a symbol outside the table reads as nil at runtime. The engine folds that
+        # read to the nil-free value union `0 | 1 | 2`, which `internal-spec/inference-engine.md`
+        # § "HashShape receivers" declares OPTIMISTIC rather than proof and forbids the `&&`/`||` polarity
+        # gate from concluding on — but the optimism is laundered through the `.nil?` predicate into a bare
+        # `Constant[false]` that the gate then reads unmarked, so `flow.always-truthy-condition` fires. The
+        # bare single-operand form (`return false if parent_rank.nil?`) correctly stays silent; only the
+        # `||` composition misfires. Engine defect, reported as issue #313 — the directive goes when the
+        # `OptimisticOrigin` mark propagates through the predicate fold.
         def visibility_reduced?(parent_visibility, override_visibility)
           parent_rank = VISIBILITY_RANK[parent_visibility]
           override_rank = VISIBILITY_RANK[override_visibility]
-          return false if parent_rank.nil? || override_rank.nil?
+          return false if parent_rank.nil? || override_rank.nil? # rigor:disable flow.always-truthy-condition
 
           override_rank < parent_rank
         end

--- a/lib/rigor/analysis/rule_catalog.rb
+++ b/lib/rigor/analysis/rule_catalog.rb
@@ -660,6 +660,8 @@ module Rigor
             "The token resolves (canonical id, legacy alias, `all`, family wildcard, known engine id).",
             "The token starts with `plugin.` — plugins load dynamically, so their rule vocabulary cannot " \
             "be enumerated statically and under-warning is the FP-safe direction.",
+            "The marker does not open the comment (documentation prose quoting the syntax, a doubled " \
+            "`##` comment, or an `=begin` block) — that is not parsed as a suppression either.",
             "The comment merely mentions the marker followed by non-token text (documentation prose " \
             "like \"`# rigor:disable <rule>` comments\") — that is not parsed as a suppression either."
           ],
@@ -684,6 +686,7 @@ module Rigor
           does_not_fire_when: [
             "At least one token follows the marker (each token is then checked by " \
             "`suppression.unknown-rule` instead).",
+            "The marker does not open the comment (documentation prose quoting the syntax).",
             "Non-token text follows the marker (documentation prose mentioning the syntax)."
           ],
           suppression: "Complete the marker (`# rigor:disable <rule>` / `all`) or delete it; " \
@@ -730,7 +733,7 @@ module Rigor
           summary: "A comment uses a suppression marker Rigor does not recognise " \
                    "(`rigor:disable-next-line`, `rigor:enable`, ...).",
           fires_when: [
-            "A comment carries `rigor:disable-<suffix>` with a suffix other than `file`, or " \
+            "A comment OPENS with `rigor:disable-<suffix>` for a suffix other than `file`, or with " \
             "`rigor:enable[-<suffix>]` — typically the RuboCop reflex `# rigor:disable-next-line " \
             "<rule>` — followed by nothing or a rule-list-shaped remainder.",
             "Such a marker is invisible to the whole suppression grammar, so it silently suppresses " \
@@ -740,6 +743,7 @@ module Rigor
           does_not_fire_when: [
             "The marker is one of the two recognised forms (their tokens are then checked by " \
             "`suppression.unknown-rule` / `suppression.empty` instead).",
+            "The marker does not open the comment (documentation prose quoting the spelling).",
             "Non-token text follows the marker (documentation prose mentioning the spelling)."
           ],
           suppression: "Rewrite as `# rigor:disable <rules>` on the offending line (Rigor has no " \

--- a/sig/rigor.rbs
+++ b/sig/rigor.rbs
@@ -58,6 +58,10 @@ module Rigor
       # `node` / `location` are Prism values, received as `untyped`).
       def self.from_node: (untyped node, path: String, message: String, ?severity: Symbol, ?rule: String?, ?source_family: String, ?receiver_type: untyped, ?method_name: untyped, ?project_definition_site: untyped) -> Rigor::Analysis::Diagnostic
       def self.from_location: (untyped location, path: String, message: String, ?severity: Symbol, ?rule: String?, ?source_family: String, ?receiver_type: untyped, ?method_name: untyped, ?project_definition_site: untyped) -> Rigor::Analysis::Diagnostic
+      # `from_message_loc` / `from_name_loc` forward `**` to `from_location`, so their keyword surface is
+      # `from_location`'s; only the positional node differs.
+      def self.from_message_loc: (untyped node, path: String, message: String, ?severity: Symbol, ?rule: String?, ?source_family: String, ?receiver_type: untyped, ?method_name: untyped, ?project_definition_site: untyped) -> Rigor::Analysis::Diagnostic
+      def self.from_name_loc: (untyped node, path: String, message: String, ?severity: Symbol, ?rule: String?, ?source_family: String, ?receiver_type: untyped, ?method_name: untyped, ?project_definition_site: untyped) -> Rigor::Analysis::Diagnostic
     end
 
     class Result

--- a/spec/rigor/analysis/check_rules/suppression_spec.rb
+++ b/spec/rigor/analysis/check_rules/suppression_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# The `CheckRules` suppression system — `filter_suppressed` and the `suppression.*` surveillance rules that
+# guard it. Three layers compose (project `disable:`, file-level `# rigor:disable-file`, line-level
+# `# rigor:disable`), and every marker is recognised only when it OPENS the comment, so a directive quoted
+# in ordinary prose is prose (issue #306; normative in type-specification/diagnostic-policy.md §
+# "Marker position within a comment"). Every suppressing example is paired with the same fixture
+# un-suppressed, so a decline can never pass vacuously.
+RSpec.describe "diagnostic suppression", type: :runner do
+  def rules_for(source, config: {})
+    analyze(source, config: config).diagnostics.map(&:rule)
+  end
+
+  def suppression_rules(source)
+    rules_for(source).select { |rule| rule&.start_with?("suppression.") }
+  end
+
+  # The one shape every example below suppresses or fails to suppress; asserted here so a later `be_empty`
+  # can only mean "the suppression worked", never "the fixture stopped firing".
+  def unsuppressed
+    %("x".no_method\n)
+  end
+
+  it "fires on the bare fixture every other example suppresses" do
+    expect(rules_for(unsuppressed)).to include("call.undefined-method")
+  end
+
+  describe "line-level `# rigor:disable`" do
+    it "suppresses the named rule on the comment's own line" do
+      expect(rules_for(%("x".no_method # rigor:disable call.undefined-method\n))).to be_empty
+    end
+
+    # `expand_token` legacy-alias arm: the unprefixed spelling must resolve to the canonical id.
+    it "accepts the legacy unprefixed alias as a token" do
+      expect(rules_for(%("x".no_method # rigor:disable undefined-method\n))).to be_empty
+    end
+
+    # `expand_token` family arm: `call` expands to every `call.*` id rather than matching literally.
+    it "accepts a family wildcard token" do
+      expect(rules_for(%("x".no_method # rigor:disable call\n))).to be_empty
+    end
+
+    it "accepts the `all` wildcard" do
+      expect(rules_for(%("x".no_method # rigor:disable all\n))).to be_empty
+    end
+
+    it "binds only the line the comment sits on" do
+      source = <<~RUBY
+        "x".no_method # rigor:disable call.undefined-method
+        "y".also_missing
+      RUBY
+      expect(rules_for(source)).to contain_exactly("call.undefined-method")
+    end
+  end
+
+  describe "file-level `# rigor:disable-file`" do
+    it "suppresses the named rule on every line" do
+      source = <<~RUBY
+        # rigor:disable-file call.undefined-method
+        "x".no_method
+        "y".also_missing
+      RUBY
+      expect(rules_for(source)).to be_empty
+    end
+
+    it "suppresses every rule under the `all` wildcard" do
+      source = <<~RUBY
+        # rigor:disable-file all
+        "x".no_method
+        [1].rotate(1, 2)
+      RUBY
+      expect(rules_for(source)).to be_empty
+    end
+
+    # Pairs with the previous example: without the marker the same two lines both fire, so the `be_empty`
+    # above is the marker's doing.
+    it "leaves both shapes firing without the marker" do
+      source = <<~RUBY
+        "x".no_method
+        [1].rotate(1, 2)
+      RUBY
+      expect(rules_for(source)).to contain_exactly("call.undefined-method", "call.wrong-arity")
+    end
+
+    it "does not suppress rules it did not name" do
+      source = <<~RUBY
+        # rigor:disable-file call.wrong-arity
+        "x".no_method
+      RUBY
+      expect(rules_for(source)).to contain_exactly("call.undefined-method")
+    end
+  end
+
+  # `expand_rule_tokens` over the project's `.rigor.yml` `disable:` list — the branch of `filter_suppressed`
+  # no in-source marker can reach.
+  describe "project-level `disable:`" do
+    it "drops a canonical id listed in the configuration" do
+      expect(rules_for(unsuppressed, config: { "disable" => ["call.undefined-method"] })).to be_empty
+    end
+
+    it "drops a legacy unprefixed alias listed in the configuration" do
+      expect(rules_for(unsuppressed, config: { "disable" => ["undefined-method"] })).to be_empty
+    end
+
+    it "drops a whole family listed in the configuration" do
+      expect(rules_for(unsuppressed, config: { "disable" => ["call"] })).to be_empty
+    end
+
+    it "keeps a diagnostic whose rule the list does not name" do
+      expect(rules_for(unsuppressed, config: { "disable" => ["flow"] })).to contain_exactly("call.undefined-method")
+    end
+  end
+
+  describe "marker surveillance" do
+    it "warns that a typo'd token in a line marker resolves to nothing" do
+      expect(suppression_rules(%("x".no_method # rigor:disable call.undefined-metod\n)))
+        .to contain_exactly("suppression.unknown-rule")
+    end
+
+    it "warns on a typo'd token in a file marker" do
+      expect(suppression_rules("# rigor:disable-file call.undefined-metod\n")).to contain_exactly(
+        "suppression.unknown-rule"
+      )
+    end
+
+    it "stays quiet when the token resolves" do
+      expect(suppression_rules(%("x".no_method # rigor:disable call.undefined-method\n))).to be_empty
+    end
+
+    # `plugin.`-prefixed tokens are deliberately never flagged — plugin rule vocabularies load dynamically.
+    it "never flags a `plugin.`-prefixed token" do
+      expect(suppression_rules("x = 1 # rigor:disable plugin.anything.goes\n")).to be_empty
+    end
+
+    it "warns on a bare line marker that lists no rules" do
+      expect(suppression_rules("x = 1 # rigor:disable\n")).to contain_exactly("suppression.empty")
+    end
+
+    it "warns on a bare file marker that lists no rules" do
+      expect(suppression_rules("# rigor:disable-file\n")).to contain_exactly("suppression.empty")
+    end
+
+    it "warns on the RuboCop-reflex `disable-next-line` marker" do
+      expect(suppression_rules(%("x".no_method # rigor:disable-next-line call.undefined-method\n)))
+        .to contain_exactly("suppression.unknown-marker")
+    end
+
+    it "warns on a `rigor:enable` marker" do
+      expect(suppression_rules("x = 1 # rigor:enable call\n")).to contain_exactly("suppression.unknown-marker")
+    end
+
+    # The surveillance rules flow through `filter_suppressed` like any other rule, and acknowledging one
+    # never re-fires it (the token is known).
+    it "is itself suppressible without regress" do
+      source = %("x".no_method # rigor:disable call.undefined-metod, suppression.unknown-rule\n)
+      expect(suppression_rules(source)).to be_empty
+    end
+  end
+
+  # Issue #306 — the anchoring. Each decline is paired with the genuinely-anchored sibling that still works,
+  # so "nothing happened" can never be the fixture rather than the rule.
+  describe "marker position within the comment" do
+    it "ignores a file marker quoted inside prose" do
+      source = <<~RUBY
+        # Suppress the whole file with `# rigor:disable-file all` near the top.
+        "x".no_method
+      RUBY
+      expect(rules_for(source)).to contain_exactly("call.undefined-method")
+    end
+
+    it "still honours the same file marker written at the start of its comment" do
+      source = <<~RUBY
+        # rigor:disable-file all
+        "x".no_method
+      RUBY
+      expect(rules_for(source)).to be_empty
+    end
+
+    it "ignores a line marker quoted inside prose" do
+      expect(rules_for(%("x".no_method # see `# rigor:disable call.undefined-method`\n)))
+        .to contain_exactly("call.undefined-method")
+    end
+
+    it "warns about nothing when a typo'd marker is merely quoted" do
+      source = <<~RUBY
+        # A typo like `# rigor:disable call.undefined-metod` suppresses nothing.
+        x = 1
+      RUBY
+      expect(rules_for(source)).to be_empty
+    end
+
+    # The anchored sibling of the previous example: the same token, this time actually a directive.
+    it "warns when that typo'd marker opens its comment" do
+      expect(suppression_rules("# rigor:disable call.undefined-metod\nx = 1\n"))
+        .to contain_exactly("suppression.unknown-rule")
+    end
+
+    it "ignores an unknown marker quoted inside prose" do
+      source = <<~RUBY
+        # Rigor has no `# rigor:disable-next-line <rule>` form.
+        x = 1
+      RUBY
+      expect(rules_for(source)).to be_empty
+    end
+
+    # A doc-tool `##` comment is not a directive: the second `#` is neither whitespace nor the marker word.
+    it "ignores a doubled `##` marker" do
+      source = <<~RUBY
+        ## rigor:disable-file all
+        "x".no_method
+      RUBY
+      expect(rules_for(source)).to contain_exactly("call.undefined-method")
+    end
+
+    # An `=begin`/`=end` comment token starts at `=begin`, so the anchor can never match inside one.
+    it "ignores a marker inside an `=begin` block comment" do
+      source = <<~RUBY
+        =begin
+        # rigor:disable-file all
+        =end
+        "x".no_method
+      RUBY
+      expect(rules_for(source)).to contain_exactly("call.undefined-method")
+    end
+
+    # The anchor constrains position, not spacing: `#` immediately followed by the marker word still works.
+    it "accepts a marker with no space after the `#`" do
+      expect(rules_for(%("x".no_method #rigor:disable call.undefined-method\n))).to be_empty
+    end
+
+    it "accepts a marker indented on its own line" do
+      source = <<~RUBY
+        def wrapper
+          # rigor:disable-file call.undefined-method
+          "x".no_method
+        end
+      RUBY
+      expect(rules_for(source)).to be_empty
+    end
+  end
+
+  # `filter_suppressed` refuses to drop a `rule == nil` diagnostic: a parse failure is not something an
+  # author may silence away, so even the broadest marker leaves it standing.
+  it "never suppresses a rule-less diagnostic" do
+    source = <<~RUBY
+      # rigor:disable-file all
+      def broken(
+    RUBY
+    expect(analyze(source).diagnostics.map(&:rule)).to include(nil)
+  end
+end


### PR DESCRIPTION
Closes #306. Refs #135, #313.

## What

A suppression marker (`# rigor:disable` / `# rigor:disable-file`) is now recognised only when it OPENS the comment: all four recognition patterns are anchored `\A` against the Prism comment slice. A directive quoted inside prose, a doc-tool `##` line, and an `=begin` block no longer activate anything (and no longer draw `suppression.*` surveillance warnings on their own quoted examples); whole-line and trailing directives — with or without a space after `#` — work exactly as before.

The stakes: `check_rules.rb`'s own doc comment quoted `# rigor:disable-file all` in backticks, which file-suppressed every diagnostic for the 3,000-line file that defines the rules — `make check` had never actually checked it (#306 has the full reproduction; the #135 recon's 0/914 type-axis kills found it).

## What lifting the mask surfaced, carried in the same commit

- 15 `call.undefined-method` — sig drift: `sig/rigor.rbs` declared only `from_node`/`from_location`; the two newer `Diagnostic` forwarders are now declared (hand-edit; `sig-gen --print` emits no singleton factories for the class, reported per the ADR-14 policy).
- 1 `flow.always-truthy-condition` on `visibility_reduced?`'s nil guard — adjudicated as an ENGINE over-fold, not dead code: the optimistic nil-free HashShape read launders through `.nil?` into an unmarked `Constant[false]` that the `&&`/`||` polarity gate reads. Filed as #313 with a 12-line reduction; the guard stays, carrying a justified directive whose removal is #313's acceptance test.
- The normative spec (`docs/type-specification/diagnostic-policy.md`), the manual, and the rule catalogue gain the marker-position rule in the same commit. No existing MUST was reversed — "anywhere in the file" always meant the comment's position in the file.

## Evidence

- Corpus, both arms `--no-cache --no-baseline`: textbringer / liquid / mangrove diagnostic sets byte-identical (185 / 5 / 2). A Prism-accurate census over the three targets plus this repo finds 28 mid-comment `rigor:disable` occurrences — every one prose documenting the feature, all in this repo, zero in the survey targets.
- `check_rules.rb` is provably live now: poisoning a `Diagnostic.from_name_loc` call name produces 6 fresh `call.undefined-method` errors (reverted).
- New `suppression_spec.rb` (34 examples): all three suppression layers, the surveillance rules, token expansion, and the anchoring itself — every decline paired with the fixture that must still fire; two poison checks verified the spec is non-vacuous. Closes the suppression family's 12 mutation survivors from the #135 recon.
- Gates: `make verify` / `make check-plugins` / `make docs-check` / `git diff --check` / `rigor check --no-cache lib` all exit 0, run by the implementing agent and re-run independently by the auditing session.
