### PR TITLE
Add the issue #345 unused-constant probe harness

### DIFF
--- a/lib/rigor/analysis/runner.rb
+++ b/lib/rigor/analysis/runner.rb
@@ -16,6 +16,7 @@ require_relative "../plugin/source_rbs_synthesis_reporter"
 require_relative "../rbs_extended/reporter"
 require_relative "../rbs_extended/conformance_checker"
 require_relative "../reflection"
+require_relative "../unused_probe" # issue #345 spike instrumentation
 require_relative "../type/combinator"
 require_relative "../inference/coverage_scanner"
 require_relative "../inference/parameter_inference_collector"
@@ -229,6 +230,14 @@ module Rigor
         return Result.new(diagnostics: [target_ruby_error]) if target_ruby_error
 
         expansion = expand_paths(paths)
+        # Issue #345 spike instrumentation. Records the run SHAPE the probe's correctness depends on:
+        # a non-zero worker count means per-file references accumulate in a child process and never
+        # reach this one, and an attached cache store means a HIT file is never re-analyzed and
+        # contributes zero references. The report script refuses both. Inert unless the env var is set.
+        if UnusedProbe::ACTIVE
+          UnusedProbe.record_run_shape(files: expansion.fetch(:files), workers: @workers,
+                                       cache: !@cache_store.nil?)
+        end
         @snapshots.reset_for_run
         # Per-run reset of the deferred-discovery memo (see `#ensure_project_discovery`).
         @project_discovery_done = false
@@ -711,6 +720,12 @@ module Rigor
         @project_discovered_superclasses = discovery.discovered_superclasses
         @project_discovered_includes = discovery.discovered_includes
         @project_discovered_class_sources = discovery.discovered_class_sources
+        # Issue #345 spike instrumentation — the project-wide class-declaration source map, kept as a
+        # cross-check against the per-file `ScopeIndexer` hook.
+        if UnusedProbe::ACTIVE
+          UnusedProbe.record_project_class_sources(discovery.discovered_class_sources)
+          UnusedProbe.record_structural_edges(discovery.discovered_superclasses, discovery.discovered_includes)
+        end
         @project_discovered_method_visibilities = discovery.discovered_method_visibilities
         @project_discovered_methods = discovery.discovered_methods
         @project_data_member_layouts = discovery.data_member_layouts

--- a/lib/rigor/environment/rbs_loader.rb
+++ b/lib/rigor/environment/rbs_loader.rb
@@ -3,6 +3,7 @@
 require "rbs"
 
 require_relative "../type"
+require_relative "../unused_probe" # issue #345 spike instrumentation
 require_relative "../inference/rbs_type_translator"
 require_relative "rbs_hierarchy"
 
@@ -293,6 +294,9 @@ module Rigor
             next if parsed.nil? # quarantined (unparseable) or unreadable — skip so the env survives
 
             buffer, directives, decls = parsed
+            # Issue #345 spike instrumentation — project `sig/` type references. Inert unless
+            # RIGOR_UNUSED_PROBE is set.
+            UnusedProbe.record_rbs_decls(decls, file) if UnusedProbe::ACTIVE
             add_parsed_decls(env, buffer, directives, decls)
           end
         end
@@ -625,6 +629,8 @@ module Rigor
 
             buffer = ::RBS::Buffer.new(name: filename.to_s, content: content.to_s)
             _, directives, decls = ::RBS::Parser.parse_signature(buffer)
+            # Issue #345 spike instrumentation — ADR-93 inline / plugin virtual RBS type references.
+            UnusedProbe.record_rbs_decls(decls, filename.to_s) if UnusedProbe::ACTIVE
             add_parsed_decls(env, buffer, directives, decls)
           rescue ::RBS::BaseError
             # WD6 fail-soft: a single broken virtual RBS contribution does not pull the whole env down — for

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -4,6 +4,7 @@ require "prism"
 
 require_relative "../scope"
 require_relative "../type"
+require_relative "../unused_probe" # issue #345 spike instrumentation
 require_relative "../source/constant_path"
 require_relative "../source/node_children"
 require_relative "../cache/file_digest"
