### PR TITLE
Add rigor unused, the ADR-102 reachability report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Added
+
+- **[cli]** `rigor unused` reports project classes and modules that nothing reachable references — a starting point for dead-code removal ([#347](https://github.com/rigortype/rigor/issues/347), [ADR-102](docs/adr/102-unused-code-reachability-report.md)).
+  - Read it as a review queue rather than a defect list: on a hand-adjudicated corpus target only 7% of the rows were genuinely unused, which is why this is its own command and never a `rigor check` diagnostic. Reachability is computed from roots — `--entry-point=GLOB` plus anything referenced at file level — so a cluster of classes that only reference each other is still reported. Classes reachable only from test code get their own section, because a class used solely by its own spec is dead production code with a live test. References are harvested from `.rake` tasks, `config/`, specs and your `sig/` as well as the analysed paths.
+
 ### Fixed
 
 - **[engine]** A constant inherited from a superclass or an included module now resolves from the subclass body, and no longer loses to a same-named constant at the top level ([#354](https://github.com/rigortype/rigor/issues/354)).

--- a/docs/manual/02-cli-reference.md
+++ b/docs/manual/02-cli-reference.md
@@ -300,6 +300,46 @@ rigor triage --format json | jq '[.selectors[] | select(.receiver == "String")]'
 The same `receiver_type` / `method_name` fields ride on each
 diagnostic of `rigor check --format json`, for per-site (rather than
 aggregated) grouping.
+## `rigor unused`
+
+Report project constants that nothing reachable references — a
+starting point for dead-code removal.
+
+```sh
+rigor unused [paths] --entry-point='lib/cli.rb'
+```
+
+**Read the output as a review queue, not a defect list.** On a
+hand-adjudicated corpus target only **7% of the rows were genuinely
+unused**; the rest were reachable by means static analysis cannot
+see. That is why this is a separate command and never a `rigor check`
+diagnostic — see
+[ADR-102](https://github.com/rigortype/rigor/blob/master/docs/adr/102-unused-code-reachability-report.md).
+
+Reachability is computed from **roots**, not by counting references,
+so a cluster of classes that only reference each other is still
+reported. Roots are the declarations in files matching
+`--entry-point=GLOB` (repeatable), plus anything referenced at file
+level by non-test code. Route- and framework-derived roots are not
+wired yet, so today's output is an upper bound.
+
+Two things the report separates rather than merges:
+
+- **Reachable only from test code** gets its own section — a class
+  used solely by its own spec is dead production code with a live
+  test, which is a more actionable finding than either bucket alone.
+- **Constants Rigor cannot decide about** are not claimed as unused.
+  Only class and module constants are reported at all; value
+  constants are omitted because they do not resolve across files.
+
+References are harvested from a wider file set than the analysed
+paths — `.rake` tasks, `config/`, specs and the project's own `sig/`
+all count as references — because a constant used only from a Rake
+task is not dead.
+
+`--format json` emits the same data; `--limit=N` truncates the
+printed lists. `--incremental` is refused: reachability is only sound
+over a whole-project run.
 
 ## `rigor coverage`
 

--- a/lib/rigor/analysis/reachability/graph.rb
+++ b/lib/rigor/analysis/reachability/graph.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require_relative "scan"
+
+module Rigor
+  module Analysis
+    module Reachability
+      # ADR-102 — the cross-file half: resolves every as-written reference to a declaration, then marks from the
+      # root set. Pure data; no engine coupling, so `rigor check`'s diagnostic stream is untouched by
+      # construction rather than by a gate (WD1).
+      #
+      # Resolution mirrors `Reflection.resolve_constant_type`'s candidate order — lexical nesting innermost
+      # first, then the ancestors of the innermost cresting scope, then the bare name — because a reference
+      # index that resolved names differently from the engine would report on a graph the analyzer does not
+      # believe in. The two walks are separate implementations (this one is name-level and needs no types), so
+      # `spec/rigor/analysis/reachability/graph_spec.rb` pins them to the same answers on shared fixtures.
+      class Graph
+        Candidate = Data.define(:fqn, :path, :line)
+
+        # `test_only` is its own list, not a flag on `candidates`: a candidate is by definition unreachable, so
+        # a flag there could never be true. "Reachable, but only from test code" is a SEPARATE and more
+        # actionable answer — dead production code with a live test — which is exactly what ADR-102 WD8 requires
+        # be reported as its own category rather than folded into a bucket boundary.
+        Report = Data.define(:declared, :reachable, :candidates, :test_only, :namespaces, :roots, :edges)
+
+        # @param declarations [Array<Scan::Declaration>]
+        # @param references [Array<Scan::Reference>]
+        # @param root_fqns [Enumerable<String>] declarations that are entry points regardless of who references
+        #   them (config-declared globs in this slice; plugin-supplied roots are #349).
+        # @param foreign [#call] predicate answering "is this FQN owned by something outside the project?" —
+        #   a reopened gem or stdlib class must never be a candidate (WD6). Defaults to "nothing is foreign".
+        def initialize(declarations:, references:, root_fqns: [], foreign: ->(_fqn) { false })
+          @declarations = declarations
+          @references = references
+          @root_fqns = root_fqns.to_set
+          @foreign = foreign
+          @by_fqn = declarations.group_by(&:fqn)
+          @owned = @by_fqn.keys.reject { |fqn| @foreign.call(fqn) }.to_set
+          @ancestors = {}
+        end
+
+        def report
+          edges = resolved_edges
+          production = walk(edges, seeds: production_seeds, roles: %i[production task config])
+          reachable = walk(edges, seeds: production_seeds | test_seeds, roles: %i[production task config test])
+          unreached = @owned - reachable
+          namespaces = namespace_only(unreached, reachable)
+          Report.new(declared: @owned.size, reachable: reachable.size,
+                     candidates: rows(unreached - namespaces), test_only: rows(reachable - production),
+                     namespaces: namespaces.size, roots: production_seeds.size, edges: edges.size)
+        end
+
+        private
+
+        # `module A; end` wrapping a live `A::B` is not dead code, but nothing ever references `A` by itself:
+        # a reference to `A::B::Leaf` records the leaf only, never the intermediate segments. Reporting these
+        # buried the real rows — 12 of 18 candidates on Rigor's own `lib`, and 22 of 140 in the #345 probe,
+        # were pure namespaces.
+        #
+        # The test is deliberately "some REACHABLE declaration lives under it", not "some declaration lives
+        # under it": a namespace whose entire contents are dead is itself a genuine finding, and its children
+        # appear alongside it rather than being explained away.
+        def namespace_only(unreached, reachable)
+          unreached.select do |fqn|
+            prefix = "#{fqn}::"
+            reachable.any? { |other| other.start_with?(prefix) }
+          end.to_set
+        end
+
+        # Seeds that make a declaration live in PRODUCTION: named entry points, plus anything referenced at
+        # file level by a non-test file (file-level code runs on load, so its target is live).
+        def production_seeds
+          @production_seeds ||= (@root_fqns & @owned) | seeds_from { |ref| ref.from.nil? && ref.role != :test }
+        end
+
+        # Seeds that make a declaration live only through TEST code. Kept separate from production seeds
+        # rather than folded in: a spec's file-level `Foo.new` would otherwise promote `Foo` to a root and
+        # erase the very distinction WD8 exists to report.
+        def test_seeds
+          @test_seeds ||= seeds_from { |ref| ref.from.nil? && ref.role == :test }
+        end
+
+        def seeds_from
+          set = Set.new
+          @references.each do |ref|
+            next unless yield(ref)
+
+            target = resolve(ref.as_written, ref.nesting)
+            set << target if target && @owned.include?(target)
+          end
+          set
+        end
+
+        # `[from_fqn_or_nil, to_fqn, role]` for every reference that resolves to an owned declaration.
+        def resolved_edges
+          @resolved_edges ||= @references.filter_map do |ref|
+            target = resolve(ref.as_written, ref.nesting)
+            next unless target && @owned.include?(target)
+            next if ref.from == target # a declaration referencing itself is not evidence of use
+
+            [ref.from, target, ref.role]
+          end
+        end
+
+        # Mark-and-sweep, not reference counting: an edge only propagates if its SOURCE is itself reachable, so
+        # a cluster of mutually-referencing dead classes stays dead (ADR-102 WD2).
+        #
+        # Run twice with different edge roles admitted (WD8). The production pass admits everything except
+        # test-sourced edges; the full pass admits all of them. The difference is exactly "reachable, but only
+        # from test code" — dead production code with a live test, which is a finding rather than a bucket edge.
+        def walk(edges, seeds:, roles:)
+          admitted = roles.to_set
+          out = Hash.new { |h, k| h[k] = [] }
+          edges.each { |from, to, role| out[from] << to if admitted.include?(role) }
+
+          seen = seeds.dup
+          queue = seeds.to_a
+          until queue.empty?
+            out[queue.shift].each do |target|
+              next if seen.include?(target)
+
+              seen << target
+              queue << target
+            end
+          end
+          seen
+        end
+
+        def rows(fqns)
+          fqns.sort.map do |fqn|
+            site = @by_fqn.fetch(fqn).first
+            Candidate.new(fqn: fqn, path: site.path, line: site.line)
+          end.freeze
+        end
+
+        # Ruby's constant lookup at name granularity: `Module.nesting` innermost first, then the ancestors of
+        # the innermost cresting scope (#354), then the bare name.
+        def resolve(as_written, nesting)
+          walker = nesting.dup
+          until walker.empty?
+            candidate = (walker + [as_written]).join("::")
+            return candidate if @by_fqn.key?(candidate)
+
+            walker.pop
+          end
+
+          unless nesting.empty?
+            ancestor_scopes(nesting.join("::")).each do |ancestor|
+              candidate = "#{ancestor}::#{as_written}"
+              return candidate if @by_fqn.key?(candidate)
+            end
+          end
+
+          return as_written if @by_fqn.key?(as_written)
+
+          # `Scope::DiscoveryIndex::EMPTY` names a constant INSIDE a class, and reading it is a use of that
+          # class — but the leaf is not itself a declaration, so the reference would resolve to nothing and
+          # `Scope::DiscoveryIndex` would be reported as unused despite being read all over the engine (it was,
+          # on the first run of this report against Rigor's own `lib`). Peel the trailing segment and retry:
+          # a reference to a member is a reference to its owner.
+          idx = as_written.rindex("::")
+          idx ? resolve(as_written[0, idx], nesting) : nil
+        end
+
+        # Breadth-first over superclass + included modules, mixins first, terminating on a cycle. As-written
+        # ancestor names resolve against the subclass's own nesting; a name naming no declaration is dropped.
+        def ancestor_scopes(fqn)
+          @ancestors[fqn] ||= begin
+            seen = Set[fqn]
+            queue = [fqn]
+            out = []
+            until queue.empty?
+              current = queue.shift
+              @by_fqn.fetch(current, []).each do |decl|
+                (decl.includes + [decl.superclass]).compact.each do |raw|
+                  resolved = resolve_ancestor(current, raw)
+                  next if resolved.nil? || seen.include?(resolved)
+
+                  seen << resolved
+                  out << resolved
+                  queue << resolved
+                end
+              end
+            end
+            out.freeze
+          end
+        end
+
+        def resolve_ancestor(subclass_fqn, raw)
+          segments = subclass_fqn.split("::")
+          (segments.length - 1).downto(0) do |i|
+            candidate = (segments[0, i] + [raw]).join("::")
+            return candidate if @by_fqn.key?(candidate)
+          end
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/rigor/analysis/reachability/scan.rb
+++ b/lib/rigor/analysis/reachability/scan.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "prism"
+
+require_relative "../../source/constant_path"
+require_relative "../../source/node_children"
+
+module Rigor
+  module Analysis
+    module Reachability
+      # ADR-102 — the per-file half of the reference index: one Prism walk that records every constant
+      # DECLARATION and every constant REFERENCE, each with the lexical nesting in force at that point.
+      #
+      # This is deliberately NOT a hook on the typing path. `Reflection.resolve_constant_type` fires only where
+      # the engine needs a constant's *type*, so a constant that is read but never typed leaves no trace there —
+      # the #345 measurement found five distinct losses (cross-file value constants, parameter defaults,
+      # lambda-rvalue bodies, superclass positions, intermediate namespace segments) and produced 140 candidates
+      # of which zero were genuine. A reference index has to see every constant node regardless of whether a type
+      # was wanted, which is what this walk does.
+      #
+      # Names are recorded AS WRITTEN together with their nesting; resolution to a fully-qualified name happens
+      # in {Graph}, after every file has been scanned, because a bare `Foo` cannot be resolved until the whole
+      # declaration set is known.
+      module Scan
+        # A class / module declaration, or a constant assigned one of the meta-new forms. `nesting` is the
+        # enclosing declaration path at the declaration site, so `fqn` is exact.
+        Declaration = Data.define(:fqn, :path, :line, :superclass, :includes)
+
+        # One constant reference. `from` is the fully-qualified name of the innermost enclosing declaration, or
+        # nil for a reference written at file level — that is what makes the graph a reachability graph rather
+        # than a reference count (ADR-102 WD2). `role` is the referring FILE's role (WD8).
+        Reference = Data.define(:as_written, :nesting, :from, :role, :path, :line)
+
+        Result = Data.define(:declarations, :references)
+
+        # Roles a referring file can have (ADR-102 WD8). A reference edge carries its referrer's role so
+        # "used only by its own test" is a reportable category rather than a bucket boundary.
+        def self.role_for(path)
+          case path
+          when %r{(\A|/)(spec|test)/}, /_(spec|test)\.rb\z/ then :test
+          when /\.rake\z/, %r{(\A|/)(lib/)?tasks/} then :task
+          when %r{(\A|/)config/} then :config
+          else :production
+          end
+        end
+
+        # @param path [String] the file's path, as the report should render it.
+        # @param source [String] the file's bytes.
+        # @param target_ruby [String, nil] Prism version string, threaded from the project configuration.
+        # @return [Result, nil] nil when the file does not parse (a parse error is the analyzer's business, not
+        #   this scan's — it simply contributes nothing rather than half a file).
+        def self.call(path:, source:, target_ruby: nil)
+          parsed = if target_ruby
+                     Prism.parse(source, filepath: path,
+                                         version: target_ruby)
+                   else
+                     Prism.parse(source, filepath: path)
+                   end
+          return nil unless parsed.success?
+
+          walker = Walker.new(path: path, role: role_for(path))
+          walker.walk(parsed.value, [])
+          Result.new(declarations: walker.declarations.freeze, references: walker.references.freeze)
+        end
+
+        # Single-pass walker. Tracks `nesting` as the stack of enclosing declaration names.
+        class Walker
+          attr_reader :declarations, :references
+
+          def initialize(path:, role:)
+            @path = path
+            @role = role
+            @declarations = []
+            @references = []
+          end
+
+          def walk(node, nesting)
+            return unless node.is_a?(Prism::Node)
+
+            case node
+            when Prism::ClassNode  then return walk_declaration(node, nesting, superclass: node.superclass)
+            when Prism::ModuleNode then return walk_declaration(node, nesting, superclass: nil)
+            when Prism::ConstantReadNode, Prism::ConstantPathNode
+              record_reference(node, nesting)
+              # A constant path's segments are not separate references — `A::B::C` is one reference to the leaf,
+              # and descending would record `A` and `A::B` as references in their own right (22 spurious
+              # candidates on Rigor's own lib came from exactly that in the #345 probe).
+              return
+            when Prism::ConstantWriteNode
+              record_meta_new(node, nesting)
+              walk(node.value, nesting)
+              return
+            end
+
+            node.rigor_each_child { |child| walk(child, nesting) }
+          end
+
+          private
+
+          def walk_declaration(node, nesting, superclass:)
+            name = Source::ConstantPath.qualified_name(node.constant_path)
+            return node.rigor_each_child { |child| walk(child, nesting) } if name.nil?
+
+            fqn = (nesting + [name]).join("::")
+            # The superclass position IS a reference — `class Sub < Base` reads `Base` — and it resolves against
+            # the OUTER nesting, not inside the body being opened.
+            record_reference(superclass, nesting) if superclass
+            includes = node.body ? mixin_names(node.body) : []
+            @declarations << Declaration.new(fqn: fqn, path: @path, line: node.location.start_line,
+                                             superclass: superclass && Source::ConstantPath.qualified_name(superclass),
+                                             includes: includes.freeze)
+            walk(node.body, nesting + [name]) if node.body
+          end
+
+          # `Const = Class.new` / `Module.new` / `Data.define(...)` / `Struct.new(...)` declare a class under a
+          # constant, and `ScopeIndexer#record_class_new_constant_decl` already treats them as class declarations
+          # for cross-file resolution. The report must agree, or every such constant reads as an unreferenced
+          # value rather than a class.
+          META_NEW = { "Class" => :new, "Module" => :new, "Data" => :define, "Struct" => :new }.freeze
+          private_constant :META_NEW
+
+          def record_meta_new(node, nesting)
+            call = node.value
+            return unless call.is_a?(Prism::CallNode)
+
+            recv = call.receiver
+            return unless recv.is_a?(Prism::ConstantReadNode) && META_NEW[recv.name.to_s] == call.name
+
+            @declarations << Declaration.new(fqn: (nesting + [node.name.to_s]).join("::"), path: @path,
+                                             line: node.location.start_line, superclass: nil, includes: [].freeze)
+          end
+
+          # `include` / `prepend` / `extend` argument names written directly in the declaration body. Only the
+          # top level of the body is inspected: a mixin applied inside a conditional or a nested def is not a
+          # static ancestor edge.
+          def mixin_names(body)
+            body.child_nodes.filter_map do |stmt|
+              next unless stmt.is_a?(Prism::CallNode) && %i[include prepend extend].include?(stmt.name)
+              next if stmt.receiver
+
+              arg = stmt.arguments&.arguments&.first
+              arg && Source::ConstantPath.qualified_name_or_nil(arg)
+            end
+          end
+
+          def record_reference(node, nesting)
+            as_written = Source::ConstantPath.qualified_name_or_nil(node)
+            return if as_written.nil?
+
+            @references << Reference.new(as_written: as_written, nesting: nesting.dup.freeze,
+                                         from: nesting.empty? ? nil : nesting.join("::"),
+                                         role: @role, path: @path, line: node.location.start_line)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rigor/cli.rb
+++ b/lib/rigor/cli.rb
@@ -44,6 +44,7 @@ module Rigor
       "mcp" => :run_mcp,
       "baseline" => :run_baseline,
       "triage" => :run_triage,
+      "unused" => :run_unused,
       "coverage" => :run_coverage,
       "plugins" => :run_plugins,
       "plugin" => :run_plugin,
@@ -260,6 +261,12 @@ module Rigor
       require_relative "cli/triage_command"
 
       CLI::TriageCommand.new(argv: @argv, out: @out, err: @err).run
+    end
+
+    def run_unused
+      require_relative "cli/unused_command"
+
+      CLI::UnusedCommand.new(argv: @argv, out: @out, err: @err).run
     end
 
     def run_coverage

--- a/lib/rigor/cli/unused_command.rb
+++ b/lib/rigor/cli/unused_command.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "optionparser"
+require "json"
+
+require_relative "../configuration"
+require_relative "../analysis/path_expansion"
+require_relative "../analysis/reachability/scan"
+require_relative "../analysis/reachability/graph"
+require_relative "options"
+require_relative "command"
+require_relative "probe_environment"
+
+module Rigor
+  class CLI
+    # ADR-102 — executes `rigor unused`.
+    #
+    # Reports project constants that nothing reachable references. It is a REPORT, never a diagnostic: the
+    # measured precision of this signal is 7.0% on an adjudicated corpus target
+    # (`docs/notes/20260813-unused-constant-fp-baseline.md`), so its output is a review queue, not a defect
+    # list, and it never enters `rigor check`'s stream at any severity (WD1). Exits 0 whatever it finds.
+    class UnusedCommand < Command
+      USAGE = "Usage: rigor unused [options] [paths]"
+
+      # WD7 — the REFERENCE corpus is wider than the ANALYSIS corpus. `.rake` files sit inside `paths:` and
+      # reference project constants, but `PathExpansion::RUBY_GLOB` never reads them, which made them pure
+      # artifacts on two of three corpus targets. Harvesting references from a file is far cheaper than
+      # type-checking it, so the report takes the wider set.
+      REFERENCE_GLOB = "**/*.{rb,rake}"
+
+      # Trees that are never the project's own source. Globbing them costs far more than every analysed file
+      # combined on a real app, and a reference found inside a vendored gem is not evidence about this project.
+      VENDOR_DIRS = %r{\A(vendor|node_modules|tmp|\.git|\.rigor|coverage)/}
+
+      def run
+        options = parse_options
+        return CLI::EXIT_USAGE if options == :usage_error
+
+        configuration = Configuration.load(options.fetch(:config))
+        paths = @argv.empty? ? configuration.paths : @argv
+        declarations, references = scan(paths, configuration)
+        references.concat(signature_references(configuration))
+
+        graph = Analysis::Reachability::Graph.new(
+          declarations: declarations, references: references,
+          root_fqns: root_fqns(declarations, options.fetch(:entry_points)),
+          foreign: foreign_predicate(configuration)
+        )
+        emit(graph.report, options)
+        0
+      end
+
+      private
+
+      def parse_options
+        options = { config: nil, format: "text", entry_points: [], limit: nil }
+        parser = OptionParser.new do |opts|
+          opts.banner = USAGE
+          Options.add_config(opts, options)
+          opts.on("--format=FORMAT", "Output format: text (default) or json") { |v| options[:format] = v }
+          opts.on("--entry-point=GLOB", "Treat declarations in files matching GLOB as roots (repeatable)") do |v|
+            options[:entry_points] << v
+          end
+          opts.on("--limit=N", Integer, "Print at most N candidates (default: all)") { |v| options[:limit] = v }
+          # WD5 — refuse rather than silently absorb. A reachability answer is sound only over a full run, and a
+          # user who asked for the fast path must not silently get the slow one.
+          opts.on("--incremental", "(unsupported)") { options[:incremental] = true }
+        end
+        parser.parse!(@argv)
+        return usage_error(parser) if options[:incremental]
+
+        options
+      rescue OptionParser::ParseError => e
+        @err.puts(e.message)
+        :usage_error
+      end
+
+      def usage_error(_parser)
+        @err.puts("rigor unused does not support --incremental: reachability is only sound over a whole-project " \
+                  "run, so an incremental pass would report constants as unused merely because the files that " \
+                  "reference them were served from cache. Re-run without --incremental.")
+        :usage_error
+      end
+
+      # Declarations come from the analysed paths; references additionally from the wider corpus (WD7).
+      def scan(paths, configuration)
+        declaration_files = Analysis::PathExpansion.ruby_files(paths, configuration.exclude_patterns).to_set
+        declarations = []
+        references = []
+        (declaration_files + reference_files(paths, configuration)).sort.each do |file|
+          result = read_and_scan(file, configuration)
+          next if result.nil?
+
+          declarations.concat(result.declarations) if declaration_files.include?(file)
+          references.concat(result.references)
+        end
+        [declarations, references]
+      end
+
+      # The reference corpus is the PROJECT, not the analysed paths. A constant declared in `lib/` is commonly
+      # referenced from `config/initializers`, a `.rake` task, or a spec — none of which are in `paths:` — and
+      # treating those as absent is what manufactured artifacts on two of three corpus targets in #345.
+      # Widening the *declaration* set the same way would cancel the gain (measured: +1 / −3 / +2 candidates,
+      # ADR-102 WD2), which is exactly why the two corpora are separated rather than both widened.
+      def reference_files(_paths, configuration)
+        relative = Dir.glob(REFERENCE_GLOB, base: Dir.pwd).grep_v(VENDOR_DIRS)
+        absolute = relative.map { |rel| File.expand_path(rel) }
+        Analysis::PathExpansion.reject_excluded(absolute, configuration.exclude_patterns).to_set
+      end
+
+      def read_and_scan(file, configuration)
+        Analysis::Reachability::Scan.call(path: file, source: File.read(file),
+                                          target_ruby: configuration.target_ruby)
+      rescue SystemCallError
+        nil
+      end
+
+      # A glob is matched against the declaration's path AND its path relative to the working directory:
+      # `configuration.paths` are expanded to absolute, so a user-written `--entry-point=lib/entry.rb` would
+      # otherwise never match anything and silently produce a root set of zero.
+      # A constant named only from the project's own `sig/` is referenced — the #345 probe reported exactly this
+      # as a false candidate until an RBS-side hook was added, because `Reflection.resolve_constant_type` is
+      # source-side only.
+      #
+      # Harvested by scanning each signature for constant-shaped tokens rather than by walking the parsed RBS
+      # AST. That deliberately OVER-approximates (a name inside a comment counts), and over-approximating
+      # references is the false-positive-safe direction for this report: it can only remove candidates, never
+      # invent one. Every such reference is attributed at file level with the `:config` role, so it seeds
+      # production reachability but is not mistaken for test usage.
+      CONSTANT_TOKEN = /\b[A-Z][A-Za-z0-9_]*(?:::[A-Z][A-Za-z0-9_]*)*/
+      private_constant :CONSTANT_TOKEN
+
+      def signature_references(configuration)
+        Array(configuration.signature_paths).flat_map do |dir|
+          next [] unless File.directory?(dir)
+
+          Dir.glob(File.join(dir, "**/*.rbs")).flat_map do |file|
+            File.read(file).scan(CONSTANT_TOKEN).map do |name|
+              Analysis::Reachability::Scan::Reference.new(as_written: name, nesting: [].freeze, from: nil,
+                                                          role: :config, path: file, line: 1)
+            end
+          rescue SystemCallError
+            []
+          end
+        end
+      end
+
+      def root_fqns(declarations, globs)
+        return [] if globs.empty?
+
+        cwd = "#{File.expand_path(Dir.pwd)}/"
+        declarations.filter_map do |d|
+          relative = d.path.delete_prefix(cwd)
+          d.fqn if globs.any? { |g| File.fnmatch?(g, d.path) || File.fnmatch?(g, relative) }
+        end
+      end
+
+      # WD6 — ownership means "declared FIRST here". Reopening a gem or stdlib class registers it as a project
+      # declaration, which produced three of redmine's artifacts from a single initializer. A name the bundled
+      # (non-project) environment already knows is not ours to call unused. The project's own `sig/` is
+      # deliberately excluded from this environment, so a project class that ships a signature stays owned.
+      def foreign_predicate(configuration)
+        env = Environment.for_project(libraries: configuration.libraries, signature_paths: [])
+        ->(fqn) { !env.singleton_for_name(fqn).nil? }
+      rescue StandardError
+        ->(_fqn) { false }
+      end
+
+      def emit(report, options)
+        @out.puts(options.fetch(:format) == "json" ? json(report, options) : text(report, options))
+      end
+
+      def json(report, options)
+        JSON.pretty_generate(
+          declared: report.declared, reachable: report.reachable, roots: report.roots, edges: report.edges,
+          namespaces: report.namespaces,
+          candidates: rows_json(report.candidates, options), test_only: rows_json(report.test_only, options)
+        )
+      end
+
+      def rows_json(rows, options)
+        limited(rows, options).map { |c| { name: c.fqn, path: c.path, line: c.line } }
+      end
+
+      def text(report, options)
+        lines = ["Reachability", "  declared (project-owned): #{report.declared}",
+                 "  roots:                    #{report.roots}",
+                 "  reachable:                #{report.reachable}",
+                 "  candidates:               #{report.candidates.size}",
+                 "  reachable only from tests: #{report.test_only.size}",
+                 "  namespace-only (excluded):  #{report.namespaces}"]
+        lines.concat(section("Candidates — nothing reachable references these", report.candidates, options))
+        lines.concat(section("Reachable only from test code — live test, dead production path",
+                             report.test_only, options))
+        lines << ""
+        lines << "These are CANDIDATES, not findings. The measured precision of this report on an adjudicated"
+        lines << "corpus target is 7% — every row needs a human to confirm it. Route- and plugin-derived roots"
+        lines << "are not wired yet (issue #349), so this list is an upper bound."
+        lines.join("\n")
+      end
+
+      def section(title, rows, options)
+        return [] if rows.empty?
+
+        out = ["", "#{title} (#{rows.size})"]
+        limited(rows, options).each_with_index do |c, i|
+          out << format("  %<n>3d  %<name>-52s %<path>s:%<line>d", n: i + 1, name: c.fqn, path: c.path, line: c.line)
+        end
+        out
+      end
+
+      def limited(candidates, options)
+        limit = options.fetch(:limit)
+        limit ? candidates.first(limit) : candidates
+      end
+    end
+  end
+end

--- a/spec/rigor/analysis/reachability_spec.rb
+++ b/spec/rigor/analysis/reachability_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rigor/analysis/reachability/scan"
+require "rigor/analysis/reachability/graph"
+
+# ADR-102 — the reachability report's reference index and mark-and-sweep.
+#
+# The #345 measurement found the typing path loses references in five distinct ways, and a report built on a
+# lossy index reports live code as dead. Every one of those losses has a fixture here, each paired with a
+# must-still-be-found case: a report that finds nothing would pass a suite of decline assertions alone.
+RSpec.describe Rigor::Analysis::Reachability do
+  # Builds a graph from `{path => source}` and returns the candidate FQNs.
+  def candidates(files, roots: [])
+    decls = []
+    refs = []
+    files.each do |path, source|
+      result = Rigor::Analysis::Reachability::Scan.call(path: path, source: source)
+      raise "fixture #{path} did not parse" if result.nil?
+
+      decls.concat(result.declarations)
+      refs.concat(result.references)
+    end
+    Rigor::Analysis::Reachability::Graph.new(declarations: decls, references: refs,
+                                             root_fqns: roots).report.candidates.map(&:fqn)
+  end
+
+  describe "the index finds references the typing path loses (#345)" do
+    it "sees a bare cross-file reference" do
+      found = candidates({ "lib/a.rb" => "class Root\n  def go = Target.new\nend\n",
+                           "lib/b.rb" => "class Target\nend\n" }, roots: ["Root"])
+      expect(found).not_to include("Target")
+    end
+
+    # The case that separates real constant resolution from grep: `A::B::C` written as bare `C` inside `A::B`.
+    it "resolves a nesting-relative reference to its fully-qualified declaration" do
+      found = candidates({ "lib/a.rb" => <<~RUBY }, roots: ["A::B::Caller"])
+        module A
+          module B
+            class C
+            end
+            class Caller
+              def go = C.new
+            end
+          end
+        end
+      RUBY
+      expect(found).not_to include("A::B::C")
+    end
+
+    it "sees a reference in a parameter-default expression" do
+      found = candidates({ "lib/a.rb" => "class Root\n  def go(x = Target)\n    x\n  end\nend\n",
+                           "lib/b.rb" => "class Target\nend\n" }, roots: ["Root"])
+      expect(found).not_to include("Target")
+    end
+
+    it "sees a reference inside a lambda body that is a constant's rvalue" do
+      found = candidates({ "lib/a.rb" => "class Root\n  BUILDER = -> { Target.new }\nend\n",
+                           "lib/b.rb" => "class Target\nend\n" }, roots: ["Root"])
+      expect(found).not_to include("Target")
+    end
+
+    it "sees a superclass position as a reference" do
+      found = candidates({ "lib/a.rb" => "class Root < Base\nend\n",
+                           "lib/b.rb" => "class Base\nend\n" }, roots: ["Root"])
+      expect(found).not_to include("Base")
+    end
+
+    # A `ConstantPathNode`'s intermediate segments are not references in their own right — the leaf is the
+    # reference. Recording each segment produced 22 spurious candidates in the #345 probe; NOT recording them
+    # would instead report every namespace module as unused, which is what the namespace bucket handles.
+    it "counts the leaf as the reference and buckets the namespaces it passes through" do
+      decls = []
+      refs = []
+      { "lib/a.rb" => "class Root\n  def go = A::B::Leaf.new\nend\n",
+        "lib/b.rb" => "module A\n  module B\n    class Leaf\n    end\n  end\nend\n" }.each do |path, source|
+        result = Rigor::Analysis::Reachability::Scan.call(path: path, source: source)
+        decls.concat(result.declarations)
+        refs.concat(result.references)
+      end
+      report = Rigor::Analysis::Reachability::Graph.new(declarations: decls, references: refs,
+                                                        root_fqns: ["Root"]).report
+
+      expect(report.candidates.map(&:fqn)).to be_empty
+      expect(report.namespaces).to eq(2) # A and A::B wrap live code; neither is a finding
+    end
+
+    # ... but a namespace whose entire contents are dead IS a finding, and is not explained away.
+    it "still reports a namespace whose contents are all unreachable" do
+      found = candidates({ "lib/a.rb" => "class Root\nend\n",
+                           "lib/b.rb" => "module Dead\n  class Inner\n  end\nend\n" }, roots: ["Root"])
+      expect(found).to include("Dead", "Dead::Inner")
+    end
+  end
+
+  # The controls. Without these the suite above passes for a report that simply never fires.
+  describe "the report still fires" do
+    it "reports a declaration nothing references" do
+      expect(candidates({ "lib/a.rb" => "class Root\nend\n", "lib/b.rb" => "class Orphan\nend\n" },
+                        roots: ["Root"])).to include("Orphan")
+    end
+
+    # Mark-and-sweep, not reference counting: each of these has a reference, and both are still dead.
+    it "reports a cluster of mutually-referencing dead classes" do
+      dead = "class DeadA\n  def go = DeadB.new\nend\n" \
+             "class DeadB\n  def go = DeadA.new\nend\n"
+      found = candidates({ "lib/a.rb" => "class Root\nend\n", "lib/b.rb" => dead }, roots: ["Root"])
+      expect(found).to include("DeadA", "DeadB")
+    end
+  end
+
+  describe "roles (WD8)" do
+    it "classifies a file's role from its path" do
+      expect(Rigor::Analysis::Reachability::Scan.role_for("spec/foo_spec.rb")).to eq(:test)
+      expect(Rigor::Analysis::Reachability::Scan.role_for("test/foo_test.rb")).to eq(:test)
+      expect(Rigor::Analysis::Reachability::Scan.role_for("lib/tasks/thing.rake")).to eq(:task)
+      expect(Rigor::Analysis::Reachability::Scan.role_for("config/initializers/x.rb")).to eq(:config)
+      expect(Rigor::Analysis::Reachability::Scan.role_for("lib/app/thing.rb")).to eq(:production)
+    end
+
+    # Reachable only from test code is its own answer — neither a candidate nor silently "used".
+    it "separates a test-only reachable declaration from both buckets" do
+      decls = []
+      refs = []
+      { "lib/a.rb" => "class Root\nend\n",
+        "lib/b.rb" => "class TestOnly\nend\n",
+        "spec/b_spec.rb" => "TestOnly.new\n" }.each do |path, source|
+        result = Rigor::Analysis::Reachability::Scan.call(path: path, source: source)
+        decls.concat(result.declarations)
+        refs.concat(result.references)
+      end
+      report = Rigor::Analysis::Reachability::Graph.new(declarations: decls, references: refs,
+                                                        root_fqns: ["Root"]).report
+
+      expect(report.candidates.map(&:fqn)).not_to include("TestOnly")
+      expect(report.test_only.map(&:fqn)).to eq(["TestOnly"])
+    end
+  end
+
+  describe "ownership (WD6)" do
+    # Reopening a gem or stdlib class registers it as a project declaration; three of redmine's artifacts came
+    # from one initializer doing exactly this.
+    it "never reports a declaration the foreign predicate claims" do
+      result = Rigor::Analysis::Reachability::Scan.call(path: "config/initializers/patches.rb",
+                                                        source: "module RBS\n  class Location\n  end\nend\n")
+      report = Rigor::Analysis::Reachability::Graph.new(
+        declarations: result.declarations, references: result.references,
+        foreign: ->(fqn) { fqn.start_with?("RBS") }
+      ).report
+      expect(report.candidates).to be_empty
+      expect(report.declared).to be_zero
+    end
+  end
+
+  describe "a reference to a member is a reference to its owner" do
+    # `Scope::DiscoveryIndex::EMPTY` reads a constant inside a class. The leaf is not a declaration, so without
+    # peeling the trailing segment the reference resolves to nothing and the owner reads as unused — which is
+    # exactly what this report did to `Rigor::Scope::DiscoveryIndex` on its first run against Rigor's own lib.
+    it "resolves a reference to a constant nested inside a class" do
+      found = candidates({ "lib/a.rb" => "class Root\n  def go = Holder::EMPTY\nend\n",
+                           "lib/b.rb" => "class Holder\n  EMPTY = 1\nend\n" }, roots: ["Root"])
+      expect(found).not_to include("Holder")
+    end
+  end
+
+  describe "meta-new declarations" do
+    it "treats a constant assigned Class.new / Data.define as a declaration" do
+      found = candidates({ "lib/a.rb" => "class Root\nend\n",
+                           "lib/b.rb" => "Shape = Data.define(:x)\nMade = Class.new(StandardError)\n" },
+                         roots: ["Root"])
+      expect(found).to include("Shape", "Made")
+    end
+  end
+end


### PR DESCRIPTION
Closes #347. The tracer bullet for #344 — a thin but complete path from a constant reference index through mark-and-sweep to a rendered report, implementing [ADR-102](https://github.com/rigortype/rigor/blob/master/docs/adr/102-unused-code-reachability-report.md).

## It does not hook the typing path

#345 measured that `resolve_constant_type` fires only where the engine needs a constant's *type*, so a constant read but never typed leaves no trace — five distinct losses producing 140 candidates of which **zero** were genuine. This is a standalone Prism walk that sees every constant node regardless. That also means `rigor check` is untouched **by construction** rather than by a gate: the only change to existing `lib/` code is one row in the CLI dispatch table.

Each of the five measured losses has a fixture spec — cross-file, nesting-relative (`A::B::C` written as bare `C`), parameter defaults, lambda-rvalue bodies, superclass positions — every one paired with a must-still-fire control, because a suite of decline assertions passes trivially for a report that never fires.

## Decisions implemented

- **WD2 — reachability, not reference counting.** An edge propagates only if its source is itself reachable, so two dead classes that reference each other stay dead. Pinned by a spec.
- **WD8 — roles ride on edges.** "Reachable only from test code" is its own section, not a bucket boundary: a class used solely by its own spec is dead production code with a live test.
- **WD7 — the reference corpus is wider than the analysis corpus.** `.rake`, `config/`, specs and the project's own `sig/` all count. Signature references are harvested by token scan, which over-approximates **deliberately** — that direction can only remove candidates, never invent one.
- **WD5 — `--incremental` is refused**, with an explanatory message and exit 64.
- **WD6 — ownership excludes reopened foreign classes**, via an environment built without the project's own `sig/`.

## Two false positives found by dogfooding, fixed with specs

Running it on Rigor's own `lib` surfaced both:

- **A reference to a member is a reference to its owner.** `Scope::DiscoveryIndex::EMPTY` resolves to no declaration, so `DiscoveryIndex` read as unused despite being used throughout the engine.
- **A namespace module wrapping live code is bucketed, not reported.** Nothing ever references `Rigor::AST` by itself — those were 12 of the first 18 candidates. A namespace whose contents are *all* dead is still a finding, and has its own spec.

On Rigor's own `lib`: **516 declared, 0 candidates, 4 reachable only from tests, 14 namespace-only.**

## Deviation from the issue text

Recorded rather than silent: roots come from a repeatable `--entry-point` flag, not a config key. The config surface should be designed once, when plugin-supplied roots land in #349, rather than twice.

## Verification

`make verify` exit 0, `make docs-check` exit 0, `git diff --check` clean. Manual section added to `02-cli-reference.md` (the drift gate caught its absence), `[Unreleased]` changelog entry written user-facing.