### PR TITLE
Fix the builtin-catalogue extractor's mutate and raises facets

### DIFF
--- a/data/builtins/ruby_core/array.yml
+++ b/data/builtins/ruby_core/array.yml
@@ -83,9 +83,8 @@ classes:
         arity: 0
         defined_at: references/ruby/array.c:8882
         c_body_at: references/ruby/array.c:3148
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "() -> Array[E]"
         rbs_at: references/rbs/core/array.rbs:3795
@@ -97,7 +96,6 @@ classes:
         c_body_at: references/ruby/array.c:3184
         c_effects:
         - block
-        - mutate
         - raises
         purity: block_dependent
         rbs:
@@ -234,9 +232,8 @@ classes:
         arity: -1
         defined_at: references/ruby/array.c:8896
         c_body_at: references/ruby/array.c:5721
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "(*array[untyped] other_arrays) -> Array[E]"
         rbs_at: references/rbs/core/array.rbs:1596
@@ -547,9 +544,8 @@ classes:
         arity: 0
         defined_at: references/ruby/array.c:8924
         c_body_at: references/ruby/array.c:3601
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "() -> Array[E]"
         - "() { (E a, E b) -> Comparable::_CompareToZero } -> Array[E]"
@@ -593,7 +589,6 @@ classes:
         c_body_at: references/ruby/array.c:3759
         c_effects:
         - block
-        - mutate
         purity: block_dependent
         rbs:
         - "[T] () { (E item) -> T } -> Array[T]"
@@ -621,7 +616,6 @@ classes:
         c_body_at: references/ruby/array.c:3759
         c_effects:
         - block
-        - mutate
         purity: block_dependent
       map!:
         source: c
@@ -641,7 +635,6 @@ classes:
         c_body_at: references/ruby/array.c:4000
         c_effects:
         - block
-        - mutate
         purity: block_dependent
         rbs:
         - "() { (E element) -> boolish } -> Array[E]"
@@ -668,7 +661,6 @@ classes:
         c_body_at: references/ruby/array.c:4000
         c_effects:
         - block
-        - mutate
         purity: block_dependent
       filter!:
         source: c
@@ -770,7 +762,6 @@ classes:
         c_body_at: references/ruby/array.c:4680
         c_effects:
         - block
-        - mutate
         purity: block_dependent
         rbs:
         - "() -> Array[[ E ]]"
@@ -790,9 +781,8 @@ classes:
         defined_at: references/ruby/array.c:8943
         c_body_at: references/ruby/array.c:4753
         c_effects:
-        - mutate
         - raises
-        purity: mutates_self
+        purity: leaf
         rbs:
         - "() -> Array[Array[untyped]]"
         rbs_at: references/rbs/core/array.rbs:3857
@@ -938,9 +928,8 @@ classes:
         arity: 1
         defined_at: references/ruby/array.c:8959
         c_body_at: references/ruby/array.c:5673
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "(array[untyped] other_array) -> Array[E]"
         rbs_at: references/rbs/core/array.rbs:726
@@ -950,9 +939,8 @@ classes:
         arity: 1
         defined_at: references/ruby/array.c:8960
         c_body_at: references/ruby/array.c:5782
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "(array[untyped] other_array) -> Array[E]"
         rbs_at: references/rbs/core/array.rbs:675
@@ -1175,7 +1163,6 @@ classes:
         c_body_at: references/ruby/array.c:7668
         c_effects:
         - block
-        - mutate
         - raises
         purity: block_dependent
         rbs:

--- a/data/builtins/ruby_core/enumerable.yml
+++ b/data/builtins/ruby_core/enumerable.yml
@@ -58,9 +58,8 @@ classes:
         arity: 0
         defined_at: references/ruby/enum.c:5210
         c_body_at: references/ruby/enum.c:1387
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
       sort_by:
         source: c
         cfunc: enum_sort_by
@@ -69,7 +68,6 @@ classes:
         c_body_at: references/ruby/enum.c:1707
         c_effects:
         - block
