### PR TITLE
Stop the Ractor pool from hanging when a worker dies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[cli]** A parallel run whose worker dies now degrades and says so instead of hanging. This is reachable only through the experimental `RIGOR_POOL_BACKEND=ractor` override — the default `fork` backend already recovered — where every worker died on startup and the run then waited for them forever ([#414](https://github.com/rigortype/rigor/issues/414)).
+  - That backend remains unable to analyse anything under rbs 4.x, for a reason outside Rigor: rbs interns namespaces through a process-wide mutable cache a Ractor may not read. It now reports that per file rather than hanging. The default `fork` backend is unaffected.
 - **[engine]** `rigor unused` no longer lets a class root itself through its own RBS signature ([#373](https://github.com/rigortype/rigor/issues/373)).
   - A mixin argument inside a signature was recorded pre-qualified with the enclosing class name, and the report resolves a reference to a member as a reference to its owner — so `SignageResource::Alba::Resource` peeled back to `SignageResource` and rooted it. On one application this hid three genuinely dead classes on the default run; they were visible only with `signature_paths:` emptied.
 - **[cli]** `rigor unused --entry-point` now matches `**` the way the manual documents it ([#371](https://github.com/rigortype/rigor/issues/371)).

--- a/lib/rigor/analysis/runner/pool_coordinator.rb
+++ b/lib/rigor/analysis/runner/pool_coordinator.rb
@@ -264,6 +264,14 @@ module Rigor
         # replayed into the runner-side accumulators via their `record_*` APIs, which dedupe on the same
         # keys as a single-session run would. Net result: reporter state is identical to the sequential
         # path.
+        #
+        # **This backend cannot analyse a file under rbs 4.x, and the blocker is upstream** (#414).
+        # `RBS::Namespace.[]` interns every namespace through a process-wide flyweight cache held in
+        # module ivars (`@intern_trie_absolute` / `@intern_trie_relative`, mutable by design), and reading
+        # an unshareable module ivar from a non-main Ractor is `Ractor::IsolationError` — so every file a
+        # worker touches comes back as an internal analyzer error. What the code below fixes is the
+        # failure MODE, not the backend: the run used to hang forever instead of saying anything. Reviving
+        # the backend needs an upstream change, which is why `pool_backend` keeps `fork` as the default.
         def analyze_files_in_pool(files) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
           # Pre-warm class-level lazy memos on the MAIN Ractor. `Environment::ClassRegistry.default` is the
           # default kwarg threaded through `Environment.new` inside each worker session; lazy-initialising
@@ -317,15 +325,30 @@ module Rigor
             end
           end
 
+          # #414 — every worker is monitored BEFORE any file is dispatched, so a worker that dies at
+          # construction is still observed. `Ractor#monitor` posts `:exited` / `:aborted` to this
+          # Ractor's default port, which is the same mailbox the workers push their results to.
+          pool.each { |worker| worker.monitor(Ractor.current.default_port) }
+
           files.each_with_index { |path, index| pool[index % pool.size].send(path) }
           pool.each { |worker| worker.send(nil) }
 
           prepare_diagnostics = nil
           results_by_path = {}
-          done_count = 0
+          terminated = 0
 
-          while done_count < pool.size
+          # Bounded by TERMINATION, not by `:done`. A worker that dies never says `:done`, and the loop
+          # that counted `:done` blocked on `Ractor.receive` for as long as the process lived — the whole
+          # backend hung that way once `Environment.for_project` started raising `Ractor::IsolationError`
+          # inside `WorkerSession#initialize` (#414). Monitor notices are bare Symbols; worker messages
+          # are Arrays, so the two never collide.
+          while terminated < pool.size
             message = Ractor.receive
+            if message.is_a?(Symbol)
+              terminated += 1
+              next
+            end
+
             case message.first
             when :prepare
               prepare_diagnostics ||= message.last
@@ -333,13 +356,27 @@ module Rigor
               results_by_path[message[1]] = message[2]
             when :done
               merge_worker_reporters(message.last)
-              done_count += 1
             end
           end
 
-          pool.each(&:join)
+          # `join` re-raises an abnormal worker's exception as `Ractor::RemoteError`; the degrade below is
+          # this path's answer to that, so the raise carries no information the coordinator acts on.
+          pool.each do |worker|
+            worker.join
+          rescue Ractor::Error
+            nil
+          end
 
-          Array(prepare_diagnostics) + files.flat_map { |path| results_by_path.fetch(path, []) }
+          # The files no worker reported — every file of a worker that died, and any file in flight when
+          # it did. Re-analysed in process, exactly as the fork backend re-analyses a dead child's slice.
+          degraded = files.reject { |path| results_by_path.key?(path) }
+          unless degraded.empty?
+            environment = build_runner_environment(source_files: files)
+            degraded.each { |path| results_by_path[path] = @analyze_file.call(path, environment) }
+          end
+
+          diagnostics = Array(prepare_diagnostics) + files.flat_map { |path| results_by_path.fetch(path, []) }
+          degraded.empty? ? diagnostics : diagnostics.unshift(pool_degraded_diagnostic(degraded.size, "ractor"))
         end
 
         # ADR-15 Amendment (2026-05-20) — fork-based worker pool, the active backend for `workers > 0`.
@@ -397,7 +434,7 @@ module Rigor
 
           diagnostics = Array(session.prepare_diagnostics) +
                         files.flat_map { |path| results_by_path.fetch(path, []) }
-          degraded.empty? ? diagnostics : diagnostics.unshift(fork_degraded_diagnostic(degraded.size))
+          degraded.empty? ? diagnostics : diagnostics.unshift(pool_degraded_diagnostic(degraded.size, "fork"))
         end
 
         # Child-process body for {#analyze_files_in_fork_pool}. Analyses the slice with the
@@ -467,10 +504,12 @@ module Rigor
           nil
         end
 
-        def fork_degraded_diagnostic(count)
+        # Both pool backends degrade the same way — the files a dead worker owed are re-analysed in
+        # process — so they say so the same way, naming which backend it was (#414).
+        def pool_degraded_diagnostic(count, backend)
           Diagnostic.new(
             path: ".rigor.yml", line: 1, column: 1,
-            message: "fork pool degraded: #{count} file(s) re-analysed in-process " \
+            message: "#{backend} pool degraded: #{count} file(s) re-analysed in-process " \
                      "after a worker exited abnormally",
             severity: :warning, rule: "pool-degraded", source_family: :builtin
           )

--- a/lib/rigor/environment.rb
+++ b/lib/rigor/environment.rb
@@ -311,11 +311,18 @@ module Rigor
       # activesupport, the Rack status table) can then require the analyzed project's own locked gems when
       # Rigor's host gem environment does not carry them — the standalone `gem install rigortype` case,
       # where activesupport is deliberately not a runtime dependency.
+      # The hand-off is a module ivar, which a non-main Ractor may not write (`Ractor::IsolationError`) —
+      # and every Ractor-pool worker builds its Environment inside its own Ractor, so an unguarded write
+      # killed the whole backend at `WorkerSession#initialize` (#414). The resolution is deterministic per
+      # configuration and `Runner`'s pre-passes already perform it on the main Ractor before the pool
+      # spawns, so a worker reads the value the main set (a frozen String, hence shareable) and skips the
+      # write. The local return value is unaffected, so the missing-gem constant index still gets its root
+      # even when the write is skipped.
       def resolve_target_bundle_root(bundle_path:, project_root:, auto_detect:)
         bundle_root = BundleSigDiscovery.resolve_bundle_path(
           bundle_path: bundle_path, project_root: project_root, auto_detect: auto_detect
         )&.to_s
-        Plugin::Isolation.target_bundle_root = bundle_root
+        Plugin::Isolation.target_bundle_root = bundle_root if Ractor.current == Ractor.main
         bundle_root
       end
 

--- a/lib/rigor/plugin/isolation.rb
+++ b/lib/rigor/plugin/isolation.rb
@@ -43,8 +43,11 @@ module Rigor
         @target_bundle_root
       end
 
+      # Frozen so the value stays `Ractor.shareable?`: a Ractor-pool worker READS this (its Environment
+      # build resolves the same root and skips the write — #414), and reading an unshareable value out of
+      # a module ivar from a non-main Ractor is the same `Ractor::IsolationError` as writing one.
       def target_bundle_root=(root)
-        @target_bundle_root = root.nil? ? nil : File.expand_path(root.to_s)
+        @target_bundle_root = root.nil? ? nil : File.expand_path(root.to_s).freeze
       end
 
       # Requires `feature`, falling back to the analyzed project's bundler install tree. The fallback

--- a/spec/rigor/analysis/runner/pool_coordinator_spec.rb
+++ b/spec/rigor/analysis/runner/pool_coordinator_spec.rb
@@ -687,9 +687,9 @@ RSpec.describe Rigor::Analysis::Runner::PoolCoordinator do
   # its opt-in gate. The self-mutation sweep's survivors on `#analyze_files_in_pool`'s own lines are accepted
   # as a scope reduction for that reason, not a missed gap — recorded here rather than left implicit.
 
-  describe "#fork_degraded_diagnostic (private)" do
+  describe "#pool_degraded_diagnostic (private)" do
     it "builds a :warning pool-degraded diagnostic naming the degraded file count" do
-      diagnostic = build_coordinator.send(:fork_degraded_diagnostic, 3)
+      diagnostic = build_coordinator.send(:pool_degraded_diagnostic, 3, "fork")
 
       expect(diagnostic.rule).to eq("pool-degraded")
       expect(diagnostic.severity).to eq(:warning)


### PR DESCRIPTION
Part of #414 — fixes the failure *mode*, not the backend. See "What this does not fix" below.

## What was wrong

`RIGOR_POOL_BACKEND=ractor` did not fail. It hung, past a 10-minute timeout, reproducibly, with the working directory inside or outside a Bundler project.

Two defects compounded:

1. **`Environment.for_project` was not Ractor-safe.** It resolves the analyzed project's bundle root and hands it to `Plugin::Isolation` through a module ivar (ADR-82 WD9 / ADR-90). A non-main Ractor may not write one, and every Ractor-pool worker builds its Environment inside its own Ractor — so every worker died in `WorkerSession#initialize` with `Ractor::IsolationError`.
2. **The coordinator's drain loop counted `:done` messages.** A dead worker never sends one, so with no survivors the loop blocked on `Ractor.receive` for as long as the process lived. The fork backend has always detected an abnormal child and re-analysed its slice in process; the Ractor path had no equivalent.

## What this changes

The resolution is deterministic per configuration and `Runner`'s pre-passes already perform it on the main Ractor before the pool spawns, so a worker now skips the write and reads what the main set. The setter freezes the value, because reading an unshareable module ivar from a non-main Ractor is the same error as writing one.

The drain loop is bounded by **termination** rather than by `:done`. Each worker is monitored before any file is dispatched (`Ractor#monitor` posts `:exited` / `:aborted` to the same mailbox — monitor notices are bare Symbols where worker messages are Arrays), and whatever files no worker reported are re-analysed in process. `fork_degraded_diagnostic` becomes `pool_degraded_diagnostic(count, backend)` so both backends say the same thing, naming which one degraded; the fork message is byte-identical to before.

## Verification

`make verify` green, `make docs-check` green, `git diff --check` clean.

The degrade path was verified with a positive control — a temporary `raise` at the top of the Ractor body:

```
.rigor.yml:1:1: warning: ractor pool degraded: 2 file(s) re-analysed in-process after a worker exited abnormally
```

seconds instead of the previous unbounded hang. That control is deliberately **not** a committed spec: exercising it means spawning real Ractors, and `spec/rigor/analysis/runner_pool_spec.rb` is isolated into its own rspec process precisely because real Ractor spawns destabilise later specs. Adding a flaky example to CI for a backend that cannot analyse a file (below) is a bad trade; the reproduction is recorded on the issue instead.

## What this does not fix

The backend still cannot analyse anything under rbs 4.x, and the blocker is upstream. `RBS::Namespace.[]` interns every namespace through a process-wide flyweight cache held in module ivars (`@intern_trie_absolute` / `@intern_trie_relative`, mutable by design — `references/rbs/lib/rbs/namespace.rb:16-44`), and reading an unshareable module ivar from a non-main Ractor is `Ractor::IsolationError`. So each file a worker touches now comes back as `internal analyzer error` rather than hanging the run.

That is recorded in the code where the next person will look, and it is the fact #410 and #409 need: "carry the effect side-table through the non-fork pool backends" cannot be delivered against this backend, so the graduation precondition needs an owner decision — relax to "without `fork`, a collecting run degrades to sequential and says so" (today's behaviour), or retire the Ractor backend outright.