@@ -92,6 +93,12 @@ module Rigor
         seeded_scope = seeded_scope.with_discovery(
           seeded_scope.discovery.with(in_source_constants: in_source_constants)
         )
+        # Issue #345 spike instrumentation. `discovered_classes` and `in_source_constants` here are the
+        # PER-FILE tables (before the cross-file project seed merges in), so the declaration source is
+        # exactly `default_scope.source_path`. Inert unless RIGOR_UNUSED_PROBE is set.
+        if UnusedProbe::ACTIVE
+          UnusedProbe.record_file_declarations(default_scope.source_path, discovered_classes, in_source_constants)
+        end
 
         # Slice 7 phase 12. In-source method discovery. Walks every class/module body for `Prism::DefNode` and
         # recognised `define_method` calls and records the introduced method names. `rigor check` consults the table to

--- a/lib/rigor/reflection.rb
+++ b/lib/rigor/reflection.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "type"
+require_relative "unused_probe" # issue #345 spike instrumentation; inert unless RIGOR_UNUSED_PROBE is set
 
 module Rigor
   # Read-side facade over Rigor's three reflection sources:
@@ -123,21 +124,33 @@ module Rigor
       in_source = scope.in_source_constants
       lexical_constant_candidates(name, scope: scope).each do |candidate|
         singleton = env.singleton_for_name(candidate)
-        return singleton if singleton
+        return probe_resolved(candidate, singleton) if singleton
 
         in_source_class = discovered[candidate]
-        return in_source_class if in_source_class
+        return probe_resolved(candidate, in_source_class) if in_source_class
 
         # In-source value-bearing constants take precedence over RBS constant decls because
         # user code is the authoritative source for its own constants.
         in_source_value = in_source[candidate]
-        return in_source_value if in_source_value
+        return probe_resolved(candidate, in_source_value) if in_source_value
 
         value = env.constant_for_name(candidate)
-        return value if value
+        return probe_resolved(candidate, value) if value
       end
       nil
     end
+
+    # Issue #345 spike instrumentation. `candidate` at the moment {.resolve_constant_type}
+    # returns IS the fully-qualified name the lexical walk resolved to; this is the only place
+    # that local is observable. Returns `type` untouched so every `return` site keeps its value.
+    # A no-op (one frozen-constant read) unless `RIGOR_UNUSED_PROBE` is set.
+    def probe_resolved(candidate, type)
+      UnusedProbe.record_reference(candidate) if UnusedProbe::ACTIVE
+      type
+    end
+    # Private so the ADR-2 public read-side facade surface (and its `public_api_drift_spec`
+    # snapshot) is unchanged by the spike.
+    private_class_method :probe_resolved
 
     # The candidate qualified names to try, in Ruby's lexical order: most-qualified first (the
     # enclosing class path joined to `name`), then progressively less-qualified, then the bare