-        - mutate
         - raises
         purity: block_dependent
       grep:
@@ -248,9 +246,8 @@ classes:
         arity: -1
         defined_at: references/ruby/enum.c:5231
         c_body_at: references/ruby/enum.c:1285
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
       first:
         source: c
         cfunc: enum_first
@@ -542,7 +539,6 @@ classes:
         c_body_at: references/ruby/enum.c:4905
         c_effects:
         - block
-        - mutate
         purity: block_dependent
       compact:
         source: c

--- a/data/builtins/ruby_core/exception.yml
+++ b/data/builtins/ruby_core/exception.yml
@@ -101,9 +101,8 @@ classes:
         arity: -1
         defined_at: references/ruby/error.c:3642
         c_body_at: references/ruby/error.c:1726
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "(?highlight: bool?, ?order: (:top | :bottom | string)?) -> String"
         rbs_at: references/rbs/core/exception.rbs:484
@@ -113,9 +112,8 @@ classes:
         arity: 0
         defined_at: references/ruby/error.c:3643
         c_body_at: references/ruby/error.c:1837
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "() -> String"
         rbs_at: references/rbs/core/exception.rbs:305
@@ -635,7 +633,6 @@ classes:
         arity: 0
         defined_at: references/ruby/error.c:3727
         c_body_at: references/ruby/error.c:263
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
     undefined: []

--- a/data/builtins/ruby_core/hash.yml
+++ b/data/builtins/ruby_core/hash.yml
@@ -399,9 +399,8 @@ classes:
         arity: 0
         defined_at: references/ruby/hash.c:7394
         c_body_at: references/ruby/hash.c:3770
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "() -> Array[K]"
         rbs_at: references/rbs/core/hash.rbs:1430
@@ -411,9 +410,8 @@ classes:
         arity: 0
         defined_at: references/ruby/hash.c:7395
         c_body_at: references/ruby/hash.c:3817
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "() -> Array[V]"
         rbs_at: references/rbs/core/hash.rbs:2098
@@ -423,9 +421,8 @@ classes:
         arity: -1
         defined_at: references/ruby/hash.c:7396
         c_body_at: references/ruby/hash.c:2689
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "(*_Key arg0) -> Array[V?]"
         rbs_at: references/rbs/core/hash.rbs:2116
@@ -435,9 +432,8 @@ classes:
         arity: -1
         defined_at: references/ruby/hash.c:7397
         c_body_at: references/ruby/hash.c:2725
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "(*_Key keys) -> Array[V]"
         - "[K2 < _Key, T] (*K2 keys) { (K2 key) -> T } -> Array[V | T]"
@@ -567,9 +563,8 @@ classes:
         arity: -1
         defined_at: references/ruby/hash.c:7409
         c_body_at: references/ruby/hash.c:2620
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "[K2 < _Key] (*K2 keys) -> Hash[K2, V]"
         rbs_at: references/rbs/core/hash.rbs:1703
@@ -579,9 +574,8 @@ classes:
         arity: -1
         defined_at: references/ruby/hash.c:7410
         c_body_at: references/ruby/hash.c:2655
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "(*_Key keys) -> Hash[K, V]"
         rbs_at: references/rbs/core/hash.rbs:1151
@@ -897,9 +891,8 @@ classes:
         defined_at: references/ruby/hash.c:7355
         c_body_at: references/ruby/hash.c:1787
         c_effects:
-        - mutate
         - raises
-        purity: mutates_self
+        purity: leaf
         rbs:
         - "[K, V] (hash[K, V] hash) -> instance"
         - "[K, V] (array[_Pair[K, V]] two_element_arrays) -> instance"

--- a/data/builtins/ruby_core/io.yml
+++ b/data/builtins/ruby_core/io.yml
@@ -1282,9 +1282,8 @@ classes:
         arity: -1
         defined_at: references/ruby/io.c:15906
         c_body_at: references/ruby/io.c:13884
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
       readpartial:
         source: c
         cfunc: argf_readpartial
