### PR TITLE
Stop a class rooting itself through its own RBS signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** `rigor unused` no longer lets a class root itself through its own RBS signature ([#373](https://github.com/rigortype/rigor/issues/373)).
+  - A mixin argument inside a signature was recorded pre-qualified with the enclosing class name, and the report resolves a reference to a member as a reference to its owner — so `SignageResource::Alba::Resource` peeled back to `SignageResource` and rooted it. On one application this hid three genuinely dead classes on the default run; they were visible only with `signature_paths:` emptied.
 - **[cli]** `rigor unused --entry-point` now matches `**` the way the manual documents it ([#371](https://github.com/rigortype/rigor/issues/371)).
   - `--entry-point='lib/workers/**/*.rb'` matched only files nested a level below `lib/workers/`, never the ones directly in it, so declarations the glob was written to root stayed in the report reading as dead code. The manual's own example was affected.
 - **[cli]** `rigor unused` no longer crashes on a source file with a magic encoding comment, and no longer reads git submodules ([#365](https://github.com/rigortype/rigor/issues/365)).

--- a/lib/rigor/analysis/reachability/signature_scan.rb
+++ b/lib/rigor/analysis/reachability/signature_scan.rb
@@ -31,10 +31,10 @@ module Rigor
         #   file cannot be read or parsed — a broken signature is the analyzer's business, not this scan's.
         def call(file)
           _, _, decls = ::RBS::Parser.parse_signature(::RBS::Buffer.new(name: file, content: File.read(file)))
-          names = []
-          decls.each { |decl| walk(decl, [], names) }
-          names.uniq.map do |name|
-            Scan::Reference.new(as_written: name, nesting: [].freeze, from: nil, role: :config, path: file,
+          found = []
+          decls.each { |decl| walk(decl, [], found) }
+          found.uniq.map do |name, nesting|
+            Scan::Reference.new(as_written: name, nesting: nesting, from: nil, role: :config, path: file,
                                 line: 1)
           end
         rescue ::RBS::BaseError, SystemCallError, ArgumentError
@@ -103,18 +103,26 @@ module Rigor
           end
         end
 
-        # A name is recorded both as written under its nesting and bare, because the graph resolves an
-        # `as_written` name against a single nesting and an RBS file's names may be absolute (`::Foo::Bar`),
-        # relative to the enclosing module, or top-level. Over-approximating WHICH of those a name is cannot
-        # invent a candidate — it can only fail to remove one — whereas guessing wrong would.
+        # Records the name AS WRITTEN together with the nesting it was written under, and lets
+        # {Graph#resolve} do the lexical walk — the same walk it does for a name read out of Ruby source.
+        #
+        # An earlier version hand-built the qualified form instead (`"#{nesting}::#{bare}"`) on the reasoning
+        # that over-approximating which of absolute / relative / top-level a name is could only fail to remove
+        # a candidate. That was wrong, and it resurrected the very defect #363 fixed. `include Alba::Resource`
+        # inside `class SignageResource` produced `SignageResource::Alba::Resource`; the graph resolves a
+        # reference to a member as a reference to its owner, so it peeled that to `SignageResource::Alba` and
+        # then to `SignageResource` — a declaration. The reference is file-level, so the class rooted ITSELF,
+        # and three genuinely dead classes stayed out of the report on the project where this was found.
+        #
+        # Passing the real nesting cannot do that: the walk tries the qualified candidate, misses, and the peel
+        # then applies to the written name alone.
         def record(type_name, nesting, out)
           return if type_name.nil?
 
           bare = type_name.to_s.delete_prefix("::")
           return if bare.empty?
 
-          out << bare
-          out << "#{nesting.join('::')}::#{bare}" unless nesting.empty?
+          out << [bare, nesting.dup.freeze]
         end
 
         def segments(type_name)

--- a/rigor-unused-adjudicate-workspace/iteration-2/eval-0-find-dead-code/with_skill/outputs/answer.md
+++ b/rigor-unused-adjudicate-workspace/iteration-2/eval-0-find-dead-code/with_skill/outputs/answer.md
@@ -1,0 +1,81 @@
+# conference-app の棚卸し結果
+
+`rigor unused` を回して、出てきた行を1件ずつ手で判定しました。結論から言うと **消せるものは思ったより少なくて、9ファイル・36行程度** です。
+
+`rigor unused` のレポートはそのまま削除リストにはなりません（このレポートの実測精度は約7%＝ほとんどが偽陽性）。なので全19行を手で潰した結果を、確信度の順に3段階で出します。
+
+---
+
+## 1. 確実に死んでいる（3クラス / 18行）
+
+Alba のシリアライザ3つが、どこからも参照されていません。
+
+| クラス | ファイル |
+| --- | --- |
+| `SignageResource` | `app/resources/signage_resource.rb:1` |
+| `SignageDeviceAssignResource` | `app/resources/signage_device_assign_resource.rb:1` |
+| `SignageScheduleAssignResource` | `app/resources/signage_schedule_assign_resource.rb:1` |
+
+**根拠。** `app/resources/` の8個のうち、実際に生きているのは `SignagesController#index` から入る連鎖だけです。
+
+```
+SignageDeviceResource（コントローラから）
+  → SignagePanelResource
+    → SignageScheduleResource
+      → SignagePageResource ＋ SignagePanelAssignResource
+```
+
+上の3つはこの連鎖の外にあります。リポジトリ全体（`.git`・`vendor` を除く全ファイル、ERB・YAML 含む）を検索して、**出現箇所は自分自身の定義と自動生成された `sig/generated/resources/*.rbs` の2箇所だけ**でした。snake_case のオートロードパス表記（`signage_resource` 等）でも検索しましたが、同じ2ファイルしか出ません。専用の spec もありません。
+
+`SignageResource` と `SignageScheduleAssignResource` は `SignageScheduleResource` を参照していますが、参照される側は生きているので巻き添えはありません。
+
+削除するなら `app/resources/*.rb` と対応する `sig/generated/resources/*.rbs` をセットで。
+
+## 2. 「機能ごと使っていない」雛形（3クラス / 12行）
+
+死んだコードというより、`rails new` が作ったまま一度も使われていない機能です。クラス単体ではなく**機能を畳むかどうかの判断**になります。
+
+**ActionCable** — `ApplicationCable::Channel`, `ApplicationCable::Connection`
+`app/channels/` にチャネルが1つもなく、`turbo_stream_from` もブロードキャストも JS 側の `createConsumer` も、`/cable` のマウントもありません。`BroadcastAnnouncementJob` は名前に反して Cable を使わず `UnreadAnnouncement` を insert しているだけです。畳むなら `config/cable.yml` と `config/application.rb:14` の `require "action_cable/engine"` も一緒に。Redis 設定もぶら下がっているので、この一群は少し慎重に。
+
+**ApplicationMailer** — `app/mailers/application_mailer.rb`
+サブクラスが1つもなく、`mail(`・`deliver_later`・`deliver_now` がリポジトリ内に一切ありません。畳むなら `app/views/layouts/mailer.html.erb` / `.text.erb`（これも雛形）と `config/application.rb:10` の `require "action_mailer/railtie"` も。
+
+## 3. 空のジェネレータ残骸（3モジュール / 6行）
+
+`HomeHelper`, `ProfilesHelper`, `SignageHelper` — **中身が `module X \n end` だけ**です。
+
+Rails の `include_all_helpers` は無効化されていないので、これらは「読み込まれている」という意味では生きています。ただしメソッドを1つも定義していないので、消しても何も起きません。*死んだコード* ではなく *残骸* として扱ってください。レビュアーに求める注意の量が違います。
+
+---
+
+## 消せなかったもの（＝レポートに出たが生きていた10件）
+
+ここが一番大事なところで、レポートを鵜呑みにしていたら壊していた行です。
+
+| クラス | 生きている理由 |
+| --- | --- |
+| `SpeakersTalk` | `has_many :speakers_talks` の中間モデル。定数として誰も書かない |
+| `ProfileBadgesProfile` | 同上（`app/models/profile.rb:3`） |
+| `SendTalkReminderPushNotificationJob` | `config/recurring.yml` に**文字列で**クラス名指定（3分ごと実行） |
+| `DigestedAssetsPathResolver` | 上のジョブが使っている。ジョブが誤判定されると芋づるで落ちる典型 |
+| `TalkDecorator` ほか3つ | `active_decorator` gem がモデル名から規約で解決する |
+| `TalksHelper` | `app/views/talks/*.erb` の3箇所から `time_with_zone_to_anchor` を呼んでいる（ビューは解析対象外） |
+
+---
+
+## 調査上の注意（数字の信頼度）
+
+**デフォルト実行では本命3件が見えませんでした。** 素直に `rigor unused` を回すと候補は3行（ActionCable×2 と ApplicationMailer）だけで、**上の「確実に死んでいる」3つは1つも出てきません**。この repo は `sig/` を `signature_paths:` に配線していて、それを外して再実行すると候補が3→9に増えます（roots が 90→53）。今回の収穫はすべて署名なし実行側から出たものです。両方の和集合を判定しました。Rigor 側の挙動として報告に値すると思うので、必要なら issue を立てます。
+
+**Git 履歴が使えません。** shallow clone（74コミット）で、しかもほぼ Dependabot のバージョン上げです。通常なら「このファイルは最後にいつ触られたか」を判断材料にしますが、今回それは使えないので、上の判定はすべて参照関係の実地調査だけに基づいています。「最近追加されて配線されていないだけの未完成コード」を取り違える可能性は、原理的には残ります。
+
+**取りこぼしはあります（量は不明）。** このレポートが答えるのは「どのクラスも定数として参照されていないか」だけです。具体的には：
+
+- **メソッド単位の死んだコードは一切対象外。** 定数が1回でも名指しされていれば、全メソッドが死んでいてもそのクラスは「到達可能」です。体感的に棚卸しの本丸はこちらだと思いますが、この道具では出せません。
+- 解析対象は `paths:` の `app` と `lib` のみ（102ファイル / 2,195行）。`config/`・`db/`・ビューのクラスは対象外です。
+- `TIMEOUT = 30` のような値定数は最初から除外されています。
+
+**まとめると**、104クラス中で自信を持って「死んでいる」と言えるのは3クラス。機能ごと畳む判断を含めても9ファイル・36行で、全体の1.6%程度です。棚卸しとしては「思ったより綺麗」という結論になります。
+
+なお conference-app には一切変更を加えていません（Rigor は開発チェックアウトから読み取り専用で実行）。

--- a/rigor-unused-adjudicate-workspace/iteration-2/eval-1-triage-report/with_skill/outputs/answer.md
+++ b/rigor-unused-adjudicate-workspace/iteration-2/eval-1-triage-report/with_skill/outputs/answer.md
@@ -1,0 +1,37 @@
+6件すべて手で裏取りしました。結論から言うと **「テストからしか使われていない」ものは 1件もありません。消していいのは 0件、掃除として消せるのが 3件** です。
+
+## 先に前提の確認（レポートをどう読むべきか）
+
+- **roots は効いています** — `roots: 90 (44 from plugins, 2 matched no declaration)`。Rails プラグインが routes からコントローラを root にしているので、レポート全体は「読む価値がある」状態です（`0 from plugins` なら設定を直すのが先でした）。
+- **`paths: [app, lib]` なので `app/views/**/*.erb` は解析対象外です。** ヘルパーの行はこの穴に落ちます。ヘルパー4件はまずここを疑うべき行でした。
+- **git 履歴は使えません。** このクローンは shallow (`git rev-parse --is-shallow-repository` → true、74コミット) で、6ファイルすべての「最終更新」が同一の依存bumpコミット (`build(deps): bump jwt …`) として出ます。これは grafts の産物であって、ファイルの古さの証拠にはなりません。なので「最終更新日」は今回の判断材料から外しています。
+- **`signature_paths` を空にして再実行**したところ、test-only が 6→10、candidates が 3→9 に増えました（`ProfileDecorator` などの decorator 4件、`SpeakersTalk` / `ProfileBadgesProfile` の中間モデル、`Signage*Resource` 3件が追加）。今回の6件の判定には影響しませんが、`sig/` が参照としてカウントされることで見えなくなっている行がある、という事実だけ頭に置いておいてください（これらも FP 定番の形なので、慌てて消さないこと）。
+
+## 6件の判定
+
+| # | クラス | 判定 | 根拠 |
+| --- | --- | --- | --- |
+| 1 | `DigestedAssetsPathResolver` | **本番で生きている。消すな** | `app/jobs/send_talk_reminder_push_notification_job.rb:10` で `DigestedAssetsPathResolver.new` として呼ばれている。#4 が誤判定された巻き添えで一緒に落ちてきた行 |
+| 2 | `HomeHelper` | 生きている（ただし**空**） | `include_all_helpers` はデフォルト true で、このアプリはどこでも無効化していない → 全ビューに include される。中身は `module HomeHelper; end` の空 |
+| 3 | `ProfilesHelper` | 生きている（ただし**空**） | 同上 |
+| 4 | `SendTalkReminderPushNotificationJob` | **本番で生きている。消すと壊れる** | `config/recurring.yml` に `class: "SendTalkReminderPushNotificationJob"` として production/development 両方に登録、`Procfile` の `worker: bin/jobs --recurring_schedule_file=config/recurring.yml` で実際にそのファイルが読まれている。3分おきに走る定期ジョブ |
+| 5 | `SignageHelper` | 生きている（ただし**空**） | 同上（`include_all_helpers`）。なお `SignageController` は存在せず（あるのは `SignagesController` / `SignageDevicesController`）、命名規約のペアすら外れている |
+| 6 | `TalksHelper` | **生きている。消すな** | `time_with_zone_to_anchor` が `app/views/talks/show.html.erb:47`、`app/views/talks/index.html.erb:13,22` の計3箇所で使われている。ERB は解析対象外なので Ruby からの呼び出し元が見えなかっただけ |
+
+## じゃあ何をすればいいか
+
+**消してはいけない（3件）**: `SendTalkReminderPushNotificationJob`、`DigestedAssetsPathResolver`、`TalksHelper`。特に #4 は消しても `rigor check` もテストも通ってしまい、気づくのは「トーク開始のプッシュ通知が来ない」とユーザーに言われたときです。
+
+**掃除として消せる（3件）**: `HomeHelper` / `ProfilesHelper` / `SignageHelper`。ただしこれは「デッドコードを見つけた」ではなく **「`rails generate` の残骸を見つけた」** です。中身が空で、include されても何も足していません。消すなら3点セットで:
+
+- `app/helpers/{home,profiles,signage}_helper.rb`
+- `spec/helpers/{home,profiles,signage}_helper_spec.rb` — 中身は `pending "add some examples to (or delete) #{__FILE__}"` だけの雛形で、コメントにも「delete」と書いてあります
+- `sig/generated/helpers/{home,profiles,signage}_helper.rbs` — 生成物なので再生成でも可
+
+レビュアーに出すときは「デッドコード削除」ではなく「ジェネレータ残骸の削除」と書いたほうが通りやすいはずです。
+
+## このレポートについて補足
+
+- `rigor unused` の測定済み精度は **7%**（適正化済みコーパスで57行中4行が本当に dead）です。今回 6/6 が false positive だったのは、その水準からすると外れ値ではありません。レポートは欠陥リストではなくレビューキューです。
+- 逆方向の見落としもあります。このコマンドは過少報告もするので、「レポートに出ていない = 生きている」ではありません。
+- 気づいた点として、`config/recurring.yml` の `"SendTalkReminderPushNotificationJob"` という文字列は、今回のレポートでは `cannot decide` への降格材料として拾われていませんでした（`cannot decide: 0`）。`paths:` に `config` が入っていないことと関係している可能性があります。YAML に文字列でクラス名を書くタイプの仕組み（定期ジョブ、キュー定義、設定ファイル）は、当面は自分で grep して確認してください。

--- a/rigor-unused-adjudicate-workspace/iteration-2/eval-1-triage-report/with_skill/timing.json
+++ b/rigor-unused-adjudicate-workspace/iteration-2/eval-1-triage-report/with_skill/timing.json
@@ -1,0 +1,1 @@
+{"total_tokens": 72481, "duration_ms": 193432, "total_duration_seconds": 193.4}

--- a/spec/fixtures/signage_resource.rbs
+++ b/spec/fixtures/signage_resource.rbs
@@ -1,0 +1,3 @@
+class SignageResource
+  include Alba::Resource
+end

--- a/spec/rigor/analysis/reachability/signature_scan_spec.rb
+++ b/spec/rigor/analysis/reachability/signature_scan_spec.rb
@@ -72,11 +72,24 @@ RSpec.describe Rigor::Analysis::Reachability::SignatureScan do
   end
 
   describe "nesting" do
-    # A name written relative to an enclosing module has to reach the graph in a form its candidate walk can
-    # resolve, or the reference is silently lost and the class becomes a false candidate.
-    it "records a relative reference under its enclosing namespace as well as bare" do
-      names = names_in("module Admin\n  class Report < Base\n  end\nend\n")
-      expect(names).to include("Base", "Admin::Base")
+    # The name is recorded AS WRITTEN with the nesting it was written under, and `Graph#resolve` does the
+    # lexical walk. Hand-building the qualified form here instead is what resurrected #363: `include
+    # Alba::Resource` inside `class SignageResource` produced `SignageResource::Alba::Resource`, the graph
+    # peeled that to its owner `SignageResource`, and the class rooted ITSELF.
+    it "records the name as written, carrying the nesting rather than pre-qualifying it" do
+      refs = described_class.call(write_signature("module Admin\n  class Report < Base\n  end\nend\n"))
+      base = refs.find { |r| r.as_written == "Base" }
+
+      expect(base).not_to be_nil
+      expect(base.nesting).to eq(["Admin"])
+      expect(refs.map(&:as_written)).not_to include("Admin::Base")
+    end
+
+    it "never emits a name prefixed with the declaration that encloses it" do
+      refs = described_class.call(write_signature("class SignageResource\n  include Alba::Resource\nend\n"))
+
+      expect(refs.map(&:as_written)).to contain_exactly("Alba::Resource")
+      expect(refs.map(&:nesting)).to all(eq(["SignageResource"]))
     end
 
     it "strips a leading :: from an absolute name" do
@@ -100,6 +113,7 @@ RSpec.describe Rigor::Analysis::Reachability::SignatureScan do
 
       expect(reference.from).to be_nil
       expect(reference.role).to eq(:config)
+      # A superclass resolves against the scope ENCLOSING the class being declared, not inside it.
       expect(reference.nesting).to eq([])
     end
   end

--- a/spec/rigor/analysis/reachability_spec.rb
+++ b/spec/rigor/analysis/reachability_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 require "rigor/analysis/reachability/scan"
 require "rigor/analysis/reachability/graph"
+require "rigor/analysis/reachability/signature_scan"
 
 # ADR-102 — the reachability report's reference index and mark-and-sweep.
 #
@@ -247,6 +248,31 @@ RSpec.describe Rigor::Analysis::Reachability do
                            "lib/b.rb" => "Shape = Data.define(:x)\nMade = Class.new(StandardError)\n" },
                          roots: ["Root"])
       expect(found).to include("Shape", "Made")
+    end
+  end
+
+  # Issue #373 — a class must not root itself through its own signature. The scan records a name as written
+  # with its nesting; hand-building the qualified form instead produced `SignageResource::Alba::Resource`,
+  # which `resolve` peels to its owner (a reference to a member is a reference to its owner) and so rooted
+  # `SignageResource`. On the project where this was found it hid three genuinely dead classes.
+  describe "signature references do not root their own declaration" do
+    it "leaves a class declared only in its own signature as a candidate" do
+      source = Rigor::Analysis::Reachability::Scan.call(
+        path: "app/resources/signage_resource.rb",
+        source: "class SignageResource\n  include Alba::Resource\nend\n"
+      )
+      root = Rigor::Analysis::Reachability::Scan.call(path: "lib/root.rb", source: "class Root\nend\n")
+      signature = Rigor::Analysis::Reachability::SignatureScan.call(
+        File.join(__dir__, "..", "..", "fixtures", "signage_resource.rbs")
+      )
+
+      report = Rigor::Analysis::Reachability::Graph.new(
+        declarations: source.declarations + root.declarations,
+        references: source.references + root.references + signature,
+        root_fqns: ["Root"]
+      ).report
+
+      expect(report.candidates.map(&:fqn)).to include("SignageResource")
     end
   end
 end


### PR DESCRIPTION
Closes #373. Same defect as #363, arriving at the same outcome by a different route — and it hid three genuinely dead classes on the project where it was found.

## Mechanism

`SignatureScan.record` emitted each name twice: as written, and hand-qualified with the enclosing nesting. `include Alba::Resource` inside `class SignageResource` produced `SignageResource::Alba::Resource` as well as `Alba::Resource`.

The graph cannot resolve the first, so it peels the trailing segment — correctly, because a reference to a member is a reference to its owner (`Scope::DiscoveryIndex::EMPTY` is a use of `DiscoveryIndex`). The peel runs twice: `SignageResource::Alba::Resource` → `SignageResource::Alba` → **`SignageResource`**, which is a declaration. The reference is file-level, so it seeds production reachability and **the class roots itself**.

The code comment justified the double emission as "can only fail to remove a candidate, never invent one". That reasoning did not account for the peel, which already existed. I wrote both.

## Fix

`Scan::Reference` carries a `nesting` field that was being passed empty while the qualification was built by hand. Passing the real nesting and letting `Graph#resolve` do the lexical walk — the same walk it does for a name read out of Ruby source — cannot produce the self-reference: the qualified candidate is tried and missed, and the peel then applies to the written name alone.

## Measured

`conference-app`, default run:

| | before | after |
| --- | ---: | ---: |
| roots | 90 | **76** |
| candidates | 3 | **7** |

The new rows include `SignageResource`, `SignageDeviceAssignResource` and `SignageScheduleAssignResource` — Alba serializers whose only occurrences are their own declaration and their generated signature, confirmed by hand.

## How it was found

Three independent adjudication passes over this project all reported the same discrepancy — "the default run hides rows that appear with `signature_paths:` emptied" — before the mechanism was located. None of them could explain it, and I nearly filed it as a documentation caveat instead of chasing it.

## Verification

New specs pin both directions: a class declared in its own signature with a qualified mixin stays a candidate, and a name written relative to an enclosing module still resolves — the control, since over-correcting here re-opens the false candidates the #345 probe measured.

`make verify` exit 0, `make docs-check` exit 0, `git diff --check` clean.