--- a/lib/rigor/unused_probe.rb
+++ b/lib/rigor/unused_probe.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+# THROWAWAY INSTRUMENTATION — issue #345 spike. Not production code. Delete with the spike.
+#
+# Hook sites (all gated, all `require_relative`d from the file they instrument):
+#   lib/rigor/reflection.rb            resolve_constant_type  -> record_reference
+#   lib/rigor/inference/scope_indexer.rb  .index              -> record_file_declarations
+#   lib/rigor/analysis/runner.rb       run_analysis           -> record_run_shape
+#   lib/rigor/analysis/runner.rb       apply_discovery_result -> record_project_class_sources,
+#                                                               record_structural_edges
+#   lib/rigor/environment/rbs_loader.rb add_project_signatures / add_virtual_rbs -> record_rbs_decls
+#
+# Collects the substrate for a future `rigor unused` reachability report:
+#
+# 1. **Resolved constant references** — recorded at `Rigor::Reflection.resolve_constant_type`'s
+#    choke point, as the fully-qualified name the lexical walk actually resolved TO (not the
+#    name as written).
+# 2. **Declared constants** — recorded per analyzed file from `Inference::ScopeIndexer.index`
+#    (`build_declaration_artifacts`'s per-file `discovered_classes`, and the per-file
+#    `in_source_constants` table), keyed by declaration source path. Cross-checked against the
+#    project-wide `discovered_class_sources` table the runner adopts.
+#
+# Everything is gated on `RIGOR_UNUSED_PROBE=<output.json>`. With the variable unset every hook
+# short-circuits on one frozen-false read and the run is unchanged.
+module Rigor
+  module UnusedProbe
+    # Set once at load time so an unset run never touches ENV again.
+    OUTPUT_PATH = ENV.fetch("RIGOR_UNUSED_PROBE", nil)
+    ACTIVE = !(OUTPUT_PATH.nil? || OUTPUT_PATH.empty?)
+
+    # The pid that owns the dump. A forked worker inherits ACTIVE but must NOT write (it would
+    # clobber the parent's file), and anything it accumulated is lost — which is exactly why the
+    # harness forces `--workers=0`. `record_run_shape` below stores the effective worker count so
+    # the report can refuse to report on a pooled run instead of silently under-counting.
+    OWNER_PID = Process.pid
+
+    @references = Hash.new(0)
+    @rbs_references = Hash.new(0)
+    @rbs_reference_sources = {}
+    @declared_classes = {}
+    @declared_constants = {}
+    @project_class_sources = {}
+    @structural_edges = {}
+    @analyzed_files = []
+    @workers = nil
+    @cache_enabled = nil
+    @notes = []
+
+    class << self
+      def active? = ACTIVE
+
+      # Hook 1 — `Reflection.resolve_constant_type` returned `candidate` as the resolved FQN.
+      def record_reference(fqn)
+        @references[fqn.to_s] += 1
+      end
+
+      # Hook 2 — one analyzed file's declarations, from `ScopeIndexer.index`.
+      def record_file_declarations(source_path, classes, constants)
+        path = source_path.to_s
+        return if path.empty?
+
+        classes.each_key { |name| (@declared_classes[name.to_s] ||= []) << path }
+        constants.each_key { |name| (@declared_constants[name.to_s] ||= []) << path }
+      end
+
+      # Hook 5 — project-side RBS. `Reflection.resolve_constant_type` is the SOURCE-side lexical
+      # resolver; a constant named only from a `.rbs` type annotation never passes through it, so
+      # without this hook every class whose only consumer is a signature reads as unreferenced.
+      # `decls` is the parsed declaration list of one project `sig/` file (or one ADR-93 inline
+      # virtual RBS); every `RBS::TypeName` reachable from it counts as a reference, EXCEPT a
+      # declaration's own name (`class Foo` in RBS is a declaration, not a use).
+      def record_rbs_decls(decls, source)
+        names = []
+        Array(decls).each { |decl| walk_rbs(decl, names, 0) }
+        names.uniq.each do |name|
+          @rbs_references[name] += 1
+          (@rbs_reference_sources[name] ||= []) << source.to_s
+        end
+      end
+
+      # Declaration nodes whose OWN `@name` is a declaration site rather than a reference.
+      SELF_NAMED_DECLS = %w[
+        RBS::AST::Declarations::Class RBS::AST::Declarations::Module
+        RBS::AST::Declarations::Interface RBS::AST::Declarations::TypeAlias
+        RBS::AST::Declarations::Constant RBS::AST::Declarations::Global
+      ].freeze
+
+      # Generic reflective walk. RBS's AST has no single public "every type name in here" visitor
+      # that is stable across the 3.x/4.x range the gemspec supports, so the probe reflects over
+      # ivars of `RBS::`-namespaced objects. Depth-capped; throwaway-grade by design.
+      def walk_rbs(obj, acc, depth)
+        return if depth > 40
+
+        case obj
+        when ::RBS::TypeName then acc << obj.to_s.delete_prefix("::")
+        when Array then obj.each { |o| walk_rbs(o, acc, depth + 1) }
+        when Hash then obj.each do |k, v|
+          walk_rbs(k, acc, depth + 1)
+          walk_rbs(v, acc, depth + 1)
+        end
+        when Symbol, String, Numeric, true, false, nil then nil
+        else walk_rbs_object(obj, acc, depth)
+        end
+      end
+
+      def walk_rbs_object(obj, acc, depth)
+        klass = obj.class.name.to_s
+        return unless klass.start_with?("RBS::")
+
+        skip_name = SELF_NAMED_DECLS.include?(klass)
+        obj.instance_variables.each do |ivar|
+          next if skip_name && ivar == :@name
+
+          walk_rbs(obj.instance_variable_get(ivar), acc, depth + 1)
+        end
+      end
+
+      # Hook 3 — the project-wide `discovered_class_sources` table (name => Set[path]) the runner
+      # adopts from the cross-file discovery pre-pass. Kept separate from hook 2 so the report can
+      # show whether the per-file hook missed any file.
+      def record_project_class_sources(table)
+        table.each { |name, paths| (@project_class_sources[name.to_s] ||= []).concat(Array(paths).map(&:to_s)) }
+      end
+
+      # Hook 3b — MEASURED GAP (fixture3): `class Sub < Base` never reaches
+      # `resolve_constant_type`, so a base class used only as a superclass reads as unreferenced
+      # (`Rigor::CLI::Command`, `Rigor::Cache::RbsCacheProducer`). The names here are recorded AS
+      # WRITTEN, not resolved; the report resolves them lexically against the declared set.
+      # `includes` is carried for symmetry even though `include Foo` IS a normal call (and so
+      # already resolves) — a plugin-rewritten include might not be.
+      def record_structural_edges(superclasses, includes)
+        superclasses.each { |sub, sup| (@structural_edges[sub.to_s] ||= []) << sup.to_s }
+        includes.each do |klass, mods|
+          Array(mods).each { |m| (@structural_edges[klass.to_s] ||= []) << m.to_s }
+        end
+      end
+
+      # Hook 4 — run shape. `files` is the expanded analysis file set; `workers` the effective
+      # worker count; `cache` whether a persistent cache store is attached.
+      def record_run_shape(files:, workers:, cache:)
+        @analyzed_files = Array(files).map(&:to_s)
+        @workers = workers
+        @cache_enabled = cache
+      end
+
+      def note(message)
+        @notes << message.to_s
+      end
+
+      def dump!
+        return unless ACTIVE
+        return unless Process.pid == OWNER_PID
+
+        require "json"
+        payload = {
+          "schema" => 1,
+          "pid" => Process.pid,
+          "cwd" => Dir.pwd,
+          "workers" => @workers,
+          "cache_enabled" => @cache_enabled,
+          "notes" => @notes,
+          "analyzed_files" => @analyzed_files,
+          "references" => @references,
+          "rbs_references" => @rbs_references,
+          "rbs_reference_sources" => @rbs_reference_sources.transform_values(&:uniq),
+          "declared_classes" => @declared_classes.transform_values(&:uniq),
+          "declared_constants" => @declared_constants.transform_values(&:uniq),
+          "project_class_sources" => @project_class_sources.transform_values(&:uniq),
+          "structural_edges" => @structural_edges.transform_values(&:uniq)
+        }
+        File.write(OUTPUT_PATH, JSON.pretty_generate(payload))
+      end
+    end
+
+    at_exit { dump! } if ACTIVE
+  end
+end

