### PR TITLE
Release the closure oracle's mutant file at the end of an example

### DIFF
--- a/lib/rigor/protection/closure_kill_oracle.rb
+++ b/lib/rigor/protection/closure_kill_oracle.rb
@@ -112,6 +112,18 @@ module Rigor
         [path, *(@dependents[path] || [])]
       end
 
+      # Release the process-private mutant file now, instead of waiting for `Tempfile`'s finalizer at process
+      # exit. A one-shot `rigor coverage` run does not need this — the process ends and the file goes with it —
+      # but a caller that outlives the oracle does: the spec suite's `after(:suite)` residue check (issue #330)
+      # runs while the process is still alive, so an un-released file reads as a leak there even though it
+      # would have been reclaimed a moment later. Idempotent, and safe on an oracle that never mutated
+      # anything (the file is created lazily).
+      def release!
+        @mutant_file&.close!
+        @mutant_file = nil
+        @mutant_pid = nil
+      end
+
       private
 
       # The diagnostic signatures the dependents of `path` report while `source` stands in for it. Empty (and

--- a/spec/rigor/protection/closure_kill_oracle_spec.rb
+++ b/spec/rigor/protection/closure_kill_oracle_spec.rb
@@ -92,19 +92,29 @@ RSpec.describe Rigor::Protection::ClosureKillOracle do
     account_source.sub('Account.wrap("account")', "Account.wrap(nil)")
   end
 
+  let(:built_oracles) { [] }
   let(:configuration) { Rigor::Configuration.load(nil) }
   let(:context) { Rigor::LanguageServer::ProjectContext.new(configuration: configuration) }
+
+  after { built_oracles.each(&:release!) }
 
   # `discovery_seed:` is what `discovery-seeded-mutation-sites` supplies. nil (the default here) is the
   # closure feature adopted ALONE: the mutated file's verdict is then the shipped single-file oracle's,
   # unchanged, and the closure is the only thing this class adds.
+  # Every oracle this spec builds is registered for release after the example. The oracle's mutant `Tempfile`
+  # is otherwise reclaimed only by its finalizer at process exit, which is AFTER `after(:suite)` — so the
+  # residue check added for issue #330 saw two `rigor-mutant-*.rb` files and failed the suite on CI while
+  # passing locally, where GC happened to have run first. Registering here rather than at each call site is
+  # what keeps a later example from reintroducing it by forgetting.
   def oracle_for(paths, dependents:, seeded: false)
-    described_class.new(
+    oracle = described_class.new(
       configuration: configuration, environment: context.environment, project_scan: context.project_scan,
       paths: paths, dependents: dependents,
       seed_bundles: Rigor::Protection::DiscoverySeed.bundles(paths: paths),
       discovery_seed: seeded ? discovery_seed_for(paths) : nil
     )
+    built_oracles << oracle
+    oracle
   end
 
   def discovery_seed_for(paths)


### PR DESCRIPTION
Refs #330. **Fixes a red master** — [PR #334](https://github.com/rigortype/rigor/pull/334) merged with its CI red; I misread my own check output and merged on a failure. This is the repair.

The failure was the new residue guard doing its job: `spec suite leaked 2 temp entries … rigor-mutant-*.rb`. `ClosureKillOracle`'s mutant `Tempfile` is reclaimed only by `Tempfile`'s finalizer at process exit, which runs **after** `after(:suite)`. Locally GC happened to have collected the oracles first, so the same tree passed on macOS and failed on Linux — the guard caught a real residue that PR #334's own before/after measurement structurally could not see, since that measurement was taken after the process had exited.

`ClosureKillOracle#release!` closes and unlinks the file explicitly. A one-shot `rigor coverage` run does not need it — the process ends and the file goes with it — but a caller that outlives the oracle does, and now has a way to say so. Idempotent, and safe on an oracle that never mutated anything, since the file is created lazily.

The spec registers every oracle at `oracle_for`, the single place that builds them, and releases in an `after`. Releasing at each call site would have worked today and rotted the first time someone added an example.

Evidence: full `make test` exit 0 with the guard active and **zero** `rigor-mutant` residue (the guard raises if any remains, so a pass IS the assertion); `make verify` exit 0; `git diff --check` exit 0 — all read unpiped.