### PR TITLE
Add the cannot-decide tier to rigor unused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 ### Added
 
 - **[cli]** `rigor unused` reports project classes and modules that nothing reachable references — a starting point for dead-code removal ([#347](https://github.com/rigortype/rigor/issues/347), [ADR-102](docs/adr/102-unused-code-reachability-report.md)).
+  - Constants something can name at runtime are demoted to a `cannot decide` section with the reason rather than claimed as unused: `"Foo".constantize` names `Foo` exactly and counts as an ordinary reference, while `"Foo::#{key}".constantize` marks everything under `Foo` undecidable, and a class name appearing as a string in a `.yml` or template file demotes it the same way.
   - Read it as a review queue rather than a defect list: on a hand-adjudicated corpus target only 7% of the rows were genuinely unused, which is why this is its own command and never a `rigor check` diagnostic. Reachability is computed from roots — `--entry-point=GLOB` plus anything referenced at file level — so a cluster of classes that only reference each other is still reported. Classes reachable only from test code get their own section, because a class used solely by its own spec is dead production code with a live test. References are harvested from `.rake` tasks, `config/`, specs and your `sig/` as well as the analysed paths.
 
 ### Fixed

--- a/docs/internal-spec/inference-engine.md
+++ b/docs/internal-spec/inference-engine.md
@@ -420,6 +420,19 @@ The following carry no mark and MUST keep firing:
 
 `Environment#constant_for_name(name)` MUST consult the attached `RbsLoader` and return `nil` when the loader is absent or the name has no constant decl. `RbsLoader#constant_type(name)` MUST translate `RBS::AST::Declarations::Constant#type` through `Rigor::Inference::RbsTypeTranslator.translate` and return the resulting `Rigor::Type`, or `nil` when translation produces `Type::Bot` (an empty type). The query MUST NOT raise on malformed inputs; the loader stays fail-soft.
 
+### Reachability report tiers (ADR-102)
+
+`rigor unused` reports on a reference graph built by `Analysis::Reachability::Scan` (a standalone Prism walk, NOT the typing path) and swept by `Analysis::Reachability::Graph`. The output tiers are normative:
+
+1. **`candidates`** — project-owned declarations no reachable declaration references. Mark-and-sweep, not reference counting: an edge MUST propagate reachability only when its source is itself reachable, so a cluster of mutually-referencing dead declarations MUST still be reported.
+2. **`undecidable`** — a declaration something can name at runtime. A `constantize` / `safe_constantize` / `const_get` whose subject is a **literal** string or symbol MUST resolve to that exact constant and contribute an ordinary reference; only a non-literal subject demotes. An interpolated subject with a literal head (`"Foo::#{k}"`) MUST taint `Foo` and everything beneath it and nothing else; a subject with no literal head MUST taint **nothing** — poisoning the whole project would empty the report. A declaration whose fully-qualified name appears as a string in a template or data file (`.erb`, `.haml`, `.slim`, `.yml`, `.yaml`, `.json`) MUST demote to this tier rather than count as a reference: a data-file match is weaker evidence than a constant node, and treating it as proof would hide real dead code. Every row MUST carry the reason it was demoted.
+3. **`test_only`** — reachable, but only through edges whose referring file has the `:test` role. Reported separately from both other tiers (ADR-102 WD8).
+4. **`namespaces`** — an unreached declaration under which some *reachable* declaration lives. Excluded from `candidates`, because nothing references an intermediate namespace segment by itself. A namespace whose contents are **all** unreachable MUST remain a candidate.
+
+Ownership: a declaration is project-owned only when it is declared in an analysed file AND the name is unknown to an environment built **without** the project's own `signature_paths`. Reopening a gem or stdlib class MUST NOT make it a candidate.
+
+Constant resolution inside the report MUST follow the same candidate order as `Reflection.resolve_constant_type` (nesting, then ancestors, then bare name), with one addition: when a name resolves to no declaration, the trailing `::segment` MUST be peeled and retried, so a reference to `Foo::BAR` counts as a reference to `Foo`.
+
 ### Declaration-position overrides (Slice A-declarations)
 
 `Rigor::Scope` carries a `declared_types` table — an identity-comparing `Hash[Prism::Node, Rigor::Type]` that overrides `ExpressionTyper#type_of` for specific node identities. Since [ADR-53](../adr/53-scope-discovery-index-separation.md) it is one of the [Discovery Index](#discovery-index-adr-53-track-a) tables (read through the `Scope#declared_types` delegate, seeded through `Scope#with_discovery`); the default value is a frozen empty hash. `Scope#with_local`, `Scope#with_fact`, `Scope#with_self_type`, and the join helpers MUST carry the index — and so the table — through by reference.

--- a/docs/manual/02-cli-reference.md
+++ b/docs/manual/02-cli-reference.md
@@ -323,14 +323,25 @@ reported. Roots are the declarations in files matching
 level by non-test code. Route- and framework-derived roots are not
 wired yet, so today's output is an upper bound.
 
-Two things the report separates rather than merges:
+Three things the report separates rather than merges:
 
 - **Reachable only from test code** gets its own section — a class
   used solely by its own spec is dead production code with a live
   test, which is a more actionable finding than either bucket alone.
-- **Constants Rigor cannot decide about** are not claimed as unused.
-  Only class and module constants are reported at all; value
-  constants are omitted because they do not resolve across files.
+- **Constants something can name at runtime** are demoted to a
+  `cannot decide` section with the reason, never claimed as unused.
+  `"Foo".constantize` names `Foo` exactly, so it counts as an ordinary
+  reference; `"Foo::#{key}".constantize` instead marks everything
+  under `Foo` undecidable. A class name appearing as a string in a
+  `.yml`, `.json`, or template file demotes it the same way — that is
+  weaker evidence than a constant reference, so it is neither proof of
+  use nor grounds to call it dead.
+- **Namespace modules** wrapping live code are excluded and counted,
+  because nothing references an intermediate namespace by itself. A
+  namespace whose contents are *all* unreachable is still reported.
+
+Only class and module constants are reported at all; value constants
+are omitted because they do not resolve across files.
 
 References are harvested from a wider file set than the analysed
 paths — `.rake` tasks, `config/`, specs and the project's own `sig/`

--- a/docs/notes/20260813-unused-constant-fp-baseline.md
+++ b/docs/notes/20260813-unused-constant-fp-baseline.md
@@ -224,3 +224,41 @@ Not adjudicated exhaustively; recorded because they identify the same artifact c
 7. **The value-constant tier stays out of any shipped report** until the cross-file seed carries
    `in_source_constants`. It is 38 / 89 / 0 candidates across the corpus with, by construction, no
    way to be right.
+
+## Addendum 2026-08-15 — the shipped `rigor unused`, with the cannot-decide tier
+
+The measurements above were taken with the throwaway probe. `rigor unused` (#347) and its
+`cannot-decide` tier (#348) have since shipped, and the same three targets were re-run through the
+real command.
+
+**These numbers are not a continuation of the decay table above, and should not be read as one.**
+The instrument changed in two ways that move the denominator: the reference index is now a dedicated
+constant-node walk rather than a hook on the typing path, and ownership now excludes names known to
+an environment built without the project's own `sig/`. Redmine's project-owned declaration count is
+504 here against the probe's 697 for that reason. What the table shows is the shape of the shipped
+report, not a further stage of the original funnel.
+
+Run with no `--entry-point`, so roots come only from file-level references:
+
+| target | declared | candidates | cannot decide | test-only | namespace-only |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| redmine | 504 | 129 | 99 | 2 | 12 |
+| mastodon | 1,497 | 278 | 118 | 454 | 8 |
+| conference-app | 103 | 2 | 0 | 0 | 0 |
+
+Three things worth recording.
+
+**The cannot-decide tier carries real volume.** 99 rows on redmine and 118 on mastodon are
+declarations that would otherwise have been asserted as unused, each now demoted with the reason
+that demoted it. On redmine that is 43 % of what the report would otherwise have claimed.
+
+**Mastodon's test-only bucket is inflated, and the inflation is diagnostic rather than alarming.**
+454 declarations reachable only from test code is not a finding about mastodon; it is what a Rails
+app looks like when route-derived roots are missing. Controllers and models are reached from routes
+and the framework, neither of which #347 knows about — the specs are the only thing left referencing
+them. The bucket should collapse when #349 lands, and its size is a usable before/after measure for
+that slice.
+
+**conference-app is the clean case**: 2 candidates out of 103 declarations, no undecidable rows. A
+small app with a real `sig/` tree and few dynamic constructions is the shape the report handles best,
+which is worth knowing when setting expectations in the manual.

--- a/lib/rigor/analysis/reachability/graph.rb
+++ b/lib/rigor/analysis/reachability/graph.rb
@@ -21,7 +21,13 @@ module Rigor
         # a flag there could never be true. "Reachable, but only from test code" is a SEPARATE and more
         # actionable answer — dead production code with a live test — which is exactly what ADR-102 WD8 requires
         # be reported as its own category rather than folded into a bucket boundary.
-        Report = Data.define(:declared, :reachable, :candidates, :test_only, :namespaces, :roots, :edges)
+        Report = Data.define(:declared, :reachable, :candidates, :undecidable, :test_only, :namespaces,
+                             :roots, :edges)
+
+        # A candidate demoted out of `candidates` because something can reach it by a mechanism this reading
+        # cannot follow (ADR-102 WD4). Carries the reason so the reader can judge it rather than take the
+        # bucket on trust.
+        Undecidable = Data.define(:fqn, :path, :line, :reason)
 
         # @param declarations [Array<Scan::Declaration>]
         # @param references [Array<Scan::Reference>]
@@ -29,9 +35,12 @@ module Rigor
         #   them (config-declared globs in this slice; plugin-supplied roots are #349).
         # @param foreign [#call] predicate answering "is this FQN owned by something outside the project?" —
         #   a reopened gem or stdlib class must never be a candidate (WD6). Defaults to "nothing is foreign".
-        def initialize(declarations:, references:, root_fqns: [], foreign: ->(_fqn) { false })
+        # @param dynamic_uses [Array<Scan::DynamicUse>] sites where a constant is reached by name at runtime.
+        #   A literal-argument site contributes a real reference; a dynamic one taints a namespace (WD4).
+        def initialize(declarations:, references:, root_fqns: [], dynamic_uses: [], foreign: ->(_fqn) { false })
           @declarations = declarations
-          @references = references
+          @dynamic_uses = dynamic_uses
+          @references = references + literal_dynamic_references(dynamic_uses)
           @root_fqns = root_fqns.to_set
           @foreign = foreign
           @by_fqn = declarations.group_by(&:fqn)
@@ -45,12 +54,47 @@ module Rigor
           reachable = walk(edges, seeds: production_seeds | test_seeds, roles: %i[production task config test])
           unreached = @owned - reachable
           namespaces = namespace_only(unreached, reachable)
+          undecidable = tainted(unreached - namespaces)
           Report.new(declared: @owned.size, reachable: reachable.size,
-                     candidates: rows(unreached - namespaces), test_only: rows(reachable - production),
+                     candidates: rows(unreached - namespaces - undecidable.keys.to_set),
+                     undecidable: undecidable.map { |fqn, reason| undecidable_row(fqn, reason) }.freeze,
+                     test_only: rows(reachable - production),
                      namespaces: namespaces.size, roots: production_seeds.size, edges: edges.size)
         end
 
         private
+
+        # A literal-argument `"Foo::Bar".constantize` names its constant exactly, so it is a REFERENCE, not an
+        # unknown. Keeping this distinct from the taint below is what stops the tier being a blanket namespace
+        # poison — Rigor knows the argument's shape, and a type-free indexer does not.
+        def literal_dynamic_references(dynamic_uses)
+          dynamic_uses.filter_map do |use|
+            next if use.name.nil?
+
+            Scan::Reference.new(as_written: use.name.sub(/\A::/, ""), nesting: [].freeze, from: nil,
+                                role: :production, path: use.path, line: use.line)
+          end
+        end
+
+        # `{fqn => reason}` for every unreached declaration a dynamic site could still be naming. A site with a
+        # literal prefix taints that namespace and everything under it; a site with no prefix at all cannot be
+        # bounded, so it taints nothing rather than everything — poisoning the whole project would empty the
+        # report and teach the reader that the tier means nothing.
+        def tainted(unreached)
+          prefixes = @dynamic_uses.filter_map { |use| [use.prefix, use] if use.name.nil? && use.prefix }
+
+          return {} if prefixes.empty?
+
+          unreached.each_with_object({}) do |fqn, out|
+            _, use = prefixes.find { |prefix, _| fqn == prefix || fqn.start_with?("#{prefix}::") }
+            out[fqn] = use.site.nil? ? use.reason : "#{use.reason} (#{use.site})" if use
+          end
+        end
+
+        def undecidable_row(fqn, reason)
+          site = @by_fqn.fetch(fqn).first
+          Undecidable.new(fqn: fqn, path: site.path, line: site.line, reason: reason)
+        end
 
         # `module A; end` wrapping a live `A::B` is not dead code, but nothing ever references `A` by itself:
         # a reference to `A::B::Leaf` records the leaf only, never the intermediate segments. Reporting these

--- a/lib/rigor/analysis/reachability/scan.rb
+++ b/lib/rigor/analysis/reachability/scan.rb
@@ -31,7 +31,14 @@ module Rigor
         # than a reference count (ADR-102 WD2). `role` is the referring FILE's role (WD8).
         Reference = Data.define(:as_written, :nesting, :from, :role, :path, :line)
 
-        Result = Data.define(:declarations, :references)
+        # ADR-102 WD4 — a site where a constant is reached by a mechanism the static reading cannot follow.
+        # `name` is the exact constant when the argument is a literal (`"Foo".constantize`), in which case this
+        # is as good as a reference. `prefix` is the namespace a dynamic construction can reach into
+        # (`"Foo::#{k}".constantize` → `"Foo"`, and `nil` when even that is unknown), which taints every
+        # declaration at or below it rather than proving any single one used.
+        DynamicUse = Data.define(:name, :prefix, :reason, :site, :path, :line)
+
+        Result = Data.define(:declarations, :references, :dynamic_uses)
 
         # Roles a referring file can have (ADR-102 WD8). A reference edge carries its referrer's role so
         # "used only by its own test" is a reportable category rather than a bucket boundary.
@@ -60,18 +67,20 @@ module Rigor
 
           walker = Walker.new(path: path, role: role_for(path))
           walker.walk(parsed.value, [])
-          Result.new(declarations: walker.declarations.freeze, references: walker.references.freeze)
+          Result.new(declarations: walker.declarations.freeze, references: walker.references.freeze,
+                     dynamic_uses: walker.dynamic_uses.freeze)
         end
 
         # Single-pass walker. Tracks `nesting` as the stack of enclosing declaration names.
         class Walker
-          attr_reader :declarations, :references
+          attr_reader :declarations, :references, :dynamic_uses
 
           def initialize(path:, role:)
             @path = path
             @role = role
             @declarations = []
             @references = []
+            @dynamic_uses = []
           end
 
           def walk(node, nesting)
@@ -90,6 +99,8 @@ module Rigor
               record_meta_new(node, nesting)
               walk(node.value, nesting)
               return
+            when Prism::CallNode
+              record_dynamic_use(node)
             end
 
             node.rigor_each_child { |child| walk(child, nesting) }
@@ -141,6 +152,55 @@ module Rigor
               arg = stmt.arguments&.arguments&.first
               arg && Source::ConstantPath.qualified_name_or_nil(arg)
             end
+          end
+
+          # Names that turn a String into a constant. `constantize` / `safe_constantize` are ActiveSupport;
+          # `const_get` is core and may carry an explicit receiver (`Object.const_get`, `self.class.const_get`).
+          DYNAMIC_RESOLVERS = %i[constantize safe_constantize const_get].freeze
+          private_constant :DYNAMIC_RESOLVERS
+
+          SUBJECT_SHAPES = {
+            Prism::StringNode => "a literal string",
+            Prism::SymbolNode => "a literal symbol",
+            Prism::InterpolatedStringNode => "an interpolated string"
+          }.freeze
+          private_constant :SUBJECT_SHAPES
+
+          # Rigor knows the argument's shape, which is the whole reason this can be tiered rather than treated
+          # as a blanket namespace poison: a literal argument names the exact constant and is as good as a
+          # written reference, while an interpolated one can only bound the namespace it reaches into.
+          def record_dynamic_use(node)
+            return unless DYNAMIC_RESOLVERS.include?(node.name)
+
+            subject = node.name == :const_get ? node.arguments&.arguments&.first : node.receiver
+            return if subject.nil?
+
+            reason = "#{node.name} on #{SUBJECT_SHAPES.fetch(subject.class, 'a computed value')}"
+            case subject
+            when Prism::StringNode, Prism::SymbolNode
+              @dynamic_uses << DynamicUse.new(name: subject.unescaped, prefix: nil, reason: reason,
+                                              site: site(node), path: @path, line: node.location.start_line)
+            when Prism::InterpolatedStringNode
+              @dynamic_uses << DynamicUse.new(name: nil, prefix: literal_prefix(subject), reason: reason,
+                                              site: site(node), path: @path, line: node.location.start_line)
+            else
+              @dynamic_uses << DynamicUse.new(name: nil, prefix: nil, reason: reason,
+                                              site: site(node), path: @path, line: node.location.start_line)
+            end
+          end
+
+          # The literal head of an interpolated name: `"Foo::Bar::#{k}"` bounds the reach to `Foo::Bar`. Returns
+          # nil when the interpolation starts the string, which bounds nothing.
+          def site(node)
+            "#{@path}:#{node.location.start_line}"
+          end
+
+          def literal_prefix(node)
+            head = node.parts.first
+            return nil unless head.is_a?(Prism::StringNode)
+
+            trimmed = head.unescaped.sub(/::\z/, "")
+            trimmed.empty? ? nil : trimmed
           end
 
           def record_reference(node, nesting)

--- a/lib/rigor/cli/unused_command.rb
+++ b/lib/rigor/cli/unused_command.rb
@@ -32,17 +32,24 @@ module Rigor
       # combined on a real app, and a reference found inside a vendored gem is not evidence about this project.
       VENDOR_DIRS = %r{\A(vendor|node_modules|tmp|\.git|\.rigor|coverage)/}
 
+      # Templates and data files that carry class names as strings. A name here is NOT counted as a reference —
+      # a YAML value is far weaker evidence than a constant node, and treating it as proof would silently hide
+      # real dead code. It demotes the declaration to `cannot-decide` instead, with the file named, so the
+      # reader judges it (ADR-102 WD4).
+      TEMPLATE_GLOB = "**/*.{erb,haml,slim,yml,yaml,json}"
+
       def run
         options = parse_options
         return CLI::EXIT_USAGE if options == :usage_error
 
         configuration = Configuration.load(options.fetch(:config))
         paths = @argv.empty? ? configuration.paths : @argv
-        declarations, references = scan(paths, configuration)
+        declarations, references, dynamic_uses = scan(paths, configuration)
         references.concat(signature_references(configuration))
+        dynamic_uses.concat(template_mentions(declarations))
 
         graph = Analysis::Reachability::Graph.new(
-          declarations: declarations, references: references,
+          declarations: declarations, references: references, dynamic_uses: dynamic_uses,
           root_fqns: root_fqns(declarations, options.fetch(:entry_points)),
           foreign: foreign_predicate(configuration)
         )
@@ -87,14 +94,16 @@ module Rigor
         declaration_files = Analysis::PathExpansion.ruby_files(paths, configuration.exclude_patterns).to_set
         declarations = []
         references = []
+        dynamic_uses = []
         (declaration_files + reference_files(paths, configuration)).sort.each do |file|
           result = read_and_scan(file, configuration)
           next if result.nil?
 
           declarations.concat(result.declarations) if declaration_files.include?(file)
           references.concat(result.references)
+          dynamic_uses.concat(result.dynamic_uses)
         end
-        [declarations, references]
+        [declarations, references, dynamic_uses]
       end
 
       # The reference corpus is the PROJECT, not the analysed paths. A constant declared in `lib/` is commonly
@@ -145,6 +154,24 @@ module Rigor
         end
       end
 
+      def template_mentions(declarations)
+        names = declarations.map(&:fqn)
+        return [] if names.empty?
+
+        Dir.glob(TEMPLATE_GLOB, base: Dir.pwd).grep_v(VENDOR_DIRS).flat_map do |rel|
+          text = File.read(File.expand_path(rel))
+          names.filter_map do |fqn|
+            next unless text.include?(fqn)
+
+            Analysis::Reachability::Scan::DynamicUse.new(name: nil, prefix: fqn, site: nil,
+                                                         reason: "named as a string in #{rel}",
+                                                         path: rel, line: 1)
+          end
+        rescue SystemCallError, ArgumentError
+          []
+        end
+      end
+
       def root_fqns(declarations, globs)
         return [] if globs.empty?
 
@@ -174,7 +201,10 @@ module Rigor
         JSON.pretty_generate(
           declared: report.declared, reachable: report.reachable, roots: report.roots, edges: report.edges,
           namespaces: report.namespaces,
-          candidates: rows_json(report.candidates, options), test_only: rows_json(report.test_only, options)
+          candidates: rows_json(report.candidates, options), test_only: rows_json(report.test_only, options),
+          undecidable: limited(report.undecidable, options).map do |u|
+            { name: u.fqn, path: u.path, line: u.line, reason: u.reason }
+          end
         )
       end
 
@@ -188,15 +218,29 @@ module Rigor
                  "  reachable:                #{report.reachable}",
                  "  candidates:               #{report.candidates.size}",
                  "  reachable only from tests: #{report.test_only.size}",
+                 "  cannot decide:            #{report.undecidable.size}",
                  "  namespace-only (excluded):  #{report.namespaces}"]
         lines.concat(section("Candidates — nothing reachable references these", report.candidates, options))
         lines.concat(section("Reachable only from test code — live test, dead production path",
                              report.test_only, options))
+        lines.concat(undecidable_section(report.undecidable, options))
         lines << ""
         lines << "These are CANDIDATES, not findings. The measured precision of this report on an adjudicated"
         lines << "corpus target is 7% — every row needs a human to confirm it. Route- and plugin-derived roots"
         lines << "are not wired yet (issue #349), so this list is an upper bound."
         lines.join("\n")
+      end
+
+      def undecidable_section(rows, options)
+        return [] if rows.empty?
+
+        out = ["", "Cannot decide — something can name these at runtime (#{rows.size})"]
+        limited(rows, options).each_with_index do |u, i|
+          out << format("  %<n>3d  %<name>-52s %<path>s:%<line>d", n: i + 1, name: u.fqn, path: u.path,
+                                                                   line: u.line)
+          out << "       #{u.reason}"
+        end
+        out
       end
 
       def section(title, rows, options)

--- a/spec/rigor/analysis/reachability_spec.rb
+++ b/spec/rigor/analysis/reachability_spec.rb
@@ -163,6 +163,56 @@ RSpec.describe Rigor::Analysis::Reachability do
     end
   end
 
+  # ADR-102 WD4 — a constant reachable by a mechanism this reading cannot follow is reported as undecidable,
+  # never folded into "unused" and never silently treated as used.
+  describe "the cannot-decide tier (WD4)" do
+    def report_for(files, roots: [])
+      decls = []
+      refs = []
+      dyn = []
+      files.each do |path, source|
+        result = Rigor::Analysis::Reachability::Scan.call(path: path, source: source)
+        decls.concat(result.declarations)
+        refs.concat(result.references)
+        dyn.concat(result.dynamic_uses)
+      end
+      Rigor::Analysis::Reachability::Graph.new(declarations: decls, references: refs, dynamic_uses: dyn,
+                                               root_fqns: roots).report
+    end
+
+    # The case that proves the tier is not a blanket namespace poison: Rigor knows the argument's shape, so a
+    # literal names the exact constant and is as good as a written reference.
+    it "resolves a literal-argument constantize to the named constant and marks it reachable" do
+      report = report_for({ "lib/a.rb" => %(class Root\n  def go = "Target".constantize\nend\n),
+                            "lib/b.rb" => "class Target\nend\n" }, roots: ["Root"])
+      expect(report.candidates.map(&:fqn)).not_to include("Target")
+      expect(report.undecidable.map(&:fqn)).not_to include("Target")
+    end
+
+    it "resolves a literal const_get argument the same way" do
+      report = report_for({ "lib/a.rb" => %(class Root\n  def go = Object.const_get("Target")\nend\n),
+                            "lib/b.rb" => "class Target\nend\n" }, roots: ["Root"])
+      expect(report.candidates.map(&:fqn)).to be_empty
+    end
+
+    it "demotes a namespace an interpolated constantize can reach, with a reason" do
+      report = report_for({ "lib/a.rb" => %(class Root\n  def go(k) = "H::\#{k}".constantize\nend\n),
+                            "lib/b.rb" => "module H\n  class Alpha\n  end\nend\n" }, roots: ["Root"])
+      expect(report.candidates.map(&:fqn)).to be_empty
+      expect(report.undecidable.map(&:fqn)).to include("H", "H::Alpha")
+      expect(report.undecidable.first.reason).to include("interpolated string")
+    end
+
+    # An unbounded site taints nothing rather than everything: poisoning the whole project would empty the
+    # report and teach the reader the tier means nothing.
+    it "does not let an unbounded dynamic site poison the whole project" do
+      report = report_for({ "lib/a.rb" => "class Root\n  def go(k) = k.constantize\nend\n",
+                            "lib/b.rb" => "class Orphan\nend\n" }, roots: ["Root"])
+      expect(report.candidates.map(&:fqn)).to eq(["Orphan"])
+      expect(report.undecidable).to be_empty
+    end
+  end
+
   describe "meta-new declarations" do
     it "treats a constant assigned Class.new / Data.define as a declaration" do
       found = candidates({ "lib/a.rb" => "class Root\nend\n",


### PR DESCRIPTION
Closes #348. Implements [ADR-102](https://github.com/rigortype/rigor/blob/master/docs/adr/102-unused-code-reachability-report.md) WD4.

A constant Rigor cannot **prove** unreferenced is reported as undecidable — never folded into "unused", and never silently treated as used. Every row carries the reason it was demoted.

## Not a blanket namespace poison

That distinction is the part a type-free indexer cannot make. Rigor knows the argument's shape:

| site | effect |
| --- | --- |
| `"Foo".constantize`, `Object.const_get("Foo")` | names `Foo` exactly → an ordinary **reference**; `Foo` stays out of every bucket |
| `"Foo::#{k}".constantize` | taints `Foo` and everything beneath it, **and nothing else** |
| `k.constantize` (no literal head) | taints **nothing** |

The last row is the one worth arguing about, and it has its own spec. Poisoning the whole project on an unbounded site would empty the report and teach the reader that the tier means nothing — a report that demotes everything is indistinguishable from no report.

Class names carried as strings in templates and data files (`.erb`, `.haml`, `.slim`, `.yml`, `.yaml`, `.json`) **demote rather than count as references**. A YAML value is far weaker evidence than a constant node, and treating it as proof of use would silently hide real dead code — exactly the failure this report exists to avoid.

## Corpus

Appended to the #345 note. Run with no `--entry-point`:

| target | declared | candidates | cannot decide | test-only | namespace-only |
| --- | ---: | ---: | ---: | ---: | ---: |
| redmine | 504 | 129 | 99 | 2 | 12 |
| mastodon | 1,497 | 278 | 118 | 454 | 8 |
| conference-app | 103 | 2 | 0 | 0 | 0 |

The tier moves 99 rows on redmine and 118 on mastodon out of what the report would otherwise have asserted — 43 % of redmine's claim.

**The note is explicit that these are NOT a further stage of the original decay table.** The instrument changed (a dedicated constant-node walk, not the probe) and so did the ownership predicate, so the denominator moved — redmine is 504 project-owned declarations here against the probe's 697. Reading them as a continuation would be wrong, so the note says so rather than letting the tables sit next to each other and imply it.

Mastodon's 454 test-only rows are not a finding about mastodon: that is what a Rails app looks like when route-derived roots are missing. The bucket is a usable before/after measure for #349.

## Verification

Four new specs, including the unbounded-site control. `make verify` exit 0, `make docs-check` exit 0, `git diff --check` clean. Tier semantics written into `docs/internal-spec/inference-engine.md` in the same commit, manual and `[Unreleased]` changelog updated.