### PR TITLE
Resolve five of the effect graduation preconditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Added
+
+- **[effects]** An effect policy or envelope that names Steins' `failure.*` labels now parses instead of earning `effect.unknown-label`, so a policy written for the PHP analyzer reads unchanged here ([#378](https://github.com/rigortype/rigor/issues/378), [ADR-103](docs/adr/103-effect-labels.md)).
+  - Rigor produces no `failure.*` label of its own — in Steins the family names why a failure arm exists rather than what a method does — so a bound that names one is satisfied vacuously, the same way `io.output.buffer` is already registered here without any Ruby method producing it.
+
 ## [0.3.4] - 2026-08-21
 
 v0.3.4 is about what your code *does*, not only what it returns. The headline is the effect system ([ADR-103](docs/adr/103-effect-labels.md)): `rigor effects` reports the effects of every method, `rigor effects update` commits that report as a reviewable record the way `db/schema.rb` records a schema, and an `%a{pure}` or `%a{rigor:v1:effect io.db}` annotation becomes a contract Rigor checks. The whole family is opt-in behind an `effects:` block, and a project without one gets a byte-identical `rigor check` at unchanged cost. Alongside it, `rigor unused` ([ADR-102](docs/adr/102-unused-code-reachability-report.md)) reports classes and modules nothing reachable references, with your plugins supplying the roots a framework reaches by name. Other fixes cover constant resolution through the ancestor chain and several `rigor unused` edge cases.

--- a/data/effects/registry.yml
+++ b/data/effects/registry.yml
@@ -53,9 +53,18 @@ labels:
   - io.db.write
   - io.db.transaction
 
-  # Application-meaning roots, small and shared. These are the labels a policy actually names
-  # ("presenters do not enqueue jobs") and the ones `tolerated:` grips, so they must spell the same
-  # in Steins and Rigor.
+  # Steins carries these (its ADR-0042) and Rigor does not produce them: they name a failure arm's
+  # value provenance rather than an effect. Registered for the same reason `io.output.buffer` is —
+  # so a policy written against Steins parses here — and never inferred (ADR-103 WD16).
+  - failure
+  - failure.environment
+  - failure.input
+  - failure.resource
+
+  # Application-meaning roots. These are the labels a policy actually names ("presenters do not
+  # enqueue jobs") and the ones `tolerated:` grips, so a project must not need a plugin before it
+  # can write one. Rigor-owned and proposed to Steins, which holds ecosystem labels outside its
+  # builtin set and supplies them through a plugin manifest (ADR-103 WD16).
   - telemetry
   - email.send
   - job.enqueue

--- a/docs/CURRENT_WORK.md
+++ b/docs/CURRENT_WORK.md
@@ -16,89 +16,73 @@ Transient; replaced wholesale. Backlog lives in GitHub Issues, release planning 
 (`v0.3.0` / `v0.4.x` / `v1.0.0`). If this file disagrees with an ADR, the CHANGELOG, or an issue,
 this file is the one that is wrong.
 
-## Next session: build the manual and the user stories together
+## Next session: build the effect manual and the user stories together
 
-**This is the release blocker the owner named**, ahead of any version bump: work the effect system's
-user-facing manual and its user experience as one task — draft the manual, build the user stories that
-manual implies, and **feed what the stories expose back into the feature**. Author a SKILL where the
-workflow needs one. The `rigor-docs-review` skill runs the five-layer review battery over
-`docs/manual/` + `docs/handbook/` and is the right instrument once there is a draft to review.
+**Still the release blocker the owner named.** Draft the manual, build the user stories that manual
+implies, and **feed what the stories expose back into the feature**. Author a SKILL where the
+workflow needs one. `rigor-docs-review` runs the five-layer battery once there is a draft.
 
 Scope: the `rigor effects` chapters, the snapshot workflow (`effects update` / `check` / `diff` /
 `explain`), envelopes and `%a{pure}`, `effects.tolerated:` / `attribution:` / `envelopes:`, and the