@@ -1307,18 +1306,16 @@ classes:
         arity: -1
         defined_at: references/ruby/io.c:15909
         c_body_at: references/ruby/io.c:10611
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
       to_a:
         source: c
         cfunc: argf_readlines
         arity: -1
         defined_at: references/ruby/io.c:15910
         c_body_at: references/ruby/io.c:10611
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
       gets:
         source: c
         cfunc: argf_gets

--- a/data/builtins/ruby_core/numeric.yml
+++ b/data/builtins/ruby_core/numeric.yml
@@ -1294,9 +1294,8 @@ classes:
         arity: 0
         defined_at: references/ruby/numeric.c:6656
         c_body_at: references/ruby/numeric.c:951
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "() -> String"
         rbs_at: references/rbs/core/float.rbs:1156

--- a/data/builtins/ruby_core/proc.yml
+++ b/data/builtins/ruby_core/proc.yml
@@ -419,9 +419,8 @@ classes:
         defined_at: references/ruby/proc.c:4621
         c_body_at: references/ruby/proc.c:3339
         c_effects:
-        - mutate
         - dispatch
-        purity: mutates_self
+        purity: dispatch
         rbs:
         - "() -> String"
         rbs_at: references/rbs/core/method.rbs:87
@@ -432,9 +431,8 @@ classes:
         defined_at: references/ruby/proc.c:4622
         c_body_at: references/ruby/proc.c:3339
         c_effects:
-        - mutate
         - dispatch
-        purity: mutates_self
+        purity: dispatch
       to_proc:
         source: c
         cfunc: method_to_proc
@@ -621,9 +619,8 @@ classes:
         defined_at: references/ruby/proc.c:4648
         c_body_at: references/ruby/proc.c:3339
         c_effects:
-        - mutate
         - dispatch
-        purity: mutates_self
+        purity: dispatch
         rbs:
         - "() -> String"
         rbs_at: references/rbs/core/unbound_method.rbs:212
@@ -634,9 +631,8 @@ classes:
         defined_at: references/ruby/proc.c:4649
         c_body_at: references/ruby/proc.c:3339
         c_effects:
-        - mutate
         - dispatch
-        purity: mutates_self
+        purity: dispatch
       name:
         source: c
         cfunc: method_name

--- a/data/builtins/ruby_core/re.yml
+++ b/data/builtins/ruby_core/re.yml
@@ -578,9 +578,8 @@ classes:
         arity: 1
         defined_at: references/ruby/re.c:4902
         c_body_at: references/ruby/re.c:2495
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "(Array[Symbol]? array_of_names) -> Hash[Symbol, String?]"
         rbs_at: references/rbs/core/match_data.rbs:273
@@ -590,9 +589,8 @@ classes:
         arity: -1
         defined_at: references/ruby/re.c:4903
         c_body_at: references/ruby/re.c:2321
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "(*capture | range[int?] backrefs) -> Array[String?]"
         rbs_at: references/rbs/core/match_data.rbs:636
@@ -635,9 +633,8 @@ classes:
         arity: 0
         defined_at: references/ruby/re.c:4907
         c_body_at: references/ruby/re.c:2608
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "() -> String"
         rbs_at: references/rbs/core/match_data.rbs:353

--- a/data/builtins/ruby_core/set.yml
+++ b/data/builtins/ruby_core/set.yml
@@ -563,9 +563,8 @@ classes:
         arity: 0
         defined_at: references/ruby/set.c:2309
         c_body_at: references/ruby/set.c:644
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "() -> Array[A]"
         rbs_at: references/rbs/core/set.rbs:729

--- a/data/builtins/ruby_core/string.yml
+++ b/data/builtins/ruby_core/string.yml
@@ -981,7 +981,6 @@ classes:
         c_body_at: references/ruby/string.c:10666
         c_effects:
         - block
-        - mutate
         purity: block_dependent
         rbs:
         - "(Regexp pattern) -> Array[String | Array[String?]]"
