### PR TITLE
Stop rigor unused crashing on ill-encoded sources and reading submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[cli]** `rigor unused` no longer crashes on a source file with a magic encoding comment, and no longer reads git submodules ([#365](https://github.com/rigortype/rigor/issues/365)).
+  - A string literal in a `# encoding: big5` file parses to bytes that are not valid UTF-8; the report took one as a constant name and died on the whole run. A name that is not valid UTF-8 cannot be a constant, so it is dropped. Submodules are separate projects whose files are neither your declarations nor references to them — on a checkout that vendors upstream sources they were 77% of the files read.
 - **[engine]** `rigor unused` no longer treats a class's own RBS signature as a reference to that class, so a project that ships generated signatures stops hiding its own dead code ([#363](https://github.com/rigortype/rigor/issues/363)).
   - Signature files both declare and reference, and only references count: `class Talk < ApplicationRecord` in `sig/` references `ApplicationRecord`, while the `Talk` it declares is not evidence that anything uses `Talk`. On one application 48 of 101 roots came from `sig/` and eleven rows never appeared in the report.
 - **[engine]** A constant inherited from a superclass or an included module now resolves from the subclass body, and no longer loses to a same-named constant at the top level ([#354](https://github.com/rigortype/rigor/issues/354)).

--- a/lib/rigor/analysis/reachability/project_files.rb
+++ b/lib/rigor/analysis/reachability/project_files.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Rigor
+  module Analysis
+    module Reachability
+      # Which files in a checkout are the PROJECT's, for the purpose of harvesting references.
+      #
+      # `rigor unused` reads references from the whole project rather than only the analysed `paths:` (ADR-102
+      # WD7), which makes "the whole project" a question that needs answering rather than assuming.
+      module ProjectFiles
+        # Trees that are never a project's own source. A reference found inside a vendored gem is not evidence
+        # about this project, and globbing them can cost more than every analysed file combined.
+        VENDOR_DIRS = %r{\A(vendor|node_modules|tmp|\.git|\.rigor|coverage)/}
+
+        module_function
+
+        # Path prefixes of the checkout's git submodules, from `.gitmodules`.
+        #
+        # A submodule is a separate project that happens to live inside this one; its contents are neither this
+        # project's declarations nor references to them. Rigor's own repository is the case that made this
+        # unmissable — it vendors upstream sources under `references/`, 13,894 of the 18,002 files the
+        # reference glob would otherwise read, and one of them crashed the run outright.
+        #
+        # Reads `.gitmodules` rather than probing for nested `.git` entries: it is one cheap file against a
+        # second full tree walk, and it is what the repository itself declares. A nested checkout that is not a
+        # registered submodule is therefore not detected — `exclude:` covers that case.
+        def submodule_prefixes(root)
+          gitmodules = File.join(root, ".gitmodules")
+          return [] unless File.file?(gitmodules)
+
+          File.read(gitmodules).scan(/^\s*path\s*=\s*(.+)$/).flatten.filter_map do |path|
+            trimmed = path.strip
+            "#{trimmed.delete_suffix('/')}/" unless trimmed.empty?
+          end
+        rescue SystemCallError
+          []
+        end
+
+        # @param relative_paths [Array<String>] paths relative to `root`.
+        # @return [Array<String>] those that belong to the project itself.
+        def own(relative_paths, root)
+          prefixes = submodule_prefixes(root)
+          relative_paths.grep_v(VENDOR_DIRS).reject { |rel| prefixes.any? { |prefix| rel.start_with?(prefix) } }
+        end
+      end
+    end
+  end
+end

--- a/lib/rigor/analysis/reachability/scan.rb
+++ b/lib/rigor/analysis/reachability/scan.rb
@@ -56,6 +56,17 @@ module Rigor
         # @param target_ruby [String, nil] Prism version string, threaded from the project configuration.
         # @return [Result, nil] nil when the file does not parse (a parse error is the analyzer's business, not
         #   this scan's — it simply contributes nothing rather than half a file).
+        # A constant name is ASCII by construction, so a byte sequence that is not valid UTF-8 cannot be one.
+        # Dropping it is both correct and the only safe answer: carrying it forward crashed the whole run on
+        # the first `String#sub` downstream, which is how this surfaced — `rigor unused` on Rigor's own
+        # repository, which vendors a CRuby checkout containing deliberately ill-encoded encoding fixtures.
+        def self.usable_name(raw)
+          return nil if raw.nil?
+
+          name = raw.dup.force_encoding(Encoding::UTF_8)
+          name.valid_encoding? ? name : nil
+        end
+
         def self.call(path:, source:, target_ruby: nil)
           parsed = if target_ruby
                      Prism.parse(source, filepath: path,
@@ -175,17 +186,26 @@ module Rigor
             subject = node.name == :const_get ? node.arguments&.arguments&.first : node.receiver
             return if subject.nil?
 
-            reason = "#{node.name} on #{SUBJECT_SHAPES.fetch(subject.class, 'a computed value')}"
+            name, prefix = dynamic_target(subject)
+            # A literal whose bytes are not valid UTF-8 cannot name a constant; dropping it is the only safe
+            # answer, and carrying it forward crashed the whole run downstream.
+            return if subject.is_a?(Prism::StringNode) && name.nil?
+            return if subject.is_a?(Prism::SymbolNode) && name.nil?
+
+            @dynamic_uses << DynamicUse.new(
+              name: name, prefix: prefix, site: site(node), path: @path, line: node.location.start_line,
+              reason: "#{node.name} on #{SUBJECT_SHAPES.fetch(subject.class, 'a computed value')}"
+            )
+          end
+
+          # `[exact name, bounded namespace]` for a dynamic-resolution subject. A literal names its constant
+          # exactly; an interpolation can only bound the namespace its literal head names; anything else bounds
+          # nothing.
+          def dynamic_target(subject)
             case subject
-            when Prism::StringNode, Prism::SymbolNode
-              @dynamic_uses << DynamicUse.new(name: subject.unescaped, prefix: nil, reason: reason,
-                                              site: site(node), path: @path, line: node.location.start_line)
-            when Prism::InterpolatedStringNode
-              @dynamic_uses << DynamicUse.new(name: nil, prefix: literal_prefix(subject), reason: reason,
-                                              site: site(node), path: @path, line: node.location.start_line)
-            else
-              @dynamic_uses << DynamicUse.new(name: nil, prefix: nil, reason: reason,
-                                              site: site(node), path: @path, line: node.location.start_line)
+            when Prism::StringNode, Prism::SymbolNode then [Scan.usable_name(subject.unescaped), nil]
+            when Prism::InterpolatedStringNode then [nil, literal_prefix(subject)]
+            else [nil, nil]
             end
           end
 
@@ -199,7 +219,10 @@ module Rigor
             head = node.parts.first
             return nil unless head.is_a?(Prism::StringNode)
 
-            trimmed = head.unescaped.sub(/::\z/, "")
+            literal = Scan.usable_name(head.unescaped)
+            return nil if literal.nil?
+
+            trimmed = literal.sub(/::\z/, "")
             trimmed.empty? ? nil : trimmed
           end
 

--- a/lib/rigor/cli/unused_command.rb
+++ b/lib/rigor/cli/unused_command.rb
@@ -9,6 +9,7 @@ require_relative "../analysis/reachability/scan"
 require_relative "../analysis/reachability/graph"
 require_relative "../analysis/reachability/plugin_roots"
 require_relative "../analysis/reachability/signature_scan"
+require_relative "../analysis/reachability/project_files"
 require_relative "options"
 require_relative "command"
 require_relative "probe_environment"
@@ -29,10 +30,6 @@ module Rigor
       # artifacts on two of three corpus targets. Harvesting references from a file is far cheaper than
       # type-checking it, so the report takes the wider set.
       REFERENCE_GLOB = "**/*.{rb,rake}"
-
-      # Trees that are never the project's own source. Globbing them costs far more than every analysed file
-      # combined on a real app, and a reference found inside a vendored gem is not evidence about this project.
-      VENDOR_DIRS = %r{\A(vendor|node_modules|tmp|\.git|\.rigor|coverage)/}
 
       # Templates and data files that carry class names as strings. A name here is NOT counted as a reference —
       # a YAML value is far weaker evidence than a constant node, and treating it as proof would silently hide
@@ -116,7 +113,7 @@ module Rigor
       # Widening the *declaration* set the same way would cancel the gain (measured: +1 / −3 / +2 candidates,
       # ADR-102 WD2), which is exactly why the two corpora are separated rather than both widened.
       def reference_files(_paths, configuration)
-        relative = Dir.glob(REFERENCE_GLOB, base: Dir.pwd).grep_v(VENDOR_DIRS)
+        relative = Analysis::Reachability::ProjectFiles.own(Dir.glob(REFERENCE_GLOB, base: Dir.pwd), Dir.pwd)
         absolute = relative.map { |rel| File.expand_path(rel) }
         Analysis::PathExpansion.reject_excluded(absolute, configuration.exclude_patterns).to_set
       end
@@ -162,8 +159,8 @@ module Rigor
         names = declarations.map(&:fqn)
         return [] if names.empty?
 
-        Dir.glob(TEMPLATE_GLOB, base: Dir.pwd).grep_v(VENDOR_DIRS).flat_map do |rel|
-          text = File.read(File.expand_path(rel))
+        Analysis::Reachability::ProjectFiles.own(Dir.glob(TEMPLATE_GLOB, base: Dir.pwd), Dir.pwd).flat_map do |rel|
+          text = File.read(File.expand_path(rel)).scrub
           names.filter_map do |fqn|
             next unless text.include?(fqn)
 

--- a/spec/rigor/analysis/reachability/project_files_spec.rb
+++ b/spec/rigor/analysis/reachability/project_files_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "rigor/analysis/reachability/project_files"
+
+# `rigor unused` harvests references from the whole project rather than only the analysed paths (ADR-102 WD7),
+# which makes "the whole project" a question needing an answer. Reading a vendored checkout is wrong twice
+# over: its code is not this project's, and on Rigor's own repository it is 77% of the files.
+RSpec.describe Rigor::Analysis::Reachability::ProjectFiles do
+  let(:root) { Dir.mktmpdir("rigor-project-files-") }
+
+  after { FileUtils.remove_entry(root) if File.directory?(root) }
+
+  def gitmodules(content)
+    File.write(File.join(root, ".gitmodules"), content)
+  end
+
+  describe ".submodule_prefixes" do
+    it "reads the declared paths" do
+      gitmodules(<<~CONF)
+        [submodule "references/rbs"]
+        \tpath = references/rbs
+        \turl = https://example.invalid/rbs.git
+        [submodule "references/ruby"]
+        \tpath = references/ruby
+        \turl = https://example.invalid/ruby.git
+      CONF
+      expect(described_class.submodule_prefixes(root)).to eq(["references/rbs/", "references/ruby/"])
+    end
+
+    it "normalises a declared path that already ends in a slash" do
+      gitmodules("[submodule \"x\"]\n\tpath = vendored/x/\n")
+      expect(described_class.submodule_prefixes(root)).to eq(["vendored/x/"])
+    end
+
+    it "returns nothing when the checkout has no submodules" do
+      expect(described_class.submodule_prefixes(root)).to eq([])
+    end
+  end
+
+  describe ".own" do
+    it "drops files inside a submodule" do
+      gitmodules("[submodule \"references/ruby\"]\n\tpath = references/ruby\n")
+      paths = ["lib/app.rb", "references/ruby/lib/set.rb", "references/ruby_helper.rb"]
+
+      # `references/ruby_helper.rb` must survive: the prefix is a directory boundary, not a string prefix.
+      expect(described_class.own(paths, root)).to eq(["lib/app.rb", "references/ruby_helper.rb"])
+    end
+
+    it "drops vendored trees" do
+      paths = ["lib/app.rb", "vendor/bundle/gems/x/lib/x.rb", "node_modules/y/index.rb", "tmp/scratch.rb"]
+      expect(described_class.own(paths, root)).to eq(["lib/app.rb"])
+    end
+
+    # The control: without this the two examples above would pass for a predicate that rejects everything.
+    it "keeps ordinary project files" do
+      paths = ["lib/app.rb", "app/models/talk.rb", "config/initializers/x.rb", "lib/tasks/y.rake"]
+      expect(described_class.own(paths, root)).to eq(paths)
+    end
+  end
+end

--- a/spec/rigor/analysis/reachability_spec.rb
+++ b/spec/rigor/analysis/reachability_spec.rb
@@ -213,6 +213,34 @@ RSpec.describe Rigor::Analysis::Reachability do
     end
   end
 
+  # A byte sequence that is not valid UTF-8 cannot be a constant name. Carrying one forward crashed the whole
+  # run on the first `String#sub` downstream — `rigor unused` on Rigor's own repository, which vendors a CRuby
+  # checkout containing deliberately ill-encoded encoding fixtures.
+  describe "ill-encoded source" do
+    # The real shape, taken from the file that crashed the run: a magic encoding comment makes Prism parse
+    # SUCCESSFULLY and hand back an `unescaped` string tagged Big5 / ISO-8859-9 whose bytes are not valid
+    # UTF-8. A source that merely fails to parse would not reproduce this — the scan already contributes
+    # nothing for those.
+    let(:ill_encoded) do
+      (+"# encoding: big5\nx = \"\xA7\xA6\".constantize\n").force_encoding(Encoding::ASCII_8BIT)
+    end
+
+    it "parses, and contributes no dynamic use rather than raising" do
+      result = nil
+      expect { result = Rigor::Analysis::Reachability::Scan.call(path: "lib/a.rb", source: ill_encoded) }
+        .not_to raise_error
+      expect(result).not_to be_nil # the premise: this source DOES parse
+      expect(result.dynamic_uses).to eq([])
+    end
+
+    # The control: a well-formed literal in the same position must still be recorded, or the guard above would
+    # be indistinguishable from dropping every literal `constantize`.
+    it "still records a well-formed literal constantize" do
+      result = Rigor::Analysis::Reachability::Scan.call(path: "lib/a.rb", source: %(x = "Target".constantize\n))
+      expect(result.dynamic_uses.map(&:name)).to eq(["Target"])
+    end
+  end
+
   describe "meta-new declarations" do
     it "treats a constant assigned Class.new / Data.define as a declaration" do
       found = candidates({ "lib/a.rb" => "class Root\nend\n",


### PR DESCRIPTION
Closes #365. Found by running the report on Rigor's own repository after #363 landed — it died outright.

## The crash

```
invalid byte sequence in US-ASCII (ArgumentError)
```

A magic encoding comment makes Prism parse **successfully** and return an `unescaped` string tagged Big5 or ISO-8859-9 whose bytes are not valid UTF-8. The dynamic-use scan took one as a constant name and the first `String#sub` downstream took the whole run with it.

A source that merely *fails* to parse never reproduced this — the scan already contributes nothing for those — which is why the existing fixtures did not catch it. My first attempt at a spec made exactly that mistake and passed for the wrong reason; the committed one uses the real shape and asserts the source parses, plus a control proving a well-formed literal is still recorded.

## The over-walk that exposed it

The reference corpus included git submodules. On this repository that is **13,894 of 18,002 files — 77% of the work** — reading a vendored CRuby checkout whose code is by definition not ours, and where the ill-encoded fixtures live.

Submodule paths come from `.gitmodules` rather than probing for nested `.git` entries: one cheap file against a second full tree walk, and it is what the repository declares. A nested checkout that is not a registered submodule is not detected — `exclude:` covers that. Matching is on a directory boundary, so `references/ruby_helper.rb` survives while `references/ruby/**` does not.

## Result

`rigor unused` now completes on Rigor's own repository: 523 declared, **0 candidates**, 4 reachable-only-from-tests, 14 namespace-only.

The file-set logic moved into `Reachability::ProjectFiles` so it is a pure function with its own specs rather than a private method inside the command.

`make verify` exit 0, `make docs-check` exit 0, `git diff --check` clean — all re-run after the changelog edit this time.