--- a/tool/unused_probe/fixtures/cross_file_values/.rigor.yml
+++ b/tool/unused_probe/fixtures/cross_file_values/.rigor.yml
@@ -1,0 +1,4 @@
+target_ruby: "4.0"
+paths:
+  - lib
+plugins: []

--- a/tool/unused_probe/fixtures/cross_file_values/lib/consts.rb
+++ b/tool/unused_probe/fixtures/cross_file_values/lib/consts.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Holder
+  SAME_FILE_USED = 1
+  CROSS_FILE_USED = 2
+  NEVER_USED = 3
+
+  def self.read_same_file
+    SAME_FILE_USED
+  end
+end

--- a/tool/unused_probe/fixtures/cross_file_values/lib/consts_user.rb
+++ b/tool/unused_probe/fixtures/cross_file_values/lib/consts_user.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Holder
+  # Same constant namespace, DIFFERENT file: a bare-name read.
+  def self.read_bare_cross_file
+    CROSS_FILE_USED
+  end
+end
+
+Holder.read_same_file
+Holder.read_bare_cross_file
+Holder::CROSS_FILE_USED

--- a/tool/unused_probe/fixtures/gate/.rigor.yml
+++ b/tool/unused_probe/fixtures/gate/.rigor.yml
@@ -1,0 +1,6 @@
+target_ruby: "4.0"
+paths:
+  - lib
+signature_paths:
+  - sig
+plugins: []

