### PR TITLE
Correct with_inferred_param_mark's account of its own drop rule

### DIFF
--- a/lib/rigor/scope.rb
+++ b/lib/rigor/scope.rb
@@ -352,8 +352,11 @@ module Rigor
     # whose type is an open-call-site *lower bound* — firing against a lower bound is a false positive by
     # construction (the ADR-67 WD1 reasoning at the parameter boundary, carried one hop into the body). The
     # distinct kind keeps the inferred-param sites separable from ADR-58's ivar-copy `:local` mark, which a
-    # later un-guarding slice (WD6b) needs. `with_local` drops it on any flow-live rewrite of the local
-    # (`drop_local_declaration_marks`), so only the pristine parameter binding carries it.
+    # later un-guarding slice (WD6b) needs — and the two kinds behave OPPOSITELY on both axes: `:local` is
+    # dropped by `with_local` and intersected by `join`, while `:inferred_param` is sticky across `with_local`
+    # and unioned by `join`. See {#without_inferred_param_mark} below for the clearing contract, and
+    # `docs/internal-spec/inference-engine.md` § "Declaration-sourced provenance mark (ADR-58)" for the
+    # normative statement of both.
     def with_inferred_param_mark(name)
       rebuild(declaration_sourced: add_declaration_sourced(:inferred_param, name))
     end


### PR DESCRIPTION
Closes #332.

`Scope#with_inferred_param_mark`'s comment claimed `with_local` drops the inferred-param mark and cited a `drop_local_declaration_marks` helper that exists nowhere in the repository. The sibling comment twelve lines below states the opposite — the mark is deliberately **sticky** across `with_local`, cleared only by `without_inferred_param_mark` at a genuine rewrite — and the implementation follows the sibling. So the defect is documentation, but of the expensive kind: two comments about the same method disagreeing, with a plausible-looking helper name making the wrong one read as authoritative.

The replacement does more than delete the wrong sentence. It names the axis that makes the pair confusing in the first place: `:local` and `:inferred_param` share one `Set` and behave **oppositely on both axes** — `:local` dropped by `with_local` and intersected by `join`, `:inferred_param` sticky and unioned. That is precisely what a maintainer editing `join_declaration_sourced` needs to know, and it is now stated at the site as well as normatively in `docs/internal-spec/inference-engine.md` § "Declaration-sourced provenance mark (ADR-58)" (PR #331), which the comment now points at rather than restating.

Comment-only; no behaviour change, no CHANGELOG entry. Gates read unpiped: `make verify` exit 0, `git diff --check` exit 0, and `rg drop_local_declaration_marks` now returns nothing.