### PR TITLE
Fold a run's effect collections in one pass

### DIFF
--- a/docs/internal-spec/effect-summaries.md
+++ b/docs/internal-spec/effect-summaries.md
@@ -197,6 +197,8 @@ A file contributes a `FileCollection`: its units' direct summaries, the calls it
 
 Merging is **associative and commutative** in every table: summaries join per key, edge lists union, ancestry merges. Folding a run's files in pool-completion order therefore yields exactly the table sequential analysis yields.
 
+A run's collections MUST be folded in **one pass** (`FileCollection.merge_all`), not by a `reduce` over pairwise `#merge`. Each pairwise merge rebuilds and re-freezes the whole accumulated table, so a per-file fold costs O(files × methods) — which is what put collection at +50 % wall on mastodon and +230 % on gitlab before it was measured ([`docs/notes/20260817-effect-collection-perf.md`](../notes/20260817-effect-collection-perf.md)). This is a cost contract, not a semantic one: both spellings produce the same table.
+
 An ancestry name is recorded **as written** (`class Loud < Base` inside `module Tracer` names `Base`), so the collection carries the candidate list Ruby's own lexical lookup would try, most-qualified first, and the propagator picks the one the merged project defines.
 
 ## Propagation
@@ -212,7 +214,9 @@ The subclass index resolves each as-written superclass to a single parent — th
 
 An edge that reaches no project definition is **dropped**, not tainted: most such calls are ordinary inherited ones the catalogue has no row for, and tainting them would make the bit carry no information.
 
-**Fixpoint.** A round-robin worklist in sorted key order, to a true fixpoint:
+Edge resolution is memoised on `(receiver class, kind, selector)`, and the transitive subclass closure on the class name. Both are required, not incidental: one triple is asked for once per call site, and a Rails root class's subclass forest is otherwise re-walked thousands of times.
+
+**Fixpoint.** A worklist in sorted key order, to a true fixpoint:
 
 - `proven(m) = direct(m) ∪ ⋃ proven(callee)`
 - `exhaustive(m) = direct_exhaustive(m) ∧ ⋀ exhaustive(callee)`
@@ -220,7 +224,9 @@ An edge that reaches no project definition is **dropped**, not tainted: most suc
 
 The lattice is finite (label sets over a closed vocabulary × one bit × a closed cause enum) and every step is monotone, so a recursive or mutually recursive cycle converges on its own. **No recursion cap is used or wanted here** — unlike the return-type walk's Kleene iteration, there is no widening to force.
 