--- a/tool/unused_probe/fixtures/gate/lib/consumer.rb
+++ b/tool/unused_probe/fixtures/gate/lib/consumer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Consumer
+  def call
+    UsedFromOtherFile.new.hello
+  end
+end

--- a/tool/unused_probe/fixtures/gate/lib/entrypoint.rb
+++ b/tool/unused_probe/fixtures/gate/lib/entrypoint.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Top-level driver: declares NO constant of its own, so it adds no declaration to the census.
+# It exists only to make Consumer / A::B::Caller / RbsConsumer referenced, leaving NeverUsed as
+# the fixture's single genuinely-unreferenced class.
+Consumer.new.call
+A::B::Caller.new.go
+RbsConsumer.new.make

--- a/tool/unused_probe/fixtures/gate/lib/nested.rb
+++ b/tool/unused_probe/fixtures/gate/lib/nested.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Case 2: A::B::NestedOnly is referenced ONLY as the bare `NestedOnly` from inside A::B.
+# The full name A::B::NestedOnly appears nowhere in the sources.
+module A
+  module B
+    class NestedOnly
+      def value = 1
+    end
+
+    class Caller
+      def go
+        NestedOnly.new.value
+      end
+    end
+  end
+end

--- a/tool/unused_probe/fixtures/gate/lib/never_used.rb
+++ b/tool/unused_probe/fixtures/gate/lib/never_used.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Case 4: referenced NOWHERE. The only true candidate in this fixture.
+class NeverUsed
+  def dead = :dead
+end

--- a/tool/unused_probe/fixtures/gate/lib/rbs_consumer.rb
+++ b/tool/unused_probe/fixtures/gate/lib/rbs_consumer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RbsConsumer
+  def make
+    build
+  end
+
+  def build
+    raise NotImplementedError
+  end
+end

--- a/tool/unused_probe/fixtures/gate/lib/rbs_only.rb
+++ b/tool/unused_probe/fixtures/gate/lib/rbs_only.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Case 3: referenced ONLY from sig/rbs_consumer.rbs, never from Ruby source.
+class RbsOnlyReferenced
+  def tag = :rbs
+end

--- a/tool/unused_probe/fixtures/gate/lib/used_from_other_file.rb
+++ b/tool/unused_probe/fixtures/gate/lib/used_from_other_file.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Case 1: declared here, referenced from consumer.rb by its bare name.
+class UsedFromOtherFile
+  def hello = "hi"
+end

--- a/tool/unused_probe/fixtures/gate/sig/rbs_consumer.rbs
+++ b/tool/unused_probe/fixtures/gate/sig/rbs_consumer.rbs
@@ -1,0 +1,4 @@
+class RbsConsumer
+  def make: () -> RbsOnlyReferenced
+  def build: () -> RbsOnlyReferenced
+end

--- a/tool/unused_probe/fixtures/superclass_and_defaults/.rigor.yml
+++ b/tool/unused_probe/fixtures/superclass_and_defaults/.rigor.yml
@@ -1,0 +1,4 @@
+target_ruby: "4.0"
+paths:
+  - lib
+plugins: []

--- a/tool/unused_probe/fixtures/superclass_and_defaults/lib/base.rb
+++ b/tool/unused_probe/fixtures/superclass_and_defaults/lib/base.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class BaseOnlySubclassed
+  def hi = 1
+end
+
+module Mixin
+  def mixed = 2
+end

--- a/tool/unused_probe/fixtures/superclass_and_defaults/lib/defaults.rb
+++ b/tool/unused_probe/fixtures/superclass_and_defaults/lib/defaults.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Defaults
+  SAME_FILE_DEFAULT = "x"
+  SAME_FILE_BODY = "y"
+
+  def initialize(root = SAME_FILE_DEFAULT)
+    @root = root
+  end
+
+  def body = SAME_FILE_BODY
+end