-CLI-reference sections for `rigor effects` and `rigor unused`. The system shipped with 15 CHANGELOG
-entries and no reader has walked it end to end.
+CLI-reference sections for `rigor effects` and `rigor unused`. There is **no narrative chapter** in
+either `docs/manual/` or `docs/handbook/` today — only reference sections in 02/03/16. The system
+shipped in v0.3.4 and no reader has walked it end to end.
+
+**Write it default-on-shaped** (owner ruling, 2026-08-22): the chapter's narrative assumes v0.4.0's default,
+with the opt-in stated plainly where it bites — "v0.3.x needs an `effects:` block; from v0.4.0 it is
+the default". Writing it opt-in-shaped means a full rewrite at the flip.
 
 ## Where things stand
 
-- `make verify` + `make docs-check` green on the integrated master at `c1d8dc64`. Released version is
-  still **v0.3.3**; `[Unreleased]` carries 35 entries (Added + Fixed only — nothing breaking).
-- **Merged this session**: #419 (catalogue extractor's `mutate` / `raises` facets — #417, #418) ·
-  #421 (#321 suppression self-ack polarity) · #422 (#369 Solid Queue roots for `rigor unused`).
-- **Open PR**: #423 — the WD13 effect-budget harness + advisory CI job. CI green.
-- **#322 and #323 are still open and should be closed as no-change.** Both were already pinned by
-  `7591f802` (2026-07-16), three weeks before they were filed; evidence is posted on each. #322's
-  substantive half — `raise Object.new` is a missed diagnostic — is split out as **#420**.
+- **v0.3.4 released** (tag `v0.3.4`, 2026-08-21); `[Unreleased]` carries one entry.
+- `make verify` + `make docs-check` green on `design/effects-graduation-rulings`.
+- **Open PR**: the WD16 decision record (this branch). Dependabot: #413 (rack) and #412 (rbs 4.1.3)
+  are CI-green — **audit the rbs marshal patch before merging #412**; #343 (rubocop 1.89.0) fails
+  Lint and needs the offences fixed; #86 stays held on the `Style/ArrayIntersect` autocorrect bug.
 
-## The release plan (owner ruling, 2026-08-19)
+## The v0.4.0 graduation is nearly unblocked (ADR-103 WD16, 2026-08-22)
 
-- **v0.3.4** — ships the opt-in effect system as it stands, plus the WD13 harness. Gated on the
-  manual/UX work above, not on #409.
-- **v0.3.5 → v0.3.9** — the optimisation window, **#424**: bring effect collection inside the WD13
-  budget.
-- **v0.4.0** — a **Go / No-Go** on effects-default-on, decided against the CI band.
+Five of #409's six preconditions are resolved. Two of WD15's premises were written from the design
+rather than the code and did not survive contact:
 
-## The WD13 measurement — RETRACTED, and what survives
+- **Non-fork backends** — there is no thread backend, and the Ractor one cannot analyse a file under
+  rbs 4.x (upstream `RBS::Namespace` interning). Replaced by the sequential degrade, which is sound.
+  **#410 and #414 are closed.**
+- **Vocabulary** — read against Steins on 2026-08-22: the `mutate` spellings already agree, `io.db.*`
+  is ours and evolution-safe, and the application-meaning roots diverge *architecturally* (Steins
+  keeps ecosystem labels out of its builtin set entirely). Rigor keeps them; the spec's "shared /
+  MUST" claim was the thing that was wrong. Vocabulary 1 ships as it stands. #378 stays open as the
+  upstream conversation, not as a gate.
+- **WD13 budget** — the advisory CI `effect-budget` job is the sole arbiter. The gitlab closure
+  (`Propagator.propagate` 1.34 s vs 1 s) is #424's target for v0.3.5-v0.3.9, not a gate.
+- **`effects.lsp`** — editor mode stays effect-free, spelled as a key defaulting to `false`.
 