-Sorted iteration order is what makes a pooled run and a sequential run produce the same table rather than merely equivalent ones.
+A key's closure moving can only move the closures of the methods that **call** it, so each pass re-visits exactly the callers of what changed in the previous one — never the whole table. Joining a lane along an edge MUST NOT allocate when it adds nothing, which is what makes a pass over a converged region free.
+
+Sorted iteration order is what makes a pooled run and a sequential run produce the same table rather than merely equivalent ones. (The lattice is finite and every step monotone, so the least fixpoint is unique and visit order could not change it; the sorted pass makes the *work* reproducible too.)
 
 The result is a `Rigor::Effects::EffectTable` on the runner (`Runner#effect_table`), with the merged direct collections available separately (`Runner#effect_collection`). **It is not a diagnostic**: it never enters `rigor check`'s stream, and the run's exit code is identical whether or not it was computed ([ADR-102](../adr/102-unused-code-reachability-report.md)'s report-versus-diagnostic line).
 

--- a/docs/notes/20260817-effect-catalogue-corpus.md
+++ b/docs/notes/20260817-effect-catalogue-corpus.md
@@ -175,6 +175,10 @@ the propagator's round-robin worklist, which iterates the whole merged method ta
 in sorted key order — superlinear in the table's size, run once after the pool. This is a
 measurement, not a diagnosis; profiling it belongs to whoever takes the budget on.
 
+*(Followed up in [`20260817-effect-collection-perf.md`](20260817-effect-collection-perf.md). The
+suspect above was wrong: the fixpoint was a quarter of a second. The superlinear term was the
+per-file fold of the collections, and it is gone.)*
+
 Read the RSS column with the noise in mind. Three runs of the *same* `rigor check` config on
 redmine spanned 367–401 MB, so a +16% delta on a 372 MB base is close to the floor; gitlab's
 +1% on 7.8 GB is the figure to trust, and it says the per-file collections are cheap — which is

--- a/docs/notes/20260817-effect-collection-perf.md
+++ b/docs/notes/20260817-effect-collection-perf.md
@@ -1,0 +1,167 @@
+# Effect collection — where the WD13 budget went, and what got it back (#382)
+
+Status: measurement note, no design commitments. Taken against Rigor 0.3.3 on branch
+`claude/effect-labels/05-collection-perf`, stacked on the catalogue slice. It answers the
+question [`20260817-effect-catalogue-corpus.md`](20260817-effect-catalogue-corpus.md) § The WD13
+budget left open: collection cost +17 % / +50 % / +230 % of wall on redmine / mastodon / gitlab,
+sharply superlinear in project size, and that note called the profiling somebody else's job.
+
+## Harness
+
+Identical to the catalogue note's, and re-read from it rather than re-invented: the project's own
+committed `.rigor.dist.yml` with `baseline:` removed and three keys added — `parallel: {workers: 0}`,
+a scratch `cache.path`, and (for the `+effects` column) `effects: {}`. The cache directory is wiped
+before every run, so **every measurement is cold**.
+
+```sh
+cd ~/repo/ruby/rigor-survey/<project>
+BUNDLE_GEMFILE=<rigor>/Gemfile /usr/bin/time -l bundle exec <rigor>/exe/rigor \
+  check --no-ci-detect app lib --config <scratch>/<project>-check{,fx}.yml
+```
+
+Survey checkouts: redmine `a12198ea0`, mastodon `163f96cee`, gitlab `1a15763b5119`. Nothing was
+written into a survey checkout.
+
+The phase attribution below comes from a second harness: `Rigor::CLI.start` driven in-process with
+`Propagator.propagate`, `Collector.collect_for`, `Scanner.scan` and `FileCollection#merge` wrapped in
+a monotonic-clock stamp. Sequential, so no fork hides the work.
+
+**Read the wall columns as ratios within one block, not across the two.** "Before" and "after" were
+measured in separate sessions on the same laptop and the machine drifted badly between them —
+`rigor check` alone, with no collection in it either way, was mastodon 12.5 s against 14.3 s and
+gitlab 174.5 s against 231.7 s. Each block's two columns are contemporaneous, so each block's ratio
+is sound; the absolute seconds are not comparable across blocks. The before block reproduces the
+catalogue note's published +17 % / +50 % to the digit, which is what says the harness is the same one.
+
+## Before — where the time was
+
+Cold and sequential. Redmine and mastodon are medians of three; gitlab is one run each way.
+
+| project | `rigor check` | with collection | Δ wall | Δ peak RSS |
+| --- | --- | --- | --- | --- |
+| redmine | 9.35 s / 398 MB | 11.25 s / 420 MB | **+20 %** | +6 % |
+| mastodon | 14.27 s / 657 MB | 21.38 s / 703 MB | **+50 %** | +7 % |
+| gitlab | 231.7 s / 6.76 GB | 689.1 s / 7.28 GB | **+197 %** | +8 % |
+
+(One redmine collecting run came in at 21.28 s against its siblings' 10.86 s and 11.25 s — something
+else on the machine, discarded by the median rather than by judgment.)
+
+Phase attribution, mastodon (1,312 files, 7,361 methods):
+
+| phase | wall | n |
+| --- | --- | --- |
+| `FileCollection#merge` — the run's fold | **5.077 s** | 1,312 |
+| `Collector.build` (the per-def `Scanner` walk) | 0.228 s | 1,312 |
+| `Propagator.propagate` | 0.235 s | 1 |
+| `Collector.record_call` | ~0.26 s | 492,592 |
+
+Redmine's is the same shape one size down: merge 1.120 s, build 0.233 s, propagate 0.151 s — 1.50 s
+of a ~1.9 s overhead. **The fold is the whole superlinear term, and everything else is linear.**
+
+`Runner#effect_collection` folded the run with
+`effect_collections.reduce(FileCollection.empty) { |merged, c| merged.merge(c) }`, and
+`FileCollection#merge` is written as a value-object merge: it rebuilds every accumulated table, runs
+`freeze_table`'s `transform_values` over all of it, and re-`uniq`s **and re-sorts every accumulated
+edge list** — per file. That is O(files × methods) with a sort inside, and it is exactly the observed
+shape: the overhead itself (1.90 s / 7.11 s / 457.3 s) grows 1 : 3.7 : 241 against a method count that
+grows 1 : 1.8 : 16.
+
+Nothing else was superlinear. The suspects the task listed and the measurement cleared: the
+closed-world override join is already a per-run index; `Collector.active?` really is an integer read;
+`record_call` costs 0.5 µs a site; the per-def `Scanner` walk is linear in AST size; and the
+post-pool fixpoint, the headline suspect in the catalogue note, was a quarter of a second.
+
+## What changed
+
+- **`Effects::FileCollection.merge_all`** (`lib/rigor/effects/file_collection.rb:88`) folds a run in
+  one pass — each key's summaries join once, each table is built and frozen once, edge lists are
+  de-duplicated and sorted once at the end. `#merge` stays, for the two-collection case its cost
+  model fits, and delegates. `Runner#effect_collection` (`lib/rigor/analysis/runner.rb:87`) calls it.
+- **The propagator's fixpoint is a real worklist** (`lib/rigor/effects/propagator.rb:74`). A key's
+  closure moving can only move its *callers*' closures, so each pass re-visits exactly those instead
+  of round-robining the whole table; the reverse adjacency is built once. Causes ride through the
+  fixpoint as a `Set` rather than an Array re-concatenated and re-`uniq`ed on every visit of every
+  edge (`:106`).
+- **Edge resolution is memoised** on `(receiver class, kind, selector)`, and the transitive subclass
+  closure on the class name (`lib/rigor/effects/propagator.rb:161`). One triple is asked for once per
+  call site, and `ApplicationRecord`'s subclass forest was being re-walked thousands of times.
+- **`LabelSet#join` returns `self` without allocating when the join adds nothing**
+  (`lib/rigor/effects/label_set.rb:84`) — the common case in any loop that joins, and the thing that
+  makes a worklist pass over a converged region free.
+- **`Collector.record_call` asks whether the node is already recorded before building anything**
+  (`lib/rigor/effects/collector.rb:114`). First write wins, and `CheckRules` re-runs `type_of` over
+  the same nodes, so about half of all recording calls were building a `Data` and running an origin
+  lookup only to drop the result.
+- **Values that are the same at every site are built once**: the construct origins
+  (`lib/rigor/effects/unit_scan.rb:54`), the synthesised `attr_writer` summary
+  (`lib/rigor/effects/scanner.rb:51`), and a catalogue row's un-narrowed `Entry`
+  (`lib/rigor/effects/catalog.rb:246`).
+
+None of it changes what is collected. The `rigor check` diagnostic stream is byte-identical with and
+without `effects:` on all three projects (`cmp`; 710,800 bytes on gitlab), which was already the
+coexistence gate and still holds.
+
+With collection **off** nothing here runs at all, and the measurement says so: `exe/rigor check lib`
+over Rigor's own tree is diagnostic-identical to the parent commit (only the wall / RSS report line
+differs), and its whole-run allocation count moves 17,926,639 → 17,939,795 — the eleven frozen values
+now built at load time, +0.07 %. Peak RSS on that run reads 8 % higher, which is the noise floor: the
+same binary measured three times spans 266–296 MB.
+
+## After
+
+| project | `rigor check` | with collection | Δ wall | Δ peak RSS |
+| --- | --- | --- | --- | --- |
+| redmine | 8.61 s / 384 MB | 9.08 s / 420 MB | **+5.5 %** | +9 % |
+| mastodon | 12.54 s / 663 MB | 13.03 s / 668 MB | **+3.9 %** | +0.8 % |
+| gitlab | 174.5 s / 8.33 GB | 178.7 s / 8.00 GB | **+2.4 %** | −4 % |
+
+Redmine and mastodon are medians of three; gitlab is one cold run each way.
+
+**The overhead now falls with project size instead of growing with it**, which is the shape a
+per-file linear cost has against a base that is superlinear in its own right. Mastodon is inside
+WD13's ≤ ~5 % wall / RSS. Redmine sits just outside on wall at +5.5 %: it is the smallest of the
+three and the per-file scan is the largest share of the smallest base, so this is the linear term
+showing, not a residue of the old one.
+
+RSS is the noisy column, exactly as the catalogue note warned — three runs of the *same* `rigor
+check` config on redmine spanned 371–403 MB. Gitlab's −4 % on 8 GB and mastodon's +0.8 % on 663 MB
+are the figures to trust, and both say the collections themselves are cheap.
+
+### The fixpoint at gitlab scale
+
+The graph is 65,148 methods, 47,441 methods with edges, 133,565 edges after resolution.
+
+| step | wall |
+| --- | --- |
+| edge resolution (ancestry + closed-world override join) | 0.446 s |
+| **the fixpoint itself** | **0.642 s** |
+| building the table's 65,148 entries | 0.202 s |
+| `Propagator.propagate` end to end | 1.340 s |
+
+WD13 budgets "≤ 1 s of fixpoint at gitlab scale". The fixpoint is 0.64 s and inside it; the whole
+propagation step, which also resolves every edge and materialises every row, is 1.34 s — 0.7 % of the
+run it sits at the end of. Stated both ways rather than picking the flattering one.
+
+### Allocations
+
+Mastodon, in-process, `GC.stat(:total_allocated_objects)` over the whole run:
+
+| | allocations |
+| --- | --- |
+| `rigor check` | 37.2 M |
+| with collection, before | 87.2 M |
+| with collection, after | 38.7 M |
+
+Collection went from **+134 %** allocations to **+4 %**. On a corpus that is allocation-bound
+(GC ≈ 57 % of CPU on mastodon, `20260620-corpus-cold-warm-reprofile.md`) that is the number behind
+the wall column.
+
+## What remains
+
+A linear per-file cost that WD13 anticipates and does not budget away: the effect scan is a
+**separate Prism descent** per file (3.77 s of gitlab's 178.7 s, 0.24 s of mastodon's 13.0 s), taken
+rather than riding `ScopeIndexer`'s existing `def` walk because the scanner must attribute each
+recorded call *node* to its enclosing unit, and doing that inside the indexer would put an
+effects-shaped concern on the hot path of every run — including the runs with collection off. Folding
+the two walks together is the remaining ~2 % and is a WD13-scoped change to the indexer, not a
+collection one.

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -72,6 +72,7 @@ comparison) appears nowhere else in this index.
 | 2026-08-06 | [`if` / `unless` elision — provenance census of the optimistic carrier, and a two-directional A/B (issue #286)](20260806-issue-286-optimistic-carrier-provenance-census.md) |
 | 2026-08-13 | [Unused-constant false-positive baseline — three-project corpus measurement (issue #345)](20260813-unused-constant-fp-baseline.md) |
 | 2026-08-17 | [Effect catalogue — corpus measurement, before and after (issue #380)](20260817-effect-catalogue-corpus.md) |
+| 2026-08-17 | [Effect collection — where the WD13 budget went, and what got it back (issue #382)](20260817-effect-collection-perf.md) |
 
 ## Analyzer self-testing (teeth / false-negatives)
 

--- a/lib/rigor/analysis/runner.rb
+++ b/lib/rigor/analysis/runner.rb
@@ -85,7 +85,7 @@ module Rigor
       # closure. #381's snapshot records these, because a diff over direct summaries stays attributable to
       # the pull request's own lines.
       def effect_collection
-        effect_collections.reduce(Effects::FileCollection.empty) { |merged, collection| merged.merge(collection) }
+        Effects::FileCollection.merge_all(effect_collections)
       end
 
       # Which file each effect unit was defined in — `{ "Class#m" => [path, …] }`, sorted, one entry per

--- a/lib/rigor/effects/catalog.rb
+++ b/lib/rigor/effects/catalog.rb
@@ -65,8 +65,10 @@ module Rigor
         end
       end
 
-      # One row of the data file, resolved.
-      Row = Data.define(:labels, :narrow, :mutates_receiver)
+      # One row of the data file, resolved. `entry` is the row's own unnarrowed {Entry}, built at load
+      # time: the lookup sits inside the effect scan's walk, and every un-narrowed row hit in a project
+      # answers the same value.
+      Row = Data.define(:labels, :narrow, :mutates_receiver, :entry)
       private_constant :Row
 
       # One class of the data file, resolved: its two method buckets, its posture's labels, its mutator
@@ -180,8 +182,10 @@ module Rigor
       # A narrowed row's own `effects:` is its **unnarrowed** answer — the upper bound the handler
       # degrades to — so a caller that has no call node still gets a sound reading rather than ∅.
       def row_entry(row, call_node)
-        labels = row.narrow && call_node ? Narrowing.apply(row.narrow, call_node) : row.labels
-        Entry.new(labels: labels, mutates_receiver: row.mutates_receiver, from_posture: false)
+        return row.entry unless row.narrow && call_node
+
+        Entry.new(labels: Narrowing.apply(row.narrow, call_node), mutates_receiver: row.mutates_receiver,
+                  from_posture: false)
       end
 
       def build_postures(defaults)
@@ -224,7 +228,7 @@ module Rigor
 
         rows.to_h do |name, body|
           key = name.to_s
-          [key, build_row("#{class_name}##{key}", body || {}, mutators&.include?(key))]
+          [key, build_row("#{class_name}##{key}", body || {}, mutators&.include?(key) == true)]
         end.freeze
       end
 
@@ -233,10 +237,13 @@ module Rigor
         raise Error, "#{key}: unknown narrowing handler #{narrow.inspect}" if narrow && !Narrowing.known?(narrow)
         raise Error, "#{key}: every catalogue row needs a `why:` justification" if body["why"].to_s.empty?
 
+        labels = LabelSet.new(Array(body["effects"]).map(&:to_s))
+        mutates_receiver = body["mutates"].to_s == "receiver" || in_mutator_set
         Row.new(
-          labels: LabelSet.new(Array(body["effects"]).map(&:to_s)),
+          labels: labels,
           narrow: narrow,
-          mutates_receiver: body["mutates"].to_s == "receiver" || !!in_mutator_set
+          mutates_receiver: mutates_receiver,
+          entry: Entry.new(labels: labels, mutates_receiver: mutates_receiver, from_posture: false)
         )
       end
 

--- a/lib/rigor/effects/collector.rb
+++ b/lib/rigor/effects/collector.rb
@@ -56,6 +56,13 @@ module Rigor
           @calls[node] = call_record unless @calls.key?(node)
         end
 
+        # Whether this node's decision is already pinned. Asked BEFORE the record is built, because the
+        # re-queries below are roughly half of all recording calls on a Rails app and building a record
+        # only to drop it is the whole of that half's cost.
+        def recorded?(node)
+          @calls.key?(node)
+        end
+
         def mark_unresolved(node)
           existing = @calls[node]
           @calls[node] = existing.with(resolved: false) if existing
@@ -102,6 +109,9 @@ module Rigor
       def record_call(node, receiver, scope)
         accumulator = Thread.current[KEY]
         return if accumulator.nil? || accumulator.path != scope.source_path
+        # First write wins, so a re-query has nothing to add — and asking here rather than inside
+        # {Accumulator#record} is what stops it paying for the `Data` and the origin lookup below.
+        return if accumulator.recorded?(node)
 
         dynamic = receiver.is_a?(Type::Dynamic)
         class_name, kind = descriptor_for(receiver)

--- a/lib/rigor/effects/file_collection.rb
+++ b/lib/rigor/effects/file_collection.rb
@@ -65,18 +65,65 @@ module Rigor
       end
 
       # Folds another collection into this one. Summaries join per key, edge lists union, ancestry merges.
+      #
+      # **Fold a whole run with {merge_all}, not with this in a `reduce`.** Every call here rebuilds and
+      # re-freezes the accumulated tables, so folding a run one file at a time costs O(files × methods) —
+      # it was 5.1 s of mastodon's 6.4 s collection overhead and the whole of gitlab's superlinear one
+      # (`docs/notes/20260817-effect-collection-perf.md`). This stays for a two-collection merge, which is
+      # what its cost model fits.
       def merge(other)
         return self if other.empty? && !other.failed?
 
-        self.class.new(
-          path: nil,
-          summaries: merge_summaries(other.summaries),
-          edges: merge_edges(other.edges),
-          superclasses: @superclasses.merge(other.superclasses),
-          includes: merge_includes(other.includes),
-          failed: @failed || other.failed?
-        )
+        self.class.merge_all([self, other])
       end
+
+      # Folds a run's collections in one linear pass: each key's summaries join once, each table is built
+      # once, and the frozen result is constructed once at the end. Order-independent in every table
+      # except `superclasses`, where a later collection's spelling wins exactly as a chain of {merge}
+      # calls would leave it, so a path-sorted fold is reproducible.
+      #
+      # A collection that is {empty?} and not {failed?} contributes nothing, which is {merge}'s own
+      # short-circuit spelled once: a file with no methods and no calls has no summary to fold, and its
+      # ancestry has no unit to attach to.
+      def self.merge_all(collections)
+        summaries = {}
+        edges = {}
+        superclasses = {}
+        includes = {}
+        failed = false
+
+        collections.each do |collection|
+          failed ||= collection.failed?
+          next if collection.empty?
+
+          fold_summaries(summaries, collection.summaries)
+          fold_lists(edges, collection.edges)
+          superclasses.update(collection.superclasses)
+          fold_lists(includes, collection.includes)
+        end
+
+        includes.each_value(&:uniq!)
+        new(path: nil, summaries: summaries, edges: edges,
+            superclasses: superclasses, includes: includes, failed: failed)
+      end
+
+      def self.fold_summaries(into, table)
+        table.each do |key, summary|
+          existing = into[key]
+          into[key] = existing ? existing.join(summary) : summary
+        end
+      end
+      private_class_method :fold_summaries
+
+      # De-duplication is deferred to the single pass at the end of {merge_all} — `freeze_edges` uniqs
+      # and sorts anyway, and uniqing per file is what made the fold quadratic.
+      def self.fold_lists(into, table)
+        table.each do |key, list|
+          existing = into[key]
+          existing ? existing.concat(list) : into[key] = list.dup
+        end
+      end
+      private_class_method :fold_lists
 
       def ==(other)
         other.is_a?(FileCollection) && other.summaries == @summaries && other.edges == @edges &&
@@ -90,24 +137,6 @@ module Rigor
 
       private
 
-      def merge_summaries(other)
-        return @summaries if other.empty?
-
-        @summaries.merge(other) { |_key, mine, theirs| mine.join(theirs) }
-      end
-
-      def merge_edges(other)
-        return @edges if other.empty?
-
-        @edges.merge(other) { |_key, mine, theirs| (mine + theirs).uniq }
-      end
-
-      def merge_includes(other)
-        return @includes if other.empty?
-
-        @includes.merge(other) { |_key, mine, theirs| (mine + theirs).uniq }
-      end
-
       def freeze_table(table)
         return NO_TABLE if table.empty?
 
@@ -115,12 +144,15 @@ module Rigor
       end
 
       # Edge lists are sorted so a marshalled worker collection and a sequential one are `==` and the
-      # report they feed is byte-identical.
+      # report they feed is byte-identical. The key is TOTAL over the de-duplicated list — `self_call` is
+      # in it because two edges can otherwise agree on every other field, and `sort_by` is not stable.
       def freeze_edges(table)
         return NO_TABLE if table.empty?
 
         table.transform_values do |list|
-          list.uniq.sort_by { |edge| [edge.receiver_class.to_s, edge.kind.to_s, edge.selector] }.freeze
+          sorted = list.uniq
+          sorted.sort_by! { |edge| [edge.receiver_class.to_s, edge.kind.to_s, edge.selector, edge.self_call ? 1 : 0] }
+          sorted.freeze
         end.freeze
       end
     end

--- a/lib/rigor/effects/label_set.rb
+++ b/lib/rigor/effects/label_set.rb
@@ -77,12 +77,19 @@ module Rigor
       end
 
       # Union. {TOP} absorbs: a join involving it is {TOP}.
+      #
+      # A join that adds nothing returns `self` **without allocating**. That is the common case wherever
+      # sets are joined in a loop — the propagator's fixpoint re-joins every edge on every visit — and the
+      # sets are single-digit-sized, so the containment scan is cheaper than the construction it avoids.
       def join(other)
         return TOP if @top || other.top?
         return other if @labels.empty?
-        return self if other.to_a.empty?
 
-        self.class.new(@labels + other.to_a)
+        others = other.to_a
+        return self if others.empty?
+        return self if others.all? { |label| @labels.include?(label) }
+
+        self.class.new(@labels + others)
       end
 
       # Whether every member of this set is admitted by `bound_set` — the envelope check, modulo
@@ -95,6 +102,8 @@ module Rigor
       end
 
       def ==(other)
+        return true if equal?(other)
+
         other.is_a?(LabelSet) && other.top? == @top && other.to_a == @labels
       end
       alias eql? ==

--- a/lib/rigor/effects/propagator.rb
+++ b/lib/rigor/effects/propagator.rb
@@ -25,6 +25,9 @@ module Rigor
     # Propagation is graph-only: it reads no source, types nothing, and touches no `Scope`. It is
     # fail-soft as a whole — an exception yields the empty table rather than failing the run.
     module Propagator
+      NO_EDGES = [].freeze
+      private_constant :NO_EDGES
+
       module_function
 
       # @param collection [FileCollection] the run's merged per-file collections
@@ -50,22 +53,53 @@ module Rigor
         end
       end
 
+      # Causes are carried as a Set through the fixpoint and flattened back to a sorted Array in
+      # {build_entries}. A Set is what {absorb} needs: unioning one along an edge must cost the source's
+      # size and allocate NOTHING when it adds nothing, and the array-concat-and-uniq it replaces
+      # allocated twice on every visit of every edge.
       def seed(summaries)
         summaries.transform_values do |summary|
-          { proven: summary.proven, exhaustive: summary.exhaustive?, causes: summary.causes }
+          { proven: summary.proven, exhaustive: summary.exhaustive?, causes: Set.new(summary.causes) }
         end
       end
 
-      # Round-robin to a fixpoint in sorted key order, so the answer does not depend on Hash insertion
-      # order and a pooled run agrees with a sequential one bit for bit.
+      # A worklist to a fixpoint. `state[key]` changing can only change the methods that CALL `key`, so a
+      # pass re-visits exactly those and the round-robin over the whole table is gone — that walk cost
+      # O(passes × edges) and the passes are the graph's depth.
+      #
+      # Each pass still runs in sorted key order, so the answer does not depend on Hash insertion order
+      # and a pooled run agrees with a sequential one bit for bit. (The lattice is finite and every step
+      # monotone, so the least fixpoint is unique and visit order cannot change it; the sorted pass keeps
+      # the *work* reproducible too.)
       def iterate(state, edges)
         order = state.keys.sort
+        callers = reverse_edges(edges)
+        pending = nil
+
         loop do
-          changed = false
+          dirty = nil
           order.each do |key|
-            edges[key]&.each { |callee| changed = true if absorb(state, key, callee) }
+            next if pending && !pending.include?(key)
+
+            list = edges[key]
+            next if list.nil?
+
+            changed = false
+            list.each { |callee| changed = true if absorb(state, key, callee) }
+            next unless changed
+
+            (dirty ||= Set.new).merge(callers[key]) if callers.key?(key)
           end
-          break unless changed
+          break if dirty.nil?
+
+          pending = dirty
+        end
+      end
+
+      # `{callee_key => [caller_key]}` — who has to be re-visited when a key's closure moves.
+      def reverse_edges(edges)
+        edges.each_with_object({}) do |(caller_key, list), out|
+          list.each { |callee| (out[callee] ||= []) << caller_key }
         end
       end
 
@@ -84,11 +118,9 @@ module Rigor
           target[:exhaustive] = false
           changed = true
         end
-        merged = (target[:causes] + source[:causes]).uniq
-        return changed if merged.size == target[:causes].size
-
-        target[:causes] = merged
-        true
+        causes = target[:causes]
+        source[:causes].each { |cause| changed = true if causes.add?(cause) }
+        changed
       end
 
       def build_entries(summaries, edges, state)
@@ -100,12 +132,12 @@ module Rigor
             proven: closed[:proven],
             exhaustive: closed[:exhaustive],
             causes: closed[:causes].sort_by { |cause, detail| [cause, detail.to_s] }.freeze,
-            edges: edges.fetch(key, [].freeze)
+            edges: edges.fetch(key, NO_EDGES)
           )
         end
       end
 
-      private_class_method :resolve_edges, :seed, :iterate, :absorb, :build_entries
+      private_class_method :resolve_edges, :seed, :iterate, :reverse_edges, :absorb, :build_entries
 
       # The class graph a run's collections describe, and the edge resolution over it. Built once per
       # propagation; every lookup is a Hash read.
@@ -116,23 +148,37 @@ module Rigor
           @includes = collection.includes
           @classes = build_classes(collection)
           @descendants = build_descendants(collection.superclasses)
+          @descendant_closures = {}
+          @targets = {}
         end
 
         # Every project method key `edge` may reach: the definition its ancestry resolves to, plus every
         # override of the same selector in a project subclass of the receiver's class.
+        #
+        # Memoised on `(receiver class, kind, selector)` — the answer depends on nothing else, and one
+        # such triple is asked for once per call site in the project. `ApplicationRecord#save` alone is
+        # thousands of sites on a Rails app, each of which used to re-walk the whole subclass forest.
         def targets_for(edge)
-          separator = edge.kind == :singleton ? "." : "#"
-          targets = []
-          owner = resolve_owner(edge.receiver_class, separator, edge.selector)
-          targets << owner if owner
-          descendants_of(edge.receiver_class).each do |subclass|
-            key = "#{subclass}#{separator}#{edge.selector}"
-            targets << key if @summaries.key?(key)
+          @targets[[edge.receiver_class, edge.kind, edge.selector]] ||= begin
+            separator = edge.kind == :singleton ? "." : "#"
+            targets = []
+            owner = resolve_owner(edge.receiver_class, separator, edge.selector)
+            targets << owner if owner
+            descendant_closure(edge.receiver_class).each do |subclass|
+              key = "#{subclass}#{separator}#{edge.selector}"
+              targets << key if @summaries.key?(key)
+            end
+            targets.freeze
           end
-          targets
         end
 
         private
+
+        # The transitive subclass closure, memoised per class. A deep hierarchy's root is asked for it
+        # once, not once per selector reaching it.
+        def descendant_closure(class_name)
+          @descendant_closures[class_name] ||= descendants_of(class_name).freeze
+        end
 
         # Ancestry order mirrors the engine's: the class itself, the modules it includes, then its
         # superclass, recursively. Cycle-guarded, because a project may declare one. Ancestry names

--- a/lib/rigor/effects/scanner.rb
+++ b/lib/rigor/effects/scanner.rb
@@ -46,6 +46,11 @@ module Rigor
       MUTATE_SELF = LabelSet.new(["mutate.self"])
       private_constant :MUTATE_SELF
 
+      # A synthesised writer's summary is the same value at every `attr_accessor` in the project, so it is
+      # built once rather than per accessor.
+      WRITER_SUMMARY = Summary.new(bundles: { Origin.construct("attr-writer") => MUTATE_SELF })
+      private_constant :WRITER_SUMMARY
+
       def self.scan(root:, path:, calls:)
         new(path: path, calls: calls).scan(root)
       end
@@ -151,8 +156,7 @@ module Rigor
           merge_unit("#{class_name}##{name}", Summary.empty, []) unless node.name == :attr_writer
           next if node.name == :attr_reader
 
-          writer = Summary.new(bundles: { Origin.construct("attr-writer") => MUTATE_SELF })
-          merge_unit("#{class_name}##{name}=", writer, [])
+          merge_unit("#{class_name}##{name}=", WRITER_SUMMARY, [])
         end
       end
 

--- a/lib/rigor/effects/unit_scan.rb
+++ b/lib/rigor/effects/unit_scan.rb
@@ -48,6 +48,22 @@ module Rigor
       # positional argument being present.
       EVAL_SELECTORS = %i[eval instance_eval class_eval module_eval].to_set.freeze
 
+      # The construct origins this scan can produce, spelled once. A construct origin is line-free and
+      # carries no per-site state, so every site that produces one produces the SAME value — allocating a
+      # fresh `Data` per `@ivar` write in a project's every method was pure garbage.
+      DEFINE_METHOD = Origin.construct("define-method")
+      XSTRING = Origin.construct("xstring")
+      GVAR_READ = Origin.construct("gvar-read")
+      GVAR_WRITE = Origin.construct("gvar-write")
+      CVAR_READ = Origin.construct("cvar-read")
+      CVAR_WRITE = Origin.construct("cvar-write")
+      IVAR_WRITE = Origin.construct("ivar-write")
+      ALIAS = Origin.construct("alias")
+      UNDEF = Origin.construct("undef")
+      RECEIVER_MUTATION = Origin.construct("receiver-mutation")
+      private_constant :DEFINE_METHOD, :XSTRING, :GVAR_READ, :GVAR_WRITE, :CVAR_READ, :CVAR_WRITE,
+                       :IVAR_WRITE, :ALIAS, :UNDEF, :RECEIVER_MUTATION
+
       GLOBAL_READ = LabelSet.new(["global.read"])
       GLOBAL_WRITE = LabelSet.new(["global.write"])
       MUTATE_STATIC = LabelSet.new(["mutate.static"])
@@ -133,7 +149,7 @@ module Rigor
           return false unless declared
 
           @nested << declared
-          add(Origin.construct("define-method"), MUTATE_STATIC)
+          add(DEFINE_METHOD, MUTATE_STATIC)
           true
         else
           false
@@ -144,24 +160,24 @@ module Rigor
         case node
         when Prism::CallNode then visit_call(node)
         when Prism::XStringNode, Prism::InterpolatedXStringNode
-          add(Origin.construct("xstring"), IO_PROCESS)
+          add(XSTRING, IO_PROCESS)
         when Prism::GlobalVariableReadNode
-          add(Origin.construct("gvar-read"), GLOBAL_READ) unless FRAME_LOCAL_GLOBALS.include?(node.name.to_s)
+          add(GVAR_READ, GLOBAL_READ) unless FRAME_LOCAL_GLOBALS.include?(node.name.to_s)
         when Prism::GlobalVariableWriteNode, Prism::GlobalVariableOperatorWriteNode,
              Prism::GlobalVariableOrWriteNode, Prism::GlobalVariableAndWriteNode
-          add(Origin.construct("gvar-write"), GLOBAL_WRITE)
+          add(GVAR_WRITE, GLOBAL_WRITE)
         when Prism::ClassVariableReadNode
-          add(Origin.construct("cvar-read"), GLOBAL_READ)
+          add(CVAR_READ, GLOBAL_READ)
         when Prism::ClassVariableWriteNode, Prism::ClassVariableOperatorWriteNode,
              Prism::ClassVariableOrWriteNode, Prism::ClassVariableAndWriteNode
-          add(Origin.construct("cvar-write"), MUTATE_STATIC)
+          add(CVAR_WRITE, MUTATE_STATIC)
         when Prism::InstanceVariableWriteNode, Prism::InstanceVariableOperatorWriteNode,
              Prism::InstanceVariableOrWriteNode, Prism::InstanceVariableAndWriteNode
-          add(Origin.construct("ivar-write"), @singleton ? MUTATE_STATIC : MUTATE_SELF)
+          add(IVAR_WRITE, @singleton ? MUTATE_STATIC : MUTATE_SELF)
         when Prism::AliasMethodNode, Prism::AliasGlobalVariableNode
-          add(Origin.construct("alias"), MUTATE_STATIC)
+          add(ALIAS, MUTATE_STATIC)
         when Prism::UndefNode
-          add(Origin.construct("undef"), MUTATE_STATIC)
+          add(UNDEF, MUTATE_STATIC)
         when Prism::IndexOperatorWriteNode, Prism::IndexOrWriteNode, Prism::IndexAndWriteNode,
              Prism::CallOperatorWriteNode, Prism::CallOrWriteNode, Prism::CallAndWriteNode
           classify_mutation(node.receiver)
@@ -312,7 +328,7 @@ module Rigor
         labels = @mutation.label_for(receiver)
         return taint("unknown-ownership") if labels.nil?
 
-        add(Origin.construct("receiver-mutation"), labels)
+        add(RECEIVER_MUTATION, labels)
       end
 
       # An `eval` family call carrying code rather than a block, or a bare `binding`. Both hand the


### PR DESCRIPTION
Slice 5 of the effect-labels stack (ADR-103, umbrella #376), stacked on #399. Meets the ADR-103 WD13 cost budget the catalogue census (#399) found unmet.

The census suspected the propagator; profiling put 5.1 s of mastodon's 6.4 s overhead in `Runner#effect_collection`'s fold — `FileCollection#merge` rebuilt, re-froze, re-`uniq`ed and re-sorted every accumulated table per file, O(files × methods) with a sort inside. Fixed with a one-pass `FileCollection.merge_all`; also a reverse-adjacency worklist with memoised edge resolution in `Propagator`, an allocation-free `LabelSet#join` when nothing changes, an early 'already recorded' check in `record_call`, and once-built construct origins / catalogue entries.

After: redmine +5.5 % wall / +9 % RSS, **mastodon +3.9 % / +0.8 %**, **gitlab +2.4 % / −4 %** (was +20 % / +50 % / +197 %); the superlinear term is gone and overhead falls with project size; gitlab fixpoint 0.64 s. Diagnostics byte-identical with and without `effects:` on all three projects; effects-off `rigor check lib` diagnostic-identical to the parent. Note: `docs/notes/20260817-effect-collection-perf.md`. `make verify` (9568 examples), `make docs-check`, `git diff --check` green.