--- a/tool/unused_probe/fixtures/superclass_and_defaults/lib/sub.rb
+++ b/tool/unused_probe/fixtures/superclass_and_defaults/lib/sub.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Sub < BaseOnlySubclassed
+  include Mixin
+end

--- a/tool/unused_probe/report.rb
+++ b/tool/unused_probe/report.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+# THROWAWAY — issue #345 spike. Reads the JSON dump produced by `Rigor::UnusedProbe`
+# (lib/rigor/unused_probe.rb) and reports project-owned constants that no resolved constant
+# reference ever pointed at.
+#
+#   ruby tool/unused_probe/report.rb PROBE.json [--root DIR] [--limit N] [--json]
+#
+# Correctness guards (each ABORTS rather than reporting a number it cannot stand behind):
+#   * workers != 0        — per-file references accumulated in a worker process and were lost.
+#   * cache_enabled       — a cache HIT file is never re-analyzed and contributes zero references.
+#   * zero references     — the probe never fired; the run did not reach the choke point at all.
+
+require "json"
+require "optparse"
+
+options = { root: nil, limit: nil, json: false }
+parser = OptionParser.new do |opts|
+  opts.banner = "usage: ruby tool/unused_probe/report.rb PROBE.json [options]"
+  opts.on("--root DIR", "restrict declarations to this directory prefix (default: the analyzed file set)") do |v|
+    options[:root] = v
+  end
+  opts.on("--limit N", Integer, "show only the first N candidates") { |v| options[:limit] = v }
+  opts.on("--json", "emit machine-readable JSON instead of the text report") { options[:json] = true }
+  opts.on("--allow-cache", "do not abort when the run had a cache store attached (UNSAFE)") do
+    options[:allow_cache] = true
+  end
+end
+parser.parse!
+path = ARGV.shift or abort(parser.banner)
+
+data = JSON.parse(File.read(path))
+
+def summarize_paths(paths)
+  return paths.join(", ") if paths.size <= 3
+
+  "#{paths.first(3).join(', ')} (+#{paths.size - 3} more)"
+end
+
+def die(message)
+  warn "unused-probe: REFUSING TO REPORT — #{message}"
+  exit 2
+end
+
+workers = data["workers"]
+unless workers.nil? || workers.to_i.zero?
+  die("run used workers=#{workers}; references from worker processes never reached the dump. " \
+      "Re-run with --workers=0.")
+end
+unless options[:allow_cache] || data["cache_enabled"] == false
+  die("run had a persistent cache store attached; cached files are not re-analyzed and contribute " \
+      "zero references. Re-run with --no-cache.")
+end
+references = data.fetch("references")
+rbs_references = data.fetch("rbs_references", {})
+die("zero constant references recorded; the probe never fired.") if references.empty?
+
+analyzed = data.fetch("analyzed_files").to_set
+
+# --- declaration ownership -------------------------------------------------------------------
+# The predicate: a declaration is PROJECT-OWNED when its source file is a member of this run's
+# expanded analysis file set (optionally further restricted by --root). Declarations reached only
+# through RBS, bundled stdlib signatures, or a gem never pass through `ScopeIndexer.index` at all,
+# so they are absent from the tables by construction.
+root_prefix = options[:root] && (options[:root].chomp("/") + "/")
+
+def owned?(paths, analyzed, root_prefix)
+  paths.any? do |p|
+    next false unless analyzed.empty? || analyzed.include?(p)
+    next true unless root_prefix
+
+    p.start_with?(root_prefix)
+  end
+end
+
+declared = {} # fqn => { kind: , paths: [] }
+data.fetch("declared_classes").each do |name, paths|
+  next unless owned?(paths, analyzed, root_prefix)
+
+  declared[name] = { "kind" => "class/module", "paths" => paths }
+end
+data.fetch("declared_constants").each do |name, paths|
+  next unless owned?(paths, analyzed, root_prefix)
+
+  entry = declared[name]
+  if entry
+    entry["kind"] = "class/module+value"
+    entry["paths"] = (entry["paths"] + paths).uniq
+  else
+    declared[name] = { "kind" => "value", "paths" => paths }
+  end
+end
+
+# `class Sub < Base` and `include Mod` are recorded AS WRITTEN by the discovery pre-pass, not as a
+# resolved FQN (a superclass never reaches `resolve_constant_type` at all — measured in fixture3).
+# Resolve each edge the way Ruby's lexical lookup would, against the DECLARED set: try the
+# subclass's own namespace path from most-qualified down to the bare name, first declared name wins.
+def resolve_lexically(from, written, declared_names)
+  return written if written.start_with?("::") && declared_names.include?(written.delete_prefix("::"))
+
+  prefix = from.split("::")
+  while prefix.any?
+    cand = (prefix + [written]).join("::")
+    return cand if declared_names.include?(cand)
+
+    prefix.pop
+  end
+  written
+end
+
+declared_names = declared.keys.to_set
+structural = Set.new
+data.fetch("structural_edges", {}).each do |from, names|
+  names.each { |written| structural << resolve_lexically(from, written, declared_names) }
+end
+
+referenced = (references.keys + rbs_references.keys + structural.to_a).to_set
+candidates = declared.reject { |name, _| referenced.include?(name) }
+
+# A candidate that is a strict namespace prefix of some resolved reference (`A::B` when `A::B::C`
+# was resolved) is very likely a probe ARTIFACT rather than a dead constant: the engine resolved
+# the full path in one step and never recorded the intermediate segment.
+prefixes = Set.new
+referenced.each do |fqn|
+  parts = fqn.split("::")
+  (1...parts.size).each { |i| prefixes << parts[0, i].join("::") }
+end
+artifacts, real = candidates.partition { |name, _| prefixes.include?(name) }
+# MEASURED LIMITATION (fixture2): a VALUE constant declared in one file and read from another
+# never resolves — `Scope#in_source_constants` is per-file and the cross-file project seed carries
+# only `discovered_classes`, so `resolve_constant_type` returns nil and records nothing. Every
+# value-constant candidate is therefore suspect; class/module candidates are not affected (the
+# class table IS seeded cross-file).
+split = real.partition { |_, e| e["kind"] == "value" }
+value_candidates = split[0]
+class_candidates = split[1]
+
+if options[:json]
+  puts JSON.pretty_generate(
+    "declared_owned" => declared.size,
+    "referenced_distinct" => referenced.size,
+    "candidates" => candidates.size,
+    "candidates_prefix_of_reference" => artifacts.size,
+    "candidates_value_kind" => value_candidates.size,
+    "candidates_class_kind" => class_candidates.size,
+    "candidates_list" => candidates.map { |n, e| { "name" => n }.merge(e) }
+  )
+  exit 0
+end
+
+def section(title, rows, limit)
+  puts
+  puts "-- #{title} (#{rows.size}) --"
+  rows.first(limit || rows.size).each_with_index do |(name, entry), i|
+    puts format("%3d  %-62s %-18s %s", i + 1, name, entry["kind"], summarize_paths(entry["paths"]))
+  end
+end
+
+puts "probe:              #{path}"
+puts "cwd:                #{data['cwd']}"
+puts "analyzed files:     #{analyzed.size}"
+puts "workers:            #{workers.inspect}   cache_enabled: #{data['cache_enabled'].inspect}"
+puts "declared (owned):   #{declared.size}"
+puts "distinct refs:      #{referenced.size}   " \
+     "(source: #{references.size} names / #{references.values.sum} resolutions, " \
+     "rbs: #{rbs_references.size} names, structural: #{structural.size} names)"
+puts "CANDIDATES:         #{candidates.size}"
+puts "  namespace-prefix of a resolved reference (artifact):      #{artifacts.size}"
+puts "  value constants (UNRELIABLE — a cross-file, parameter-default,"
+puts "  or lambda-body value read does not resolve):              #{value_candidates.size}"
+puts "  class / module constants (the trustworthy tier):          #{class_candidates.size}"
+
+section("class/module candidates", class_candidates, options[:limit])
+section("value-constant candidates", value_candidates, options[:limit])
+section("namespace-prefix artifacts", artifacts, options[:limit])