@@ -1543,9 +1542,8 @@ classes:
         arity: -1
         defined_at: references/ruby/string.c:12791
         c_body_at: references/ruby/string.c:2143
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
       try_convert:
         source: c
         cfunc: rb_str_s_try_convert
@@ -1602,9 +1600,8 @@ classes:
         arity: 0
         defined_at: references/ruby/string.c:12964
         c_body_at: references/ruby/string.c:12308
-        c_effects:
-        - mutate
-        purity: mutates_self
+        c_effects: []
+        purity: leaf
         rbs:
         - "() -> String"
         rbs_at: references/rbs/core/symbol.rbs:332

--- a/data/builtins/ruby_core/struct.yml
+++ b/data/builtins/ruby_core/struct.yml
@@ -118,7 +118,6 @@ classes:
         c_body_at: references/ruby/struct.c:1091
         c_effects:
         - block
-        - mutate
         purity: block_dependent
         rbs:
         - "() -> Hash[Symbol, E]"
@@ -208,7 +207,6 @@ classes:
         c_body_at: references/ruby/struct.c:1388
         c_effects:
         - block
-        - mutate
         purity: block_dependent
         rbs:
         - "() -> Enumerator[E, Array[E]]"
@@ -222,7 +220,6 @@ classes:
         c_body_at: references/ruby/struct.c:1388
         c_effects:
         - block
-        - mutate
         purity: block_dependent
       values_at:
         source: c
@@ -286,7 +283,6 @@ classes:
         c_body_at: references/ruby/struct.c:643
         c_effects:
         - block
-        - mutate
         - raises
         purity: block_dependent
         rbs:
@@ -391,7 +387,6 @@ classes:
         c_body_at: references/ruby/struct.c:1091
         c_effects:
         - block
-        - mutate
         purity: block_dependent
       members:
         source: c
@@ -434,7 +429,6 @@ classes:
         c_body_at: references/ruby/struct.c:1709
         c_effects:
         - block
-        - mutate
         - raises
         purity: block_dependent
       members:

--- a/data/builtins/ruby_core/time.yml
+++ b/data/builtins/ruby_core/time.yml
@@ -216,9 +216,8 @@ classes:
         defined_at: references/ruby/time.c:6006
         c_body_at: references/ruby/time.c:4406
         c_effects:
-        - mutate
         - dispatch
-        purity: mutates_self
+        purity: dispatch
         rbs:
         - "() -> String"
         rbs_at: references/rbs/core/time.rbs:1182
@@ -241,9 +240,8 @@ classes:
         defined_at: references/ruby/time.c:6008
         c_body_at: references/ruby/time.c:5165
         c_effects:
-        - mutate
         - raises
-        purity: mutates_self
+        purity: leaf
         rbs:
         - "(Array[Symbol]?) -> Hash[Symbol, Integer]"
         rbs_at: references/rbs/core/time.rbs:913
@@ -672,9 +670,8 @@ classes:
         defined_at: references/ruby/time.c:6053
         c_body_at: references/ruby/time.c:5315
         c_effects:
-        - mutate
         - dispatch
-        purity: mutates_self
+        purity: dispatch
         rbs:
         - "(?Integer fraction_digits) -> String"
         rbs_at: references/rbs/core/time.rbs:1663

--- a/docs/CURRENT_WORK.md
+++ b/docs/CURRENT_WORK.md
@@ -59,11 +59,12 @@ this file is the one that is wrong.
   vocabulary before v0.4.0. #389 and #390 are both measured and declined, so **every remaining
   diagnostic consumer of the effect system has now been measured away** — what is left is reporting
   and annotation surface.
