### PR TITLE
Pin the suppression self-acknowledgement polarity (#321)

### DIFF
--- a/spec/rigor/analysis/check_rules/suppression_spec.rb
+++ b/spec/rigor/analysis/check_rules/suppression_spec.rb
@@ -157,6 +157,32 @@ RSpec.describe "diagnostic suppression", type: :runner do
       source = %("x".no_method # rigor:disable call.undefined-metod, suppression.unknown-rule\n)
       expect(suppression_rules(source)).to be_empty
     end
+
+    # Issue #321. The self-acknowledgement above is the INTENDED polarity — the surveillance rules are
+    # ordinary tokens with no carve-out — but nothing pinned it over the whole diagnostic set, so a
+    # refactor that reordered "compute surveillance diagnostics" against "apply suppression filtering"
+    # could flip it with every example still green. The three below fix the polarity in place.
+    #
+    # They assert `rules_for`, not `suppression_rules`: the subset projection cannot tell "the
+    # surveillance was acknowledged" apart from "the whole line got suppressed", and those are opposite
+    # outcomes.
+    it "lets a directive acknowledge the very warning it provokes" do
+      source = "x = 1 # rigor:disable call.bogus-rule suppression.unknown-rule\n"
+      expect(rules_for(source)).to be_empty
+    end
+
+    # The control for the example above: without the acknowledging token the same directive warns, so the
+    # silence there is the self-ack and not a fixture that stopped firing.
+    it "warns on the same directive when the acknowledgement is absent" do
+      expect(rules_for("x = 1 # rigor:disable call.bogus-rule\n")).to contain_exactly("suppression.unknown-rule")
+    end
+
+    # The other half of the polarity: acknowledging the surveillance must not lend the bogus token any
+    # suppressing power it did not have. The diagnostic the typo failed to name still fires.
+    it "leaves the diagnostic the unknown token failed to name" do
+      source = %("x".no_method # rigor:disable call.bogus-rule suppression.unknown-rule\n)
+      expect(rules_for(source)).to contain_exactly("call.undefined-method")
+    end
   end
 
   # Issue #306 — the anchoring. Each decline is paired with the genuinely-anchored sibling that still works,


### PR DESCRIPTION
Wave 2 of the differential-testing backlog (#321, #322, #323). **Two of the three were already fixed**, so this PR carries one commit rather than three.

## `7a4bbdbb` — #321, the suppression self-acknowledgement polarity

`suppression.unknown-rule` flows through `filter_suppressed` like any other diagnostic, so the directive it complains about can name it and silence the complaint:

```ruby
x = 1 # rigor:disable call.bogus-rule suppression.unknown-rule
```

That is the intended polarity — the surveillance rules are ordinary tokens, no carve-out — and one example already existed for it. But that example projects to `suppression_rules`, the `suppression.*` subset, and **the projection cannot tell "the surveillance was acknowledged" apart from "the whole line got suppressed"**. Those are opposite outcomes, so the hole #321 describes was real: a refactor reordering surveillance computation against suppression filtering could flip the behaviour with every example still green.

Three examples over the whole rule list close it — the self-ack silences the warning, the same directive without the acknowledging token still warns (the control), and acknowledging the surveillance lends the bogus token no suppressing power, so the diagnostic it failed to name still fires.

## #322 and #323 — already pinned, no code in this PR

Both were closed out by [`7591f802`](https://github.com/rigortype/rigor/commit/7591f802) (2026-07-16), *"Pin the raise-non-exception asymmetries and the duplicate-key label split"* — **three weeks before either issue was filed**. Evidence posted on each; recommending both be closed as no-change.

- #322 wanted a spec row for `raise Object` firing and `raise Object.new` staying silent. `describe "singleton vs instance operand asymmetry (pinned)"` has both, plus `raise Class` and `raise Comparable`, all green.
- #323 wanted the `1.0` / `1.00` case asserting `label = 1.00`. That is the existing example verbatim, with the contract and its rationale in the comment.

Both issues came from differential runs against the rigor-rs port, which verified the *behaviour* and did not check the suite — so "no spec pins this" was untrue on arrival in both.

#322's substantive observation does survive and is now **#420**: `raise Object.new` is a `TypeError` at runtime, so the silence is a missed diagnostic. Converging the polarities widens a diagnostic and needs a corpus FP gate, which is why it is its own issue rather than an edit here.

## Verification

`make verify` green.
