### PR TITLE
Stop Date#to_time colliding with rbs's bundled stdlib/date

### DIFF
--- a/plugins/rigor-activesupport-core-ext/sig/active_support/core_ext.rbs
+++ b/plugins/rigor-activesupport-core-ext/sig/active_support/core_ext.rbs
@@ -598,8 +598,23 @@ class Date
   %a{pure}
   def advance: (untyped options) -> Date
   def all_day: () -> Range[Time]
+  # NOTE: `Date#to_time` is an OVERLOAD CONTINUATION (`| ...`), not a plain
+  # declaration — stdlib `date` already types `to_time: () -> Time`, and a
+  # second full declaration of the same method from a second signature source
+  # makes `RBS::DefinitionBuilder` raise `DuplicatedMethodDefinitionError`,
+  # which collapses `Date` AND `DateTime` to `Dynamic[top]` for every project
+  # that activates this plugin (#437 — the same failure the `DateTime#to_time`
+  # note below records). The row cannot simply be DROPPED the way
+  # `DateTime#to_time` was: ActiveSupport genuinely widens the arity, and
+  # without the row `date.to_time(:utc)` — correct Rails code — would draw an
+  # arity diagnostic. `| ...` appends this overload ahead of the stdlib one, so
+  # both arities resolve and the `%a{pure}` envelope stays attached to the
+  # ActiveSupport overload (which is the one a no-argument call selects).
+  # `| ...` requires the base declaration to exist, which `Environment.for_project`
+  # guarantees: it merges `DEFAULT_LIBRARIES` — including `date` — into every
+  # environment that loads a plugin's `signature_paths`.
   %a{pure}
-  def to_time: (?Symbol form) -> Time
+  def to_time: (?Symbol form) -> Time | ...
 end
 
 # ---------------------------------------------------------------