-- **Two builtin-catalogue extractor bugs fell out of the #390 audit and are filed** (neither is
-  effect-system work, both `ready-for-agent`): #417 — `RAISE_RE` misses every helper-macro raise, so 35
-  catalogued methods read `raises: false` while raising, `Hash#fetch` among them; #418 — `Array#sort`
-  reads `purity: mutates_self` because the mutator heuristic's "first argument is a formal parameter"
-  net fires on a parameter `rb_ary_sort` rebound to a dup, which also costs it constant folding.
+- **The two builtin-catalogue extractor bugs from the #390 audit are FIXED** on branch
+  `fix/builtin-catalog-extractor-facets`: #417 (`RAISE_RE` missed every helper-macro raise — 36 methods
+  gain `raises`, `Hash#fetch` among them) and #418 (`mutates?` short-circuited on the raw mutator list
+  before the ownership test — 51 methods change, `Array#sort` becomes non-mutating). Data corrections
+  only: nothing in `lib/` reads `c_effects`, `purity` is read only by `safe_for_folding?`, and inferred
+  types are unchanged (A/B'd). No CHANGELOG entry for that reason.
 - The next typing consumer worth trying is ADR-103 § 8 (2)'s computed purity for remembering call
   results across re-invocation (`if x.foo && x.foo.bar`): unlike B2.2's, its rule reads **locals**,
   which is the only receiver shape `call.possible-nil-receiver` fires on.

--- a/docs/notes/20260819-discarded-pure-result-corpus-gate.md
+++ b/docs/notes/20260819-discarded-pure-result-corpus-gate.md
@@ -47,9 +47,13 @@ Each cell has a mechanical cause worth recording separately:
   `rb_name_err_raise` (30 — note the curated list has the near-miss sibling `rb_name_error`),
   `rb_syserr_fail`, `rb_eof_error`, `rb_enc_raise` and `rb_memerror`.
 - `Array#sort` reads `mutates_self` because `rb_ary_sort` is
-  `ary = rb_ary_dup(ary); rb_ary_sort_bang(ary);` — the extractor's "first argument is a formal
-  parameter" mutator heuristic fires on a formal parameter that was **rebound to the dup one line
-  earlier**. This one is a fixable extractor bug rather than an inherent limit.
+  `ary = rb_ary_dup(ary); rb_ary_sort_bang(ary);` and `mutates?` short-circuited on the curated raw
+  mutator list *before* any ownership analysis ran — `rb_ary_sort_bang` appears in the body, applied to
+  the dup. (The rebinding guard already detected the reassignment; it sat on the branch the
+  short-circuit skipped. An earlier revision of this note misattributed the cause to that guard
+  misfiring.) Fixed in #418, along with #417 for the `raises` hole; `Hash#fetch` now carries `raises`
+  and `Array#sort` is non-mutating. Neither changes an inferred type — the facets had no behavioural
+  consumer on these shapes.
 - `Kernel#Integer` has neither facet: `Kernel` is not among the 21 topic files under
   `data/builtins/ruby_core/`.
 

--- a/tool/extract_builtin_catalog.rb
+++ b/tool/extract_builtin_catalog.rb
@@ -799,39 +799,18 @@ module CBodyClassifier
   /x
   COERCE_FALLBACK_RE = /\brb_num_coerce_(?:bin|cmp|relop)\b/
   BLOCK_RE = /\b(?:rb_yield\w*|rb_block_given_p|rb_iterator_p|rb_block_call\w*)\b/
-  MUTATE_RE = /
-    \b(?:
-      rb_check_frozen\w* |
-      rb_str_modify\w* |
-      rb_str_resize |
-      rb_str_set_len |
-      rb_str_buf_cat\w* |
-      rb_str_buf_append |
-      rb_str_replace |
-      rb_str_update |
-      rb_ary_modify\w* |
-      rb_ary_set_len |
-      rb_ary_resize |
-      rb_ary_replace |
-      rb_ary_store |
-      rb_ary_push\w* |
-      rb_ary_pop |
-      rb_ary_shift |
-      rb_ary_unshift |
-      rb_ary_concat\w* |
-      rb_ary_splice |
-      rb_ary_clear |
-      rb_ary_delete\w* |
-      rb_ary_insert |
-      rb_ary_sort_bang |
-      rb_hash_modify\w* |
-      rb_hash_aset |
-      rb_hash_delete\w* |
-      rb_hash_clear |
-      rb_obj_taint |
-      rb_obj_freeze\w*
-    )\b
-  /x
+  # The curated raw mutators, as patterns rather than as one alternation, because {mutates?} needs to ask
+  # WHICH VALUE each one is applied to and not merely whether the body mentions it.
+  RAW_MUTATORS = %w[
+    rb_check_frozen\w*
+    rb_str_modify\w* rb_str_resize rb_str_set_len rb_str_buf_cat\w* rb_str_buf_append
+    rb_str_replace rb_str_update
+    rb_ary_modify\w* rb_ary_set_len rb_ary_resize rb_ary_replace rb_ary_store rb_ary_push\w*
+    rb_ary_pop rb_ary_shift rb_ary_unshift rb_ary_concat\w* rb_ary_splice rb_ary_clear
+    rb_ary_delete\w* rb_ary_insert rb_ary_sort_bang
+    rb_hash_modify\w* rb_hash_aset rb_hash_delete\w* rb_hash_clear
+    rb_obj_taint rb_obj_freeze\w*
+  ].freeze
   RAISE_RE = /\b(?:rb_raise\w*|rb_num_zerodiv|rb_cmperr\w*|rb_name_error\w*|rb_bug)\b/
 
   def classify(body_text, mutator_helpers: nil, formal_params: [])
@@ -846,22 +825,21 @@ module CBodyClassifier
     }
   end
 
