### PR TITLE
Flip the re-stamp example now that the metadata loss is fixed

### DIFF
--- a/spec/rigor/analysis/check_rules/override_and_return_type_spec.rb
+++ b/spec/rigor/analysis/check_rules/override_and_return_type_spec.rb
@@ -55,13 +55,14 @@ RSpec.describe "return-type and Liskov override rules", type: :runner do
         expect(diag.message).to eq("return-type mismatch on `returns_string': declared String, inferred 42")
       end
 
-      it "loses its structured `method_name` to the severity re-stamp (current behaviour)" do
-        # Pinned as an OBSERVATION, not an endorsement. The builder passes `method_name:`, but this
-        # rule is authored `:error` and the default `balanced` profile resolves it to `:warning`;
-        # `SeverityStamp.stamp` rebuilds the Diagnostic on any severity change and its `Diagnostic.new`
-        # does not forward `method_name` / `receiver_type` / `project_definition_site`. The three
-        # override rules below are authored at the severity the profile resolves to, are returned
-        # unchanged, and DO keep `method_name` — that asymmetry is the whole point of this pair.
+      it "keeps its structured `method_name` across the severity re-stamp" do
+        # This rule is the re-stamping path: it is authored `:error` and the default `balanced` profile
+        # resolves it to `:warning`, so `SeverityStamp.stamp` rebuilds the Diagnostic rather than
+        # returning it unchanged. The rebuild used to forward only path/line/column/message/severity/
+        # rule/source_family, dropping `method_name` / `receiver_type` / `project_definition_site` — a
+        # profile-dependent loss (issue #308, fixed in PR #312). The three override rules below are
+        # authored at the severity the profile resolves to and never re-stamp, so they exercise the
+        # other arm; this example is the one that covers the rebuild.
         result = analyze(<<~RUBY, sig: demo_sig)
           class Demo
             def returns_string
@@ -69,7 +70,7 @@ RSpec.describe "return-type and Liskov override rules", type: :runner do
             end
           end
         RUBY
-        expect(return_diags(result).first&.method_name).to be_nil
+        expect(return_diags(result).first&.method_name).to eq("returns_string")
       end
 
       it "reports past `self.` on a singleton def" do


### PR DESCRIPTION
**master is currently red** — this fixes it.

Two PRs that were correct in isolation collided. [#310](https://github.com/rigortype/rigor/pull/310) landed an example pinning the CURRENT behaviour of the severity re-stamp (a `def.return-type-mismatch` diagnostic losing `method_name`), with an in-place comment saying to flip it when [#308](https://github.com/rigortype/rigor/issues/308) was fixed. [#312](https://github.com/rigortype/rigor/pull/312) fixed #308 independently. Both merged, so the example now asserts `nil` against a preserved value: `spec/rigor/analysis/check_rules/ ` is 327/328 with that one failure.

The example is flipped to assert the field survives, and keeps its place in the pair it was written as — this rule is authored `:error` and resolves to `:warning` under the `balanced` profile, so it is the arm that actually re-stamps, while the three override rules below never do and cover the unchanged-passthrough arm.

`make verify` exit 0 (8,980 examples, rubocop clean, self-check clean). #308 can be closed once this lands — #312 fixed the engine, this restores the observation that watches it.