### PR TITLE
Record the #345 unused-constant FP baseline on three Rails corpora

### DIFF
--- a/docs/notes/20260813-unused-constant-fp-baseline.md
+++ b/docs/notes/20260813-unused-constant-fp-baseline.md
@@ -1,0 +1,226 @@
+# Unused-constant false-positive baseline — three-project corpus measurement for #345
+
+Status: measurement note, no design commitments. Observations taken against the `#345` probe
+worktree @ `3b236b8b`, macOS arm64, Ruby 4.0.5, 2026-08-13.
+
+## Why
+
+[#345](https://github.com/rigortype/rigor/issues/345) asks whether Rigor's analysis substrate can
+carry a `rigor unused` reachability report. The naive form of the question — "which project-owned
+constants did no resolved constant reference point at?" — has a known-terrible false-positive rate
+on Rigor's own `lib/` (99.7 %). This note measures the same funnel on three real Rails applications
+and, on one of them, hand-adjudicates every survivor so the number has a true-positive ratio
+attached to it. A count without that ratio is not a result.
+
+The funnel is shaped after the source article's `631 → 9 → 3 → 2` decay: start from the naive count,
+then apply successively more expensive root-set knowledge and watch how much each stage buys.
+
+## Method
+
+The instrumentation is `lib/rigor/unused_probe.rb` (gated on `RIGOR_UNUSED_PROBE`, five hook sites,
+inert when unset) plus `tool/unused_probe/{run.sh,report.rb,stages.rb}`. `run.sh` forces
+`--no-cache --workers=0`; `report.rb` **exits 2 rather than printing a number** if the dump shows
+workers ≠ 0, a cache store attached, or zero recorded references. Every run below cleared those
+guards, and every reference count is reported so a silent-failure run is visible as such.
+
+The corpus projects are read as data. Nothing in them was modified, and no `.rigor.yml` was written
+— path widening is expressed as positional arguments to `rigor check`, which override
+`configuration.paths`.
+
+### Reproduction
+
+From the probe worktree, inside the Nix flake:
+
+```sh
+nix --extra-experimental-features 'nix-command flakes' develop --command \
+  tool/unused_probe/run.sh ~/repo/ruby/rigor-survey/redmine /tmp/redmine-naive.json
+
+nix --extra-experimental-features 'nix-command flakes' develop --command \
+  tool/unused_probe/run.sh ~/repo/ruby/rigor-survey/redmine /tmp/redmine-wide.json app lib config
+
+nix --extra-experimental-features 'nix-command flakes' develop --command \
+  ruby tool/unused_probe/stages.rb /tmp/redmine-wide.json \
+    --project ~/repo/ruby/rigor-survey/redmine --list
+```
+
+Substitute `~/repo/ruby/rigor-survey/mastodon` and `~/repo/ruby/conference-app` for the other two
+targets; the argument list `app lib config` is the same for all three (each target's `paths:` is
+`app`, `lib`, and each has a `config/` that was not in it). Corpus revisions: redmine `a12198ea0`,
+mastodon `163f96cee`, conference-app `3e54d61`.
+
+### The four stages
+
+1. **Naive** — the target's configured `paths:` as-is.
+2. **Widened root** — `config/` added to the analysed paths.
+3. **Route roots** — subtract controllers reachable from `config/routes.rb`, using the
+   **deliberately rough** extractor in `tool/unused_probe/stages.rb`. It is a line-oriented regex
+   scan, not a Rails router: `do`/`end` counting for `namespace` / `module:` nesting, `resources` /
+   `resource` symbol lists, `:controller =>` / `controller:` options, `controllers x: 'y'` maps, and
+   `"controller#action"` strings. `resource :x` (singular) contributes both `XController` and
+   `XsController` because there is no inflector; matching is on the full constant name **or** its
+   demodulized tail, so it over-subtracts. Over-subtraction is the safe direction for an
+   FP-baseline: it makes the surviving number a lower bound on the FP problem, not an upper one.
+   The real root extraction is [#349](https://github.com/rigortype/rigor/issues/349).
+4. **Dynamic-resolution demotion** — move to a separate "cannot decide" bucket every candidate that
+   (d1) has an enclosing namespace appearing as a literal prefix of a `constantize` /
+   `safe_constantize` / `const_get` / interpolated construction, (d2) appears verbatim inside a Ruby
+   string or symbol literal, or (d3) appears — as FQN, autoload-path form, or underscored tail — in
+   an ERB / HAML / SLIM / YAML / locale / JSON file under `app`, `lib`, `config`, `db`.
+
+### Tier reported
+
+The **class/module constant tier** is the headline. The value-constant tier is known-broken:
+`Scope#in_source_constants` is per-file by design and value constants are not carried in the
+cross-file project seed, so a value constant read from another file never resolves and the candidate
+is spurious by construction. Its counts appear below for completeness, labelled UNRELIABLE, and no
+adjudication effort was spent on them.
+
+## Run shape (the anti-silence check)
+
+| target | stage | files | declared (owned) | distinct refs | source resolutions |
+| --- | --- | ---: | ---: | ---: | ---: |
+| redmine | naive | 347 | 697 | 609 | 33,736 |
+| redmine | widened | 365 | 715 | 620 | 34,824 |
+| mastodon | naive | 1,312 | 2,109 | 1,697 | 175,582 |
+| mastodon | widened | 1,388 | 2,144 | 1,733 | 180,022 |
+| conference-app | naive | 101 | 105 | 1,438 | 2,405 |
+| conference-app | widened | 122 | 107 | 1,442 | 3,048 |
+
+All six runs recorded `workers: 0`, `cache_enabled: false`, and a five- to six-figure resolution
+count. conference-app's distinct-reference figure is dominated by the RBS path (1,411 of 1,442 names
+come from `signature_paths:`), which is exactly why it is in the corpus: it is the only target that
+exercises `record_rbs_decls`.
+
+## Decay table — class/module constant tier
+
+| target | 1 naive | 2 widened root | 3 route roots | 4 dynamic demotion | adjudicated true positives |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| redmine | 135 | 136 | 82 | **57** | **4** |
+| mastodon | 377 | 374 | 142 | **113** | not adjudicated |
+| conference-app | 59 | 61 | 20 | **14** | not adjudicated |
+
+Other tiers, for completeness (naive → widened):
+
+| target | value constants (UNRELIABLE) | namespace-prefix artifacts |
+| --- | --- | --- |
+| redmine | 38 → 38 | 24 → 30 |
+| mastodon | 86 → 89 | 91 → 95 |
+| conference-app | 0 → 0 | 0 → 0 |
+
+### Stage 2 buys nothing, and the reason is structural
+
+Widening the analysed root moves the **declaration** set and the **reference** set together, because
+both are gated on the same analysed-file predicate. The two effects very nearly cancel:
+
+| target | files | declarations | distinct refs | net class candidates |
+| --- | ---: | ---: | ---: | ---: |
+| redmine | +18 | +18 | +11 | **+1** |
+| mastodon | +76 | +35 | +36 | **−3** |
+| conference-app | +21 | +2 | +4 | **+2** |
+
+Adding `config/` to redmine added eighteen files, eighteen new project-owned declarations, and
+eleven new resolved reference names — and the candidate count went *up* by one. On two of three
+targets widening made the report slightly worse. This is worth stating plainly because "just analyse
+more of the project" is the obvious first instinct and it is, measured, not a lever. It is still
+correct to widen — `config/initializers` is where a lot of real references live — but the payoff has
+to come from stage 3 and stage 4, not from stage 2.
+
+Stage 3 is where the money is: −40 % on redmine, −62 % on mastodon, −67 % on conference-app. Stage 4
+takes a further −30 %, −20 %, −30 %. The rough extractor is doing crude work and still dominates
+every other stage combined.
+
+## Redmine adjudication
+
+All 57 survivors were hand-checked (not sampled), by grepping the whole redmine tree for each name
+and reading the declaration site and any framework wiring involved.
+
+**True positives — 4 of 57 (7.0 %).**
+
+| constant | file | why it is genuinely dead |
+| --- | --- | --- |
+| `ChangesetNotFound` | `app/controllers/repositories_controller.rb:23` | `class ChangesetNotFound < StandardError; end` — the declaration is the only occurrence in the entire repository, tests included. |
+| `ScmFetchError` | `app/models/repository.rb:20` | Same shape; never raised, never rescued, never named. |
+| `Redmine::SudoMode::SudoRequired` | `lib/redmine/sudo_mode.rb:25` | Declared and mentioned once in a prose comment at line 91. Never raised. |
+| `SvgIconHelper` | `app/helpers/svg_icon_helper.rb:20` | An empty `module SvgIconHelper; end`. The controller is `SvgIconsController` (plural), whose convention helper is `SvgIconsHelper`, which does not exist — so nothing ever includes this module. |
+
+**False positives — 53 of 57**, in ten artifact classes:
+
+| # | artifact class | mechanism | why the candidate is wrong |
+| ---: | --- | --- | --- |
+| 28 | Rails helper-module convention | `FooController` implicitly `helper`s `FooHelper` | The name is derived, never written. Redmine sets `include_all_helpers = false`, so the pairing is one-to-one and checkable — every one of these 28 has a matching controller (`GanttHelper` via an explicit `helper :gantt` in `gantts_controller.rb`). |
+| 7 | registry self-registration | `Redmine::FieldFormat::*` call `add 'link'` in the class body, which does `Redmine::FieldFormat.add(name, self)` | The class registers *itself* into a string-keyed registry. The root marker is a DSL call inside the body, not a reference from outside. |
+| 4 | Rails generator convention | `lib/generators/redmine_plugin*/…` | Reached by `rails generate redmine_plugin`, i.e. by file path and name. |
+| 3 | reopened foreign class | `ActionView::Helpers::DateHelper`, `ActionController::MimeResponds`, `…::Collector` in `config/initializers/10-patches.rb` | **Ownership-predicate artifact, not a finding**: reopening a gem class registers it as a project declaration. These are not project constants at all. |
+| 3 | test-runner roots inside `paths:` | `TreeTest*` in `lib/plugins/acts_as_tree/test/` | Minitest classes discovered by the runner. Also a configuration smell — a vendored plugin's `test/` directory is inside redmine's `lib` path. |
+| 2 | reference lives in a `.rake` file | `Redmine::IMAP`, `Redmine::POP3`, both used by `lib/tasks/email.rake` | The reference exists inside `paths:` but in a file extension the analyser does not read. |
+| 2 | dynamic construction the rough rule missed | `Redmine::WikiFormatting::{CommonMark,Textile}::HtmlParser` | Built by `"Redmine::WikiFormatting::#{name.classify}::#{m}".constantize`. Stage 4's d1 rule keys on the candidate's *immediate* parent namespace; the literal prefix here is two levels up. A correct rule must treat every namespace **at or below** a dynamic prefix as tainted. |
+| 1 | inherited-scope constant lookup | `Redmine::Scm::Adapters::AbstractAdapter::ScmCommandAborted` | `rescue ScmCommandAborted` inside `class BazaarAdapter < AbstractAdapter` resolves through the *superclass* scope chain. The resolver's lexical walk does not model that, so a real, in-analysis-set reference is not recorded. This one is an engine gap, not a root-set gap. |
+| 1 | `ActiveSupport::Concern` convention | `Redmine::SudoMode::Controller::ClassMethods` | `extend ActiveSupport::Concern` auto-extends a nested `ClassMethods` by name. |
+| 1 | published extension point | `Redmine::Hook::ViewListener` | Subclassed only by out-of-tree Redmine plugins (and by `test/`). Exported API, dead only from inside the repository. |
+| 1 | Rails validator convention | `DateValidator` | `validates :start_date, :date => true` becomes `"DateValidator".constantize`. Stage 4's top-level dynamic rule was restricted to `*Controller`; the same convention exists for validators, jobs, serializers, and more. |
+
+### What this means arithmetically
+
+The class/module tier's precision on redmine after four stages is **7.0 %** — one true finding for
+every thirteen wrong ones. Two of the ten FP classes (helper convention, registry self-registration)
+account for 35 of the 53 false positives, i.e. **66 % of the remaining FP mass sits in two rules**.
+
+## Spot checks on the other two targets
+
+Not adjudicated exhaustively; recorded because they identify the same artifact classes elsewhere.
+
+- **conference-app** (14 survivors) reproduces the pattern almost exactly: 4 Rails helper-convention
+  modules, 4 `active_decorator` decorators (the gem applies `FooDecorator` to `Foo` by name, so the
+  root is a gem convention), 3 `alba` resource classes, `ApplicationCable` (a namespace-only module
+  that the prefix-artifact rule failed to fold), `ApplicationMailer` (a Rails scaffold base class
+  with no subclasses — arguably a fifth true positive of the same species as `SvgIconHelper`), and
+  `TitoApiClient`, referenced only from `lib/tasks/tito.rake` — the identical `.rake` artifact
+  redmine produced.
+- **mastodon** (113 survivors) is dominated by controllers the rough route extractor did not reach:
+  27 of the first 30 survivors are `*Controller` under `Api::V1::…`, `WellKnown::…`, `Auth::…`,
+  `OAuth::…`. Mastodon splits routes across `config/routes/{admin,api,fasp,settings,web_app}.rb`
+  with heavy `namespace` nesting and `resource … controller:` remapping; the regex scan extracted
+  622 roots and still missed these. That is a statement about the extractor, not about mastodon —
+  and it is the clearest single argument that #349 needs a real router-shaped extractor rather than
+  a heuristic.
+
+## What this means for #347 / #349
+
+1. **The report can never be a diagnostic.** 7.0 % precision after four stages of root knowledge,
+   on the most favourable of three targets, is far outside anything ADR-5 and the "false positives
+   outrank worst-case static reading" guideline would tolerate as a check. It stays a report — an
+   opt-in, human-read listing — and the surviving count is a *review queue*, not a defect count.
+2. **Root sets are the whole game (#349).** Stage 3 alone removed 40–67 % of the class tier with a
+   regex. Every stage-4 rule combined removed 20–30 %. Whatever budget exists should go to root
+   extraction first, and the route extractor should be router-shaped, not regex-shaped — mastodon
+   shows the heuristic falling over precisely where a real app is most complex.
+3. **Two convention rules retire two thirds of the remaining FP mass.** The helper-module pairing
+   (`FooController` ⇒ `FooHelper`, respecting `include_all_helpers`) and "a class whose body calls a
+   registration DSL is a root" together cover 35 of redmine's 53 false positives, and the decorator
+   and resource groups on conference-app are the same shape. Both are naturally
+   plugin-API-shaped — `rigor-actionpack` already knows about controllers — which fits the standing
+   guideline of steering convention knowledge out of the core.
+4. **Two of the artifact classes are Rigor bugs, not root-set gaps**, and are worth splitting off
+   from #347:
+   - the **ownership predicate** counts a reopened gem/stdlib class as a project declaration
+     (3 redmine candidates came from a single initializer). A declaration whose namespace is
+     defined by an RBS the project did not author should never be a candidate.
+   - the **superclass constant-scope walk** is missing: `rescue ScmCommandAborted` inside a subclass
+     records no reference to `AbstractAdapter::ScmCommandAborted`. Isolated and filed as
+     [#354](https://github.com/rigortype/rigor/issues/354), where it turned out to be worse than an
+     under-recorded edge. `Reflection.lexical_constant_candidates` implements Ruby's lexical walk and
+     its bare-name fallback but not the ancestor step between them, so when the same name also exists
+     at top level the **bare-name fallback wins a lookup Ruby gives to the ancestor** — Rigor types
+     `KEY` inside `class Sub < Base` as the top-level constant while Ruby resolves it to `Base::KEY`.
+     That is a false positive on correct code, independent of this report.
+5. **The analysed-file extension set is too narrow for a reachability question.** `.rake` files sit
+   inside `paths:` and reference project constants; two redmine candidates and one conference-app
+   candidate are pure artifacts of not reading them. A reachability report needs a *reference*
+   corpus wider than its *analysis* corpus — reading a file for references is far cheaper than
+   type-checking it.
+6. **Widening `paths:` is not a mitigation** (stage 2, +1/−3/+2). Do not ship advice that says "add
+   `config/` and the report gets better"; it does not, because declarations and references widen
+   together.
+7. **The value-constant tier stays out of any shipped report** until the cross-file seed carries
+   `in_source_constants`. It is 38 / 89 / 0 candidates across the corpus with, by construction, no
+   way to be right.

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -70,6 +70,7 @@ comparison) appears nowhere else in this index.
 | 2026-08-05 | [`&&` / `\|\|` value-polarity gate — FP-risk evaluation (issue #152)](20260805-issue-152-and-or-polarity-gate-fp-evaluation.md) |
 | 2026-08-05 | [`if` / `unless` truthiness elision — corpus census of what the verdict rests on (issue #286)](20260805-issue-286-if-unless-truthiness-elision-census.md) |
 | 2026-08-06 | [`if` / `unless` elision — provenance census of the optimistic carrier, and a two-directional A/B (issue #286)](20260806-issue-286-optimistic-carrier-provenance-census.md) |
+| 2026-08-13 | [Unused-constant false-positive baseline — three-project corpus measurement (issue #345)](20260813-unused-constant-fp-baseline.md) |
 
 ## Analyzer self-testing (teeth / false-negatives)
 

--- a/tool/unused_probe/report.rb
+++ b/tool/unused_probe/report.rb
@@ -136,6 +136,12 @@ value_candidates = split[0]
 class_candidates = split[1]
 
 if options[:json]
+  # `bucket` is the tier the text report prints the candidate under, so a downstream stage filter
+  # (tool/unused_probe/stages.rb) does not have to re-derive the ownership + prefix logic.
+  bucket = {}
+  artifacts.each { |n, _| bucket[n] = "prefix_artifact" }
+  value_candidates.each { |n, _| bucket[n] = "value" }
+  class_candidates.each { |n, _| bucket[n] = "class" }
   puts JSON.pretty_generate(
     "declared_owned" => declared.size,
     "referenced_distinct" => referenced.size,
@@ -143,7 +149,7 @@ if options[:json]
     "candidates_prefix_of_reference" => artifacts.size,
     "candidates_value_kind" => value_candidates.size,
     "candidates_class_kind" => class_candidates.size,
-    "candidates_list" => candidates.map { |n, e| { "name" => n }.merge(e) }
+    "candidates_list" => candidates.map { |n, e| { "name" => n, "bucket" => bucket[n] }.merge(e) }
   )
   exit 0
 end

--- a/tool/unused_probe/stages.rb
+++ b/tool/unused_probe/stages.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+# THROWAWAY — issue #345 spike. Applies the decay stages 3 and 4 to a probe dump's class/module
+# candidate tier, and prints the surviving set.
+#
+#   ruby tool/unused_probe/stages.rb PROBE.json --project DIR [--json]
+#
+# Stage 3 (ROUTE ROOTS) subtracts controllers reachable from `config/routes.rb`. The extractor here
+# is DELIBERATELY ROUGH — a line-oriented regex scan, not a Rails router. It is sized to answer
+# "how big is the drop", not to be the #349 implementation. Known roughness, all deliberate:
+#   * block nesting is tracked by counting `do` / `end`, so a one-line `do … end` miscounts;
+#   * `resource :x` (singular) contributes BOTH `XController` and `XsController` because there is
+#     no inflector here;
+#   * a `'a/b#c'` string contributes both the namespaced and the bare form;
+#   * matching is on the full constant name OR its demodulized tail, so `Api::V1::FooController`
+#     is subtracted by a bare `FooController` root. This over-subtracts, which is the safe
+#     direction for an FP-baseline measurement.
+#
+# Stage 4 (DYNAMIC-RESOLUTION DEMOTION) moves to a "cannot decide" bucket every candidate whose
+# name could plausibly be produced or named outside Ruby constant syntax:
+#   d1  its enclosing namespace is a literal prefix of a `constantize` / `safe_constantize` /
+#       `const_get` / string-interpolation constant construction;
+#   d2  its fully-qualified name appears inside a Ruby string or symbol literal;
+#   d3  its name (FQN, autoload path form, or underscored tail) appears in an ERB / HAML / SLIM /
+#       YAML / locale / JSON file under the project.
+
+require "json"
+require "optparse"
+
+options = { project: nil, json: false, list: false }
+parser = OptionParser.new do |opts|
+  opts.banner = "usage: ruby tool/unused_probe/stages.rb PROBE.json --project DIR [--json] [--list]"
+  opts.on("--project DIR", "the analyzed project root (for routes + dynamic scan)") { |v| options[:project] = v }
+  opts.on("--json", "machine-readable output") { options[:json] = true }
+  opts.on("--list", "print every surviving candidate") { options[:list] = true }
+end
+parser.parse!
+probe = ARGV.shift or abort(parser.banner)
+project = options[:project] or abort(parser.banner)
+project = File.expand_path(project)
+
+here = File.expand_path(__dir__)
+report = JSON.parse(`ruby #{here}/report.rb #{probe} --json`)
+abort("report.rb refused to report") unless $CHILD_STATUS.nil? || $?.success?
+
+class_candidates = report["candidates_list"].select { |c| c["bucket"] == "class" }
+
+# ---------------------------------------------------------------------------------------------
+# Stage 3 — rough route-root extraction.
+# ---------------------------------------------------------------------------------------------
+def camelize(token)
+  token.to_s.split("/").map { |seg| seg.split("_").map(&:capitalize).join }.join("::")
+end
+
+def route_files(project)
+  files = []
+  files << File.join(project, "config/routes.rb")
+  files.concat(Dir[File.join(project, "config/routes/**/*.rb")])
+  files.select { |f| File.file?(f) }
+end
+
+def extract_route_roots(project)
+  roots = Set.new
+  route_files(project).each do |file|
+    depth = 0
+    mods = [] # [depth_at_open, segment]
+    File.read(file, encoding: "UTF-8").scrub.each_line do |raw|
+      # Strip a trailing comment only when the `#` starts a token: a route's `"controller#action"`
+      # string has no space before its `#`, and `#{}` interpolation is kept.
+      line = raw.sub(/(?:\A|\s)#(?!\{).*$/, "")
+      opens = /\bdo\b\s*(\|[^|]*\|)?\s*$/.match?(line)
+
+      segment = nil
+      segment = camelize(Regexp.last_match(1)) if line =~ %r{^\s*namespace\s+[:'"]([\w/]+)}
+      segment = camelize(Regexp.last_match(1)) if line =~ %r{(?::module\s*=>|\bmodule:)\s*['":]([\w/]+)}
+      prefix = mods.map(&:last).join("::")
+      scoped = ->(name) { prefix.empty? ? name : "#{prefix}::#{name}" }
+
+      # resources :a, :b / resource :a
+      if line =~ /^\s*(resources?)\s+(.+)$/
+        kind = Regexp.last_match(1)
+        Regexp.last_match(2).scan(/:([a-z_]\w*)/) do |(tok)|
+          base = camelize(tok)
+          roots << scoped.call("#{base}Controller")
+          roots << scoped.call("#{base}sController") if kind == "resource"
+        end
+      end
+      # explicit `controller:` / `:controller =>` / `controllers foo: 'bar'`
+      line.scan(%r{(?::controller\s*=>|\bcontrollers?\b[^#]*?[:=>]{1,2})\s*['"]([\w/]+)['"]}) do |(tok)|
+        roots << scoped.call("#{camelize(tok)}Controller")
+        roots << "#{camelize(tok)}Controller"
+      end
+      # "controller#action" strings, in any position (to:, root, get 'x' => 'y#z', …)
+      line.scan(%r{['"]([a-z_][\w/]*)#\w+['"]}) do |(tok)|
+        roots << scoped.call("#{camelize(tok)}Controller")
+        roots << "#{camelize(tok)}Controller"
+      end
+
+      mods << [depth, segment] if segment && opens
+      depth += 1 if opens
+      if /^\s*end\b/.match?(line)
+        depth -= 1
+        mods.pop while mods.any? && mods.last.first >= depth
+      end
+    end
+  end
+  roots
+end
+
+# ---------------------------------------------------------------------------------------------
+# Stage 4 — dynamic-resolution scan.
+# ---------------------------------------------------------------------------------------------
+SCAN_DIRS = %w[app lib config db].freeze
+NON_RUBY_EXT = %w[.erb .haml .slim .yml .yaml .json .rabl .jbuilder .builder].freeze
+
+def scan_files(project)
+  rb = []
+  other = []
+  SCAN_DIRS.each do |dir|
+    root = File.join(project, dir)
+    next unless File.directory?(root)
+
+    Dir[File.join(root, "**", "*")].each do |path|
+      next unless File.file?(path)
+
+      ext = File.extname(path)
+      if [".rb", ".rake"].include?(ext)
+        rb << path
+      elsif NON_RUBY_EXT.include?(ext)
+        other << path
+      end
+    end
+  end
+  [rb, other]
+end
+
+def underscore(name)
+  name.gsub("::", "/").gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase
+end
+
+def dynamic_scan(project)
+  rb, other = scan_files(project)
+  namespaces = Set.new
+  toplevel_dynamic = false
+  literals = +""
+  rb.each do |path|
+    src = File.read(path, encoding: "UTF-8").scrub
+    # d1: a literal constant prefix immediately before an interpolation or a dynamic join.
+    src.scan(/["']((?:[A-Z]\w*::)+)(?:#\{|["']\s*[+.])/) { |(pre)| namespaces << pre.sub(/::\z/, "") }
+    src.scan(/([A-Z][\w:]*)\.const_get/) { |(recv)| namespaces << recv }
+    # a bare `"#{...}"` fed to constantize / const_get means ANY top-level name is reachable.
+    toplevel_dynamic ||= /["']#\{[^}]*\}\w*["']\s*\.\s*(safe_)?constantize/.match?(src)
+    toplevel_dynamic ||= /(safe_)?constantize/.match?(src) && /["']#\{/.match?(src)
+    # d2: every string / symbol literal body.
+    src.scan(/"([^"\\\n]{0,200})"|'([^'\\\n]{0,200})'|:"([^"\n]{0,200})"/) do |m|
+      literals << (m.compact.first || "") << "\n"
+    end
+  end
+  non_ruby = +""
+  other.each { |path| non_ruby << File.read(path, encoding: "UTF-8").scrub << "\n" }
+  { namespaces: namespaces, toplevel: toplevel_dynamic, literals: literals, non_ruby: non_ruby }
+end
+
+def dynamic_reason(name, scan)
+  parent = name.include?("::") ? name.rpartition("::").first : ""
+  return "d1-dynamic-namespace" if !parent.empty? && scan[:namespaces].include?(parent)
+  return "d1-toplevel-dynamic" if parent.empty? && scan[:toplevel] && name.end_with?("Controller")
+  return "d2-ruby-string-literal" if scan[:literals].include?(name)
+
+  tail = name.split("::").last
+  variants = [name, underscore(name), underscore(tail)]
+  return "d3-non-ruby-file" if variants.any? { |v| scan[:non_ruby].include?(v) }
+
+  nil
+end
+
+# ---------------------------------------------------------------------------------------------
+roots = extract_route_roots(project)
+root_tails = roots.map { |r| r.split("::").last }.to_set
+scan = dynamic_scan(project)
+
+stage3_removed = []
+stage4_removed = []
+survivors = []
+class_candidates.each do |cand|
+  name = cand["name"]
+  if roots.include?(name) || root_tails.include?(name.split("::").last)
+    stage3_removed << cand
+    next
+  end
+  reason = dynamic_reason(name, scan)
+  if reason
+    stage4_removed << cand.merge("reason" => reason)
+    next
+  end
+  survivors << cand
+end
+
+if options[:json]
+  puts JSON.pretty_generate(
+    "stage2_class_candidates" => class_candidates.size,
+    "route_roots_extracted" => roots.size,
+    "stage3_removed" => stage3_removed.size,
+    "stage3_survivors" => class_candidates.size - stage3_removed.size,
+    "stage4_demoted" => stage4_removed.size,
+    "stage4_survivors" => survivors.size,
+    "survivors" => survivors,
+    "demoted" => stage4_removed,
+    "route_removed" => stage3_removed
+  )
+  exit 0
+end
+
+puts "project:                  #{project}"
+puts "class/module candidates:  #{class_candidates.size}"
+puts "route roots extracted:    #{roots.size} (rough)"
+puts "stage 3 (route roots):    -#{stage3_removed.size}  ->  #{class_candidates.size - stage3_removed.size}"
+puts "stage 4 (dynamic):        -#{stage4_removed.size}  ->  #{survivors.size}"
+puts "  by reason: " + stage4_removed.group_by { |c| c["reason"] }.transform_values(&:size).inspect
+if options[:list]
+  puts
+  puts "-- survivors (#{survivors.size}) --"
+  survivors.each_with_index do |c, i|
+    puts format("%3d  %-60s %s", i + 1, c["name"], Array(c["paths"]).first)
+  end
+end


### PR DESCRIPTION
Closes the measurement half of #345.

Measures the source article's `631 → 9 → 3 → 2` funnel on redmine, mastodon and conference-app, and hand-adjudicates **all 57** of redmine's survivors rather than sampling.

| target | 1 naive | 2 widened root | 3 route roots | 4 dynamic demotion | adjudicated TPs |
| --- | ---: | ---: | ---: | ---: | ---: |
| redmine | 135 | 136 | 82 | **57** | **4** |
| mastodon | 377 | 374 | 142 | **113** | not adjudicated |
| conference-app | 59 | 61 | 20 | **14** | not adjudicated |

**7.0 % precision** — four genuine findings against fifty-three artifacts. That settles "report, never a diagnostic" (#346, #347) on measured numbers rather than on the article's.

Three findings that change the downstream slices:

- **Stage 2 buys nothing, structurally.** Declarations and references are gated on the same analysed-file predicate, so widening moves both and they cancel: +1 / −3 / +2. "Analyse more of the project" is the obvious instinct and is measurably not a lever — the note says so plainly so it stops being re-proposed.
- **Stage 3 dominates** (−40 % / −62 % / −67 %) with a regex extractor crude enough to have had a comment-stripper bug found mid-run. Mastodon is where it falls over: routes split across five files with deep `namespace` nesting, 622 roots extracted and 27 controllers still missed. #349 needs a router-shaped extractor, not a heuristic.
- **Two convention rules cover 35 of the 53 artifacts** — helper-module pairing, and "a class whose body calls a registration DSL is a root". Both plugin-API shaped.

Two artifact classes turned out to be engine defects, not root-set gaps: the ownership predicate counts a reopened gem class as a project declaration (already in #347's acceptance criteria), and constant resolution skips the ancestor chain — filed as #354, where the shadowing case resolves to the **wrong** constant rather than to none.

Anti-silence check passed on all six runs (`workers: 0`, `cache_enabled: false`, 33.7k / 175.6k / 2.4k source resolutions). conference-app's references are 98 % RBS-sourced, confirming `record_rbs_decls` is genuinely exercised.

`make docs-check` green (exit code read unpiped), `git diff --check` clean.