-  # A body counts as mutating self iff:
-  # - the stripped text contains one of the curated raw
-  #   mutators in `MUTATE_RE` (`rb_str_modify`, `rb_ary_pop`,
-  #   etc.), or
-  # - the body calls a `mutator_helpers` member whose first
-  #   argument is one of the body's own formal parameters
-  #   (`time_localtime` calls `time_modify(time)` where `time`
-  #   is a formal param). The "first arg = formal param" rule
-  #   is the safety net that keeps allocator-mutators out —
-  #   `rb_ary_to_a` calls `rb_ary_replace(dup, ary)` where the
-  #   first arg is `dup` (a local), so the body falls through
-  #   the helper match.
+  # A body counts as mutating self iff it applies a mutator — a curated raw one ({RAW_MUTATORS}) or a
+  # recognised `mutator_helpers` member — **to one of its own formal parameters**, that parameter not
+  # having been rebound earlier in the body.
+  #
+  # The "first argument is a live formal" rule is the whole safety net, and it has to cover BOTH sources.
+  # Until #418 the raw list short-circuited ahead of it — `return true if text =~ MUTATE_RE` — so any
+  # body that merely *mentioned* a raw mutator was mutating, whatever it applied it to. `rb_ary_sort` is
+  # `ary = rb_ary_dup(ary); rb_ary_sort_bang(ary);`: it sorts the dup, and the receiver is untouched. The
+  # rebinding guard below already detected that; it just sat on the branch the short-circuit skipped.
+  #
+  # Applying a mutator to a local is the ordinary build-a-new-object shape (`rb_ary_to_a` calls
+  # `rb_ary_replace(dup, ary)`), and it is what separates `Array#sort` from `Array#sort!`.
   def mutates?(text, mutator_helpers, formal_params)
-    return true if text =~ MUTATE_RE
-
-    calls_helper_on_own_param?(text, mutator_helpers, formal_params)
+    calls_mutator_on_own_param?(text, RAW_MUTATORS, formal_params) ||
+      calls_helper_on_own_param?(text, mutator_helpers, formal_params)
   end
 
   # Formal parameter names that the convention reserves for variadic-method bookkeeping (`int argc, VALUE *argv, VALUE
@@ -871,17 +849,26 @@ module CBodyClassifier
   VARARG_FORMAL_NAMES = %w[argc argv _argc _argv].freeze
 
   def calls_helper_on_own_param?(body_text, helpers, formal_params)