--- a/spec/integration/plugins/activesupport_core_ext_plugin_spec.rb
+++ b/spec/integration/plugins/activesupport_core_ext_plugin_spec.rb
@@ -53,7 +53,76 @@ RSpec.describe "plugins/rigor-activesupport-core-ext" do
       expect(rbs).to match(/def #{method}:/), "expected RBS to declare `#{method}`"
     end
     expect(rbs).to include("def in?:")
-    expect(rbs).to match(/def to_time: \(\?Symbol form\) -> Time\b/)
+    # `| ...` and not a plain declaration — see the collision guard below (#437).
+    expect(rbs).to include("def to_time: (?Symbol form) -> Time | ...")
     expect(rbs).to include("def self.html_escape_once:")
+  end
+
+  # Issue #437. A method the plugin declares in full while a signature source ALREADY in the environment
+  # declares it too makes `RBS::DefinitionBuilder` raise `DuplicatedMethodDefinitionError`. Rigor fails
+  # soft, so nothing crashes — the whole class just degrades to `Dynamic[top]`, and real methods and typos
+  # alike stop being witnessed. `Date#to_time` sat in that state against rbs's bundled `stdlib/date` and
+  # took `Date` and `DateTime` down with it for every project following the plugin chapter.
+  #
+  # The collision is INVISIBLE to a fixture that loads only one signature source, which is exactly how it
+  # survived: the plugin's own `sig/` parses and validates fine on its own. So the guard below builds the
+  # real environment — `DEFAULT_LIBRARIES` (where rbs's `stdlib/date` enters) PLUS the plugin's `sig/` —
+  # and asserts every definition in it builds. That is the shape that catches the NEXT one too.
+  describe "collisions against rbs's bundled stdlib (#437)" do
+    # Exactly what `Environment.for_project` assembles for a project with the plugin active: it merges
+    # `DEFAULT_LIBRARIES` into every run unconditionally, then appends the registry's plugin sig paths.
+    # The ADR-72 ActiveSupport gem overlay is deliberately absent — `GEM_OVERLAY_PLUGIN_IDS` stands it
+    # down whenever this plugin is loaded, so the two never co-occur.
+    let(:env) do
+      Rigor::Environment::RbsLoader.build_env_for(
+        libraries: Rigor::Environment::DEFAULT_LIBRARIES,
+        signature_paths: [File.expand_path("../../../plugins/rigor-activesupport-core-ext/sig", __dir__)]
+      )
+    end
+
+    let(:builder) { RBS::DefinitionBuilder.new(env: env) }
+
+    it "builds Date and DateTime rather than collapsing them" do
+      %w[::Date ::DateTime].each do |name|
+        type_name = RBS::TypeName.parse(name)
+
+        expect(builder.build_instance(type_name)).not_to be_nil
+        expect(builder.build_singleton(type_name)).not_to be_nil
+      end
+    end
+
+    # The reason the row is an overload continuation instead of a deletion: dropping it would have left
+    # only the stdlib arity, and `date.to_time(:utc)` — correct Rails code — would draw an arity
+    # diagnostic. Both arities must resolve, and the ActiveSupport one must keep its `%a{pure}` envelope.
+    it "resolves both arities of Date#to_time, with %a{pure} on the ActiveSupport overload" do
+      method = builder.build_instance(RBS::TypeName.parse("::Date")).methods[:to_time]
+      arities = method.method_types.map { |mt| mt.type.optional_positionals.size }
+
+      expect(arities).to contain_exactly(0, 1)
+      expect(method.defs.first.member.annotations.map(&:string)).to include("pure")
+    end
+
+    # The sweep: no class or module anywhere in the plugin-active environment may fail to build. This is
+    # what generalises past `Date` — every other row in the bundle is checked against rbs's stdlib here,
+    # not one at a time as each collapse gets noticed in the field.
+    it "builds every class and module in the plugin-active environment" do
+      failures = env.class_decls.each_key.with_object([]) do |name, acc|
+        builder.build_instance(name)
+        builder.build_singleton(name)
+      rescue StandardError => e
+        acc << "#{name}: #{e.class}: #{e.message.lines.first.to_s.strip}"
+      end
+
+      expect(failures).to be_empty
+    end
+
+    # End-to-end, through a real run: a degraded class witnesses NOTHING, so a typo on a `Date` receiver
+    # going unreported is the observable symptom. This example fails if the plain declaration returns.
+    it "still witnesses a typo on a Date receiver" do
+      result = run_plugin(source: "Date.today.no_such_method_here\nDateTime.now.no_such_method_here\n")
+      undefined = result.diagnostics.select { |d| d.qualified_rule == "call.undefined-method" }
+
+      expect(undefined.size).to eq(2)
+    end
   end
 end


### PR DESCRIPTION
Fixes #437.

## The failure

rbs's bundled `stdlib/date` already declares `Date#to_time`, so the plugin's own full declaration gave `RBS::DefinitionBuilder` two definitions of one method from two loaded signature sources. It raises `DuplicatedMethodDefinitionError`, Rigor fails soft, and `Date` **and** `DateTime` both degrade to `Dynamic[top]` — real methods and typos alike stop being witnessed — for every project that activates the plugin.

Reproduced end to end on a two-file fixture with the plugin active, before the change:

```
d = Date.today     #=> Dynamic[top]
d.to_time          #=> Dynamic[top]
d.to_time(:utc)    #=> Dynamic[top]
dt = DateTime.now  #=> Dynamic[top]
dt.to_time         #=> Dynamic[top]
```

After:

```
d = Date.today     #=> Date
d.to_time          #=> Time
d.to_time(:utc)    #=> Time
dt = DateTime.now  #=> DateTime
dt.to_time         #=> Time
```

`rigor check` on a typo fixture goes from 0 diagnostics to the 2 it should have emitted all along (`undefined method 'no_such_method_here' for Date` / `for DateTime`).

## Why an overload continuation, and not the other two candidates

**Dropping the row** — the way `DateTime#to_time` was dropped beside it, and the way `data/gem_overlay/activesupport/core_ext.rbs` already handles it — loses a true fact. ActiveSupport genuinely widens the arity to `to_time(form = :local)`, so without the row `date.to_time(:utc)` — correct Rails code — draws an arity diagnostic. AGENTS.md is explicit that a false positive on working code outranks the worst-case static reading, and this one would fire on ordinary Rails.

**Declaring it conditionally** has no mechanism to hang off. RBS loading through `signature_paths` is unconditional, there is no version predicate in the format, and the stdlib declaration is not going away — a conditional would need new loader machinery in `lib/rigor/` for a single row.

**Overload continuation (`| ...`)** was measured rather than assumed, and it holds on all four counts:

- `Date` and `DateTime` build; the definition-build sweep over the whole plugin-active environment is clean.
- Both arities resolve: `["(?::Symbol form) -> ::Time", "() -> ::Time"]`.
- `%a{pure}` stays attached to the ActiveSupport overload, which is the one a no-argument call selects, and `EnvelopeScanner` still reads it — the existing `#388` purity sweep passes untouched.
- Its one requirement — the base declaration must already exist — is guaranteed by `Environment.for_project`, which merges `DEFAULT_LIBRARIES` (including `date`) into every environment that loads a plugin's signature paths. It does fail in a hand-built core-only environment, which is why the guarantee is recorded in the file next to the row.

The `DateTime#to_time` note at line 803 is the precedent for recording the *why* in the file, so the new row carries the same kind of note — including why this one could not just be deleted.

## The sweep

Two independent passes over the whole bundle, not just `Date`:

1. **Definition-build sweep** — build every class and module in the environment `Environment.for_project` actually assembles for a plugin-active project (`DEFAULT_LIBRARIES` + the plugin's `sig/`). Before: 2 failures (`::Date`, `::DateTime`, both from the one row). After: **0**. The ADR-72 ActiveSupport gem overlay is deliberately excluded — `GEM_OVERLAY_PLUGIN_IDS` stands it down whenever this plugin is loaded, so the two never co-occur in production.
2. **Parse-and-resolve cross-check** — parse the plugin's RBS, and for each declared `Class#method` ask an rbs-only baseline environment whether that same class already declares that same name. Coverage: **252 method rows across 13 classes** (`Object`, `NilClass`, `TrueClass`, `FalseClass`, `String`, `Integer`, `Float`, `Time`, `Date`, `Array`, `Enumerable`, `Hash`, `DateTime`, `ERB`). Result: **exactly one** same-class redeclaration — `Date#to_time`, now flagged `overloading=true`. Nothing else in the bundle collides.

## The pin

Four new examples plus a tightened existing one, all in `spec/integration/plugins/activesupport_core_ext_plugin_spec.rb`. Verified by reverting the row to its old form: **all five fail**, and they fail for the right reasons — build failure, missing arity, non-empty sweep, and zero witnessed typos.

The important one is the whole-environment build sweep: it is not a `Date`-shaped assertion, so it catches the *next* collision wherever it lands, which is the thing that was missing when this one and the `DateTime` one had to be found one at a time in the field. The collision was invisible to any fixture loading a single signature source — the plugin's `sig/` parses and validates fine on its own — so the guards deliberately build the two-source environment.

## Verification

`make verify` green (9906 examples, RuboCop clean, `check` and `check-plugins` clean), `git diff --check` clean.

`CHANGELOG.md` deliberately untouched — parallel branches, entry written after merge.