-I measured `effects: {}` at +9.7 % wall on redmine and +27.9 % on mastodon and reported the budget as
-failing. **That is retracted.** `docs/notes/20260817-effect-rails-layer-corpus.md` measured the same
-checkouts two days earlier, cold and sequential, with a *fuller* plugin set, and got **+3.4 % on both**
-— inside the budget. No commit since touches the collection hot path, and my host was contaminated.
-Correction on [#409](https://github.com/rigortype/rigor/issues/409); the note carries the full account.
+What is left: the **migration note** (written at the release) and the flip commit itself —
+`Configuration::DEFAULTS["effects"]`, `effects-on-by-default` `FEATURES` → `GRADUATED`, the
+`effects.lsp` key, manual / schema, CHANGELOG migration entry.
 
-**Read the checkbox as: last measured inside the budget, one unreconciled contradiction.** Not cleared,
-not failed. The advisory `effect-budget` job settles it, and #424 is re-scoped from "optimise" to
-"reconcile, then optimise only if needed".
+## Other decisions taken this session
 
-What does survive:
-- The bound's real wording — the 5 % names **mastodon** specifically, and **gitlab's bound is the
-  closure** (`Propagator.propagate` ≤ 1 s), not the run.
-- The 2026-08-17 note already reports that closure at **1.34 s** at gitlab scale — *outside* the bound,
-  unretracted, and the one figure here nobody has questioned. That is the live half.
-- One hint that the contradiction might not be pure noise: on redmine the off-arms nearly agreed
-  (8.77 vs 8.69 s) while the on-arms did not (9.07 vs 9.53 s).
+- **#370** (`rigor unused`: a data-file mention does not rescue a declaration from the test-only
+  section) — option 1: report it as its own category, "reachable from tests; also named in
+  configuration". The normative tier text lands with the behaviour, not before it.
 
-#409's other four boxes are all owner decisions: the #410 waiver, #378, `effects.lsp` semantics, and
-the flip itself.
+## Queue, in the order it consumes cleanly
+
+1. #413, then #412 (rbs marshal audit first), then #343's Lint offences.
+2. The manual + user stories above — the largest item, and the one the release waits on.
+3. #370, #420 (`raise Object.new` polarity, on corpus evidence), #391 (`sig-gen` writes `%a{pure}`).
+4. #424's propagation work in the v0.3.5-v0.3.9 window; #392 → #393 → #394 for the view slices.
 
 ## What this session learned that is not in a commit
 
