### PR TITLE
Carry the effect-drift step in the CI templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Added
 
+- **[docs]** The CI templates now carry a commented-out `rigor effects check` step, so a project adopting effect labels has one line to uncomment rather than a workflow to compose ([#376](https://github.com/rigortype/rigor/issues/376)).
+
 - **[docs]** The manual gained a chapter on effect labels — [Effect labels](docs/manual/19-effect-labels.md) — walking the whole feature end to end for the first time: the label vocabulary in one table, what the `rigor effects` report really looks like on a mid-size Rails application, the direct-versus-transitive split between the report and the snapshot, the `check` / `explain` / `update` review loop, the CI step and its exit codes, and the envelopes and `%a{pure}` annotations that turn an observation into a bound.
   - Written as the workflow around the reference material that already existed: [`rigor effects`](docs/manual/02-cli-reference.md#rigor-effects) keeps every flag, [Configuration](docs/manual/03-configuration.md#effect-labels) keeps every key. The CI chapter gained a `rigor effects check` step with its exit codes and the `--baseline <(git show origin/main:…)` review pattern, and the caching chapter now says how effect summaries are keyed.
 - **[effects]** An effect policy or envelope that names Steins' `failure.*` labels now parses instead of earning `effect.unknown-label`, so a policy written for the PHP analyzer reads unchanged here ([#378](https://github.com/rigortype/rigor/issues/378), [ADR-103](docs/adr/103-effect-labels.md)).

--- a/docs/manual/ci-templates/README.md
+++ b/docs/manual/ci-templates/README.md
@@ -26,6 +26,15 @@ comments (it works the same way against GitLab, Gerrit, Bitbucket, and Gitea
 — see the [`rigor-ci-setup`](../../../skills/rigor-ci-setup/SKILL.md) skill).
 All run Rigor the same way — only the output format and publish step differ.
 
+Every template ends with a **commented-out `rigor effects check` step**.
+Uncomment it once the project has an `effects:` block and a committed
+`.rigor-effects.yml`, and CI will fail when a branch changes what the code
+*does* — a job that starts talking to the network, a presenter that starts
+querying. It ships commented because `effects check` exits `1` when the
+snapshot file is absent, which is exactly what you want on a project that
+has one and pure noise on a project that does not. The workflow around it
+is [chapter 19, "Effect labels"](../19-effect-labels.md).
+
 ## Other runners (generic recipe)
 
 On any CI system, the four steps are: provision Ruby 4.0, install

--- a/docs/manual/ci-templates/github-actions-annotations.yml
+++ b/docs/manual/ci-templates/github-actions-annotations.yml
@@ -23,3 +23,11 @@ jobs:
       - run: gem install rigortype
 
       - run: rigor check --format github
+
+      # Effect labels (opt-in until v0.4.0, then the default): if the project
+      # has an `effects:` block and a committed .rigor-effects.yml, uncomment
+      # this to fail the build when a branch changes what the code *does*.
+      # Left commented because `effects check` exits 1 when the snapshot file
+      # is absent — which is the point on a project that has one, and noise on
+      # one that does not. See docs/manual/19-effect-labels.md § In CI.
+      # - run: rigor effects check

--- a/docs/manual/ci-templates/github-actions-reviewdog.yml
+++ b/docs/manual/ci-templates/github-actions-reviewdog.yml
@@ -35,3 +35,11 @@ jobs:
       - run: rigor check --format checkstyle | reviewdog -f=checkstyle -reporter=github-pr-review -fail-level=error
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Effect labels (opt-in until v0.4.0, then the default): if the project
+      # has an `effects:` block and a committed .rigor-effects.yml, uncomment
+      # this to fail the build when a branch changes what the code *does*.
+      # Left commented because `effects check` exits 1 when the snapshot file
+      # is absent — which is the point on a project that has one, and noise on
+      # one that does not. See docs/manual/19-effect-labels.md § In CI.
+      # - run: rigor effects check

--- a/docs/manual/ci-templates/github-actions-sarif.yml
+++ b/docs/manual/ci-templates/github-actions-sarif.yml
@@ -33,3 +33,11 @@ jobs:
         if: always()
         with:
           sarif_file: rigor.sarif
+
+      # Effect labels (opt-in until v0.4.0, then the default): if the project
+      # has an `effects:` block and a committed .rigor-effects.yml, uncomment
+      # this to fail the build when a branch changes what the code *does*.
+      # Left commented because `effects check` exits 1 when the snapshot file
+      # is absent — which is the point on a project that has one, and noise on
+      # one that does not. See docs/manual/19-effect-labels.md § In CI.
+      # - run: rigor effects check

--- a/docs/manual/ci-templates/gitlab-ci.yml
+++ b/docs/manual/ci-templates/gitlab-ci.yml
@@ -10,6 +10,13 @@ rigor:
     # Installed standalone, never in your project's Gemfile (ADR-27).
     - gem install rigortype
     - rigor check --format gitlab > gl-code-quality-report.json
+    # Effect labels (opt-in until v0.4.0, then the default): if the project has
+    # an `effects:` block and a committed .rigor-effects.yml, uncomment this to
+    # fail the job when a branch changes what the code *does*. Left commented
+    # because `effects check` exits 1 when the snapshot file is absent — which
+    # is the point on a project that has one, and noise on one that does not.
+    # See docs/manual/19-effect-labels.md § In CI.
+    # - rigor effects check
   artifacts:
     reports:
       codequality: gl-code-quality-report.json


### PR DESCRIPTION
The manual gained an [effect-labels chapter](https://github.com/rigortype/rigor/blob/master/docs/manual/19-effect-labels.md) and chapter 11 gained a *Gating effect drift* section, but the four copy-paste templates under `docs/manual/ci-templates/` — which is what people actually use — still said nothing about effects. The first-adopter walkthrough flagged exactly this: the whole CI story was one sentence, and none of the templates contained the word.

Each template now ends with a commented-out `rigor effects check` step, and the templates README explains when to uncomment it.

**Why commented rather than live.** `rigor effects check` exits `1` when `.rigor-effects.yml` is absent from the checkout. On a project that has adopted effect labels that is the point — it is what catches the pull request whose author changed a method and forgot to regenerate the snapshot. On a project that has not, it is a red build for a file it was never going to have. A live step would break every project that copies a template, so the honest default is one line to uncomment.

All four templates still parse (`yaml.safe_load`), `make docs-check` is green read unpiped, and `git diff --check` is clean. The change is comments plus one README paragraph; nothing executable moved, so I left `make verify` to CI rather than adding a fourth concurrent run on this machine.