--- a/tool/unused_probe/run.sh
+++ b/tool/unused_probe/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# THROWAWAY — issue #345 spike. Measures unreferenced project constants on one project.
+#
+#   tool/unused_probe/run.sh <PROJECT_DIR> <OUT.json> [extra rigor args...]
+#
+# Must be invoked from the Rigor worktree that carries the instrumentation, INSIDE the Nix flake:
+#
+#   nix --extra-experimental-features 'nix-command flakes' develop \
+#     --command tool/unused_probe/run.sh /path/to/project /tmp/proj.json
+#
+# `--no-cache` and `--workers=0` are forced here, not left to the target's `.rigor.yml`: a cache HIT
+# file is never re-analyzed (zero references) and a pooled run accumulates references in a child
+# process that never writes the dump. The report script re-checks both from the dump and refuses to
+# print a number if either is wrong.
+set -euo pipefail
+
+PROJECT="${1:?usage: run.sh <PROJECT_DIR> <OUT.json> [extra rigor args]}"
+OUT="${2:?usage: run.sh <PROJECT_DIR> <OUT.json> [extra rigor args]}"
+shift 2
+
+WT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT="$(cd "$(dirname "$OUT")" && pwd)/$(basename "$OUT")"
+
+cd "$PROJECT"
+RIGOR_UNUSED_PROBE="$OUT" \
+BUNDLE_GEMFILE="$WT/Gemfile" \
+BUNDLE_PATH="$WT/vendor/bundle" \
+  bundle exec ruby "$WT/exe/rigor" check --no-cache --no-ci-detect --workers=0 "$@" || true
+
+ruby "$WT/tool/unused_probe/report.rb" "$OUT" --limit 40