-    return false if helpers.nil? || helpers.empty?
+    on_own_param?(body_text, helpers, formal_params) { |helper| Regexp.escape(helper) }
+  end
+
+  # The {RAW_MUTATORS} arm. Its members are already regex source (`rb_ary_push\w*`), so unlike a helper
+  # name they are interpolated rather than escaped.
+  def calls_mutator_on_own_param?(body_text, mutators, formal_params)
+    on_own_param?(body_text, mutators, formal_params) { |mutator| mutator }
+  end
+
+  # Whether the body applies any of `callees` to one of its own formal parameters as the first argument.
+  def on_own_param?(body_text, callees, formal_params)
+    return false if callees.nil? || callees.empty?
     return false if formal_params.nil? || formal_params.empty?
 
-    text = body_text.is_a?(String) ? body_text : body_text.to_s
-    text = strip_comments(text)
-    candidates = formal_params - VARARG_FORMAL_NAMES
-    candidates.any? do |param|
+    text = strip_comments(body_text.to_s)
+    (formal_params - VARARG_FORMAL_NAMES).any? do |param|
       next false if formal_param_reassigned?(text, param)
 
-      helpers.any? do |helper|
-        text.match?(/\b#{Regexp.escape(helper)}\s*\(\s*#{Regexp.escape(param)}\b/)
+      callees.any? do |callee|
+        text.match?(/\b#{yield(callee)}\s*\(\s*#{Regexp.escape(param)}\b/)
       end
     end
   end

--- a/tool/extract_builtin_catalog.rb
+++ b/tool/extract_builtin_catalog.rb
@@ -811,7 +811,29 @@ module CBodyClassifier
     rb_hash_modify\w* rb_hash_aset rb_hash_delete\w* rb_hash_clear
     rb_obj_taint rb_obj_freeze\w*
   ].freeze
-  RAISE_RE = /\b(?:rb_raise\w*|rb_num_zerodiv|rb_cmperr\w*|rb_name_error\w*|rb_bug)\b/
+  # Every way a C body reaches a Ruby exception. Curated rather than shaped: CRuby is full of
+  # `*_error*` names that only read, print or flag an exception (`rb_errinfo`, `rb_ec_raised_p`,
+  # `rb_ec_error_print`, the whole `rb_debug_*` family), and a `\w*(raise|error|fail)\w*` pattern
+  # sweeps those in.
+  #
+  # Deliberately NOT here, because they answer a different question and folding one into this facet
+  # would make it unusable in the opposite direction (#417):
+  #
+  # - argument coercion and arity — `rb_num2*`, `rb_check_arity`, `rb_scan_args`. Every `-1`-arity C
+  #   function checks its arity; a TypeError on a bad argument is not the raise-as-validation idiom a
+  #   consumer of this facet is trying to exclude.
+  # - the frozen gate — `rb_check_frozen*`, which is a {RAW_MUTATORS} member and is recorded as
+  #   mutation, not as raising.
+  RAISERS = %w[
+    rb_raise\w* rb_f_raise rb_exc_raise rb_exc_fatal
+    rb_key_err_raise rb_name_err_raise rb_name_error\w* rb_enc_raise rb_enc_reg_raise
+    rb_cstr_to_dbl_raise rb_invalid_str rb_must_asciicompat
+    rb_sys_fail\w* rb_syserr_fail\w* rb_sys_enc_fail\w* rb_exec_fail rb_execarg_fail
+    rb_eof_error rb_loaderror\w* rb_memerror rb_error_arity rb_error_frozen\w*
+    rb_econv_check_error rb_num_zerodiv rb_cmperr\w*
+    rb_bug rb_bug_errno rb_bug_for_fatal_signal rb_async_bug_errno rb_assert_failure\w*
+  ].freeze
+  RAISE_RE = /\b(?:#{RAISERS.join('|')})\b/
 
   def classify(body_text, mutator_helpers: nil, formal_params: [])
     text = strip_comments(body_text)


### PR DESCRIPTION
Fixes the two builtin-catalogue extractor bugs that fell out of the #390 gate audit. Both regenerate `data/builtins/ruby_core/*.yml`, so they share a branch rather than colliding as separate PRs.

**These are data corrections with no behaviour change.** Nothing in `lib/` reads `c_effects`; `purity` is read only by `MethodCatalog#safe_for_folding?`. Inferred types were A/B'd on literal receivers before and after and are identical, so there is no CHANGELOG entry. The generator was confirmed byte-reproducible against the checked-in files before any change, which is what makes the regenerated diff reviewable.

## `bcdeff3c` — #418, the raw mutator list bypassed the ownership test

`mutates?` short-circuited:

```ruby
return true if text =~ MUTATE_RE
calls_helper_on_own_param?(text, mutator_helpers, formal_params)
```

A body that merely *mentioned* a curated raw mutator was mutating, whatever it applied it to. `rb_ary_sort` is `ary = rb_ary_dup(ary); rb_ary_sort_bang(ary);` — it sorts the dup. The existing `formal_param_reassigned?` guard detects that rebinding correctly; it just sat on the branch the short-circuit skipped. (The issue body's original diagnosis blamed that guard, and is corrected in a comment there.)

Both arms now ask the same question, so there is one rule instead of a short-circuit plus a rule.

**51 methods change.** 16 were already `block_dependent` and only shed a wrong `mutate` marker; 35 lose `mutates_self` — 29 to `leaf`, 6 to `dispatch`. Every one is a build-a-new-object shape: `Array#sort`, `Array#&`, `Array#-`, `Array#transpose`, `Hash#keys`, `Hash#values`, `Hash#slice`, `Hash#except`, `Enumerable#sort`, `Set#to_a`, `Float#to_s`, `Symbol#inspect`, `MatchData#inspect`, `String.new`.

Genuine mutators are untouched — `String#replace` and `String#initialize_copy` reach the helper arm through `str_modifiable(str)`, whose first argument is a live formal. `Set#merge` still reads `mutates_self`, which is correct and was worth confirming since its selector name suggests otherwise.

`ARGF#read` / `#readlines` / `#to_a` land on `leaf` and were adjudicated rather than blocklisted: `purity` is a fold-safety classification, no fold tier dispatches on ARGF (it appears nowhere in `lib/`), and the stream advance that makes them non-reproducible is carried by the effects catalogue, where ARGF is rowed `posture: stdin`. The `mutate` marker was never what recorded it.

## `08cd1320` — #417, the `raises` facet missed every helper-macro raise

`\brb_raise` cannot match inside a name that merely ends in `raise`, so exceptions reached through CRuby's helper macros were invisible: `rb_exc_raise` (103 call sites), `rb_sys_fail*` (264), `rb_syserr_fail*` (74), `rb_name_err_raise` (30 — the curated list carried the near-miss sibling `rb_name_error`), `rb_eof_error`, `rb_memerror`, `rb_enc_raise`, `rb_key_err_raise`.

`Hash#fetch` is the case that found it: `rb_hash_fetch_m` raises through `rb_key_err_raise`, so the canonical raise-as-validation idiom read `raises: false`.

The list stays **curated** rather than becoming a `\w*(raise|error|fail)\w*` shape with a deny-list. CRuby is full of `*_error*` names that only read, print or flag an exception — `rb_errinfo`, `rb_ec_raised_p`, `rb_ec_error_print`, the whole `rb_debug_*` family — and a shaped pattern trades a recall hole for a precision one.

Two families are deliberately excluded, with the reason written at the constant: argument coercion and arity (`rb_num2*`, `rb_check_arity`), because every `-1`-arity C function checks its arity and a TypeError on a bad argument is not the validation idiom; and the frozen gate `rb_check_frozen*`, which is a `RAW_MUTATORS` member and is recorded as mutation.

**36 methods gain `raises`**: `Hash#fetch`, the `File` / `IO` syscall wrappers failing through `rb_sys_fail`, the `ARGF` / `IO` readers ending a stream through `rb_eof_error`, `Date.today` / `DateTime.now`, `IO.popen`.

## Verification

`make verify` green after each commit. `make docs-check` green. The per-method diff was reviewed in full — all 87 changed entries — not sampled.
