### PR TITLE
Distinguish RBS declarations from references in rigor unused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,6 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
-### Fixed
-
-- **[engine]** `rigor unused` no longer treats a class's own RBS signature as a reference to that class, so a project that ships generated signatures stops hiding its own dead code ([#363](https://github.com/rigortype/rigor/issues/363)).
-  - Signature files both declare and reference, and only references count: `class Talk < ApplicationRecord` in `sig/` references `ApplicationRecord`, while the `Talk` it declares is not evidence that anything uses `Talk`. On one application 48 of 101 roots came from `sig/` and eleven rows never appeared in the report.
-
 ### Added
 
 - **[cli]** `rigor unused` reports project classes and modules that nothing reachable references — a starting point for dead-code removal ([#347](https://github.com/rigortype/rigor/issues/347), [ADR-102](docs/adr/102-unused-code-reachability-report.md)).
@@ -41,6 +36,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** `rigor unused` no longer treats a class's own RBS signature as a reference to that class, so a project that ships generated signatures stops hiding its own dead code ([#363](https://github.com/rigortype/rigor/issues/363)).
+  - Signature files both declare and reference, and only references count: `class Talk < ApplicationRecord` in `sig/` references `ApplicationRecord`, while the `Talk` it declares is not evidence that anything uses `Talk`. On one application 48 of 101 roots came from `sig/` and eleven rows never appeared in the report.
 - **[engine]** A constant inherited from a superclass or an included module now resolves from the subclass body, and no longer loses to a same-named constant at the top level ([#354](https://github.com/rigortype/rigor/issues/354)).
   - Ruby looks a constant up through the enclosing lexical scopes, then through the ancestors of the innermost one, and only then at the top level. Rigor skipped the ancestor step, so `KEY` written inside `class Sub < Base` was typed as the top-level `KEY` rather than `Base::KEY` — everything downstream of that read was then reasoning about the wrong type. Constants owned by a class outside your project, such as a gem superclass, are still only found by their full name.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Fixed
+
+- **[engine]** `rigor unused` no longer treats a class's own RBS signature as a reference to that class, so a project that ships generated signatures stops hiding its own dead code ([#363](https://github.com/rigortype/rigor/issues/363)).
+  - Signature files both declare and reference, and only references count: `class Talk < ApplicationRecord` in `sig/` references `ApplicationRecord`, while the `Talk` it declares is not evidence that anything uses `Talk`. On one application 48 of 101 roots came from `sig/` and eleven rows never appeared in the report.
+
 ### Added
 
 - **[cli]** `rigor unused` reports project classes and modules that nothing reachable references — a starting point for dead-code removal ([#347](https://github.com/rigortype/rigor/issues/347), [ADR-102](docs/adr/102-unused-code-reachability-report.md)).

--- a/docs/manual/18-removing-dead-code.md
+++ b/docs/manual/18-removing-dead-code.md
@@ -272,23 +272,17 @@ baseline file for this command.
 
 ### If your project ships generated RBS
 
-A class's own generated signature is currently counted as a reference
-to itself, and because signature references are file-level they become
-roots. On one application 48 of 101 roots came from `sig/`, hiding
-seven candidates and ten test-only rows. This is [issue #363][issue-363].
+Signature files both declare and reference, and only the references
+count. `class Talk < ApplicationRecord` in `sig/` references
+`ApplicationRecord`; the `Talk` it declares is not a reference to
+`Talk`. If it were, every class with a generated signature would root
+itself and the report would be empty of exactly the rows you want.
 
-Until it is fixed, compare against a signature-free run. Copy your
-config, empty one key, and pass it explicitly:
-
-```sh
-cp .rigor.yml /tmp/no-sig.yml   # then set: signature_paths: []
-rigor unused --config /tmp/no-sig.yml
-```
-
-This cannot invent false candidates. `rigor unused` performs no type
-inference — `signature_paths:` feeds only the reference harvest — so
-removing signatures removes references and nothing else. Where the two
-runs disagree, the signature-free one is the more honest number.
+That is worth knowing because it was wrong until recently, and the
+symptom was silent: on one application 48 of 101 roots came from `sig/`
+and eleven rows never appeared. If you are on a release before this was
+fixed ([issue #363][issue-363]), compare against a run with
+`signature_paths:` emptied — a large gap between the two is the tell.
 
 ## Automating it
 

--- a/lib/rigor/analysis/reachability/signature_scan.rb
+++ b/lib/rigor/analysis/reachability/signature_scan.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "rbs"
+
+require_relative "scan"
+
+module Rigor
+  module Analysis
+    module Reachability
+      # ADR-102 WD7 / issue #363 — the RBS half of the reference corpus.
+      #
+      # A constant named only from the project's own `sig/` is genuinely referenced, which is why signatures
+      # are read at all: the #345 probe reported such constants as false candidates until an RBS-side hook was
+      # added. But a signature file also DECLARES, and the two must not be confused.
+      #
+      # The first implementation scanned each file for constant-shaped tokens, which cannot tell the
+      # difference. With `rbs-inline`-generated signatures — where every project class has a mirror
+      # declaration under `sig/` — that made a large fraction of the project unconditionally reachable: on one
+      # application 48 of 101 roots came from `sig/`, hiding seven candidates and ten test-only rows. Over-supply
+      # is the worse direction (an under-supplied root leaves a row where a human can see it; an over-supplied
+      # one removes it where nobody will), so this parses instead.
+      #
+      # The rule: a declaration's own name is a DECLARATION and contributes nothing. Every type name appearing
+      # in a POSITION — a superclass, a mixin argument, a parameter or return type, a constant's type, a type
+      # alias body, a generic argument — is a reference and counts.
+      module SignatureScan
+        module_function
+
+        # @param file [String] path to a `.rbs` file.
+        # @return [Array<Scan::Reference>] one file-level reference per distinct referenced name. Empty when the
+        #   file cannot be read or parsed — a broken signature is the analyzer's business, not this scan's.
+        def call(file)
+          _, _, decls = ::RBS::Parser.parse_signature(::RBS::Buffer.new(name: file, content: File.read(file)))
+          names = []
+          decls.each { |decl| walk(decl, [], names) }
+          names.uniq.map do |name|
+            Scan::Reference.new(as_written: name, nesting: [].freeze, from: nil, role: :config, path: file,
+                                line: 1)
+          end
+        rescue ::RBS::BaseError, SystemCallError, ArgumentError
+          []
+        end
+
+        # Walks a declaration, threading the lexical nesting so a name written relative to an enclosing module
+        # resolves the way the graph's own candidate walk expects. Without this, `module A; class B < C; end`
+        # would contribute a bare `C` that resolves against nothing.
+        def walk(node, nesting, out)
+          case node
+          when ::RBS::AST::Declarations::Class then walk_class(node, nesting, out)
+          when ::RBS::AST::Declarations::Module then walk_module(node, nesting, out)
+          when ::RBS::AST::Declarations::Interface
+            descend(node, nesting + segments(node.name), out)
+          when ::RBS::AST::Members::Include, ::RBS::AST::Members::Extend, ::RBS::AST::Members::Prepend
+            record(node.name, nesting, out)
+            node.args&.each { |arg| collect_types(arg, nesting, out) }
+          when ::RBS::AST::Members::MethodDefinition
+            node.overloads.each { |overload| collect_types(overload.method_type, nesting, out) }
+          when *TYPED_NODES
+            collect_types(node.type, nesting, out)
+          end
+        end
+
+        # Nodes whose whole contribution is the type they carry: a constant's or alias's right-hand side, and
+        # the attribute / variable families.
+        TYPED_NODES = [
+          ::RBS::AST::Declarations::Constant, ::RBS::AST::Declarations::TypeAlias,
+          ::RBS::AST::Members::AttrReader, ::RBS::AST::Members::AttrWriter,
+          ::RBS::AST::Members::AttrAccessor, ::RBS::AST::Members::InstanceVariable,
+          ::RBS::AST::Members::ClassInstanceVariable, ::RBS::AST::Members::ClassVariable
+        ].freeze
+
+        def walk_class(node, nesting, out)
+          record(node.super_class&.name, nesting, out)
+          node.super_class&.args&.each { |arg| collect_types(arg, nesting, out) }
+          descend(node, nesting + segments(node.name), out)
+        end
+
+        def walk_module(node, nesting, out)
+          node.self_types&.each { |self_type| record(self_type.name, nesting, out) }
+          descend(node, nesting + segments(node.name), out)
+        end
+
+        def descend(node, nesting, out)
+          node.members&.each { |member| walk(member, nesting, out) }
+        end
+
+        # Every `RBS::TypeName` reachable from a type, found reflectively. RBS's type zoo is wide (unions,
+        # intersections, tuples, records, optionals, procs, generics) and grows between releases; enumerating
+        # the classes would silently drop references the day a new one lands, and dropping a reference here
+        # manufactures a false candidate.
+        def collect_types(type, nesting, out)
+          return if type.nil?
+
+          record(type.name, nesting, out) if type.respond_to?(:name) && type.name.is_a?(::RBS::TypeName)
+          type.instance_variables.each do |ivar|
+            value = type.instance_variable_get(ivar)
+            case value
+            when ::RBS::TypeName then record(value, nesting, out)
+            when Array then value.each { |v| collect_types(v, nesting, out) }
+            when Hash then value.each_value { |v| collect_types(v, nesting, out) }
+            else collect_types(value, nesting, out) if value.respond_to?(:instance_variables)
+            end
+          end
+        end
+
+        # A name is recorded both as written under its nesting and bare, because the graph resolves an
+        # `as_written` name against a single nesting and an RBS file's names may be absolute (`::Foo::Bar`),
+        # relative to the enclosing module, or top-level. Over-approximating WHICH of those a name is cannot
+        # invent a candidate — it can only fail to remove one — whereas guessing wrong would.
+        def record(type_name, nesting, out)
+          return if type_name.nil?
+
+          bare = type_name.to_s.delete_prefix("::")
+          return if bare.empty?
+
+          out << bare
+          out << "#{nesting.join('::')}::#{bare}" unless nesting.empty?
+        end
+
+        def segments(type_name)
+          type_name.to_s.delete_prefix("::").split("::")
+        end
+      end
+    end
+  end
+end

--- a/lib/rigor/cli/unused_command.rb
+++ b/lib/rigor/cli/unused_command.rb
@@ -8,6 +8,7 @@ require_relative "../analysis/path_expansion"
 require_relative "../analysis/reachability/scan"
 require_relative "../analysis/reachability/graph"
 require_relative "../analysis/reachability/plugin_roots"
+require_relative "../analysis/reachability/signature_scan"
 require_relative "options"
 require_relative "command"
 require_relative "probe_environment"
@@ -132,28 +133,13 @@ module Rigor
       # otherwise never match anything and silently produce a root set of zero.
       # A constant named only from the project's own `sig/` is referenced — the #345 probe reported exactly this
       # as a false candidate until an RBS-side hook was added, because `Reflection.resolve_constant_type` is
-      # source-side only.
-      #
-      # Harvested by scanning each signature for constant-shaped tokens rather than by walking the parsed RBS
-      # AST. That deliberately OVER-approximates (a name inside a comment counts), and over-approximating
-      # references is the false-positive-safe direction for this report: it can only remove candidates, never
-      # invent one. Every such reference is attributed at file level with the `:config` role, so it seeds
-      # production reachability but is not mistaken for test usage.
-      CONSTANT_TOKEN = /\b[A-Z][A-Za-z0-9_]*(?:::[A-Z][A-Za-z0-9_]*)*/
-      private_constant :CONSTANT_TOKEN
-
+      # source-side only. A signature also DECLARES, though, and {Analysis::Reachability::SignatureScan} is
+      # what keeps the two apart (issue #363).
       def signature_references(configuration)
         Array(configuration.signature_paths).flat_map do |dir|
           next [] unless File.directory?(dir)
 
-          Dir.glob(File.join(dir, "**/*.rbs")).flat_map do |file|
-            File.read(file).scan(CONSTANT_TOKEN).map do |name|
-              Analysis::Reachability::Scan::Reference.new(as_written: name, nesting: [].freeze, from: nil,
-                                                          role: :config, path: file, line: 1)
-            end
-          rescue SystemCallError
-            []
-          end
+          Dir.glob(File.join(dir, "**/*.rbs")).flat_map { |file| Analysis::Reachability::SignatureScan.call(file) }
         end
       end
 

--- a/spec/rigor/analysis/reachability/signature_scan_spec.rb
+++ b/spec/rigor/analysis/reachability/signature_scan_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "rigor/analysis/reachability/signature_scan"
+
+# Issue #363 — a signature file both DECLARES and REFERENCES, and the reachability report must not confuse
+# the two. Counting a declaration as a reference makes a class root itself, which on a project with generated
+# RBS silently hides dead code; counting no references at all re-opens the false candidates the #345 probe
+# measured. Every "does not reference" example below is therefore paired with one that must still reference.
+RSpec.describe Rigor::Analysis::Reachability::SignatureScan do
+  let(:dir) { Dir.mktmpdir("rigor-signature-scan-") }
+
+  after { FileUtils.remove_entry(dir) if File.directory?(dir) }
+
+  def write_signature(rbs)
+    File.join(dir, "sig.rbs").tap { |path| File.write(path, rbs) }
+  end
+
+  def names_in(rbs)
+    described_class.call(write_signature(rbs)).map(&:as_written)
+  end
+
+  describe "declarations do not reference themselves" do
+    it "does not treat a class declaration as a reference to the class" do
+      expect(names_in("class Orphan\nend\n")).not_to include("Orphan")
+    end
+
+    it "does not treat a module declaration as a reference to the module" do
+      expect(names_in("module Orphan\nend\n")).not_to include("Orphan")
+    end
+
+    # The exact shape that hid rows on a real project: `rbs-inline` mirrors every class into `sig/`, so a
+    # nested declaration must not root itself or its enclosing namespace either.
+    it "does not reference a nested declaration or its namespace" do
+      names = names_in("module ApplicationCable\n  class Channel\n  end\nend\n")
+      expect(names).not_to include("ApplicationCable", "ApplicationCable::Channel", "Channel")
+    end
+
+    it "does not treat a constant or type-alias declaration as a reference to its own name" do
+      expect(names_in("TIMEOUT: Integer\n")).not_to include("TIMEOUT")
+      expect(names_in("type result = Integer\n")).not_to include("result")
+    end
+  end
+
+  describe "positions are references" do
+    it "references a superclass" do
+      expect(names_in("class Talk < ApplicationRecord\nend\n")).to include("ApplicationRecord")
+    end
+
+    it "references a mixin argument" do
+      expect(names_in("class Talk\n  include Publishable\nend\n")).to include("Publishable")
+    end
+
+    it "references parameter and return types" do
+      names = names_in("class Talk\n  def bookmark_by: (User user) -> TalkBookmark?\nend\n")
+      expect(names).to include("User", "TalkBookmark")
+    end
+
+    it "references a type inside a generic argument" do
+      expect(names_in("class Talk\n  def all: () -> Array[Speaker]\nend\n")).to include("Speaker")
+    end
+
+    it "references an attribute's type" do
+      expect(names_in("class Talk\n  attr_reader venue: Venue\nend\n")).to include("Venue")
+    end
+
+    it "references a constant declaration's type" do
+      expect(names_in("DEFAULT: Venue\n")).to include("Venue")
+    end
+  end
+
+  describe "nesting" do
+    # A name written relative to an enclosing module has to reach the graph in a form its candidate walk can
+    # resolve, or the reference is silently lost and the class becomes a false candidate.
+    it "records a relative reference under its enclosing namespace as well as bare" do
+      names = names_in("module Admin\n  class Report < Base\n  end\nend\n")
+      expect(names).to include("Base", "Admin::Base")
+    end
+
+    it "strips a leading :: from an absolute name" do
+      expect(names_in("class Talk < ::ApplicationRecord\nend\n")).to include("ApplicationRecord")
+    end
+  end
+
+  describe "fail-soft" do
+    it "returns nothing for an unparseable signature rather than raising" do
+      expect(names_in("class Talk < <<<\n")).to eq([])
+    end
+
+    it "returns nothing for a missing file rather than raising" do
+      expect(described_class.call(File.join(dir, "absent.rbs"))).to eq([])
+    end
+  end
+
+  describe "the reference shape the graph consumes" do
+    it "emits file-level references carrying the config role" do
+      reference = described_class.call(write_signature("class Talk < ApplicationRecord\nend\n")).first
+
+      expect(reference.from).to be_nil
+      expect(reference.role).to eq(:config)
+      expect(reference.nesting).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
Closes #363.

A signature file both declares and references, and only the references are evidence that anything uses a class. The harvest was a regex over the file text, which cannot tell the two apart, so `class Talk` under `sig/` counted as a reference to `Talk` and rooted it.

On a project using `rbs-inline` — where every class has a generated mirror declaration — that roots most of the project.

## Measured

| conference-app | before | after |
| --- | ---: | ---: |
| roots | 101 | **90** |
| candidates | 2 | **3** |
| reachable only from tests | 0 | **6** |

48 of 101 roots came from `sig/`; eleven rows never appeared. The correct answer sits **between** the buggy 2 and the 9 a signature-free run gives, because genuine signature references still root what they name — `ApplicationRecord` in a superclass position, `User` and `TalkBookmark` in `def bookmark_by: (User user) -> TalkBookmark?`.

redmine and mastodon are **byte-identical** before and after. Neither ships project signatures, so this moves only projects that do. (My first measurement of those two showed a collapse to 27 and 36 roots — that was broken shell quoting swallowing `--config`, not a regression. Re-measured with a script file.)

## Approach

Parses the signature and records only names in **positions**: a superclass, a mixin argument, a parameter or return type, a constant's or alias's right-hand side, a generic argument. Declaration names contribute nothing.

Type walking is reflective rather than an enumeration of RBS's type classes — that zoo is wide and grows between releases, and a dropped reference here manufactures a false candidate.

Names are recorded both bare and under their enclosing nesting, because RBS names may be absolute, relative to an enclosing module, or top-level, and the graph resolves an as-written name against one nesting. Over-approximating which of the three a name is can only fail to remove a candidate; guessing wrong would invent one.

## Verification

15 specs, each "does not reference" example paired with one that must still reference — the failure mode of over-correcting here is re-opening the false candidates the #345 probe measured, which a suite of decline assertions alone would pass.

`make verify` exit 0, `make docs-check` exit 0, `git diff --check` clean. Manual chapter 18 loses the signature-free-run workaround it recommended, which this makes obsolete, and `[Unreleased]` carries a user-facing entry.