### PR TITLE
Emit a documentation_url that resolves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[cli]** The `documentation_url` carried by every diagnostic in `rigor check --format json`, and printed by `rigor explain`, now resolves: it points at the catalogue page on the documentation site instead of a GitHub branch this project has never had, so following one no longer lands on a 404 ([#438](https://github.com/rigortype/rigor/issues/438)).
+  - Three more links shipped with the same wrong branch and are fixed too: the plugins link in the `.rigor.yml` that `rigor init` writes, and the homepage and installation links of the VS Code extension.
 - **[effects]** `effect.envelope-exceeded` is reported on every run, not only on the first one after clearing `.rigor/cache` ([#428](https://github.com/rigortype/rigor/issues/428)).
   - A warm run used to serve its diagnostics from the cache without re-checking your envelopes, so a project whose CI caches `.rigor/cache` between builds — the setup the manual recommends — saw the check fire once and stay silent afterwards, with the silence reading as a clean result. Both ways of declaring a bound were affected: an `effects.envelopes:` stanza in `.rigor.yml` and an `%a{pure}` / `%a{rigor:v1:effect …}` annotation in your signatures. The `effect.annotations-unchecked` notice went the same way and is back too.
   - Editing an envelope, a `tolerated:` list or an annotation now re-judges your code on the next run even though no Ruby file changed. Declaring an envelope costs a warm run about three quarters of a second on a mid-sized Rails application, because Rigor has to re-check it rather than replay the previous answer; a project with `effects:` on and no envelope declared is unaffected.

--- a/docs/adr/65-diagnostic-evidence-tier-and-doc-url.md
+++ b/docs/adr/65-diagnostic-evidence-tier-and-doc-url.md
@@ -1,6 +1,8 @@
 # ADR-65 — Diagnostic evidence tier and documentation URL
 
-Status: **Accepted — implemented 2026-06-15.** Two additive fields on
+Status: **Accepted — implemented 2026-06-15; `documentation_url` moved off
+the GitHub blob path to the published docs host (Amendment 2026-08-23).**
+Two additive fields on
 the public diagnostic surface: every built-in rule carries an
 **`evidence_tier`** (`high` / `medium` / `low`, or none for an
 informational helper) — Rigor's own confidence that a firing is a true
@@ -106,6 +108,9 @@ manufacture a gate, neither of which the user asked for.
 
 ### WD3 — `documentation_url` is a per-rule anchor in the published catalogue
 
+*The base URL below is superseded by the 2026-08-23 amendment; the
+per-rule anchor scheme is unchanged.*
+
 The URL is the published diagnostics manual page anchored per rule —
 `…/docs/manual/04-diagnostics.md#rule-<id-with-dots-as-dashes>` — mirroring
 the gemspec `documentation_uri` scheme. The catalogue page carries the
@@ -156,3 +161,69 @@ before any rule fires), so it carries no information.
   is the real per-rule reference, and the manual anchor resolves today.
 - **Feeding the tier into severity or the exit code** — rejected: the tier
   routes attention, it does not gate (WD2 guardrail).
+
+## Amendment (2026-08-23) — the URL drops the git ref ([#438](https://github.com/rigortype/rigor/issues/438))
+
+WD3 shipped a base of `…/blob/main/docs/manual/04-diagnostics.md`.
+This repository's default branch is `master` and `origin` has never had a
+`main`, so **every `documentation_url` Rigor has ever emitted 404ed** —
+for the whole life of the field, on every `rigor check --format json` and
+every `rigor explain`. The catalogue anchor was right; the page it hung
+off did not exist. `DOCUMENTATION_BASE` is now
+`https://rigor.typedduck.fail/manual/04-diagnostics/`.
+
+**The form, and why not the obvious repair.** Rewriting `main` to
+`master` fixes today and reinstates the defect class: a branch name is a
+*mutable* component sitting inside a contract we froze, and the rename
+that breaks it need not even happen here — GitHub's default-branch
+migration is exactly the event this repository would eventually take. A
+released tag (`blob/v0.3.4/…`) is immutable but resolves only after that
+tag is pushed, so every build between a version bump and its tag — the
+window in which contributors and agents actually read these URLs, and the
+window in which #438 was found — would emit 404s again, harder to notice
+because most versions work. The published docs host carries no ref at
+all: there is nothing in the string that a rename or a release can
+invalidate. It renders `docs/manual/04-diagnostics.md` verbatim,
+`<a id="rule-…">` tags included, so the fragment half of WD3 — the half
+`spec/docs/manual_drift_spec.rb` axis 4 already guarded — is unchanged,
+and the anchors carried over one-for-one at the cut.
+
+This does **not** reverse WD3's rejection of a documentation site. What
+was rejected was *inventing* `rigor.dev/rules/<kind>`, a per-rule surface
+that did not exist — "a URL to a non-existent page is dishonest". The
+docs host publishes the catalogue chapter itself, which is what WD3 chose
+to point at; only the rendering moves. The single source of truth is
+still `docs/manual/04-diagnostics.md` in this repository, and
+`rigor explain <rule>` is still the offline authority.
+
+**Is changing a frozen contract value a breaking change?** No, and it
+needs no deprecation dance. ADR-50 freezes the public output surface so
+consumers can *rely* on it; what is frozen is the field's presence, name,
+type, and meaning — "a stable URL to this rule's entry in the published
+catalogue" — all of which are untouched. The value was never usable: it
+resolved for nobody, so no consumer can have built on it, and the only
+behaviour that changes for anyone is that following the link now works.
+A deprecation window here would mean deliberately emitting a known-404
+for another release to protect a compatibility nobody has. The
+FP/honesty ethos WD3 invokes runs the other way: emit only what resolves.
+The rule this sets for the next such case is narrow — a frozen field's
+*value* may be corrected without ceremony when the old value is
+demonstrably inoperative (it 404s, it fails to parse, it names something
+that does not exist); a value that works and merely displeases us is a
+breaking change and takes the full dance.
+
+**The invariant, and what now enforces it.** No frozen public contract
+may embed a mutable git ref. Two gates, both network-free so they fail on
+a rename rather than on a flaky connection:
+
+- `spec/docs/manual_drift_spec.rb` axis 4 now checks the *page* as well
+  as the fragment — the base must be a `<host>/manual/<slug>/` URL whose
+  host README.md itself uses, whose `docs/manual/<slug>.md` the gemspec
+  actually packages, and which contains no `blob` / `tree` / `raw` path
+  segment.
+- `spec/docs/link_integrity_spec.rb` sweeps every shipped surface for
+  self-referential `github.com/rigortype/rigor/<blob|tree|raw>/<ref>/`
+  URLs and requires `<ref>` to be the default branch named in
+  `.github/workflows/ci.yml`. It found three more live 404s that shipped
+  with the same assumption: the `rigor init` config template's plugins
+  link, and the VS Code extension's `homepage` and README.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -78,7 +78,7 @@ This directory contains the Architecture Decision Records (ADRs) for Rigor. Each
 | ADR-62 | [Mutation-testing the analyzer (false-negative / teeth measurement)](62-mutation-testing-teeth-measurement.md) | Accepted (harness + first fixes landed 2026-06-13; remaining backlog demand-gated) |
 | ADR-63 | [User-facing type-protection coverage](63-type-protection-coverage.md) | Accepted (Tier 1 and Tier 2 both implemented 2026-06-14) |
 | ADR-64 | [Non-nil argument-type-mismatch and the coerce barrier](64-non-nil-argument-type-mismatch.md) | Accepted (non-nil channel built and gated for multi-overload methods) |
-| ADR-65 | [Diagnostic evidence tier and documentation URL](65-diagnostic-evidence-tier-and-doc-url.md) | Accepted (implemented 2026-06-15; precision-additive) |
+| ADR-65 | [Diagnostic evidence tier and documentation URL](65-diagnostic-evidence-tier-and-doc-url.md) | Accepted (implemented 2026-06-15; doc URL amended 2026-08-23) |
 | ADR-66 | [Discriminated-union member typing (tag-keyed narrowing)](66-discriminated-union-member-typing.md) | Proposed (not implemented; demand-gated) |
 | ADR-67 | [Parameter type inference (the M3 frontier)](67-parameter-type-inference.md) | Accepted (WD6 landed opt-in; default-on declined 2026-07-30; WD6c incremental exclusion lifted; WD2 deferred) |
 | ADR-68 | [Plugin-declarable class-builder folding](68-class-builder-folding.md) | Proposed (demand-gated) |

--- a/docs/internal-spec/diagnostic-shape.md
+++ b/docs/internal-spec/diagnostic-shape.md
@@ -56,7 +56,7 @@ diagnostic ([ADR-65](../adr/65-diagnostic-evidence-tier-and-doc-url.md)):
 | Field | Type | Meaning |
 | --- | --- | --- |
 | `evidence_tier` | `String?` | Rigor's own confidence a firing is a true positive: `"high"` / `"medium"` / `"low"`. **Omitted** (absent) for informational rules that carry no tier. Orthogonal to `severity`; it never gates. |
-| `documentation_url` | `String` | Stable per-rule URL into the published diagnostics catalogue (`docs/manual/04-diagnostics.md#…`). |
+| `documentation_url` | `String` | Stable per-rule URL into the published diagnostics catalogue: `https://rigor.typedduck.fail/manual/04-diagnostics/#rule-<id-with-dots-as-dashes>`, the published rendering of `docs/manual/04-diagnostics.md`. The URL carries **no git ref** — no `blob/<branch>` or `tree/<tag>` path — because a ref inside a frozen contract rots (see the ADR-65 amendment). |
 
 Both are enriched in `CLI::CheckCommand#enrich_json` only for diagnostics
 whose `source_family` is the default `:builtin` and whose `rule` is

--- a/docs/manual/04-diagnostics.md
+++ b/docs/manual/04-diagnostics.md
@@ -27,7 +27,8 @@ built-in rule ID; `rigor explain` with no argument lists them all.
 Each built-in rule has a stable per-rule anchor on this page
 (`#rule-<family>-<name>`, dots written as dashes) — the
 `documentation_url` field in `--format json` and `rigor explain`'s
-`Documentation:` line both point here. The `Evidence` column is
+`Documentation:` line both point here, at this chapter's published
+copy on <https://rigor.typedduck.fail/manual/04-diagnostics/>. The `Evidence` column is
 Rigor's confidence that a firing is a true positive (see
 [Evidence tier](#evidence-tier) below). The one exception is
 `rbs_extended.unsatisfied-conformance`, an `rbs_extended`-family rule

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -23,7 +23,7 @@ exposes settings, and surfaces lifecycle state.
 - A **trusted** workspace (the server is not started in restricted mode).
 - The **`rigortype` gem ≥ 0.1.6**, installed so `rigor` is on `PATH`
   (or reachable through a `mise` / `asdf` shim). See the manual's
-  [Installing Rigor](https://github.com/rigortype/rigor/blob/main/docs/manual/01-installation.md)
+  [Installing Rigor](https://github.com/rigortype/rigor/blob/master/docs/manual/01-installation.md)
   chapter — `mise` is the recommended channel and ships a stable
   `rigor` shim the extension auto-discovers. Rigor is a tool, not a
   library, and does **not** go in the project's `Gemfile`. A legacy
@@ -57,7 +57,7 @@ loaded — fix the setup and run **Rigor: Restart Server**.
 
 `mise` is the recommended way to install Rigor — `mise use
 gem:rigortype` (see the manual's
-[Installing Rigor](https://github.com/rigortype/rigor/blob/main/docs/manual/01-installation.md)
+[Installing Rigor](https://github.com/rigortype/rigor/blob/master/docs/manual/01-installation.md)
 chapter). A GUI-launched VS Code does not inherit the shell `PATH`
 that `mise activate` sets up, so step 3 above often misses a
 mise-managed `rigor` — step 4 covers that automatically by finding
@@ -107,7 +107,7 @@ diagnostics are tagged `source: "rigor"` in the Problems panel.
 
 ## Troubleshooting
 
-See the [editor integration guide](https://github.com/rigortype/rigor/blob/main/docs/manual/09-editor-integration.md)
+See the [editor integration guide](https://github.com/rigortype/rigor/blob/master/docs/manual/09-editor-integration.md)
 for diagnostics-not-appearing, empty-completion, and `untyped`-hover
 cases. For server-side detail, set `rigor.server.logPath` and open the
 log with **Rigor: Show Server Log**.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -28,7 +28,7 @@
   "bugs": {
     "url": "https://github.com/rigortype/rigor/issues"
   },
-  "homepage": "https://github.com/rigortype/rigor/tree/main/editors/vscode",
+  "homepage": "https://github.com/rigortype/rigor/tree/master/editors/vscode",
   "main": "./dist/extension.js",
   "activationEvents": [
     "onLanguage:ruby",

--- a/lib/rigor/analysis/rule_catalog.rb
+++ b/lib/rigor/analysis/rule_catalog.rb
@@ -36,9 +36,16 @@ module Rigor
     module RuleCatalog # rubocop:disable Metrics/ModuleLength
       # Stable documentation home for a built-in rule. `documentation_url` appends a per-rule fragment that
       # resolves to the rule's anchor in the published diagnostics catalogue; the page itself points at
-      # `rigor explain <rule>` as the authoritative per-rule reference. Mirrors the gemspec
-      # `documentation_uri` URL scheme (`…/tree/main`).
-      DOCUMENTATION_BASE = "https://github.com/rigortype/rigor/blob/main/docs/manual/04-diagnostics.md"
+      # `rigor explain <rule>` as the authoritative per-rule reference.
+      #
+      # The canonical docs host, deliberately NOT a `github.com/…/blob/<ref>/…` path (ADR-65 amendment,
+      # #438): a git ref inside a frozen public contract is a mutable component, and the one that was
+      # baked in here — `main`, a branch this repository has never had — made every emitted URL 404 from
+      # the day the field shipped. A branch name rots on a rename and a tag only resolves once that tag
+      # is pushed (so every unreleased build would emit 404s); the published site carries no ref at all.
+      # The site renders `docs/manual/04-diagnostics.md` verbatim, `<a id="rule-…">` anchors included, so
+      # the fragment half of the contract is unchanged.
+      DOCUMENTATION_BASE = "https://rigor.typedduck.fail/manual/04-diagnostics/"
 
       class Entry < Data.define(:id, :summary, :fires_when, :does_not_fire_when,
                                 :suppression, :severity_authored, :severity_by_profile,

--- a/lib/rigor/cli.rb
+++ b/lib/rigor/cli.rb
@@ -160,7 +160,7 @@ module Rigor
         # - paths:       directories scanned by `rigor check` and
         #                `rigor type-scan` when no path is given.
         # - plugins:     opt-in list of plugin gem names to load.
-        #                See https://github.com/rigortype/rigor/tree/main/plugins
+        #                See https://github.com/rigortype/rigor/tree/master/plugins
         #                for production plugins (rigor-activerecord, rigor-sorbet, …).
         # - disable:     list of `rigor check` rule identifiers to
         #                silence project-wide. The shipped rules are

--- a/spec/docs/link_integrity_spec.rb
+++ b/spec/docs/link_integrity_spec.rb
@@ -12,10 +12,17 @@
 # External links (http/https) and pure in-page anchors (#section) are not checked — only relative file
 # references. A trailing `:line` / `:line:col` position suffix (a `file.rb:42` source pointer) is stripped
 # before the existence check.
+#
+# One class of external link IS gated: a SELF-referential GitHub URL, `github.com/rigortype/rigor/<blob|tree|
+# raw>/<ref>/…`. Its `<ref>` is a git ref in this repository, so it can be checked against an in-repo
+# authority without a network call — and it is the class that broke in #438, where four surfaces (the emitted
+# `documentation_url`, the `.rigor.yml` init template, and the VS Code extension's manifest + README) named a
+# `main` branch this repository has never had. Every one of them 404ed for as long as it shipped.
 
 require "spec_helper"
 
 LINK_INTEGRITY_DOCS_ROOT = File.expand_path("../../docs", __dir__)
+LINK_INTEGRITY_REPO_ROOT = File.expand_path("../..", __dir__)
 
 # The `references/` git submodules hold vendored upstream sources. Contributors check them out, but CI
 # does not (the test job runs without submodules), so a link into `references/` is legitimately present
@@ -24,6 +31,31 @@ LINK_INTEGRITY_REFERENCES_ROOT = File.expand_path("../../references", __dir__)
 
 # Paths (relative to docs/) whose links are intentionally not gated — see the header comment.
 LINK_INTEGRITY_EXCLUDE = %r{\A(notes/|CHANGELOG-0\.\d+\.x\.md\z)}
+
+# The repository's default branch, read from the CI workflow's push trigger. That is the authority available
+# offline: CI gates pushes to the default branch by name, so a rename that skipped this file would leave the
+# project with no CI at all — the one place the branch name cannot go stale unnoticed.
+LINK_INTEGRITY_DEFAULT_BRANCH = File.read(
+  File.join(LINK_INTEGRITY_REPO_ROOT, ".github", "workflows", "ci.yml"), encoding: "utf-8"
+)[/^\s*branches:\s*\[\s*([\w.-]+)\s*\]/, 1]
+
+# A self-referential GitHub URL and the git ref it names.
+LINK_INTEGRITY_SELF_REF_URL = %r{https://github\.com/rigortype/rigor/(?:blob|tree|raw)/([\w.-]+)/}
+
+# The surfaces gated for self-referential refs: everything a user or an editor can be handed. `docs/notes/` and
+# the frozen changelog archives are excluded for the same reasons as above — a note records what a URL said at
+# the time, and rewriting a frozen record to satisfy a gate would falsify it.
+LINK_INTEGRITY_SELF_REF_FILES = Dir.chdir(LINK_INTEGRITY_REPO_ROOT) do
+  Dir.glob(
+    %w[
+      README.md CONTRIBUTING.md rigortype.gemspec
+      lib/**/*.rb exe/* schemas/*.json
+      editors/*/*.md editors/*/package.json editors/*/src/**/*.ts
+      skills/**/*.md docs/**/*.md plugins/**/*.md examples/**/*.md
+      .github/workflows/*.yml
+    ]
+  ).grep_v(%r{\Adocs/(notes/|CHANGELOG-0\.\d+\.x\.md\z)}).sort
+end.freeze
 
 module LinkIntegrityHelpers
   def extract_relative_links(content, base_dir)
@@ -69,6 +101,34 @@ RSpec.describe "documentation link integrity" do
       expect(broken).to be_empty,
                         "Broken links in #{md_path.delete_prefix("#{LINK_INTEGRITY_DOCS_ROOT}/")}:\n" +
                         broken.map { |t| "  → #{t.delete_prefix("#{LINK_INTEGRITY_DOCS_ROOT}/")} " }.join("\n")
+    end
+  end
+
+  # #438: a self-referential GitHub URL names a ref in THIS repository, so it is checkable offline — and it is
+  # the only external link class where a rename here (not upstream) is what breaks it.
+  describe "self-referential GitHub URLs" do
+    it "reads the default branch out of the CI workflow (guards the parse)" do
+      expect(LINK_INTEGRITY_DEFAULT_BRANCH).to eq("master")
+    end
+
+    it "scans a non-empty file set (guards the globs against a tree reshuffle)" do
+      expect(LINK_INTEGRITY_SELF_REF_FILES).to include("rigortype.gemspec", "README.md",
+                                                       "lib/rigor/analysis/rule_catalog.rb")
+    end
+
+    # A tag would resolve too, and is deliberately NOT allowed: `blob/v0.4.0/…` 404s for every build made
+    # between the version bump and the tag push, which is precisely the window a contributor reads these URLs
+    # in. Pin to the default branch, or drop the ref entirely and use the published docs host.
+    it "all name the repository's default branch" do
+      offenders = LINK_INTEGRITY_SELF_REF_FILES.filter_map do |path|
+        refs = File.read(File.join(LINK_INTEGRITY_REPO_ROOT, path), encoding: "utf-8")
+                   .scan(LINK_INTEGRITY_SELF_REF_URL).flatten.uniq
+                   .reject { |ref| ref == LINK_INTEGRITY_DEFAULT_BRANCH }
+        "  → #{path}: #{refs.join(', ')}" unless refs.empty?
+      end
+      expect(offenders).to be_empty,
+                           "Self-referential GitHub URLs naming a ref other than " \
+                           "`#{LINK_INTEGRITY_DEFAULT_BRANCH}` (these 404):\n#{offenders.join("\n")}"
     end
   end
 end

--- a/spec/docs/manual_drift_spec.rb
+++ b/spec/docs/manual_drift_spec.rb
@@ -6,9 +6,12 @@
 #   2. Config keys — every top-level key in Configuration::DEFAULTS must be mentioned in the configuration reference.
 #   3. Rule IDs — every ID in CheckRules::ALL_RULES must appear in the diagnostic catalogue or the handbook
 #      errors chapter.
-#   4. Rule documentation_url anchors — every RuleCatalog entry's `documentation_url` (ADR-65, a frozen public
-#      contract) points at `04-diagnostics.md#rule-<id>`, so the catalogue must carry the matching anchor or the
-#      published URL silently 404s within the page.
+#   4. Rule documentation_url — every RuleCatalog entry's `documentation_url` (ADR-65, a frozen public contract)
+#      points at the published `04-diagnostics` catalogue, anchored per rule. Both halves are checked: the
+#      fragment (the catalogue must carry the matching `<a id>` anchor or the URL 404s within the page) and the
+#      page itself (host + path must map back to a catalogue file the gem actually packages, and must carry no
+#      mutable git ref — #438 shipped `blob/main/…` against a repository whose branch is `master`, so every
+#      emitted URL 404ed while the fragment half stayed green).
 #   5. Declared diagnostic families — every family the type spec's identifier taxonomy declares resolves to a
 #      real emitted id, or says in the row that it does not (ADR-92 WD4). Axes 1-4 all run impl -> doc; this
 #      one runs doc -> impl, the direction that let five divergences ship unnoticed.
@@ -34,6 +37,22 @@ MANUAL_DRIFT_HANDBOOK_DIR = File.join(MANUAL_DRIFT_DOCS_ROOT, "handbook")
 # Introspection helpers: emitted by the engine but documented in the handbook type-inspection chapter (05),
 # not the diagnostic catalogue.
 MANUAL_DRIFT_INTROSPECTION_RULES = %w[dump.type assert.type-mismatch].freeze
+
+# Axis 4: surfaces outside docs/ that the documentation_url page check is pinned against.
+MANUAL_DRIFT_REPO_ROOT = File.expand_path("../..", __dir__)
+
+# Axis 4: the files the gem actually ships, read straight from the gemspec — the in-repo authority for "this
+# catalogue page is published", available without a network call. `Gem::Specification#files` globs relative to
+# the process cwd, so the load is pinned to the repo root rather than wherever rspec was invoked.
+MANUAL_DRIFT_PACKAGED_FILES = Dir.chdir(MANUAL_DRIFT_REPO_ROOT) do
+  Gem::Specification.load(File.join(MANUAL_DRIFT_REPO_ROOT, "rigortype.gemspec")).files
+end.freeze
+
+# Axis 4: the canonical documentation host and its manual-path convention, witnessed by README.md — an authority
+# independent of the constant under test. Every README manual link is `https://<host>/manual/<slug>/`, mapping
+# 1:1 onto `docs/manual/<slug>.md`.
+MANUAL_DRIFT_README_MANUAL_LINKS = File.read(File.join(MANUAL_DRIFT_REPO_ROOT, "README.md"), encoding: "utf-8")
+                                       .scan(%r{(https://[a-z0-9.-]+)/manual/([a-z0-9-]+)/}).uniq.freeze
 
 # Axis 5: families whose ids are contributed at runtime rather than by the engine, so the vocabulary cannot be
 # enumerated here. `CheckRules.known_suppression_token?` takes the same under-warning stance for the same reason.
@@ -169,9 +188,9 @@ RSpec.describe "manual accuracy" do
     end
   end
 
-  # ── 4. Rule documentation_url anchor integrity (ADR-65) ──────────
+  # ── 4. Rule documentation_url integrity (ADR-65) ─────────────────
 
-  describe "rule documentation_url anchors (04-diagnostics.md)" do
+  describe "rule documentation_url (04-diagnostics.md)" do
     let(:catalogue_doc) { File.read(File.join(MANUAL_DRIFT_MANUAL_DIR, "04-diagnostics.md"), encoding: "utf-8") }
 
     # `RuleCatalog#documentation_url` is a frozen public contract (ADR-65): it points every built-in rule at
@@ -186,6 +205,52 @@ RSpec.describe "manual accuracy" do
                                    "RuleCatalog rules whose documentation_url anchor is missing from " \
                                    "04-diagnostics.md: #{missing.map(&:id).inspect}\n" \
                                    "Add `<a id=\"rule-<id-with-dots-as-dashes>\"></a>` for each."
+    end
+
+    # The PAGE half of the same contract. Only the fragment was ever gated, which is exactly how #438 shipped: the
+    # base pointed at `github.com/rigortype/rigor/blob/main/docs/manual/04-diagnostics.md` — a branch this
+    # repository has never had — so every emitted URL 404ed while the anchor check above stayed green, because it
+    # reads the local file and never looks at the host or the path.
+    #
+    # Pinned to two in-repo authorities so it fails on a rename rather than on a flaky network: README.md's own
+    # canonical doc links (the host, and the `/manual/<slug>/` ↔ `docs/manual/<slug>.md` convention) and the
+    # gemspec's packaged-file list (the catalogue page the gem really ships).
+    it "points at a catalogue page the project publishes, on the canonical docs host" do
+      base = Rigor::Analysis::RuleCatalog::DOCUMENTATION_BASE
+      host, slug = base.match(%r{\A(https://[a-z0-9.-]+)/manual/([a-z0-9-]+)/\z})&.captures
+
+      expect(slug).to eq("04-diagnostics"),
+                      "documentation_url's base is not a `<host>/manual/04-diagnostics/` page: #{base.inspect}"
+      expect(MANUAL_DRIFT_README_MANUAL_LINKS.map(&:first)).to include(host),
+                                                               "documentation_url points at #{host.inspect}, " \
+                                                               "which README.md uses for no doc link — the " \
+                                                               "canonical docs host is whatever README links to."
+      expect(MANUAL_DRIFT_PACKAGED_FILES).to include("docs/manual/#{slug}.md"),
+                                             "documentation_url points at a page the gemspec does not package: " \
+                                             "docs/manual/#{slug}.md"
+    end
+
+    # Guards the convention the check above rests on: every manual link README publishes must resolve to a real
+    # packaged chapter. Also catches the regex above matching nothing after a README reflow.
+    it "README's manual links all resolve to packaged chapters (guards the convention)" do
+      expect(MANUAL_DRIFT_README_MANUAL_LINKS).not_to be_empty
+
+      missing = MANUAL_DRIFT_README_MANUAL_LINKS
+                .map(&:last)
+                .reject { |slug| MANUAL_DRIFT_PACKAGED_FILES.include?("docs/manual/#{slug}.md") }
+      expect(missing).to be_empty,
+                         "README.md links manual chapters that are not packaged: #{missing.inspect}"
+    end
+
+    # #438's root cause stated as an invariant: a frozen public contract may not embed a mutable git ref. A branch
+    # name rots on a rename (what happened) and a tag resolves only once it is pushed, so every unreleased build
+    # would emit 404s. The published docs host carries neither.
+    it "embeds no mutable git ref" do
+      offenders = Rigor::Analysis::RuleCatalog.all
+                                              .map(&:documentation_url)
+                                              .grep(%r{/(?:blob|tree|raw)/})
+      expect(offenders.uniq).to be_empty,
+                                "documentation_url must not embed a branch or tag: #{offenders.uniq.inspect}"
     end
   end
 

--- a/spec/rigor/analysis/rule_catalog_spec.rb
+++ b/spec/rigor/analysis/rule_catalog_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Rigor::Analysis::RuleCatalog do
   describe ".documentation_url" do
     it "points at the rule's per-rule anchor in the published catalogue" do
       expect(described_class.documentation_url("call.undefined-method"))
-        .to end_with("/docs/manual/04-diagnostics.md#rule-call-undefined-method")
+        .to eq("https://rigor.typedduck.fail/manual/04-diagnostics/#rule-call-undefined-method")
       expect(described_class.documentation_url("def.return-type-mismatch"))
         .to end_with("#rule-def-return-type-mismatch")
     end

--- a/spec/rigor/cli/check_command_spec.rb
+++ b/spec/rigor/cli/check_command_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Rigor::CLI::CheckCommand do
 
     diag = JSON.parse(out).fetch("diagnostics").find { |d| d["rule"] == "call.undefined-method" }
     expect(diag.fetch("evidence_tier")).to eq("high")
-    expect(diag.fetch("documentation_url")).to end_with("04-diagnostics.md#rule-call-undefined-method")
+    expect(diag.fetch("documentation_url")).to end_with("04-diagnostics/#rule-call-undefined-method")
   end
 
   it "adds a coverage block under --coverage --format=json" do

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -1082,7 +1082,7 @@ RSpec.describe Rigor::CLI do
       expect(out).to include("Authored severity:")
       expect(out).to include("Severity by profile:")
       expect(out).to include("Evidence tier: high")
-      expect(out).to include("Documentation: https://github.com/rigortype/rigor")
+      expect(out).to include("Documentation: https://rigor.typedduck.fail/manual/04-diagnostics/")
       expect(out).to include("Since: rigor")
     end
 


### PR DESCRIPTION
Fixes #438.

Every `documentation_url` Rigor has emitted since ADR-65 shipped 404s. The base named a `main` branch; the default branch is `master` and `origin` has never had a `main`. The per-rule anchor was always right — the page it hung off did not exist.

## The URL form

`DOCUMENTATION_BASE` is now `https://rigor.typedduck.fail/manual/04-diagnostics/`, the published copy of the same chapter, with no git ref in it at all.

Rewriting `main` to `master` fixes today and reinstates the defect class: a branch name is a *mutable* component sitting inside a contract we froze, and the rename that breaks it need not even happen here — GitHub's default-branch migration is the event this repository would eventually take. A released tag (`blob/v0.3.4/…`) is immutable but resolves only once that tag is pushed, so every build between a version bump and its tag would emit 404s — precisely the window in which contributors and agents read these URLs, and the window in which #438 was found. The docs host has nothing in the string that a rename or a release can invalidate.

This does not reverse ADR-65 WD3's rejection of a docs site: what WD3 rejected was *inventing* `rigor.dev/rules/<kind>`, a per-rule surface that did not exist. The docs host publishes the catalogue chapter itself. `docs/manual/04-diagnostics.md` is still the single source of truth and `rigor explain <rule>` is still the offline authority.

Evidence it resolves — and that the fragment half of the contract survived the move:

```
$ curl -s -o /dev/null -w '%{http_code}' https://rigor.typedduck.fail/manual/04-diagnostics/
200
$ curl -s https://rigor.typedduck.fail/manual/04-diagnostics/ | grep -c 'id="rule-'
32
```

All 31 `<a id="rule-…">` anchors in the local chapter are present on the published page (the 32nd is the page's own `Rule IDs` heading slug), so every emitted URL lands on its rule, not merely on the page.

## The spec that would have caught it

`spec/docs/manual_drift_spec.rb` axis 4 parsed the URL for its *fragment* and validated that against the local file — the host, branch and path were never exercised, which is why a URL that 404ed for its whole life kept a green gate. Two additions, neither of which touches the network:

- **Axis 4 now checks the page as well as the fragment.** The base must be a `<host>/manual/<slug>/` URL whose host `README.md` itself uses for doc links, whose `docs/manual/<slug>.md` the *gemspec's own file list* packages, and which contains no `blob` / `tree` / `raw` segment. Both authorities are in-repo, so it fails on a rename rather than on a flaky connection.
- **`spec/docs/link_integrity_spec.rb` gained a self-referential-URL sweep.** Every shipped surface (lib, exe, gemspec, schemas, README, docs, skills, plugin and editor files) is scanned for `github.com/rigortype/rigor/<blob|tree|raw>/<ref>/`, and `<ref>` must be the branch `.github/workflows/ci.yml` gates pushes on. That is the one place the branch name cannot go stale unnoticed — a rename that skipped it would leave the project with no CI. A tag is deliberately *not* accepted, for the reason above.

Both fail on the pre-fix tree, naming the real offenders:

```
Self-referential GitHub URLs naming a ref other than `master` (these 404):
  → lib/rigor/analysis/rule_catalog.rb: main
  → lib/rigor/cli.rb: main
```

## The sweep

The same assumption shipped in three more places, all live 404s, all fixed here:

| Surface | Was | Reaches |
| --- | --- | --- |
| `lib/rigor/cli.rb` init template | `tree/main/plugins` | every `.rigor.yml` `rigor init` has ever written |
| `editors/vscode/package.json` | `tree/main/editors/vscode` | the extension's marketplace homepage |
| `editors/vscode/README.md` (×3) | `blob/main/docs/manual/…` | the marketplace listing body |

Deliberately left alone: the ~30 `blob/master` links elsewhere in docs and skills (they resolve, and the new sweep now catches a rename atomically for anything living in this repository); the gemspec's `tree/master/docs` `documentation_uri` and `CONFIG_SCHEMA_URL`'s `raw/master/…` (both resolve, both need a repository path the docs host does not serve); `docs/notes/` and the frozen `CHANGELOG-0.x` archives, which record what a URL said at the time — rewriting a frozen record to satisfy a gate would falsify it; and third-party `blob/main` links in the deep-research notes, which name other repositories.

## The contract ruling

Recorded in ADR-65's amendment, since that is where a reader who asks "may I change this field?" will look. **Bug fix, no deprecation dance.** ADR-50 freezes the public output surface so consumers can rely on it; what is frozen is the field's presence, name, type and meaning — "a stable URL to this rule's entry in the published catalogue" — and all four are untouched. The *value* was never usable: it resolved for nobody, so no consumer can have built on it, and the only behaviour that changes is that following the link now works. A deprecation window would mean deliberately emitting a known-404 for another release to protect a compatibility nobody has, against the same honesty ethos WD3 invoked when it refused to point at a page that did not exist. The rule this sets for the next case is narrow: a frozen field's value may be corrected without ceremony when the old value is *demonstrably inoperative* — it 404s, it fails to parse, it names something that does not exist. A value that works and merely displeases us is a breaking change and takes the full dance.

`make verify` and `make docs-check` green; `git diff --check` clean.