### PR DESCRIPTION
Lands the measurement instrument for #345, the spike under #344's reachability-report arc.

Four engine hooks, each behind `UnusedProbe::ACTIVE` — a frozen constant read from `RIGOR_UNUSED_PROBE` at load time, so an unset run is unchanged. `Reflection.resolve_constant_type` is the only place a resolved constant's fully-qualified name is observable (`candidate` at the moment of return, which dies with the frame), hence the small `probe_resolved` indirection; it is private so the ADR-2 read-side facade snapshot in `public_api_drift_spec` is untouched. The other three record the declaration side, the project class-source map and structural edges, and RBS-side type references.

The run-shape hook is the load-bearing one: a non-zero worker count accumulates references in a child process that never reaches the parent, and an attached cache store means a HIT file is never re-analyzed and contributes zero references while its constants still count as declared. Both read as a long list of dead constants. `tool/unused_probe/report.rb` exits 2 rather than printing a number when either holds.

The fixtures are what makes a "no" trustworthy — `gate` covers a bare cross-file reference, a nesting-relative one (`A::B::C` written only as `C` inside `A::B`), an RBS-only reference, and a genuinely unreferenced constant; `cross_file_values` and `superclass_and_defaults` isolate two measured reference-side losses.

## Results so far

On Rigor's own `lib`: 1280 declared constants, 140 candidates, **0 genuine** — five hand-adjudicated spot-checks were all probe artifacts. Full write-up and the corpus survey are on #345.

The finding that matters: **the typing path is not a reference index.** `resolve_constant_type` fires only where the engine needs a constant's type, so a read-but-never-typed constant leaves no trace — cross-file value constants, parameter defaults, lambda-rvalue bodies, superclass positions, and intermediate namespace segments are all invisible. #347 has been corrected accordingly: the reverse index needs a dedicated constant-read-node pass, not a hook on the typing path.

## Note on scope

This is spike scaffolding in engine files, landed deliberately rather than written up and deleted — a docs-only note would throw the instrument away and the next session would rebuild it to re-ask the same question. The hot-path cost is one frozen-constant read per resolved constant. If that is not wanted in `master`, the alternative is to keep this branch unmerged and cite it from the `docs/notes/` write-up.

`make verify` green, `git diff --check` clean.