### PR TITLE
Measure the WD13 effect-collection budget on CI (#409)

### DIFF
--- a/.github/workflows/oss-sweep.yml
+++ b/.github/workflows/oss-sweep.yml
@@ -10,6 +10,12 @@ name: OSS sweep
 # thresholds as a workflow artifact.  Download the artifact and commit
 # data/oss-sweep/mastodon-thresholds.json to activate the gate.
 #
+# A second job, `effect-budget`, re-verifies ADR-103 WD13's effect-collection
+# cost budget against the same pinned target (#409). It is advisory: it reports
+# the delta and never fails the run, following the perf-bench precedent
+# (ADR-50 WD6) that a measurement earns the power to fail a release only once
+# its band is known to be stable on the measuring host.
+#
 # Pinned target: data/oss-sweep/mastodon-sha.txt
 # Rigor config:  data/oss-sweep/mastodon-rigor.yml
 # Thresholds:    data/oss-sweep/mastodon-thresholds.json
@@ -172,3 +178,82 @@ jobs:
           print(f'Precise: {s[\"precise_count\"]}')
           print(f'Dynamic (opaque): {s[\"dynamic_opaque_count\"]}')
           " || true
+
+  # ── ADR-103 WD13 effect-collection budget (#409, advisory) ────────
+  #
+  # The graduation criterion for effects-default-on is that WD13's "≤ ~5 % wall
+  # / RSS on mastodon" still holds AT THE RELEASE: the original figures were
+  # measured when only opted-in projects paid the cost, and default-on changes
+  # the population the budget has to hold for.
+  #
+  # Its own job rather than a step in `sweep`, because that job restores a warm
+  # analysis cache across weekly runs — exactly what a cold cost measurement
+  # must not have. No `actions/cache` step here, deliberately.
+  #
+  # Linux is where this is measured: peak RSS is only readable from /proc, and
+  # a developer laptop shares its cores with a browser. tool/bench.rb already
+  # names the CI runner the authoritative measurement host.
+  effect-budget:
+    name: Effect-collection budget (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout Rigor
+        uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Set up Ruby (Rigor runtime)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0"
+          bundler-cache: true
+
+      - name: Read pinned Mastodon tag
+        id: mastodon_tag
+        run: |
+          TAG=$(cat data/oss-sweep/mastodon-sha.txt | tr -d '[:space:]')
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Clone Mastodon (sparse, pinned tag)
+        run: |
+          git clone \
+            --depth 1 \
+            --filter=blob:none \
+            --sparse \
+            --branch "${{ steps.mastodon_tag.outputs.tag }}" \
+            https://github.com/mastodon/mastodon.git \
+            /tmp/mastodon
+          git -C /tmp/mastodon sparse-checkout set app lib config
+
+      - name: Measure effects on vs off
+        run: |
+          bundle exec ruby tool/effect_budget.rb \
+            --target /tmp/mastodon \
+            --base-config data/oss-sweep/mastodon-rigor.yml \
+            --reps 5 \
+            --bound-pct 5.0 \
+            --json /tmp/mastodon-effect-budget.json \
+            | tee /tmp/mastodon-effect-budget.txt
+
+      - name: Summarise
+        if: always()
+        run: |
+          {
+            echo "### ADR-103 WD13 effect budget (advisory)"
+            echo
+            echo '```'
+            tail -3 /tmp/mastodon-effect-budget.txt 2>/dev/null || echo "no measurement"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload budget artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: effect-budget-mastodon-${{ steps.mastodon_tag.outputs.tag }}-${{ github.run_id }}
+          retention-days: 90
+          path: |
+            /tmp/mastodon-effect-budget.json
+            /tmp/mastodon-effect-budget.txt

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,17 @@ coverage:
 bench-perf:
 	bundle exec ruby tool/bench.rb --target lib
 
+# ADR-103 WD13 / #409 effect-collection cost budget. Interleaved A/B of
+# `rigor check` with and without `effects:` over an external corpus target,
+# reporting median wall / peak-RSS deltas against the ~5% bound. Advisory,
+# and like `bench-perf` deliberately NOT in `verify`. The authoritative host
+# is Linux CI (peak RSS reads from /proc, and a laptop shares its cores with
+# a browser) — `.github/workflows/oss-sweep.yml` runs it against the pinned
+# Mastodon. Locally: make effect-budget TARGET=~/repo/ruby/rigor-survey/redmine \
+#   BASE_CONFIG=/tmp/redmine-base.yml
+effect-budget:
+	bundle exec ruby tool/effect_budget.rb --target $(TARGET) --base-config $(BASE_CONFIG)
+
 # `verify` chains the spec suite, the gated pool-runner spec (its
 # own rspec process — see `test-ractor-pool`), rubocop, `rigor check
 # lib`, and the plugin-tree contract check. The spec phase runs via

--- a/docs/notes/20260819-wd13-effect-budget-verification.md
+++ b/docs/notes/20260819-wd13-effect-budget-verification.md
@@ -1,0 +1,95 @@
+# Re-verifying the WD13 effect-collection budget (#409): method, and why it runs on CI
+
+Status: measurement note plus the harness it produced. No design commitments — the numbers below are
+provisional and the authoritative ones will come from
+[`oss-sweep.yml`](../../.github/workflows/oss-sweep.yml)'s `effect-budget` job.
+
+[ADR-103](../adr/103-effect-labels.md) § WD13 states the budget verbatim:
+
+> working budget ≤ ~5 % wall / RSS on mastodon and ≤ 1 s of fixpoint at gitlab scale
+
+and § WD15 makes re-verifying it a precondition for effects-default-on, because "the ≤5% wall/RSS and
+≤1s fixpoint figures were measured pre-default-on, when only opted-in projects paid the cost;
+universality changes the population the budget has to hold for."
+
+Two things about the bound are easy to get wrong and worth stating plainly. It names **mastodon**, not
+the corpus generally. And **gitlab's bound is not the run** — it is the closure, `Propagator.propagate`,
+at ≤ 1 s. A full gitlab A/B would be 11,344 files × 2 arms × N reps to answer a question the bound does
+not ask.
+
+## The harness
+
+[`tool/effect_budget.rb`](../../tool/effect_budget.rb), also `make effect-budget`. Four properties, each
+of which cost something to learn:
+
+- **Interleaved A/B** (off, on, off, on, …), not blocked. A measuring host drifts, and blocked runs
+  charge all of the drift to whichever arm ran during it. See below — this is not hypothetical.
+- **Median reported with the full range, and an explicit `separated` bit.** If the arms' ranges overlap,
+  the reps could not separate them and the delta is a number with no finding behind it. Hiding that
+  behind a median is how a noisy measurement becomes a confident wrong answer.
+- **`--no-cache`, cache directory removed between runs.** A warm slot serves an unanalysed result in
+  milliseconds ([ADR-45](../adr/45-run-result-cache.md)), which reads as a spectacular improvement.
+- **A zero-file guard.** Both arms must analyse a positive and *identical* file count or the script
+  aborts. The first version of the script wrote its variant configs to a tmpdir; a config's relative
+  `paths:` resolve against the config file's own directory, so it analysed nothing, finished in 0.18 s
+  and reported a 33 % *improvement*. The guard exists because that is what it did.
+
+## Why the authoritative run is CI, not a laptop
+
+`tool/bench.rb` already names the CI runner "the authoritative measurement host", and peak RSS is only
+readable from `/proc` — on macOS `bench.rb` reports RSS as nil and skips the gate.
+
+The local attempt made the case concretely. Partway through, an unrelated process (`target/debug/xtask`,
+99.7 % of a core for 48 minutes) took the machine to a load average of 17–29 on 12 cores. The damage is
+legible in the timestamps: round 1 finished at 08:17:31, the interloper started at 08:23:34, and the
+data breaks at exactly that boundary — mastodon reps 1–4 are tight, rep 5 jumps to 36.98 s, and a
+confirmation run afterwards produced 1069 s and 972 s for a run that takes 14 s. A release-gate figure
+cannot depend on what else the author happened to be building.
+
+The `effect-budget` job therefore lives in `oss-sweep.yml` beside the existing Mastodon sweep, and
+**as its own job** — the sweep restores a warm analysis cache across weekly runs, which is exactly what
+a cold cost measurement must not have.
+
+## Provisional local figures
+
+Sequential runs (`parallel.workers` defaults to `0`, and neither target sets it, so both arms are
+sequential — the fork-pool pinning WD13 mentions does not apply and is not a confound here). This is
+also the default user experience, which is the population #409 is asking about.
+
+| target | files | wall off → on | RSS off → on | clean? |
+| --- | --- | --- | --- | --- |
+| redmine | 347 | 8.69 → 9.53 s (**+9.7 %**) | 304 → 328 MB (+7 %) | yes — ran before the interloper |
+| mastodon | 1,312 | 14.57 → 18.63 s (**+27.9 %**) | 558 → 553 MB (noise) | reps 1–4 only; needs CI confirmation |
+
+The mastodon arms did not overlap (max off 16.69 s < min on 17.24 s), so the direction is not in doubt
+even though the magnitude is. **Both targets are over the ~5 % wall bound, redmine by ~2× and mastodon
+by ~6×.** RSS is within noise on mastodon and near the bound on redmine.
+
+A plausible mechanism, unverified: collection adds a second full AST walk per file. `Effects::Scanner`
+is explicitly "a separate walk … taken here" rather than riding `ScopeIndexer`'s descent, because it
+must attribute each recorded call node to its enclosing unit. That is a per-file cost proportional to
+the tree, which is the shape of a double-digit percentage rather than a rounding error. Confirming or
+refuting it is the obvious next step and is **not** done here.
+
+## YJIT is an RSS confounder and must be reported alongside
+
+On redmine, `RIGOR_DISABLE_YJIT=1` moves peak RSS 303 → 259 MB (−15 %) while making the run *slower*,
+8.69 → 9.50 s. Any RSS figure near a 5 % bound is inside the JIT's own swing, so the budget job records
+the YJIT-on numbers and any future recalibration should say which it measured.
+
+## What would make this a hard gate
+
+The job ships **advisory**, following the perf-bench precedent ([ADR-50](../adr/50-release-engineering-and-stability-strategy.md)
+WD6): a measurement earns the power to fail a release only once its band is known to be stable on the
+measuring host. Promoting it needs a few weekly runs establishing the CI band, and then `--gate` in the
+workflow step. Note that on today's evidence the gate would fail — which is a finding about the budget,
+not a reason to widen the bound.
+
+## Not done here
+
+- The gitlab fixpoint bound (≤ 1 s). `tool/effect_budget.rb` measures whole runs and is not it: timing
+  `Propagator.propagate` at gitlab scale is a separate measurement, and gitlab is not in the sweep at
+  all. The closure is a pure function of the merged collection, so it can be timed in-process off one
+  analysed run rather than needing an A/B.
+- Confirming the double-AST-walk mechanism above.
+- Any change to collection's cost. This note measures; it does not optimise.

--- a/tool/effect_budget.rb
+++ b/tool/effect_budget.rb
@@ -1,0 +1,180 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# ADR-103 WD13 / #409 — what does turning effect collection ON cost?
+#
+# The graduation criterion for effects-default-on is a re-verification of WD13's working budget,
+# "≤ ~5 % wall / RSS on mastodon", **at the release** — the figures were measured when only opted-in
+# projects paid the cost, and default-on changes the population the budget has to hold for.
+#
+# Method, and why each part is there:
+#
+# - **Interleaved A/B** (off, on, off, on, …) rather than blocked (off×N then on×N). A CI runner drifts
+#   — a noisy neighbour, thermal state, a cache warming somewhere — and blocked runs charge all of that
+#   drift to whichever arm ran during it. Interleaving splits it evenly. This was not hypothetical: the
+#   first local attempt at this measurement was blocked, and an unrelated process taking a core partway
+#   through moved one arm by 2x.
+# - **Median, plus the full range.** One outlier run is normal on shared hardware and must not decide a
+#   release gate; a range that OVERLAPS between the arms is the signal that the reps were too few, and
+#   is reported rather than hidden behind the median.
+# - **`--no-cache`, and the cache directory removed between runs.** A warm slot serves an unanalysed
+#   result in milliseconds, which would read as a spectacular improvement (ADR-45).
+# - **Both arms use the same config apart from `effects:`.** The variant configs are generated here from
+#   one base file rather than committed as two, so they cannot drift apart.
+#
+# Usage:
+#   ruby tool/effect_budget.rb --target /tmp/mastodon --base-config data/oss-sweep/mastodon-rigor.yml \
+#     [--reps 5] [--bound-pct 5.0] [--json OUT] [--gate]
+#
+# Exits 0 unless `--gate` is given AND a metric exceeds the bound. Advisory by default, following the
+# perf-bench precedent (ADR-50 WD6): a measurement earns the power to fail a release only once its band
+# is known to be stable on the measuring host.
+
+require "fileutils"
+require "json"
+require "optparse"
+require "tmpdir"
+
+options = {
+  target: nil, base_config: nil, reps: 5, bound_pct: 5.0, json: nil, gate: false,
+  rigor_root: File.expand_path("..", __dir__)
+}
+OptionParser.new do |o|
+  o.on("--target PATH") { |v| options[:target] = v }
+  o.on("--base-config PATH") { |v| options[:base_config] = v }
+  o.on("--reps N", Integer) { |v| options[:reps] = v }
+  o.on("--bound-pct F", Float) { |v| options[:bound_pct] = v }
+  o.on("--json PATH") { |v| options[:json] = v }
+  o.on("--gate") { options[:gate] = true }
+end.parse!
+
+abort("--target is required") unless options[:target]
+abort("--base-config is required") unless options[:base_config]
+
+ROOT = options[:rigor_root]
+TARGET = File.expand_path(options[:target])
+BASE = File.read(options[:base_config])
+
+abort("base config already sets `effects:` — the A/B needs a base with it absent") if BASE.match?(/^effects:/)
+
+# One config per arm, so the only difference is the one line under test.
+#
+# They are written INSIDE the target, not into a tmpdir: a config's relative `paths:` resolve against
+# the config file's own directory, so a config parked elsewhere analyses nothing and the whole
+# measurement completes in 0.2 s looking like a spectacular improvement. {assert_analysed!} exists
+# because that is exactly what the first version of this script did.
+def write_variants(target)
+  off = File.join(target, ".rigor.budget-off.yml")
+  on  = File.join(target, ".rigor.budget-on.yml")
+  File.write(off, BASE)
+  File.write(on, "#{BASE}\neffects: {}\n")
+  [off, on]
+end
+
+# Rigor reports its own wall time and peak RSS, which is what "measured as the corpus perf notes
+# measure" refers to; parsing them keeps this comparable with the notes rather than with `/usr/bin/time`.
+WALL_RE  = /Wall time:\s*([0-9.]+)s/
+RSS_RE   = /Memory peak:\s*([0-9.]+)\s*MB/
+FILES_RE = /Ruby source files:\s*([0-9]+)/
+
+# A measurement over zero files is not a fast run, it is no run. Both arms must actually analyse the
+# corpus, and they must analyse the SAME corpus — an arm that silently sees a different file count is
+# comparing two projects.
+def assert_analysed!(arm, files, out)
+  return if files&.positive?
+
+  warn(out)
+  abort("#{arm} arm analysed #{files.inspect} files — the config resolved no paths, so this measures nothing")
+end
+
+def run_once(config, cache_dir)
+  FileUtils.rm_rf(cache_dir)
+  cmd = [
+    "bundle", "exec", File.join(ROOT, "exe", "rigor"), "check",
+    "--config", config, "--no-cache", "--no-baseline"
+  ]
+  out = IO.popen({ "BUNDLE_GEMFILE" => File.join(ROOT, "Gemfile") }, cmd,
+                 chdir: TARGET, err: [:child, :out], &:read)
+  [out[WALL_RE, 1]&.to_f, out[RSS_RE, 1]&.to_f, out[FILES_RE, 1]&.to_i, out]
+end
+
+def median(values)
+  sorted = values.compact.sort
+  return nil if sorted.empty?
+
+  mid = sorted.size / 2
+  sorted.size.odd? ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2.0
+end
+
+def pct_delta(base, now)
+  return nil if base.nil? || now.nil? || base.zero?
+
+  ((now - base) / base) * 100.0
+end
+
+samples = { "off" => { wall: [], rss: [] }, "on" => { wall: [], rss: [] } }
+
+off_config, on_config = write_variants(TARGET)
+cache = File.join(TARGET, ".rigor", "cache")
+file_counts = {}
+
+begin
+  options[:reps].times do |rep|
+    { "off" => off_config, "on" => on_config }.each do |arm, config|
+      wall, rss, files, out = run_once(config, cache)
+      assert_analysed!(arm, files, out)
+      (file_counts[arm] ||= []) << files
+      samples[arm][:wall] << wall
+      samples[arm][:rss] << rss
+      warn(format("[rep %d %s] wall=%s rss=%s files=%d", rep + 1, arm, wall || "NA", rss || "NA", files))
+    end
+  end
+ensure
+  FileUtils.rm_f([off_config, on_config])
+end
+
+seen = file_counts.values.flatten.uniq
+abort("arms analysed different file counts (#{seen.inspect}) — not a comparison") unless seen.size == 1
+
+result = { "target" => File.basename(TARGET), "reps" => options[:reps],
+           "bound_pct" => options[:bound_pct], "files" => seen.first }
+%i[wall rss].each do |metric|
+  off = samples["off"][metric]
+  on = samples["on"][metric]
+  m_off = median(off)
+  m_on = median(on)
+  result[metric.to_s] = {
+    "off_median" => m_off, "on_median" => m_on,
+    "off_range" => [off.compact.min, off.compact.max],
+    "on_range" => [on.compact.min, on.compact.max],
+    "delta_pct" => pct_delta(m_off, m_on),
+    # Ranges that overlap mean the reps cannot separate the arms; the delta is then a number without a
+    # finding behind it, and saying so is the whole point of carrying the ranges.
+    "separated" => [off.compact.max, on.compact.min].none?(&:nil?) && off.compact.max < on.compact.min
+  }
+end
+
+puts JSON.pretty_generate(result)
+File.write(options[:json], JSON.pretty_generate(result)) if options[:json]
+
+%w[wall rss].each do |metric|
+  row = result[metric]
+  delta = row["delta_pct"]
+  next puts("#{metric}: no measurement") if delta.nil?
+
+  verdict = delta <= options[:bound_pct] ? "within" : "OVER"
+  puts format("%-4s %s bound: %+.1f%% (bound %.1f%%), off median %.2f, on median %.2f, separated=%s",
+              metric, verdict, delta, options[:bound_pct], row["off_median"], row["on_median"],
+              row["separated"])
+end
+
+if options[:gate]
+  over = %w[wall rss].select do |metric|
+    row = result[metric]
+    row["delta_pct"] && row["delta_pct"] > options[:bound_pct] && row["separated"]
+  end
+  unless over.empty?
+    warn("WD13 budget exceeded on: #{over.join(', ')}")
+    exit 1
+  end
+end


### PR DESCRIPTION
Refs #409. Adds the harness and the CI job for ADR-103 WD13's effect-collection cost budget — one of the graduation preconditions for effects-default-on, and the only one that was agent-clearable.

**It ships advisory, and on today's evidence a hard gate would fail.** That is a finding about the budget, not a reason to widen the bound.

## What the bound actually says

Two things about it are easy to get wrong, and both change the work:

> working budget **≤ ~5 % wall / RSS on mastodon** and **≤ 1 s of fixpoint at gitlab scale**

It names **mastodon**, not the corpus generally. And **gitlab's bound is not the run** — it is the closure, `Propagator.propagate`. A full gitlab A/B would have been 11,344 files × 2 arms × N reps to answer a question the bound does not ask. The gitlab half is explicitly **not** done here.

## Provisional figures (local, sequential)

| target | files | wall off → on | RSS off → on |
| --- | --- | --- | --- |
| redmine | 347 | 8.69 → 9.53 s (**+9.7 %**) | 304 → 328 MB (+7 %) |
| mastodon | 1,312 | 14.57 → 18.63 s (**+27.9 %**) | 558 → 553 MB (noise) |

The mastodon arms do not overlap (max off 16.69 s < min on 17.24 s), so the direction is solid even though the magnitude needs CI confirmation. Both targets are over the ~5 % wall bound — redmine ~2×, mastodon ~6 ×.

A plausible mechanism, **unverified and flagged as such in the note**: `Effects::Scanner` is explicitly "a separate walk … taken here" rather than riding `ScopeIndexer`'s descent, so collection adds a second full AST walk per file. That is a cost proportional to the tree, which is the shape of a double-digit percentage rather than a rounding error.

Worth noting for interpretation: `parallel.workers` defaults to `0` and neither target sets it, so both arms are sequential and WD13's fork-pool pinning is not a confound. That is also the default user experience, which is precisely the population #409 asks about.

## Why CI, and not this laptop

`tool/bench.rb` already names the CI runner "the authoritative measurement host", and peak RSS only reads from `/proc`.

The local attempt made the case concretely. Partway through, an unrelated `target/debug/xtask` took the machine to load 17–29 on 12 cores. The damage is legible in timestamps: round 1 finished 08:17:31, the interloper started 08:23:34, and the data breaks at exactly that boundary — mastodon reps 1–4 tight, rep 5 jumps to 36.98 s, and a confirmation run afterwards reported **1069 s** for a run that takes 14 s.

The job is therefore **its own job** in `oss-sweep.yml`, not a step in `sweep` — that job restores a warm analysis cache across weekly runs, which is exactly what a cold cost measurement must not have.

## The zero-file guard is the part I'd review hardest

The first version of the script wrote its variant configs to a tmpdir. A config's relative `paths:` resolve against the config file's own directory, so it analysed **nothing**, finished in 0.18 s, and reported a **33 % improvement**. Both arms must now analyse a positive and *identical* file count or the script aborts.

## Verification

`make verify` and `make docs-check` green, re-run after the note edit rather than before it. The tool was smoke-tested locally against redmine end to end — including the failure mode above, which is how the guard got written.
