### PR TITLE
Publish a pre_eval file's top-level constants project-wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
   - The report prints how many roots came from plugins and how many of them named a class your project does not declare, so an over-claiming root source — which would silently hide real dead code — is visible rather than invisible.
 - **[plugins]** A plugin can contribute entry points to `rigor unused` by publishing an array of constant names as the `:reachability_roots` fact from its `prepare` hook ([#349](https://github.com/rigortype/rigor/issues/349)).
   - Framework knowledge stays in plugins; the core only reads the fact. Documented in [`docs/internal-spec/plugin.md`](docs/internal-spec/plugin.md).
+- **[engine]** A file listed in `pre_eval:` now publishes its top-level constants to the rest of the project, so a shared `TIMEOUT = 30` is typed where it is used instead of only where it is written ([#352](https://github.com/rigortype/rigor/issues/352)).
+  - The published type is the widened class — `Integer` for `30`, `String` for `"x"`, `Hash` for a literal hash — not the exact value. A constant carrying its literal shape across files would make a call like `CONFIG.fetch(:missing)` an error in a file whose author never opened the definition, which is a worse trade than the precision is worth. Constants in files you have not listed are unchanged, and a name written in more than one listed file widens rather than becoming a union.
 
 ### Fixed
 

--- a/docs/manual/03-configuration.md
+++ b/docs/manual/03-configuration.md
@@ -70,7 +70,7 @@ cache:
 | --- | --- | --- | --- |
 | `libraries` | Array | `[]` | Standard-library / gem names whose bundled RBS to load. |
 | `signature_paths` | Array | `nil` | Extra directories of `.rbs` files. Relative entries resolve against the config file's directory. |
-| `pre_eval` | Array | `[]` | Files (or globs) walked before per-file analysis, to register project monkey-patches. |
+| `pre_eval` | Array | `[]` | Files (or globs) walked before per-file analysis, to register project monkey-patches and publish their top-level constants project-wide. |
 | `plugins` | Array | `[]` | Plugins to activate — see [Using plugins](07-plugins.md). |
 
 ### Config validation warnings

--- a/lib/rigor/analysis/runner.rb
+++ b/lib/rigor/analysis/runner.rb
@@ -20,6 +20,7 @@ require_relative "../unused_probe" # issue #345 spike instrumentation
 require_relative "../type/combinator"
 require_relative "../inference/coverage_scanner"
 require_relative "../inference/parameter_inference_collector"
+require_relative "../inference/pre_eval_constants"
 require_relative "../inference/scope_indexer"
 require_relative "../inference/synthetic_method_scanner"
 require_relative "../inference/project_patched_scanner"
@@ -190,6 +191,11 @@ module Rigor
         # scope (sequential + fork-worker) through `project_scope_seed_tables`. Empty by default, so the gate-off
         # run carries no table and is byte-identical.
         @project_param_inferred_types = {}.freeze
+        # Issue #352 / ADR-17 — the `pre_eval:` constant publication table, populated by
+        # `seed_pre_eval_constants` in `assemble_run_diagnostics` and seeded onto every per-file scope
+        # (sequential + fork-worker) through `project_scope_seed_tables`. Empty unless the project lists
+        # `pre_eval:` files that declare publishable constants, so a project without one is byte-identical.
+        @project_pre_eval_constants = {}.freeze
         # ADR-84 WD2 — per-run identity token for the user-method return memo's bucket (see
         # Scope::DiscoveryIndex#run_generation). Minted fresh in `run_analysis` so the memo never serves an
         # entry across a run boundary (LSP re-check, ADR-62 warm loop); nil until the first run so
@@ -535,6 +541,11 @@ module Rigor
         # assembles). Gate off → no-op, and `environment` is left untouched so its lazy build timing is
         # unchanged. Returns the resolved environment so the sequential dispatch reuses it (no double build).
         environment = seed_parameter_inference(expansion, environment)
+        # Issue #352 — the `pre_eval:` constant publication pre-pass. Same placement rationale as the line
+        # above: it runs on the parent BEFORE the pool split so every worker sees the same frozen table, and
+        # only on the analysis (miss) path. No `pre_eval:` entry → no-op, and `environment` passes through
+        # untouched so its lazy build timing is unchanged.
+        environment = seed_pre_eval_constants(expansion, environment)
         diagnostics = @diagnostic_aggregator.pre_file_diagnostics(expansion)
         # ADR-46 — record which project files this run actually analyzed (the `analyze_only` subset, or
         # all of them). The incremental orchestrator serves every analyzed-but-not-affected file from the
@@ -578,6 +589,34 @@ module Rigor
         environment
       rescue StandardError
         @project_param_inferred_types = {}.freeze
+        environment
+      end
+
+      # Issue #352 / ADR-17 — the `pre_eval:` CONSTANT publication pre-pass, the twin of the slice-2 patched-
+      # METHOD registry the eager pre-passes already build. Walks each listed file's constant writes with the
+      # per-file pre-pass ({Inference::ScopeIndexer.build_in_source_constants}) under a project-seeded scope,
+      # widens each result to its erased class, and populates `@project_pre_eval_constants` — which
+      # `project_scope_seed_tables` then seeds onto every per-file scope, so `TIMEOUT = 30` in a listed file
+      # reads as `Integer` instead of `Dynamic[top]` in its consumers. The widening + multi-file conflict rules
+      # live in {Inference::PreEvalConstants}.
+      #
+      # Runs here rather than in {ProjectPrePasses#run} because typing a constant's rvalue needs the RBS
+      # environment, which the eager pre-passes feed rather than consume. Fails soft — a collector error must
+      # never break a run, so the table stays empty and the run proceeds exactly as it does today.
+      def seed_pre_eval_constants(expansion, environment)
+        paths = @configuration.pre_eval.select { |path| File.file?(path) }
+        return environment if paths.empty?
+
+        environment ||= @pool_coordinator.resolve_sequential_environment(source_files: expansion.fetch(:files))
+        @project_pre_eval_constants = Inference::PreEvalConstants.collect(
+          paths: paths, target_ruby: @configuration.target_ruby, buffer: @buffer,
+          scope_builder: lambda { |path|
+            seed_project_scope(Scope.empty(environment: environment, source_path: path))
+          }
+        )
+        environment
+      rescue StandardError
+        @project_pre_eval_constants = {}.freeze
         environment
       end
 
@@ -625,7 +664,7 @@ module Rigor
       # file (`rbs_descriptor.files`), and every file each plugin read (complete post-run, so reads made
       # mid-analysis are included). Re-digested on the next run by {Descriptor#fresh?}.
       def run_dependency_descriptor(expansion, rbs_descriptor)
-        entries = analyzed_file_entries(expansion) + rbs_descriptor.files
+        entries = analyzed_file_entries(expansion) + pre_eval_file_entries + rbs_descriptor.files
         @plugin_registry.plugins.each do |plugin|
           # Read the boundary WITHOUT triggering its lazy `@io_boundary ||=` initializer: plugin instances
           # are frozen after the run, and a plugin that never built a boundary read no files through it,
@@ -641,6 +680,21 @@ module Rigor
           physical = @buffer ? @buffer.resolve(path) : path
           # ADR-87 WD1 — validation-only dependency descriptor, so the stat-then-digest `:stat` comparator
           # applies (the env-cache KEY files stay `:digest`).
+          Cache::Descriptor::FileEntry.stat(path: physical, digest: Cache::FileDigest.hexdigest(physical))
+        end
+      end
+
+      # Issue #352 — a `pre_eval:` file is a real input to the run's diagnostics: its `def`s populate the
+      # ADR-17 patched-method registry and (since #352) its constants populate the project seed. ADR-17 WD5
+      # permits listing a file under `pre_eval:` and NOT under `paths:`, and such a file never appears in the
+      # expansion — so without this entry, editing one would leave the run-result cache serving diagnostics
+      # computed against the previous version. The common case (a `lib/core_ext/` file that is also under
+      # `paths:`) contributes a duplicate entry, which the descriptor's per-path validation absorbs.
+      def pre_eval_file_entries
+        @configuration.pre_eval.filter_map do |path|
+          physical = @buffer ? @buffer.resolve(path) : path
+          next unless File.file?(physical)
+
           Cache::Descriptor::FileEntry.stat(path: physical, digest: Cache::FileDigest.hexdigest(physical))
         end
       end
@@ -1121,10 +1175,7 @@ module Rigor
           tables[:discovered_method_visibilities] = @project_discovered_method_visibilities
         end
         tables[:discovered_methods] = @project_discovered_methods unless @project_discovered_methods.empty?
-        # ADR-67 WD6a — the call-site parameter-inference table rides the same seed so a pooled `WorkerSession`
-        # scope seeds inferred parameters identically to the sequential path. Empty (and absent) unless the
-        # `parameter_inference:` gate ran the pre-pass.
-        tables[:param_inferred_types] = @project_param_inferred_types unless @project_param_inferred_types.empty?
+        seed_opt_in_pre_pass_tables(tables)
         seed_member_layout_tables(tables)
         # ADR-46 slice 1 — the class-declaration source map is read only by the ancestry accessors during
         # dependency recording, so seed it only when recording is on; a normal run never carries it.
@@ -1139,6 +1190,23 @@ module Rigor
       # from. Extracted so the seed costs {#project_scope_seed_tables} no branch of its complexity budget.
       def discovery_seed_base
         @discovery_seed ? @discovery_seed.dup : {}
+      end
+
+      # Seeds the two OPT-IN pre-pass tables — the ones an ordinary run leaves empty, so they are absent from
+      # the seed entirely unless the project asked for them. Both ride this seed so a pooled `WorkerSession`
+      # scope resolves identically to the sequential path (ADR-15 sequential equivalence).
+      #
+      # - ADR-67 WD6a `param_inferred_types`: the call-site parameter-inference table, populated only when the
+      #   `parameter_inference:` gate ran the pre-pass.
+      # - Issue #352 `in_source_constants`: the `pre_eval:` constant publication, populated only when the
+      #   project lists `pre_eval:` files that declare publishable constants.
+      #
+      # Extracted to keep {#project_scope_seed_tables} under the complexity budget.
+      def seed_opt_in_pre_pass_tables(tables)
+        tables[:param_inferred_types] = @project_param_inferred_types unless @project_param_inferred_types.empty?
+        return if @project_pre_eval_constants.empty?
+
+        tables[:in_source_constants] = @project_pre_eval_constants
       end
 
       # ADR-46 — seed the instance + singleton `"path:line"` def-source tables (each only when non-empty).

--- a/lib/rigor/inference/pre_eval_constants.rb
+++ b/lib/rigor/inference/pre_eval_constants.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "prism"
+
+require_relative "../scope"
+require_relative "../type"
+require_relative "scope_indexer"
+
+module Rigor
+  module Inference
+    # Issue #352 / [ADR-17](../../../docs/adr/17-monkey-patch-pre-evaluation.md) — the constant half of the
+    # `pre_eval:` publication surface.
+    #
+    # ADR-17 slice 2 gave `pre_eval:` a project-wide **method** registry ({ProjectPatchedMethods}). A
+    # constant declared in the same file stayed invisible across the file boundary: `Scope#in_source_constants`
+    # is per-file and is deliberately not part of `Runner#project_scope_seed_tables`, so only class-shaped
+    # constants (a `class` / `module` declaration, or one of the four meta-new forms `ScopeIndexer`'s
+    # `record_class_new_constant_decl` promotes) ever crossed. `TIMEOUT = 30` in a listed file read as
+    # `Dynamic[top]` everywhere else.
+    #
+    # This collector closes that half. It walks the `pre_eval:` files with the SAME constant pre-pass the
+    # per-file path uses ({ScopeIndexer.build_in_source_constants}) and publishes the result — widened — into
+    # the project seed. Files not listed under `pre_eval:` are untouched, so the feature is opt-in by
+    # construction and its cost stays proportional to the listed file count (ADR-17 WD1's cost-bounded
+    # argument, which is also why slice 5's full-project two-pass stayed rejectable).
+    #
+    # ## The widening rule — why the published type is not the same-file type
+    #
+    # Same-file constant propagation is **value-pinned**: `42`, `"hello"`, a `Tuple`, a `HashShape`. Carrying
+    # that verbatim across a file boundary would land diagnostics in files whose author never opened the
+    # constant's definition — `CONFIG = { a: 1 }` arriving as a closed `HashShape` makes `CONFIG.fetch(:b)`
+    # fire, `ARR = [1, 2]` arriving as a `Tuple` routes through `ShapeDispatch` instead of the RBS overload a
+    # call site relied on. Today's cross-file `Dynamic[top]` is false-positive-free *by construction*, so
+    # precision here can only spend that budget; AGENTS.md § "Implementation Guidelines" ranks false positives
+    # above worst-case static reading, so this slice spends as little of it as possible.
+    #
+    # {.widen} therefore publishes the **erased class**, never the value:
+    #
+    # | Declared | Same file | Published cross-file |
+    # | --- | --- | --- |
+    # | `INT_LIT = 42` | `42` | `Integer` |
+    # | `STR_LIT = "hello"` | `"hello"` | `String` |
+    # | `ARR_LIT = [1, 2]` | `[1, 2]` (Tuple) | `Array` (raw, elements dropped) |
+    # | `HSH_LIT = { a: 1 }` | `{ a: 1 }` (HashShape) | `Hash` (raw, keys dropped) |
+    # | `ALIAS_CLS = String` | `singleton(String)` | `singleton(String)` |
+    # | `Nest::NESTED_INT = 7` | `7` | `Integer` |
+    #
+    # Anything the rule does not recognise **declines** — the name is simply not published and reads exactly
+    # as it does today. Declining is always the safe answer here, which is why the `else` arm is `nil` rather
+    # than a fallback. `Constant[nil]` declines on purpose: a `X = nil` at declaration position is a
+    # placeholder for a value assigned at runtime far more often than it is a genuine `NilClass`, and
+    # publishing `NilClass` project-wide would make every use of it a diagnostic.
+    #
+    # Value-pinning a *provably* frozen single-write literal cross-file is a strictly later question; it needs
+    # its own FP measurement and is deliberately not attempted here.
+    #
+    # ## The multi-file write rule — widen on conflict, all the way to `Dynamic[top]`
+    #
+    # Within one file, `ScopeIndexer#record_constant_write` unions repeated writes; that union is widened as a
+    # whole (`X = 1; X = "a"` in one file publishes `Integer | String`). ACROSS files the same union would be
+    # a type neither author can see, so the rule is **widen on conflict**: when two listed files publish the
+    # same qualified name with different widened types, the name is dropped from the table entirely and reads
+    # as `Dynamic[top]` — the widest type there is, and the one the name already had. Agreeing writes (`X = 1`
+    # here, `X = 2` there — both `Integer`) are not a conflict at all, which is the point of widening first:
+    # `1 | 2` is never produced.
+    #
+    # ## Ordering
+    #
+    # The published table seeds `Scope#in_source_constants`, which `Reflection.constant_type_at` consults
+    # AFTER the class registry and `discovered_classes`. A published entry can therefore never mask a
+    # class-shaped constant that already crossed, and the per-file table always wins over the seed (see
+    # {ScopeIndexer.index}'s merge) — same-file remains the most specific authority.
+    module PreEvalConstants
+      EMPTY = {}.freeze
+
+      module_function
+
+      # Collects and widens the constants every `pre_eval:` file declares.
+      #
+      # @param paths [Array<String>] absolute paths to the `pre_eval:` files that exist on disk.
+      # @param scope_builder [#call] `path -> Rigor::Scope`; the caller supplies a project-seeded, environment-
+      #   bound scope so the rvalue typer resolves cross-file classes exactly as per-file analysis would.
+      # @param target_ruby [String, nil] the Prism parse version (`Configuration#target_ruby`).
+      # @param buffer [Rigor::Analysis::BufferBinding, nil] editor-mode binding; when set, a listed file that
+      #   matches the in-flight buffer is read from its physical bytes.
+      # @return [Hash{String => Rigor::Type}] frozen qualified-name -> published type table.
+      def collect(paths:, scope_builder:, target_ruby: nil, buffer: nil)
+        published = {}
+        conflicted = {}
+        paths.each do |path|
+          file_constants(path, scope_builder: scope_builder, target_ruby: target_ruby, buffer: buffer)
+            .each { |name, type| merge_publication(published, conflicted, name, type) }
+        end
+        published.freeze
+      end
+
+      # Folds one declaration into the accumulator under the widen-on-conflict rule. A name that has already
+      # conflicted stays out for the rest of the collection — a later agreeing write must not resurrect it.
+      def merge_publication(published, conflicted, name, type)
+        return if conflicted.key?(name)
+
+        widened = widen(type)
+        return if widened.nil?
+
+        existing = published[name]
+        return published[name] = widened if existing.nil?
+        return if existing == widened
+
+        published.delete(name)
+        conflicted[name] = true
+      end
+      private_class_method :merge_publication
+
+      # The per-file constant table, typed through the same pre-pass the per-file path runs. Deliberately NOT
+      # a full `ScopeIndexer.index`: ADR-17 WD4 keeps the pre-eval pass a discovery walk, and the constant
+      # pre-pass (plus the declaration artifacts it needs to resolve in-file class references) is exactly the
+      # discovery facet this feature consumes. Fails soft to the empty table — a pre-eval file that cannot be
+      # read or parsed already surfaces a `pre-eval.parse-error` warning from {ProjectPatchedScanner}, and it
+      # must never break the run.
+      def file_constants(path, scope_builder:, target_ruby: nil, buffer: nil)
+        physical = buffer ? buffer.resolve(path) : path
+        parse_result = Prism.parse(File.read(physical), filepath: path, version: target_ruby)
+        return EMPTY unless parse_result.errors.empty?
+
+        root = parse_result.value
+        ScopeIndexer.build_in_source_constants(root, declaration_seeded_scope(root, scope_builder.call(path)))
+      rescue StandardError
+        EMPTY
+      end
+      private_class_method :file_constants
+
+      # Mirrors the head of {ScopeIndexer.index}: seed the file's own declaration overrides and discovered
+      # classes onto the project-seeded scope so a `CONST = SomeClassDefinedRightHere.new` rvalue types the
+      # same way it does during real analysis.
+      def declaration_seeded_scope(root, scope)
+        declared_types, discovered_classes = ScopeIndexer.build_declaration_artifacts(root)
+        scope.with_discovery(
+          scope.discovery.with(
+            declared_types: declared_types,
+            discovered_classes: scope.discovered_classes.merge(discovered_classes)
+          )
+        )
+      end
+      private_class_method :declaration_seeded_scope
+
+      # The publication widening. Returns the type to publish, or `nil` to decline (the name keeps today's
+      # `Dynamic[top]` cross-file reading). See the module doc for why declining is the safe default.
+      def widen(type)
+        case type
+        when Type::Constant then widen_constant(type)
+        when Type::Refined then widen(type.base)
+        when Type::IntegerRange then Type::Combinator.nominal_of("Integer")
+        when Type::Tuple then Type::Combinator.nominal_of("Array")
+        when Type::HashShape then Type::Combinator.nominal_of("Hash")
+        when Type::Nominal then type.type_args.empty? ? type : Type::Combinator.nominal_of(type.class_name)
+        when Type::Singleton then type
+        when Type::DataInstance, Type::StructInstance then nominal_for_class_name(type.class_name)
+        when Type::Union then widen_union(type)
+        end
+      end
+
+      # `Constant[v]` publishes `v`'s class. `nil` declines (see the module doc); so does a value whose class
+      # is anonymous, which has no name to publish under.
+      def widen_constant(type)
+        return nil if type.value.nil?
+
+        nominal_for_class_name(type.value.class.name)
+      end
+      private_class_method :widen_constant
+
+      def nominal_for_class_name(class_name)
+        return nil unless class_name.is_a?(String) && !class_name.empty?
+
+        Type::Combinator.nominal_of(class_name)
+      end
+      private_class_method :nominal_for_class_name
+
+      # A union publishes only when EVERY member widens: one unrecognised arm means the union's real extent is
+      # unknown, and a partial union would be narrower than the truth — the false-positive direction.
+      def widen_union(type)
+        widened = type.members.map { |member| widen(member) }
+        return nil if widened.any?(&:nil?)
+
+        Type::Combinator.union(*widened)
+      end
+      private_class_method :widen_union
+    end
+  end
+end

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -89,10 +89,13 @@ module Rigor
         # program and types its rvalue under a scope that carries the surrounding qualified prefix as `self_type`, so
         # the rvalue typer sees in-class references resolve correctly. Multiple writes to the same qualified name union
         # via `Type::Combinator.union`.
+        # Issue #352 — the per-file table merges OVER whatever the base scope already published (the
+        # `pre_eval:` constant seed `Runner#project_scope_seed_tables` applies). Same-file declarations are the
+        # most specific authority, exactly as `merged_classes` above resolves the same collision. Without the
+        # merge, the assignment below would silently drop the project seed on every file.
         in_source_constants = build_in_source_constants(root, seeded_scope)
-        seeded_scope = seeded_scope.with_discovery(
-          seeded_scope.discovery.with(in_source_constants: in_source_constants)
-        )
+        merged_constants = merge_seeded_constants(default_scope.in_source_constants, in_source_constants)
+        seeded_scope = seeded_scope.with_discovery(seeded_scope.discovery.with(in_source_constants: merged_constants))
         # Issue #345 spike instrumentation. `discovered_classes` and `in_source_constants` here are the
         # PER-FILE tables (before the cross-file project seed merges in), so the declaration source is
         # exactly `default_scope.source_path`. Inert unless RIGOR_UNUSED_PROBE is set.
@@ -1211,6 +1214,15 @@ module Rigor
         accumulator = {}
         walk_constant_writes(root, [], default_scope, accumulator)
         accumulator.freeze
+      end
+
+      # Issue #352 — folds the project-wide `pre_eval:` constant seed under this file's own table. Returns the
+      # per-file table unchanged (same frozen object) when nothing was seeded, so a run without `pre_eval:`
+      # constants allocates and compares exactly what it did before.
+      def merge_seeded_constants(seeded, per_file)
+        return per_file if seeded.nil? || seeded.empty?
+
+        seeded.merge(per_file).freeze
       end
 
       def walk_constant_writes(node, qualified_prefix, default_scope, accumulator)

--- a/sig/rigor/inference.rbs
+++ b/sig/rigor/inference.rbs
@@ -163,6 +163,8 @@ module Rigor
     module ScopeIndexer
       def self?.index: (untyped root, default_scope: Scope) -> Hash[untyped, Scope]
       def self?.build_declaration_overrides: (untyped root) -> Hash[untyped, Type::t]
+      def self?.build_declaration_artifacts: (untyped root) -> [Hash[untyped, Type::t], Hash[String, Type::t]]
+      def self?.build_in_source_constants: (untyped root, Scope default_scope) -> Hash[String, Type::t]
       def self?.record_declarations: (untyped node, Array[String] qualified_prefix, Hash[untyped, Type::t] identity_table, Hash[String, Type::t] discovered) -> void
       def self?.discovered_classes_for_paths: (Array[String] paths, ?buffer: untyped) -> Hash[String, Type::t]
       def self?.discovered_def_index_for_paths: (Array[String] paths, ?buffer: untyped) -> Hash[Symbol, untyped]

--- a/spec/rigor/analysis/pre_eval_constants_spec.rb
+++ b/spec/rigor/analysis/pre_eval_constants_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+
+# Issue #352 / ADR-17 — a file listed under `pre_eval:` publishes its top-level constants project-wide, not
+# only its patched methods.
+#
+# Every example runs the SAME two-file project twice — once with the declaring file listed under `pre_eval:`
+# and once without — and asserts on both halves. The unlisted half is the regression guard for "a file not
+# listed behaves exactly as today"; asserting only the listed half would let a change that publishes
+# unconditionally pass.
+#
+# Each fixture also carries a SAME-FILE positive control in the declaring file, so a cross-file silence can
+# never be read as evidence: if the control is missing from the output, the harness stopped measuring the
+# engine and the example is void. (`rigor type-of` cannot answer any of this — it parses one file with no
+# project-wide pre-pass, so even a plain `class Foo` reads `Dynamic[top]` under it.)
+RSpec.describe "pre_eval: constant publication" do
+  # Runs `{ "decls.rb" => …, "uses.rb" => … }` as a project and returns the `call.undefined-method` messages.
+  # `publish:` toggles ONLY the `pre_eval:` entry — same sources, same paths, same run shape either way.
+  def undefined_method_messages(sources, publish:)
+    Dir.mktmpdir("rigor-pre-eval-constants-") do |tmpdir|
+      lib = File.join(tmpdir, "lib")
+      FileUtils.mkdir_p(lib)
+      sources.each { |name, body| File.write(File.join(lib, name), body) }
+      Dir.chdir(tmpdir) do
+        config = { "paths" => [lib] }
+        config["pre_eval"] = [File.join(lib, "decls.rb")] if publish
+        result = Rigor::Analysis::Runner.new(
+          configuration: Rigor::Configuration.new(config), cache_store: nil
+        ).run
+        result.diagnostics.select { |d| d.rule == "call.undefined-method" }.map(&:message)
+      end
+    end
+  end
+
+  # The receiver descriptor the `call.undefined-method` message reports for `NAME.probe_x`, or nil when the
+  # call produced no diagnostic at all (the `Dynamic[top]` reading).
+  def receiver_for(messages, probe)
+    messages.grep(/`#{probe}'/).first&.slice(/for (.+)\z/, 1)
+  end
+
+  # Every publishable form, with a same-file control per constant.
+  let(:decls) do
+    <<~RUBY
+      INT_LIT = 42
+      STR_LIT = "hello"
+      ARR_LIT = [1, 2]
+      HSH_LIT = { a: 1 }
+      ALIAS_CLS = String
+      CLASS_NEW = Class.new(StandardError)
+      NIL_CONST = nil
+
+      module Nest
+        NESTED_INT = 7
+      end
+
+      INT_LIT.probe_same_int
+      STR_LIT.probe_same_str
+      ARR_LIT.probe_same_arr
+      HSH_LIT.probe_same_hsh
+      ALIAS_CLS.probe_same_alias
+      NIL_CONST.probe_same_nil
+      Nest::NESTED_INT.probe_same_nested
+    RUBY
+  end
+
+  let(:uses) do
+    <<~RUBY
+      INT_LIT.probe_cross_int
+      STR_LIT.probe_cross_str
+      ARR_LIT.probe_cross_arr
+      HSH_LIT.probe_cross_hsh
+      ALIAS_CLS.probe_cross_alias
+      CLASS_NEW.probe_cross_class_new
+      NIL_CONST.probe_cross_nil
+      Nest::NESTED_INT.probe_cross_nested
+    RUBY
+  end
+
+  let(:listed) { undefined_method_messages({ "decls.rb" => decls, "uses.rb" => uses }, publish: true) }
+  let(:unlisted) { undefined_method_messages({ "decls.rb" => decls, "uses.rb" => uses }, publish: false) }
+
+  describe "the same-file positive controls" do
+    it "fires value-pinned in the declaring file whether or not the file is listed" do
+      %w[unlisted listed].each do |half|
+        messages = send(half)
+        expect(receiver_for(messages, "probe_same_int")).to eq("42"), half
+        expect(receiver_for(messages, "probe_same_str")).to eq('"hello"'), half
+        expect(receiver_for(messages, "probe_same_arr")).to eq("[1, 2]"), half
+        expect(receiver_for(messages, "probe_same_hsh")).to eq("{ a: 1 }"), half
+        expect(receiver_for(messages, "probe_same_alias")).to eq("singleton(String)"), half
+        expect(receiver_for(messages, "probe_same_nested")).to eq("7"), half
+      end
+    end
+  end
+
+  describe "an unlisted declaring file (today's behaviour, unchanged)" do
+    it "publishes nothing value-shaped across the file boundary" do
+      %w[probe_cross_int probe_cross_str probe_cross_arr
+         probe_cross_hsh probe_cross_alias probe_cross_nested].each do |probe|
+        expect(receiver_for(unlisted, probe)).to be_nil, probe
+      end
+    end
+
+    it "still crosses the meta-new class-shaped form (ScopeIndexer#record_class_new_constant_decl)" do
+      expect(receiver_for(unlisted, "probe_cross_class_new")).to eq("singleton(StandardError)")
+    end
+  end
+
+  describe "a listed declaring file" do
+    it "publishes the WIDENED type, never the value-pinned one" do
+      expect(receiver_for(listed, "probe_cross_int")).to eq("Integer")
+      expect(receiver_for(listed, "probe_cross_str")).to eq("String")
+      expect(receiver_for(listed, "probe_cross_nested")).to eq("Integer")
+    end
+
+    it "erases a Tuple to raw Array and a HashShape to raw Hash" do
+      expect(receiver_for(listed, "probe_cross_arr")).to eq("Array")
+      expect(receiver_for(listed, "probe_cross_hsh")).to eq("Hash")
+    end
+
+    it "publishes a class-alias constant, which no meta-new promotion covers" do
+      expect(receiver_for(listed, "probe_cross_alias")).to eq("singleton(String)")
+    end
+
+    it "leaves the meta-new form's existing cross-file answer untouched" do
+      expect(receiver_for(listed, "probe_cross_class_new")).to eq("singleton(StandardError)")
+    end
+
+    it "declines a nil-valued constant in both directions" do
+      expect(receiver_for(listed, "probe_cross_nil")).to be_nil
+      expect(receiver_for(unlisted, "probe_cross_nil")).to be_nil
+    end
+  end
+
+  describe "the multi-file write rule (widen on conflict)" do
+    def two_publisher_receiver(second_value)
+      messages = Dir.mktmpdir("rigor-pre-eval-conflict-") do |tmpdir|
+        lib = File.join(tmpdir, "lib")
+        FileUtils.mkdir_p(lib)
+        File.write(File.join(lib, "a.rb"), "SHARED = 1\n")
+        File.write(File.join(lib, "b.rb"), "SHARED = #{second_value}\n")
+        File.write(File.join(lib, "uses.rb"), "SHARED.probe_conflict\n")
+        Dir.chdir(tmpdir) do
+          Rigor::Analysis::Runner.new(
+            configuration: Rigor::Configuration.new(
+              "paths" => [lib],
+              "pre_eval" => [File.join(lib, "a.rb"), File.join(lib, "b.rb")]
+            ),
+            cache_store: nil
+          ).run.diagnostics.select { |d| d.rule == "call.undefined-method" }.map(&:message)
+        end
+      end
+      receiver_for(messages, "probe_conflict")
+    end
+
+    it "publishes the shared class when both writes widen to it (never `1 | 2`)" do
+      expect(two_publisher_receiver("2")).to eq("Integer")
+    end
+
+    it "drops the name entirely when two publishers disagree" do
+      expect(two_publisher_receiver('"two"')).to be_nil
+    end
+  end
+
+  describe "the pool path (ADR-15 sequential equivalence)" do
+    it "seeds a fork-worker scope with the same published table" do
+      Dir.mktmpdir("rigor-pre-eval-pool-") do |tmpdir|
+        lib = File.join(tmpdir, "lib")
+        FileUtils.mkdir_p(lib)
+        File.write(File.join(lib, "decls.rb"), "TIMEOUT = 30\n")
+        File.write(File.join(lib, "uses.rb"), "TIMEOUT.probe_pool\n")
+        Dir.chdir(tmpdir) do
+          result = Rigor::Analysis::Runner.new(
+            configuration: Rigor::Configuration.new(
+              "paths" => [lib], "pre_eval" => [File.join(lib, "decls.rb")]
+            ),
+            cache_store: nil, workers: 2
+          ).run
+          messages = result.diagnostics.select { |d| d.rule == "call.undefined-method" }.map(&:message)
+          expect(receiver_for(messages, "probe_pool")).to eq("Integer")
+        end
+      end
+    end
+  end
+end

--- a/spec/rigor/inference/pre_eval_constants_spec.rb
+++ b/spec/rigor/inference/pre_eval_constants_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rigor/inference/pre_eval_constants"
+
+# Issue #352 — the type-level half of the `pre_eval:` constant publication. The cross-file behaviour these
+# rules produce is pinned end-to-end in `spec/rigor/analysis/pre_eval_constants_spec.rb`; this file pins the
+# rules themselves, including the arms an end-to-end fixture cannot easily reach.
+RSpec.describe Rigor::Inference::PreEvalConstants do
+  let(:combinator) { Rigor::Type::Combinator }
+
+  describe ".widen" do
+    it "erases a value-pinned constant to its class" do
+      expect(described_class.widen(combinator.constant_of(42))).to eq(combinator.nominal_of("Integer"))
+      expect(described_class.widen(combinator.constant_of("x"))).to eq(combinator.nominal_of("String"))
+      expect(described_class.widen(combinator.constant_of(:sym))).to eq(combinator.nominal_of("Symbol"))
+    end
+
+    it "declines a nil-valued constant" do
+      expect(described_class.widen(combinator.constant_of(nil))).to be_nil
+    end
+
+    it "erases a bounded integer and a refinement to their base" do
+      expect(described_class.widen(combinator.integer_range(1, 6))).to eq(combinator.nominal_of("Integer"))
+      refined = Rigor::Type::Refined.new(combinator.nominal_of("String"), :"non-empty-string")
+      expect(described_class.widen(refined)).to eq(combinator.nominal_of("String"))
+    end
+
+    it "erases a Tuple to raw Array and a HashShape to raw Hash, dropping the shape" do
+      tuple = Rigor::Type::Tuple.new([combinator.constant_of(1), combinator.constant_of(2)])
+      shape = Rigor::Type::HashShape.new({ a: combinator.constant_of(1) })
+      expect(described_class.widen(tuple)).to eq(combinator.nominal_of("Array"))
+      expect(described_class.widen(shape)).to eq(combinator.nominal_of("Hash"))
+    end
+
+    it "strips a nominal's type arguments" do
+      applied = combinator.nominal_of("Array", type_args: [combinator.nominal_of("String")])
+      expect(described_class.widen(applied)).to eq(combinator.nominal_of("Array"))
+    end
+
+    it "passes a class-alias singleton through unchanged" do
+      singleton = combinator.singleton_of("String")
+      expect(described_class.widen(singleton)).to eq(singleton)
+    end
+
+    it "widens every member of a union" do
+      union = combinator.union(combinator.constant_of(1), combinator.constant_of("a"))
+      expect(described_class.widen(union))
+        .to eq(combinator.union(combinator.nominal_of("Integer"), combinator.nominal_of("String")))
+    end
+
+    it "declines a union whose extent is not fully known" do
+      union = combinator.union(combinator.constant_of(1), combinator.top)
+      expect(described_class.widen(union)).to be_nil
+    end
+
+    it "declines the carriers that already read as `Dynamic[top]` cross-file" do
+      [combinator.top, combinator.bot, combinator.untyped,
+       combinator.dynamic(combinator.nominal_of("Integer"))].each do |type|
+        expect(described_class.widen(type)).to be_nil
+      end
+    end
+  end
+
+  describe ".collect" do
+    # A stub `scope_builder` is enough here: the fixtures declare literals, so the rvalue typer never needs an
+    # RBS environment. The environment-bound path is covered end-to-end in the analysis spec.
+    def collect(files)
+      Dir.mktmpdir("rigor-pre-eval-collect-") do |dir|
+        paths = files.map do |name, body|
+          File.join(dir, name).tap { |path| File.write(path, body) }
+        end
+        described_class.collect(paths: paths, scope_builder: ->(path) { Rigor::Scope.empty(source_path: path) })
+      end
+    end
+
+    it "publishes the widened table keyed by qualified name" do
+      table = collect("a.rb" => "TOP = 1\nmodule M\n  NESTED = \"s\"\nend\n")
+      expect(table["TOP"]).to eq(combinator.nominal_of("Integer"))
+      expect(table["M::NESTED"]).to eq(combinator.nominal_of("String"))
+    end
+
+    it "keeps a name two files agree on, and drops one they disagree on" do
+      table = collect("a.rb" => "AGREE = 1\nCLASH = 1\n", "b.rb" => "AGREE = 2\nCLASH = \"two\"\n")
+      expect(table["AGREE"]).to eq(combinator.nominal_of("Integer"))
+      expect(table).not_to have_key("CLASH")
+    end
+
+    it "does not let a later agreeing write resurrect a conflicted name" do
+      table = collect("a.rb" => "X = 1\n", "b.rb" => "X = \"s\"\n", "c.rb" => "X = 2\n")
+      expect(table).not_to have_key("X")
+    end
+
+    it "fails soft on an unparseable file rather than aborting the collection" do
+      table = collect("a.rb" => "GOOD = 1\n", "b.rb" => "def broken(\n")
+      expect(table["GOOD"]).to eq(combinator.nominal_of("Integer"))
+    end
+
+    it "returns a frozen table" do
+      expect(collect("a.rb" => "K = 1\n")).to be_frozen
+    end
+  end
+end


### PR DESCRIPTION
Closes #352.

ADR-17 slice 2 gave `pre_eval:` a project-wide patched-**method** registry. A constant declared in the same file stayed invisible across the file boundary: `Scope#in_source_constants` is per-file and is deliberately not part of `Runner#project_scope_seed_tables`, so only class-shaped constants ever crossed. `TIMEOUT = 30` in a listed file read as `Dynamic[top]` everywhere else — and listing the file changed nothing, because the axis carried methods only.

## The published type is widened, never the value

| Declared | Same file | Published cross-file |
| --- | --- | --- |
| `INT_LIT = 42` | `42` | `Integer` |
| `STR_LIT = "hello"` | `"hello"` | `String` |
| `ARR_LIT = [1, 2]` | Tuple | `Array` |
| `HSH_LIT = { a: 1 }` | HashShape | `Hash` |
| `ALIAS_CLS = String` | `singleton(String)` | `singleton(String)` |

Same-file propagation is value-pinned, and carrying that verbatim across a boundary would land diagnostics in files whose author never opened the definition — a closed `HashShape` makes `CONFIG.fetch(:b)` fire, a `Tuple` routes past the RBS overload a call site relied on. Today's cross-file `Dynamic[top]` is false-positive-free **by construction**, so precision here can only spend that budget; this slice spends as little as possible. Anything the rule does not recognise declines rather than falling back, and `X = nil` declines on purpose — a placeholder far more often than a genuine `NilClass`.

Across files a repeated name **widens on conflict** rather than unioning: `1 | 2` is not what anyone expects to read.

Opt-in by construction — no `pre_eval:` entry seeds no table and is byte-identical. `pre_eval:` files now also contribute to the run-dependency descriptor: ADR-17 permits listing a file that is not under `paths:`, and such a file never appears in the expansion, so without the entry an edit would leave the run-result cache serving stale diagnostics.

## Corpus gate — and the vacuous first run

Zero new firings across ten survey targets with **every analysed file** listed under `pre_eval:` (maximum exposure — no corpus target configures the axis, so a plain A/B would be trivially zero and prove nothing).

**The first run of that gate was vacuous and I nearly reported it.** A generated config living outside the project has its relative `paths` expanded against the *config file's* directory, not cwd, so it analysed **0 files** and reported config errors as "350 diagnostics". Re-run with absolute paths (redmine 776, mastodon 2352 — comparable to normal runs).

Two independent checks that the zero is real:

- The toggle flips a fixture from **0 to 2** diagnostics, typed `Integer` and `String` — so the A/B can see a difference, and the widening rule is what actually ships.
- Instrumenting the seed on redmine prints **177 constants**, widened to `Integer` / `Regexp` / `Hash`. The feature genuinely activated on the corpus rather than silently no-opping.

## Verification

`make verify` exit 0 and `make docs-check` exit 0, both read unpiped, **on a branch rebased onto master with #359 already merged** — the two parallel slices touched disjoint files, but no single PR's CI sees the integrated tree. `git diff --check` clean. 25 new examples.

Authored largely by a subagent that stalled before finishing; I rebased, verified, ran the corpus gate, and added the changelog and manual entries.