-- **Verify a backlog item's premise before implementing it.** Two of wave 2's three issues (#322, #323)
-  were already fixed three weeks before they were filed — both came from differential runs against the
-  rigor-rs port that verified the *behaviour* and never checked the suite, so "no spec pins this" was
-  untrue on arrival. Cheap to check, and checking is what turned #321 from "add a spec" into the real
-  finding: its existing example projected to the `suppression.*` subset, which cannot distinguish
-  "the surveillance was acknowledged" from "the whole line got suppressed".
-- **A cost measurement needs a zero-work guard more than it needs precision.** The budget script's
-  first version wrote its variant configs to a tmpdir; relative `paths:` resolve against the config
-  file's own directory, so it analysed nothing, finished in 0.18 s and reported a 33 % *improvement*.
-  Both arms must analyse a positive and identical file count.
-- **Interleave A/B reps, and carry the ranges, not just the median.** A `target/debug/xtask` at 99.7 %
-  of a core invalidated a whole batch mid-run; the timestamps (round 1 ended 08:17:31, xtask started
-  08:23:34, the data breaks exactly there) are what made the clean reps separable from the ruined
-  ones. Non-overlapping ranges are what let a noisy measurement still support a direction.
-- **Regenerate-and-diff beats a reimplemented probe.** The catalogue audit's hand-rolled body
-  extractor included the C function's signature line, which `body.text` does not, and produced a
-  contaminated 53-method list with a phantom `String#replace` regression. Confirming the generator was
-  byte-reproducible against the checked-in files first made the real diff trustworthy.
-- **Search the corpus for a prior measurement BEFORE publishing a new one.** The WD13 retraction is
-  the expensive version of this: a note measuring the same targets, more thoroughly, sat in
-  `docs/notes/` two days old while I filed an issue and a comment saying the budget failed by 6×. The
-  `rigor-prior-art` skill exists for exactly this question and would have cost one call.
-- **Non-overlapping ranges are not a control.** They prove the reps separated the arms *under the
-  conditions that prevailed* — they cannot distinguish a real effect from a host artifact consistent
-  across the batch. I leaned on them precisely where they do not bear weight.
-- **My own published cause-analyses were wrong three times** (#418's mechanism, the `String#replace`
-  claim in the correction to it, and the WD13 finding). Each was corrected in the issue, the note and
-  this file. The pattern is the same every time: publishing the explanation before running the check
-  that would refute it.
+- **Read the other repository before writing an alignment issue.** #378 asked for a three-item
+  conversation with Steins; fetching `steins/docs/type-specification/effects.md` took one call and
+  showed item 3 already agreed, item 1 accurately documented, and item 2 a different *kind* of
+  divergence than the issue described — architectural, not lexical. It also surfaced a whole label
+  family (`failure.*`) our "verbatim" claim had gone stale against.
+- **A precondition can name something that does not exist.** WD15 required "the Ractor **and
+  thread** backends" to carry the side-table. `pool_backend` has three arms and none of them is a
+  thread pool. The issue built on it (#410) then inherited the phantom and scoped itself as "just a
+  message channel". Check the premise against the code before sizing the work — the same lesson the
+  last session recorded about #322 / #323, arriving from a different direction.

--- a/docs/adr/103-effect-labels.md
+++ b/docs/adr/103-effect-labels.md
@@ -4,9 +4,10 @@ Status: **Proposed, 2026-08-16.** Records the decisions reached while designing 
 [`docs/design/20260816-effect-labels.md`](../design/20260816-effect-labels.md) (the design note;
 its § 13 lists the choices, this ADR fixes them as working decisions; WD13, coexistence with
 `rigor check`, was added the same day; WD14, the pre-implementation decisions, and WD15, the
-v0.4.0 default-on ruling and its preconditions, both on 2026-08-17 — WD15's own preconditions are
-unmet, so nothing about the default changes yet). Two items remain open, both deferrable to the
-view slices. Implementation is sliced as GitHub issues under the umbrella
+v0.4.0 default-on ruling and its preconditions, both on 2026-08-17; WD16, which resolves five of
+those six preconditions, on 2026-08-22 — the sixth is the release-notes migration note, written at
+the release, so nothing about the default changes before v0.4.0). Two items remain open, both
+deferrable to the view slices. Implementation is sliced as GitHub issues under the umbrella
 [#376](https://github.com/rigortype/rigor/issues/376) (18 tracer-bullet slices, #377–#394; tracker
 convention: [ADR-98](98-development-flow-document-roles.md)).
 
@@ -285,7 +286,8 @@ today reaches the same default early. WD7's "graduates at a major" is read, for 
 rehearsal WD7 already describes for the general case (a `v0.2.x → v0.3.0` graduation), pinned to a
 specific version by owner ruling rather than left to "whenever the next minor lands".
 
-The flip is gated on clearing six preconditions first, none of which is closed as of this writing:
+The flip is gated on clearing six preconditions first, none of which was closed when this ruling
+was written; **WD16 resolves 1-4 and 6** (2026-08-22):
 
 1. **Pooled backends carry the effect side-table.** Collecting runs are pinned to the fork pool today;
    without `fork` (Windows) a run degrades to sequential. The Ractor and thread backends must carry the
@@ -305,6 +307,66 @@ The flip is gated on clearing six preconditions first, none of which is closed a
    `methods:` rows in the snapshot carry no proven label, only `unresolved:` — before `rigor init`
    recommends `effects update` to every project, whether that ratio is acceptable (and what, if anything,
    a project should be told about it) needs an answer.
+
+### WD16 — The graduation preconditions, resolved (owner ruling, 2026-08-22)
+
+WD15's list was written from the design, not from the code, and two of its premises do not hold.
+This ruling records what replaces them. Preconditions 1-4 and 6 are resolved here; 5 is written at
+the release itself.
+
+**1 — Pooled backends: the sequential degrade IS the answer.** There is no thread backend and there
+will not be one — `pool_backend` selects `:fork`, `:ractor` or `:sequential`, and a thread pool buys
+no parallelism under the GVL while sharing RBS's C-extension state across workers. The Ractor
+backend cannot analyse a single file under rbs 4.x: `RBS::Namespace.[]` interns every namespace
+through a process-wide mutable flyweight held in module ivars, a non-main Ractor may not read one,
+and pre-warming does not reach it because the trie is consulted while parsing the cached environment
+back ([#414](https://github.com/rigortype/rigor/issues/414)). The precondition as written therefore
+cannot be cleared by any work Rigor owns. It is replaced by the behaviour the code already has: with
+no `fork`, a collecting run degrades to sequential **and says so** through the same
+`pool_degraded_diagnostic` channel the fork path uses. That degrade is sound rather than merely safe
+— the sequential path still collects, so the effect graph is complete either way, and Windows pays
+wall-clock, never correctness. [#410](https://github.com/rigortype/rigor/issues/410) (carry the
+side-table through the non-fork backends) closes with it: its stated premise, "the only new piece is
+the message channel", is untrue while the backend it targets cannot analyse a file.
+
+**2 — Vocabulary: vocabulary 1 ships as it stands.** Read against Steins on 2026-08-22, the three
+items of [#378](https://github.com/rigortype/rigor/issues/378) resolve differently from how they were
+filed. The `mutate.self` / `mutate.instance` / `mutate.static` spelling already agrees (WD14). The
+`io.db.read` / `io.db.write` / `io.db.transaction` leaves are Rigor's alone — Steins' builtin set
+stops at `io.db` — which the registry table already says, and a leaf addition can never change what a
+recognised bound admits. The application-meaning roots are the real divergence, and it is
+architectural rather than lexical: Steins holds that ecosystem labels (`io.redis`, `email.send`) are
+**not builtin** and reach the registry through a plugin's own manifest, while Rigor ships
+`telemetry`, `email.send`, `job.enqueue`, `cache.read` and `cache.write` as rows of the shared file.
+Rigor keeps them: they are what `tolerated:` grips and what a policy actually names, and a project
+should not need a plugin before it can write one. What changes is the claim — the spec's registry
+table called that layer "shared" and its spelling agreement a MUST, which Steins does not today
+support, so the row becomes Rigor-owned and proposed upstream. Alignment is therefore not a blocker
+in either direction: a spelling Steins later insists on lands through `retired:` plus a vocabulary
+bump, which is the mechanism that exists for exactly this, and #378 stays open as the upstream
+conversation rather than as a gate.
+
+**3 — The WD13 budget: the CI `effect-budget` job is the arbiter.** The 2026-08-19 local measurement
+that reported the budget failing was retracted against a fuller, quieter measurement two days older;
+what separated them was host contamination, not method. A go/no-go decided on a developer host will
+keep reproducing that failure, so the advisory `effect-budget` job's band settles the mastodon half
+and nothing else does. The gitlab half — `Propagator.propagate` at 1.34 s against a 1 s bound — is
+unretracted and is the live figure, but it is a closure cost paid once per run at the largest scale
+in the corpus, not a per-project tax: it becomes the optimisation target of
+[#424](https://github.com/rigortype/rigor/issues/424) across the v0.3.5-v0.3.9 window and does **not**
+gate the flip, provided the release notes disclose it.
+
+**4 — `effects.lsp`: editor mode stays effect-free, and the config says so.** WD13's "editor mode
+does not run effects in v1" becomes the standing answer rather than a v1 caveat, spelled as a real
+key defaulting to `false`. A key that exists and is off is what keeps the seat from being silently
+empty after the flip; a hover that reports a method's labels is a v0.4.x slice with its own
+consumer, not a precondition. Nothing in `lib/rigor/language_server/` reads effects today, so the
+work is the key, its documentation, and the guard that keeps a default-on project from paying
+collection cost per keystroke.
+
+**6 — Taint-only rows** were decided by [#411](https://github.com/rigortype/rigor/issues/411) and
+shipped in [#415](https://github.com/rigortype/rigor/pull/415): a row carrying only its taint is
+omitted by default and `--full` keeps it.
 
 ## Rejected and deferred alternatives
 

--- a/docs/type-specification/effect-labels.md
+++ b/docs/type-specification/effect-labels.md
@@ -52,12 +52,13 @@ The shipped registry is the shared base plus three layers:
 
 | Layer | Contents | Who owns it |
 | --- | --- | --- |
-| Shared base | Steins' v1 set verbatim: `exit`, `ffi`, `global.read`, `global.write`, `io`, `io.db`, `io.fs`, `io.fs.read`, `io.fs.write`, `io.input`, `io.ipc`, `io.net`, `io.net.http`, `io.output`, `io.output.buffer`, `io.output.header`, `io.output.stdout`, `io.output.stderr`, `io.process`, `io.signal`, `mutate`, `mutate.local`, `nondet`, `nondet.random`, `nondet.time` | Steins and Rigor jointly; a divergence is raised upstream before it ships |
+| Shared base | Steins' v1 set: `exit`, `ffi`, `global.read`, `global.write`, `io`, `io.db`, `io.fs`, `io.fs.read`, `io.fs.write`, `io.input`, `io.ipc`, `io.net`, `io.net.http`, `io.output`, `io.output.buffer`, `io.output.header`, `io.output.stdout`, `io.output.stderr`, `io.process`, `io.signal`, `mutate`, `mutate.local`, `nondet`, `nondet.random`, `nondet.time` | Steins and Rigor jointly; a divergence is raised upstream before it ships |
+| Steins-side, unproduced here | `failure`, `failure.environment`, `failure.input`, `failure.resource` | Steins (its ADR-0042); registered here so a policy written against Steins parses |
 | Ruby leaves | `mutate.self` (self's state), `mutate.instance` (a receiver that is neither self nor frame-owned), `mutate.static` | Rigor |
 | Proposed shared core leaves | `io.db.read`, `io.db.write`, `io.db.transaction` | Rigor, pending adoption by Steins |
-| Application meaning | `telemetry`, `email.send`, `job.enqueue`, `cache.read`, `cache.write` | shared; these are the labels a policy names and a `tolerated:` set grips, so they MUST spell the same in both analyzers |
+| Application meaning | `telemetry`, `email.send`, `job.enqueue`, `cache.read`, `cache.write` | Rigor, proposed to Steins ([ADR-103](../adr/103-effect-labels.md) WD16). These are the labels a policy names and a `tolerated:` set grips, so a project must not need a plugin before it can write one — but Steins holds ecosystem labels outside its builtin set and supplies them through a plugin manifest, so the shared spelling is an intent, not yet an agreement |
 
-`io.output.buffer` and `io.output.header` are registered but unproduced in Ruby: they exist so a policy written against Steins parses here.
+`io.output.buffer`, `io.output.header` and the `failure.*` family are registered but unproduced in Ruby: they exist so a policy written against Steins parses here. `failure.*` is the odd one — in Steins it names a failure arm's *value provenance* rather than an effect, and it shares the registry only so prefix subsumption reaches it. Rigor produces no `failure.*` label and MUST NOT infer one; a bound that names it is satisfied vacuously.
 
 Framework roots (`rails.*`) are contributed by the plugin that models the framework and are not part of the shipped file.
 

--- a/spec/rigor/effects/registry_data_spec.rb
+++ b/spec/rigor/effects/registry_data_spec.rb
@@ -24,15 +24,20 @@ RSpec.describe "the shipped effect-label registry" do
   # Proposed shared core leaves, to raise with Steins.
   let(:proposed_shared) { %w[io.db.read io.db.write io.db.transaction] }
 
-  # The small shared set of application-meaning roots a policy actually names.
+  # Steins' own family (its ADR-0042), registered here and never produced: it names why a failure arm
+  # exists rather than what a method does, and exists so a Steins-authored policy parses (WD16).
+  let(:steins_side_unproduced) { %w[failure failure.environment failure.input failure.resource] }
+
+  # The small set of application-meaning roots a policy actually names. Rigor-owned and proposed to
+  # Steins, which holds ecosystem labels outside its builtin set (ADR-103 WD16).
   let(:application_meaning) { %w[telemetry email.send job.enqueue cache.read cache.write] }
 
   it "carries vocabulary version 1" do
     expect(registry.vocabulary_version).to eq(1)
   end
 
-  it "declares exactly the four groups and nothing else" do
-    expected = (steins_v1 + ruby_leaves + proposed_shared + application_meaning).sort
+  it "declares exactly the five groups and nothing else" do
+    expected = (steins_v1 + ruby_leaves + proposed_shared + steins_side_unproduced + application_meaning).sort
 
     expect(registry.labels).to eq(expected)
   end
@@ -59,8 +64,8 @@ RSpec.describe "the shipped effect-label registry" do
     expect(registry.retired("io.sql")).to be_nil
   end
 
-  it "opens only the roots the three layers name" do
-    expect(registry.roots).to eq(%w[cache email exit ffi global io job mutate nondet telemetry])
+  it "opens only the roots the layers name" do
+    expect(registry.roots).to eq(%w[cache email exit failure ffi global io job mutate nondet telemetry])
   end
 
   it "recognises the interior nodes a bound may name" do


### PR DESCRIPTION
Records [ADR-103 WD16](https://github.com/rigortype/rigor/blob/master/docs/adr/103-effect-labels.md) — the owner ruling that resolves five of the six preconditions #409 lists for the v0.4.0 effects-default-on flip. Decision record plus the one behaviour change the vocabulary ruling implies; no engine work.

## Why two preconditions needed replacing rather than clearing

WD15 was written from the design. Checking it against the code:

- **"The Ractor and thread backends must carry the effect side-table."** There is no thread backend — `pool_backend` selects `:fork`, `:ractor` or `:sequential` — and building one would buy no parallelism under the GVL while sharing RBS's C-extension state across workers. The Ractor backend cannot analyse a single file under rbs 4.x (`RBS::Namespace.[]` interns through a process-wide mutable flyweight in module ivars; a non-main Ractor may not read one, and pre-warming does not reach it). No work Rigor owns clears this as written, so it is replaced by the behaviour the coordinator already has: without `fork`, a collecting run degrades to sequential and says so. Sound, not merely safe — the sequential path collects identically, so Windows pays wall-clock rather than correctness. #410 and #414 closed with the reasoning on each.
- **"Vocabulary and `effect.*` ids settled (#378 first)."** Read against Steins on 2026-08-22, no rename is pending. The `mutate` spellings already agree (WD14); `io.db.*` is Rigor's own leaf set and evolution-safe; the application-meaning roots diverge *architecturally* — Steins holds ecosystem labels outside its builtin set entirely and supplies them through a plugin manifest. Rigor keeps them as builtin rows, because they are what `tolerated:` grips and a project should not need a plugin before it can write a policy. The spec's claim was the thing that was wrong: it called that layer "shared" and its spelling agreement a MUST.

## The one behaviour change

Reading Steins surfaced a label family our "Steins' v1 set verbatim" row predates: `failure`, `failure.environment`, `failure.input`, `failure.resource` (Steins ADR-0042). They are registered here on exactly the footing `io.output.buffer` already has — recognised so a policy written against Steins parses instead of earning `effect.unknown-label`, never inferred by Rigor, and a bound naming one satisfied vacuously. `registry_data_spec.rb` pins the shipped rows exhaustively and moves with it; vocabulary stays at 1, since a leaf addition can never change what a recognised bound admits.

## The other two rulings

- **WD13 budget** — the advisory CI `effect-budget` job is the sole arbiter. A go/no-go taken on a developer host is what produced the retracted 2026-08-19 finding, and a second local run cannot distinguish a real regression from the same class of artifact. The unretracted gitlab closure figure (`Propagator.propagate` 1.34 s against a 1 s bound) becomes #424's optimisation target for v0.3.5-v0.3.9 and does not gate the flip, provided the release notes disclose it.
- **`effects.lsp`** — editor mode stays effect-free, spelled as a real key defaulting to `false`, so the seat is not silently empty once the default flips. The key lands with the flip commit.

After this, #409 is down to the release-notes migration note and the flip commit itself.

## Verification

`make verify` and `make docs-check` green, `git diff --check` clean, inside the Flake.
