### PR TITLE
Take Array.new's element type from its block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 - **[engine]** Copying a nilable attribute into a local before passing it — `r = @right` then `insert(r)` — no longer warns about an argument type mismatch when passing the attribute directly would not have: the same value with the same origin now gets the same answer from every check, instead of only from the one that reports calling a method on it ([#324](https://github.com/rigortype/rigor/issues/324)).
 - **[rigor coverage]** A forked `--protection --mutation` worker no longer abandons its scratch file in the system temp directory, so repeated whole-project runs stop accumulating one stray file per worker per run ([#330](https://github.com/rigortype/rigor/issues/330)).
 - **[rigor check]** A `# rigor:disable` / `# rigor:disable-file` marker is now recognised only when it opens the comment, so a comment that merely quotes the syntax — documentation prose, a doc-tool `##` line, or an `=begin` block — no longer silences diagnostics and no longer warns about its own quoted examples; a whole-line or trailing directive keeps working exactly as before, including with no space after the `#` ([#306](https://github.com/rigortype/rigor/issues/306)).
+- **[engine]** `Array.new(n) { ... }` now takes its element type from the block's return value instead of the no-block overload's `nil` fill, so `Array.new(2) { "s" }[0].upcase` no longer warns about calling a method on nil ([#317](https://github.com/rigortype/rigor/issues/317)).
 
 ## [0.3.2] - 2026-08-08
 

--- a/lib/rigor/inference/method_dispatcher.rb
+++ b/lib/rigor/inference/method_dispatcher.rb
@@ -760,7 +760,9 @@ module Rigor
         struct_result = StructFolding.try_dispatch(context)
         return struct_result if struct_result
 
-        meta_result = try_meta_introspection(context.receiver, context.method_name, context.args)
+        meta_result = try_meta_introspection(
+          context.receiver, context.method_name, context.args, context.block_type
+        )
         return meta_result if meta_result
 
         PRECISE_TIERS_HEAD.each do |tier|
@@ -868,10 +870,10 @@ module Rigor
       # `Foo.class` as `Singleton[Class]` (deliberate; calling `.class` on a class object yields
       # `Class`, the metaclass). We also special-case `is_a?`-adjacent calls and the trivial
       # `instance_of?(self)` later as the rule catalogue grows; for now only `class` is handled.
-      def try_meta_introspection(receiver_type, method_name, arg_types = [])
+      def try_meta_introspection(receiver_type, method_name, arg_types = [], block_type = nil)
         case method_name
         when :class then meta_class(receiver_type)
-        when :new then meta_new(receiver_type, arg_types)
+        when :new then meta_new(receiver_type, arg_types, block_type)
         end
       end
 
@@ -891,13 +893,13 @@ module Rigor
       # `Type::Constant::SCALAR_CLASSES` accepts (today: `Pathname`), `.new(Constant<…>)` lifts
       # to a `Constant<…>` carrier so downstream method calls fold through the standard catalog
       # tier.
-      def meta_new(receiver_type, arg_types = [])
+      def meta_new(receiver_type, arg_types = [], block_type = nil)
         return nil unless receiver_type.is_a?(Type::Singleton)
 
         constant_lift = constant_constructor_lift(receiver_type.class_name, arg_types)
         return constant_lift if constant_lift
 
-        array_lift = array_new_lift(receiver_type.class_name, arg_types)
+        array_lift = array_new_lift(receiver_type.class_name, arg_types, block_type)
         return array_lift if array_lift
 
         range_lift = range_new_lift(receiver_type.class_name, arg_types)
@@ -1000,17 +1002,24 @@ module Rigor
       # `Tuple[…]` when `n` is a small `Constant<Integer>`. Cap at `ARRAY_NEW_TUPLE_LIMIT` (16)
       # so a `Array.new(1_000_000)` does not balloon the carrier; oversize calls fall back to
       # `Nominal[Array]`.
+      #
+      # #317 — `Array.new(n) { |i| ... }` fills every slot from the BLOCK's return type instead
+      # of the two-arg `(n, default_value)` overload's `nil` fill. The block and the trailing
+      # `default_value` positional are mutually exclusive per `Array#initialize`'s RBS overload
+      # set (`(int size, ?E default_value) -> void` vs `(int size) { (Integer index) -> E } ->
+      # void`), so a block present at the call site always wins over any (illegal, but tolerated
+      # rather than rejected here) second positional.
       ARRAY_NEW_TUPLE_LIMIT = 16
       private_constant :ARRAY_NEW_TUPLE_LIMIT
 
-      def array_new_lift(class_name, arg_types)
+      def array_new_lift(class_name, arg_types, block_type = nil)
         return nil unless class_name == "Array"
         return nil if arg_types.empty? || arg_types.size > 2
 
         size = array_new_size(arg_types.first)
         return nil if size.nil? || size.negative? || size > ARRAY_NEW_TUPLE_LIMIT
 
-        fill = array_new_fill(arg_types[1])
+        fill = block_type || array_new_fill(arg_types[1])
         Type::Combinator.tuple_of(*Array.new(size, fill))
       end
 

--- a/spec/rigor/inference/expression_typer_spec.rb
+++ b/spec/rigor/inference/expression_typer_spec.rb
@@ -720,6 +720,33 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       expect(type.class_name).to eq("Array")
     end
 
+    it "resolves Array.new(2) { \"s\" } as Tuple[\"s\", \"s\"] from the block's return (#317)" do
+      # The block-bearing `(int size) { (Integer index) -> E } -> void` overload of
+      # `Array#initialize` fills every slot from the block's return type, NOT from the
+      # two-arg `(int size, ?E default_value)` overload's implicit `nil` default — those two
+      # overloads are mutually exclusive at a real call site.
+      type = scope.type_of(parse_expression("Array.new(2) { \"s\" }"))
+
+      expect(type).to be_a(Rigor::Type::Tuple)
+      expect(type.elements).to eq([Rigor::Type::Combinator.constant_of("s")] * 2)
+    end
+
+    it "resolves Array.new(3) { |i| i * 2 } as Tuple[Integer, Integer, Integer] (block with index param)" do
+      type = scope.type_of(parse_expression("Array.new(3) { |i| i * 2 }"))
+
+      expect(type).to be_a(Rigor::Type::Tuple)
+      expect(type.elements).to eq([Rigor::Type::Combinator.nominal_of("Integer")] * 3)
+    end
+
+    it "Array.new(2) (no block) still fills with Constant[nil] elements" do
+      # Must-still-fire control: without a block, the two-arg overload's `nil` default
+      # genuinely applies, so a downstream `.upcase` on an element genuinely is an error.
+      type = scope.type_of(parse_expression("Array.new(2)"))
+
+      expect(type).to be_a(Rigor::Type::Tuple)
+      expect(type.elements).to eq([Rigor::Type::Combinator.constant_of(nil)] * 2)
+    end
+
     it "Hash.new(0) lifts to Hash[untyped, Integer] (B9 default-arg fold)" do
       type = scope.type_of(parse_expression("Hash.new(0)"))
 


### PR DESCRIPTION
Closes #317. First of the v0.3.3 false-positive clearance set.

```ruby
xs = Array.new(2) { "s" }
xs[0].upcase   # error: undefined method `upcase' for nil
```

## Root cause — neither of the two candidates the issue suggested

`Array.new` never reaches `RbsDispatch` or `OverloadSelector` at all for these shapes. A precise-tier constructor fold, `array_new_lift` (`dispatch_precise_tiers` → `try_meta_introspection` → `meta_new`), short-circuits every `Array.new(n[, value])` call and fills unconditionally with `Constant[nil]` when there is no second positional argument. It never received `block_type`, so `Array.new(2) { "s" }` took exactly the same nil-fill path as `Array.new(2)`. Overload selection was working correctly and simply never ran.

The fix threads `block_type` down that path and prefers the block's return as the per-slot fill.

## A latent gap found while diagnosing, and deliberately not relied on

`Array`'s `Elem` is a **class-level** RBS type parameter, while `RbsDispatch`'s block-return binding only binds variables declared in the selected overload's own **method-level** `type_params`. So even a correctly-selected block overload would have had no generic route to bind `Elem` from the block at a singleton `.new` call site. This fix computes the fill directly rather than routing through that plumbing, so it does not depend on the gap — but the gap is real and will matter to any future non-Array-specific block-return binding work on `.new`.

## Evidence

Independently reproduced by the auditing session. Only the block form moves:

| form | before | after |
|---|---|---|
| `Array.new(2) { "s" }` | `[nil, nil]` | `["s", "s"]` |
| `Array.new(3) { \|i\| i * 2 }` | `[nil, nil, nil]` | `[Integer, Integer, Integer]` |
| `Array.new(2)` | `[nil, nil]` | `[nil, nil]` — correct, untouched |
| `Array.new(2, "x")` | `["x", "x"]` | `["x", "x"]` — untouched |
| `Array.new` | `Array` | `Array` — untouched |

Must-still-fire controls, verified together with the repro in one file: `Array.new(2)[0].upcase` still fires (those elements really are nil) and `Array.new(2) { 1 }[0].upcase` still fires on `Integer`, while the repro's line goes silent.

**Corpus** (`--no-cache --no-baseline`, textbringer / liquid / mangrove / algorithms / rgl): diagnostic output byte-identical on all five. The zero is informative rather than vacuous — the instrument-can-say-yes count found **157 `Array.new(…) { … }` block sites** across four of the five targets, so the pattern is plentiful; it simply does not combine with a downstream call on a block-typed element anywhere in this corpus.

Gates (exit codes read unpiped, by both the implementing agent and the auditing session): `make verify` 0 · `make check-plugins` 0 · `make docs-check` 0 · `git diff --check` 0 · `rigor check --no-cache lib` 0 with zero diagnostics · `make coverage` 55.94% → 55.94%, floor holds.
