### PR TITLE
Give super an effect edge instead of silent exhaustiveness

### DIFF
--- a/docs/internal-spec/effect-summaries.md
+++ b/docs/internal-spec/effect-summaries.md
@@ -98,6 +98,12 @@ The label then follows the receiver's ownership, which is a syntactic question:
 
 An unprovable ownership MUST taint rather than produce a proven bare `mutate`.
 
+### `super`
+
+A `super` is a dispatch and contributes an **edge**, in every shape it takes — bare, `super()`, `super(args)`, and each of those inside a block or a rescue, both of which the containment walk descends into. The edge is the one thing the syntax settles about it: the enclosing unit's own class and selector, marked `super_call:`. Which definition sits above that class is a whole-project question, so it is resolved in § Propagation like any other edge and, unlike any other edge, taints when nothing answers.
+
+`UnitScan#delegates_upward?` reads the same node for an unrelated question — whether a class that wrote a body for a selector has *replaced* the framework's implementation or wrapped it (§ Framework units) — and the two must not be conflated: that bit is about the class, the edge is about what the parent does.
+
 ### Taints
 
 | Cause | When the tracer records it |
@@ -106,6 +112,7 @@ An unprovable ownership MUST taint rather than produce a proven bare `mutate`.
 | `dynamic-send` | `send` / `public_send` / `__send__` with a non-literal selector (a literal one is an ordinary edge) |
 | `opaque-callable` | `.call` on a receiver that is neither a lambda literal nor the unit's own block parameter and whose class is unknown or `Proc` / `Method`; or a `&expr` block argument that is neither a symbol nor the unit's block parameter |
 | `unresolved-self-call` | an implicit-self call for which **every** dispatch tier declined, and whose selector the unit's own class carries no envelope for; the detail is the selector |
+| `unresolved-super` | a `super` whose target the project's own ancestry does not define; the detail is the selector. Recorded by the **propagator**, not the tracer — only the merged ancestry can answer it (§ Propagation) |
 | `unknown-ownership` | a mutating call whose receiver ownership is not classifiable |
 | `collector-error` | the scan of that unit raised |
 
@@ -115,7 +122,6 @@ Taint never produces a finding. A non-exhaustive summary reads "these effects, a
 
 ### Known bounds of this slice
 
-- `super` is neither an edge nor a taint. Resolving it needs the ancestor *above* the enclosing class, which the propagator could supply; it is left out to keep the tracer thin.
 - An implicit-self call the dispatcher resolves optimistically through the user-class ancestor fallback does **not** taint, even when the project defines no such method. That shape is exactly what `call.self-undefined-method` covers, and it is off by default on false-positive grounds ([ADR-24](../adr/24-self-method-call-resolution.md) slice 4).
 - An uncatalogued call on a receiver whose class the catalogue does not list contributes nothing and does not taint. A class the catalogue *does* list answers its posture — see § The catalogue below.
 - Class bodies are not effect units. Their statements run at load time, which is a unit of its own that no slice models yet.
@@ -215,7 +221,14 @@ The subclass index resolves each as-written superclass to a single parent — th
 
 An edge that reaches no project definition is **dropped**, not tainted: most such calls are ordinary inherited ones the catalogue has no row for, and tainting them would make the bit carry no information.
 
-Edge resolution is memoised on `(receiver class, kind, selector)`, and the transitive subclass closure on the class name. Both are required, not incidental: one triple is asked for once per call site, and a Rails root class's subclass forest is otherwise re-walked thousands of times.
+A **`super` edge** is resolved by the same walk with two differences, and each is load-bearing:
+
+1. the walk starts *above* the enclosing class — its includes, then its superclass chain, with the class itself excluded, because a method never `super`s into itself. The includes are consulted for an instance-side `super` only: `include M` puts `M#m` where `super` looks, while `M.m` is a singleton method `include` never contributes;
+2. **no closed-world override join.** `super` in `C#m` dispatches into `C`'s ancestors, and a subclass of `C` is never among them however the receiver was constructed, so joining `D#m` would put a proven label on `C#m` that no execution of `C#m` can produce. Ruby's lack of `final` is the argument for the join at an ordinary call site and says nothing here.
+
+And a `super` edge that resolves to nothing **taints** `unresolved-super` where an ordinary one is dropped. The parent is then in a gem, in Ruby's core, or in a module prepended at run time: the call is not merely unresolved but unread, and a row that stayed exhaustive would assert a completeness it has not earned. The taint is applied to the fixpoint's seed rather than to the direct summary, so it reaches this method's callers exactly as a collected cause does — a snapshot's `methods:` table records direct summaries and does not show it; `reach:`, the report and the judgment read the closure and do.
+
+Edge resolution is memoised on `(receiver class, kind, selector, super?)`, and the transitive subclass closure on the class name. Both are required, not incidental: one tuple is asked for once per call site, and a Rails root class's subclass forest is otherwise re-walked thousands of times.
 
 **Fixpoint.** A worklist in sorted key order, to a true fixpoint:
 
@@ -362,7 +375,7 @@ Synthesising on the class rather than at the call site is what makes this work a
 
 A synthesised unit stands for the **whole** of the selector, not for the callbacks alone, so it MUST also carry the loaded plugins' own attribution row for that `(class, singleton, selector)` — the same `class_row` lookup a call site performs, with the same origin (`plugin:ActiveRecord::Base#save`), the same `taint:`, and the same `plugin-attribution` cause when the contributing plugin does not discharge. A row carrying a `narrow:` is skipped: narrowing reads an argument at a call site, and a synthesised unit has none. Without this the write was attributed at every *call site* and never on the row that names the method, and `AuthSource#save: ≤ io.db.read` — "save does not write to the database" — was what a Rails reviewer read. This enriches units that the rule above already creates; it does **not** create new ones, because a `Klass#save` row for every model in the project is precisely the noise that rule exists to prevent.
 
-The one exemption: when the class body itself defines the selector and that body never reaches `super`, the plugin's claim is dropped for that selector. Such a body has replaced the framework's implementation, and `def save = false` must keep reporting that it persists nothing. The exemption is per selector — the siblings the class did not override keep the claim — and a body that does reach `super` keeps it, since an override that delegates upward still runs whatever the superclass does. `Effects::UnitScan#delegates_upward?` is the bit; v1 gives `super` no other meaning, contributing neither an edge nor a taint.
+The one exemption: when the class body itself defines the selector and that body never reaches `super`, the plugin's claim is dropped for that selector. Such a body has replaced the framework's implementation, and `def save = false` must keep reporting that it persists nothing. The exemption is per selector — the siblings the class did not override keep the claim — and a body that does reach `super` keeps it, since an override that delegates upward still runs whatever the superclass does. `Effects::UnitScan#delegates_upward?` is the bit, and it is the *only* thing this exemption reads: the edge the same `super` contributes (§ `super`) answers what the parent does, which is a different question from whether the framework's claim about the selector still holds.
 
 The enum has **no `perform_later` → `perform`**, which is the mechanical enforcement of ADR-103 WD4's "attribution follows the code, not the clock". The one edge that looks like it — `target: :perform_now, method: :perform_later` — is emitted only by a plugin that has read the project's own `queue_adapter = :inline`, where Rails genuinely runs the job on the caller's stack.
 

--- a/docs/notes/20260823-effect-super-edge-corpus.md
+++ b/docs/notes/20260823-effect-super-edge-corpus.md
@@ -1,0 +1,117 @@
+# The edge a `super` contributes — corpus movement and cost (#446)
+
+Status: measurement note, no design commitments. Taken against Rigor 0.3.4 on branch
+`claude/effects/super-edge`, over private copies of the redmine and mastodon survey checkouts.
+
+[#446](https://github.com/rigortype/rigor/issues/446) is a soundness hole in the declared lane: a `super`
+contributed nothing to a summary **and** left the row exhaustive, so a method whose whole body delegates
+upward read as provably effect-free and passed any envelope. The fix gives `super` an edge, resolved
+above the enclosing class, and taints `unresolved-super` when the project's own ancestry answers nothing.
+Adding a call edge moves summaries corpus-wide, which is what this note measures.
+
+## Harness
+
+Both projects were `rsync`ed to a scratch directory first; nothing was written into a survey checkout.
+Checkouts: redmine `a12198ea0`, mastodon `163f96cee`. Each project's committed `.rigor.dist.yml` with
+`baseline:` dropped and `effects: {}` added — the same shape
+[`20260817-effect-collection-perf.md`](20260817-effect-collection-perf.md) uses — saved as
+`.rigor.446.yml`.
+
+```sh
+cd <scratch>/survey/<project>
+rm -rf .rigor/cache                                     # every run is COLD
+BUNDLE_GEMFILE=<rigor>/Gemfile bundle exec <rigor>/exe/rigor \
+  check   --config .rigor.446.yml --format json         # diagnostics + the stats block
+BUNDLE_GEMFILE=<rigor>/Gemfile bundle exec <rigor>/exe/rigor \
+  effects --config .rigor.446.yml --full --format json  # the whole table, per arm
+```
+
+The cache is wiped before every run because the ADR-45 run-result cache fingerprints the project and the
+configuration, neither of which changes between arms: a warm run would have replayed one arm's
+collections into the other.
+
+The two arms are the same working tree with `lib/` toggled by `git apply` / `git checkout --`, and they
+are **interleaved** — `off, on, off, on, …` for seven iterations — so a host whose load drifts moves both
+arms together. Movement is read by diffing the two `effects --full --format json` tables key by key:
+labels gained and lost per unit, the exhaustiveness bit's transitions, and which selectors sit behind an
+`unresolved-super`.
+
+## Movement
+
+Deterministic, and the reason this is the part worth trusting: it is a diff of two JSON tables, not a
+timing.
+
+| | redmine | mastodon |
+| --- | --- | --- |
+| effect units in the table | 4,683 | 8,355 |
+| `super` occurrences in `app/` + `lib/` | 166 | 114 |
+| units that **gained** a proven label | 28 (0.6 %) | 121 (1.4 %) |
+| units that **lost** a proven label | 0 | 0 |
+| units that went exhaustive → hedged | 37 (0.8 %) | 28 (0.3 %) |
+| units that went hedged → exhaustive | 0 | 0 |
+| units carrying an `unresolved-super` cause | 463 (9.9 %) | 792 (9.5 %) |
+| …of which were already hedged for another reason | 440 | 768 |
+
+Three readings.
+
+**The hedge is wide but almost free.** Roughly a tenth of all units end up carrying the cause, because it
+travels call edges like any other; but 95 % of them were already non-exhaustive for a reason of their own
+(`dynamic-receiver`, `unresolved-self-call`), so they gain a cause and not a transition. The *new*
+information — a row that used to claim completeness and no longer does — is 37 and 28 units.
+
+**Nothing lost a label**, which is the monotonicity the change should have: an edge can only add.
+
+**The labels gained are what a Rails ancestry does.** On mastodon the top three are `mutate.local` (107),
+`nondet.random` (97) and `nondet.time` (81), almost all through `super` into an ActiveRecord-shaped
+project ancestor. On redmine the spread is wider and smaller: `mutate.self` 13, `mutate.instance` 10,
+`mutate.local` 9, `io.fs.read` 5, and single digits of `io`, `io.process`, `io.net`.
+
+The selectors behind an unresolved `super` are exactly the framework boundary — redmine's `mail` (209
+units downstream), `identifier=` (65), `admin?` (33), `initialize` (33); mastodon's `current_user` (350),
+`authorize` (340), `role` (33), `initialize` (24). Every one of these has its implementation in a gem, so
+"the project's ancestry does not define it" is the truth about them and the taint is the honest answer.
+
+**`rigor check`'s diagnostic stream is byte-identical between the arms** on both projects — 792
+diagnostics on redmine, 2,349 on mastodon, zero added and zero removed, at every iteration, with only the
+`stats` block (wall time, RSS) differing. Neither project declares an envelope, and a taint never
+produces a finding, so all of the movement lands in the report and in a judgment nobody here opted into.
+That is the expected shape of a change that fixes a *false negative*: it can only ever fire where an
+author wrote a bound.
+
+## Cost
+
+ADR-103 WD13 budgets the collection path, so the edge has to be priced. Seven cold interleaved
+iterations per arm — six on redmine's `off` arm, whose first is set aside below; the numbers are
+`rigor check`'s own `wall_seconds`, which excludes process startup.
+Both arms analysed the same positive file count — 347 on redmine, 1,312 on mastodon — at every iteration.
+
+| project | arm | wall (s), range | median | peak RSS (MB) |
+| --- | --- | --- | --- | --- |
+| redmine | off | 9.33 – 9.69 (n=6) | 9.52 | 414 – 436 |
+| redmine | on | 9.41 – 9.61 | 9.54 | 416 – 424 |
+| mastodon | off | 13.89 – 14.53 | 14.17 | 697 – 712 |
+| mastodon | on | 13.65 – 14.37 | 14.16 | 677 – 716 |
+
+The ranges overlap completely in both projects and in both metrics; the medians differ by less than the
+spread within either arm. **No cost is detectable at this sample size**, which is the expected shape: the
+collector adds one edge per `super` node — 166 and 114 in these two projects, against tens of thousands
+of ordinary call edges — and the propagator's resolution is memoised on the same tuple as every other
+edge.
+
+Two things this measurement is not:
+
+- The host was **shared with three other agent sessions** working in the same repository for the whole
+  run. That is why the arms are interleaved and why the ranges are carried rather than a single median:
+  the claim being made is "the two arms are indistinguishable under identical conditions", which
+  interleaving supports, and not "collection costs 9.54 s", which this host cannot say.
+- The first run of the session (redmine, off arm, iteration 1) came in at 15.78 s against a 9.33 – 9.69 s
+  range for its own arm. It is excluded above as a session warm-up — the first cold run pays a bundled-RBS
+  build the rest of the session does not — and it is recorded here rather than silently dropped. Including
+  it would have made the *unfixed* arm look 6 s slower, which is exactly the direction a reader should be
+  suspicious of.
+
+## What this does not answer
+
+The `unresolved-super` rate is a function of how much of a project's ancestry is a gem, and both projects
+here are Rails. A library with an in-project class hierarchy would resolve nearly all of its `super`
+calls and see the label movement without the hedge; nothing here measures that shape.

--- a/docs/type-specification/effect-labels.md
+++ b/docs/type-specification/effect-labels.md
@@ -115,6 +115,7 @@ When the exhaustiveness bit is false, the summary records why, from this closed 
 | `dynamic-send` | `send` / `public_send` with a non-literal selector |
 | `method-missing` | dispatch reached a `method_missing` the analyzer does not model |
 | `unresolved-self-call` | an implicit-self call with no project-known definition |
+| `unresolved-super` | a `super` whose target the project's own ancestry does not define |
 | `opaque-callable` | a block or proc the analyzer could not follow to a body |
 | `unknown-ownership` | a mutating call whose receiver could not be proven frame-owned; the mutation is recorded as taint rather than as a proven `mutate` label |
 | `plugin-attribution` | a label contributed by a source whose trust tier does not discharge |
@@ -124,7 +125,7 @@ When the exhaustiveness bit is false, the summary records why, from this closed 
 
 The enum is closed. A new cause is a change to this document, not a producer's free choice.
 
-> As of this writing `method-missing`, `template-not-analysed` and `budget` are reserved and unproduced; the other seven have producers (`plugin-attribution` since [#385](https://github.com/rigortype/rigor/issues/385), from the configured attribution table). Which shapes reach which cause is [`effect-summaries.md`](../internal-spec/effect-summaries.md) § Taints.
+> As of this writing `method-missing`, `template-not-analysed` and `budget` are reserved and unproduced; the other eight have producers (`plugin-attribution` since [#385](https://github.com/rigortype/rigor/issues/385), from the configured attribution table; `unresolved-super` since [#446](https://github.com/rigortype/rigor/issues/446)). Which shapes reach which cause is [`effect-summaries.md`](../internal-spec/effect-summaries.md) § Taints.
 
 ## Effect envelopes
 

--- a/lib/rigor/effects/file_collection.rb
+++ b/lib/rigor/effects/file_collection.rb
@@ -30,7 +30,16 @@ module Rigor
       # receiver, or a construct that is not a call). `kind` is `:instance` for a `Nominal` receiver and
       # `:singleton` for a `Singleton` one. `self_call` marks an implicit-self call, which is the only shape
       # whose failure to resolve is an `unresolved-self-call` taint rather than silence.
-      Edge = Data.define(:receiver_class, :kind, :selector, :self_call)
+      #
+      # `super_call` marks the edge a `super` contributes (#446). It carries the ENCLOSING unit's class and
+      # selector rather than a receiver's, and the propagator resolves it against the ancestry *above* that
+      # class with no closed-world override join — a different question from every other edge, which is why
+      # it is a field rather than a convention over the other three.
+      Edge = Data.define(:receiver_class, :kind, :selector, :self_call, :super_call) do
+        # Defaulted because every producer but the `super` one records an ordinary call, and an ordinary
+        # call is not a `super`.
+        def initialize(super_call: false, **) = super
+      end
 
       NO_TABLE = {}.freeze
       private_constant :NO_TABLE
@@ -144,16 +153,21 @@ module Rigor
       end
 
       # Edge lists are sorted so a marshalled worker collection and a sequential one are `==` and the
-      # report they feed is byte-identical. The key is TOTAL over the de-duplicated list — `self_call` is
-      # in it because two edges can otherwise agree on every other field, and `sort_by` is not stable.
+      # report they feed is byte-identical. The key is TOTAL over the de-duplicated list — `self_call` and
+      # `super_call` are in it because two edges can otherwise agree on every other field (`def emit; super;
+      # emit; end` records both), and `sort_by` is not stable.
       def freeze_edges(table)
         return NO_TABLE if table.empty?
 
         table.transform_values do |list|
           sorted = list.uniq
-          sorted.sort_by! { |edge| [edge.receiver_class.to_s, edge.kind.to_s, edge.selector, edge.self_call ? 1 : 0] }
+          sorted.sort_by! { |edge| edge_order(edge) }
           sorted.freeze
         end.freeze
+      end
+
+      def edge_order(edge)
+        [edge.receiver_class.to_s, edge.kind.to_s, edge.selector, edge.self_call ? 1 : 0, edge.super_call ? 1 : 0]
       end
     end
   end

--- a/lib/rigor/effects/propagator.rb
+++ b/lib/rigor/effects/propagator.rb
@@ -53,21 +53,47 @@ module Rigor
         return EffectTable.empty if collection.summaries.empty?
 
         summaries = collection.summaries
-        edges = resolve_edges(collection)
         state = seed(summaries, discharge)
+        edges = resolve_edges(collection, state)
         iterate(state, edges)
         EffectTable.new(build_entries(summaries, edges, state))
       rescue StandardError
         EffectTable.empty
       end
 
-      # `{caller_key => [callee_key]}`, sorted and de-duplicated.
-      def resolve_edges(collection)
+      # `{caller_key => [callee_key]}`, sorted and de-duplicated. Seeds the `unresolved-super` taint in
+      # the same pass, because whether a `super` resolved is exactly what this resolution answers.
+      def resolve_edges(collection, state)
         index = Index.new(collection)
         collection.edges.each_with_object({}) do |(caller_key, list), out|
-          targets = list.flat_map { |edge| index.targets_for(edge) }.uniq.sort
+          targets = list.flat_map do |edge|
+            resolved = index.targets_for(edge)
+            taint_unresolved_super(state, caller_key, edge) if edge.super_call && resolved.empty?
+            resolved
+          end.uniq.sort
           out[caller_key] = targets.freeze unless targets.empty?
         end
+      end
+
+      # A `super` the project's own ancestry does not answer — the implementation is in a gem, in Ruby's
+      # core, or in a module prepended at run time — is the case the taint exists for (#446). Silence
+      # would be the one thing the effect model must never say: that the list is complete when a call in
+      # the body was not read. An unresolved ORDINARY edge is dropped instead, because most such calls
+      # are inherited ones the catalogue simply has no row for and the site's own taint was already
+      # decided from the typer's verdict; a `super` has no site verdict to fall back on, and it always
+      # dispatches to something.
+      #
+      # Decided here rather than in the collector because only the merged ancestry can say whether the
+      # parent resolves, and written into the SEED rather than into the direct summary so the fixpoint
+      # carries it to this method's callers exactly as it carries any other cause. A snapshot's
+      # `methods:` table records direct summaries and so does not show it; `reach:`, the report and the
+      # judgment all read the closure and do.
+      def taint_unresolved_super(state, caller_key, edge)
+        entry = state[caller_key]
+        return if entry.nil?
+
+        entry[:exhaustive] = false
+        entry[:causes] << ["unresolved-super", edge.selector].freeze
       end
 
       # Causes are carried as a Set through the fixpoint and flattened back to a sorted Array in
@@ -170,8 +196,8 @@ module Rigor
         end
       end
 
-      private_class_method :resolve_edges, :seed, :iterate, :reverse_edges, :absorb, :join_lane,
-                           :build_entries
+      private_class_method :resolve_edges, :taint_unresolved_super, :seed, :iterate, :reverse_edges,
+                           :absorb, :join_lane, :build_entries
 
       # The class graph a run's collections describe, and the edge resolution over it. Built once per
       # propagation; every lookup is a Hash read.
@@ -189,24 +215,42 @@ module Rigor
         # Every project method key `edge` may reach: the definition its ancestry resolves to, plus every
         # override of the same selector in a project subclass of the receiver's class.
         #
-        # Memoised on `(receiver class, kind, selector)` — the answer depends on nothing else, and one
-        # such triple is asked for once per call site in the project. `ApplicationRecord#save` alone is
+        # Memoised on `(receiver class, kind, selector, super?)` — the answer depends on nothing else, and
+        # one such tuple is asked for once per call site in the project. `ApplicationRecord#save` alone is
         # thousands of sites on a Rails app, each of which used to re-walk the whole subclass forest.
         def targets_for(edge)
-          @targets[[edge.receiver_class, edge.kind, edge.selector]] ||= begin
+          @targets[[edge.receiver_class, edge.kind, edge.selector, edge.super_call]] ||= begin
             separator = edge.kind == :singleton ? "." : "#"
-            targets = []
-            owner = resolve_owner(edge.receiver_class, separator, edge.selector)
-            targets << owner if owner
-            descendant_closure(edge.receiver_class).each do |subclass|
-              key = "#{subclass}#{separator}#{edge.selector}"
-              targets << key if @summaries.key?(key)
-            end
-            targets.freeze
+            edge.super_call ? super_targets(edge, separator) : call_targets(edge, separator)
           end
         end
 
         private
+
+        def call_targets(edge, separator)
+          targets = []
+          owner = resolve_owner(edge.receiver_class, separator, edge.selector)
+          targets << owner if owner
+          descendant_closure(edge.receiver_class).each do |subclass|
+            key = "#{subclass}#{separator}#{edge.selector}"
+            targets << key if @summaries.key?(key)
+          end
+          targets.freeze
+        end
+
+        # A `super` reaches **one** definition, and the closed-world override join every other edge gets
+        # is deliberately absent from it (#446). `super` in `C#m` dispatches into the ancestry above `C`
+        # in the receiver's chain, and a subclass of `C` is never in it however the receiver was
+        # constructed — so joining `D#m` would put a proven label on `C#m` that no execution of `C#m` can
+        # produce. Ruby's lack of `final` is the argument for the join at an ordinary call site and says
+        # nothing here.
+        def super_targets(edge, separator)
+          target = resolve_super(edge.receiver_class, separator, edge.selector)
+          target ? [target].freeze : NO_TARGETS
+        end
+
+        NO_TARGETS = [].freeze
+        private_constant :NO_TARGETS
 
         # The transitive subclass closure, memoised per class. A deep hierarchy's root is asked for it
         # once, not once per selector reaching it.
@@ -220,8 +264,24 @@ module Rigor
         # enqueued and the most-qualified one comes first, so the right constant wins the race and a
         # spelling that names nothing simply matches no key.
         def resolve_owner(class_name, separator, selector)
-          seen = Set.new
-          queue = [class_name]
+          walk_ancestors([class_name], Set.new, separator, selector)
+        end
+
+        # Where `super` from `class_name#selector` lands: the same ancestor walk, started one step up —
+        # the modules the class includes, then its superclass chain — with the class itself already in
+        # `seen`, because a method never `super`s into itself.
+        #
+        # The includes are instance-side only. `include M` puts `M#m` between the class and its
+        # superclass, which is exactly where `super` looks, while `M.m` is a singleton method `include`
+        # never contributes; a singleton `super` that really does reach a module went through `extend` or
+        # a `class << self` include, neither of which is collected, so it resolves to nothing and taints.
+        def resolve_super(class_name, separator, selector)
+          queue = separator == "#" ? @includes.fetch(class_name, []).dup : []
+          queue.concat(@superclasses.fetch(class_name, []))
+          walk_ancestors(queue, Set.new([class_name]), separator, selector)
+        end
+
+        def walk_ancestors(queue, seen, separator, selector)
           until queue.empty?
             current = queue.shift
             next if current.nil? || !seen.add?(current)

--- a/lib/rigor/effects/scanner.rb
+++ b/lib/rigor/effects/scanner.rb
@@ -194,7 +194,7 @@ module Rigor
           block_parameter: block_parameter_name(parameters),
           owned_locals: LocalOwnership.owned(body, names), calls: @calls,
           attribution: @attribution, envelopes: @envelopes, plugin_facts: @plugin_facts,
-          owner_class: class_name
+          owner_class: class_name, method_name: method_name
         )
         summary, edges = scan.run(body)
         merge_unit(key, summary, edges)

--- a/lib/rigor/effects/taint_cause.rb
+++ b/lib/rigor/effects/taint_cause.rb
@@ -18,6 +18,7 @@ module Rigor
         dynamic-send
         method-missing
         unresolved-self-call
+        unresolved-super
         opaque-callable
         unknown-ownership
         plugin-attribution

--- a/lib/rigor/effects/unit_scan.rb
+++ b/lib/rigor/effects/unit_scan.rb
@@ -110,9 +110,12 @@ module Rigor
       # @param plugin_facts [PluginFacts] the loaded plugins' `effect_attributions:` (#387)
       # @param owner_class [String, nil] the class this unit is defined on — the carrier an
       #   implicit-self call's envelope is looked up under, since the syntax spells `Kernel#name`
+      # @param method_name [String, nil] this unit's own selector — what a `super` in its body names as
+      #   the target the propagator resolves above `owner_class` (#446). With no name to state, a `super`
+      #   taints instead.
       def initialize(singleton:, parameters:, block_parameter:, owned_locals:, calls:, # rubocop:disable Metrics/ParameterLists
                      attribution: Attribution.empty, envelopes: EnvelopeIndex.empty,
-                     plugin_facts: PluginFacts.empty, owner_class: nil)
+                     plugin_facts: PluginFacts.empty, owner_class: nil, method_name: nil)
         @singleton = singleton
         @block_parameter = block_parameter
         @calls = calls
@@ -120,6 +123,7 @@ module Rigor
         @envelopes = envelopes
         @plugin_facts = plugin_facts
         @owner_class = owner_class
+        @method_name = method_name
         @mutation = MutationClassifier.new(
           singleton: singleton, parameters: parameters, owned_locals: owned_locals
         )
@@ -138,9 +142,10 @@ module Rigor
       # Whether this body reaches `super` — an override that delegates upward still runs whatever the
       # superclass does. Nested `def`s are unit boundaries, so a `super` counted here is this unit's.
       #
-      # v1 does nothing else with `super`: it contributes no edge and no taint, which is a gap of its own.
-      # What reads this bit is {FrameworkUnits.replaced?}, to tell a `def save` that replaces the
-      # framework's implementation from one that wraps it (#440).
+      # A separate reading of the same node from the edge {#visit_super} records: what this bit answers is
+      # whether a framework's claim about the selector survives the class having written a body for it
+      # ({FrameworkUnits.replaced?}, #440), which is a question about the *class*, not about what the
+      # parent implementation does.
       def delegates_upward?
         @delegates_upward
       end
@@ -226,8 +231,28 @@ module Rigor
              Prism::CallOperatorWriteNode, Prism::CallOrWriteNode, Prism::CallAndWriteNode
           classify_mutation(node.receiver)
         when Prism::SuperNode, Prism::ForwardingSuperNode
-          @delegates_upward = true
+          visit_super
         end
+      end
+
+      # `super` in every shape — bare, `super()`, `super(args)`, and each of those inside a block or a
+      # rescue, since the walk descends into both (#446).
+      #
+      # It is a dispatch and must contribute like one. What the scan can settle from the syntax is the
+      # *identity* of the target — this unit's own class and selector — and nothing more: which definition
+      # sits above the class is a question about the whole project, so it goes out as an edge and the
+      # propagator resolves it against the merged ancestry, tainting when nothing there answers.
+      #
+      # A unit with no class or no name has no target to state. That is not a shape the scanner produces,
+      # and the taint is what a "cannot say" must read as rather than a silently dropped call.
+      def visit_super
+        @delegates_upward = true
+        return taint("unresolved-super", @method_name) if @owner_class.nil? || @method_name.nil?
+
+        @edges << FileCollection::Edge.new(
+          receiver_class: @owner_class, kind: @singleton ? :singleton : :instance,
+          selector: @method_name, self_call: true, super_call: true
+        )
       end
 
       def visit_call(node)

--- a/spec/integration/fixtures/effects/super_edge/lib/base.rb
+++ b/spec/integration/fixtures/effects/super_edge/lib/base.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# The ancestors, in a file of their own: a `super` is resolved against the MERGED project ancestry, so the
+# parent living in another file is the shape that matters — and the one a fork-pool worker has to marshal
+# its collection back for.
+module SuperEdge
+  module Auditing
+    def emit(payload)
+      File.write("/tmp/audit", payload)
+    end
+  end
+
+  class BaseWriter
+    def emit
+      File.read("/etc/hosts")
+    end
+
+    def self.build
+      puts("built")
+    end
+  end
+end

--- a/spec/integration/fixtures/effects/super_edge/lib/writers.rb
+++ b/spec/integration/fixtures/effects/super_edge/lib/writers.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# ADR-103 #446 — every shape a `super` takes, and the two answers it may have: the parent's summary when
+# the project's own ancestry resolves it, and the `unresolved-super` taint when it does not. The ancestors
+# themselves are in `base.rb`.
+module SuperEdge
+  # The issue's own five-line reproduction: a body that is nothing but `super`.
+  class Bare < BaseWriter
+    def emit
+      super
+    end
+  end
+
+  # `super()` — an explicit empty argument list, which is a different node from a bare `super` and a
+  # different call from it too, the parent taking no arguments where this override does.
+  class Parens < BaseWriter
+    def emit(_mode = nil)
+      super()
+    end
+  end
+
+  # `super(args)`, reaching the module the class includes rather than its superclass.
+  class Args
+    include Auditing
+
+    def emit(payload)
+      super(payload.to_s)
+    end
+  end
+
+  # The walk descends into a block literal by containment, so a `super` written inside one is the
+  # enclosing method's.
+  class InBlock < BaseWriter
+    def emit
+      [1].each { super() }
+    end
+  end
+
+  class InRescue < BaseWriter
+    def emit
+      raise "boom"
+    rescue StandardError
+      super
+    end
+  end
+
+  class Singleton < BaseWriter
+    def self.build
+      super
+    end
+  end
+
+  # A `super` the project cannot resolve: `Object#to_s` is not an effect unit, and no envelope bounds it.
+  class Unresolvable
+    def to_s
+      super
+    end
+  end
+
+  # A caller of a delegating override reads the parent's effects, and a caller of an unresolvable one
+  # reads the taint.
+  class Client
+    def run
+      Bare.new.emit
+    end
+
+    def describe
+      Unresolvable.new.to_s
+    end
+  end
+end

--- a/spec/rigor/effects/propagator_spec.rb
+++ b/spec/rigor/effects/propagator_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe Rigor::Effects::Propagator do
     )
   end
 
+  # What a `super` records (#446): the enclosing unit's own class and selector, resolved above them.
+  def super_edge(owner, selector, kind: :instance)
+    Rigor::Effects::FileCollection::Edge.new(
+      receiver_class: owner, kind: kind, selector: selector, self_call: true, super_call: true
+    )
+  end
+
   def collection(summaries:, edges: {}, superclasses: {}, includes: {})
     Rigor::Effects::FileCollection.new(
       summaries: summaries, edges: edges, superclasses: superclasses, includes: includes
@@ -99,6 +106,102 @@ RSpec.describe Rigor::Effects::Propagator do
     )
 
     expect(table["T::D#run"].proven.to_a).to eq(["exit"])
+  end
+
+  # #446 — a `super` edge carries the ENCLOSING unit's class and selector, and resolves above it.
+  describe "a super edge" do
+    it "resolves to the definition the ancestry above the enclosing class answers with" do
+      table = described_class.propagate(
+        collection(
+          summaries: { "Sub#emit" => summary, "Base#emit" => summary("io.fs.read") },
+          edges: { "Sub#emit" => [super_edge("Sub", "emit")] },
+          superclasses: { "Sub" => ["Base"] }
+        )
+      )
+
+      expect(table["Sub#emit"].proven.to_a).to eq(["io.fs.read"])
+      expect(table["Sub#emit"]).to be_exhaustive
+    end
+
+    # `include M` puts `M#emit` between the class and its superclass, which is where `super` looks first.
+    it "resolves through an included module before the superclass" do
+      table = described_class.propagate(
+        collection(
+          summaries: { "Sub#emit" => summary, "M#emit" => summary("io.fs.write"), "Base#emit" => summary("exit") },
+          edges: { "Sub#emit" => [super_edge("Sub", "emit")] },
+          superclasses: { "Sub" => ["Base"] }, includes: { "Sub" => ["M"] }
+        )
+      )
+
+      expect(table["Sub#emit"].proven.to_a).to eq(["io.fs.write"])
+    end
+
+    # The guard rail, and the one place a super edge must differ from an ordinary one: `super` in `Sub#emit`
+    # dispatches into `Sub`'s ancestors, and `Deep` is never among them however the receiver was built. The
+    # closed-world join that is right for `x.emit` would put a label here that no execution can produce.
+    it "does not join a subclass override the way an ordinary call edge does" do
+      table = described_class.propagate(
+        collection(
+          summaries: { "Sub#emit" => summary, "Base#emit" => summary("io.fs.read"),
+                       "Deep#emit" => summary("io.process") },
+          edges: { "Sub#emit" => [super_edge("Sub", "emit")] },
+          superclasses: { "Sub" => ["Base"], "Deep" => ["Sub"] }
+        )
+      )
+
+      expect(table["Sub#emit"].proven.to_a).to eq(["io.fs.read"])
+      expect(table["Sub#emit"].edges).to eq(["Base#emit"])
+    end
+
+    it "never resolves to the enclosing definition itself" do
+      table = described_class.propagate(
+        collection(
+          summaries: { "Solo#emit" => summary("io.fs.read") },
+          edges: { "Solo#emit" => [super_edge("Solo", "emit")] }
+        )
+      )
+
+      expect(table["Solo#emit"].edges).to be_empty
+    end
+
+    # Where an ordinary unresolved edge is dropped in silence, an unresolved `super` taints: the parent is
+    # in a gem, in core, or in a module prepended at run time, and the row must not claim completeness.
+    it "taints the caller when the project's ancestry answers nothing" do
+      table = described_class.propagate(
+        collection(
+          summaries: { "Sub#emit" => summary }, edges: { "Sub#emit" => [super_edge("Sub", "emit")] },
+          superclasses: { "Sub" => ["ActiveRecord::Base"] }
+        )
+      )
+
+      expect(table["Sub#emit"]).not_to be_exhaustive
+      expect(table["Sub#emit"].causes).to eq([%w[unresolved-super emit]])
+    end
+
+    # The taint is seeded before the fixpoint, so it travels to callers exactly as a collected one does.
+    it "carries the taint to the callers of the delegating method" do
+      table = described_class.propagate(
+        collection(
+          summaries: { "A#run" => summary, "Sub#emit" => summary },
+          edges: { "A#run" => [edge("Sub", "emit")], "Sub#emit" => [super_edge("Sub", "emit")] }
+        )
+      )
+
+      expect(table["A#run"]).not_to be_exhaustive
+      expect(table["A#run"].causes).to eq([%w[unresolved-super emit]])
+    end
+
+    it "resolves the singleton side through the superclass chain" do
+      table = described_class.propagate(
+        collection(
+          summaries: { "Sub.build" => summary, "Base.build" => summary("nondet.time") },
+          edges: { "Sub.build" => [super_edge("Sub", "build", kind: :singleton)] },
+          superclasses: { "Sub" => ["Base"] }
+        )
+      )
+
+      expect(table["Sub.build"].proven.to_a).to eq(["nondet.time"])
+    end
   end
 
   it "drops an edge that reaches no project definition rather than tainting" do

--- a/spec/rigor/effects/super_edge_spec.rb
+++ b/spec/rigor/effects/super_edge_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rigor"
+require "rigor/analysis/runner"
+
+# ADR-103 #446 — `super` as a dispatch, end to end over the fixture app in
+# `spec/integration/fixtures/effects/super_edge`. Before this, a `super` contributed nothing AND left the
+# row exhaustive, so a method whose whole body delegates upward read as provably effect-free and passed
+# any envelope. The resolution rules over a synthetic table are `spec/rigor/effects/propagator_spec.rb`.
+RSpec.describe "a super call in an effect summary" do
+  def fixture
+    File.expand_path("../../integration/fixtures/effects/super_edge", __dir__)
+  end
+
+  def configuration(effects: {}, workers: 0)
+    data = { "paths" => ["lib"], "parallel" => { "workers" => workers } }
+    data["effects"] = effects
+    Rigor::Configuration.new(Rigor::Configuration::DEFAULTS.merge(data))
+  end
+
+  def analyze(configuration)
+    Dir.chdir(fixture) do
+      runner = Rigor::Analysis::Runner.new(configuration: configuration, cache_store: nil)
+      diagnostics = runner.run(["lib"]).diagnostics
+      [runner.effect_table, diagnostics]
+    end
+  end
+
+  let(:table) { analyze(configuration).first }
+
+  # The issue's own reproduction. `[]` and exhaustive is the one answer that is not allowed.
+  it "gives a body that is nothing but super the parent's proven labels" do
+    entry = table["SuperEdge::Bare#emit"]
+
+    expect(entry.proven.to_a).to eq(["io.fs.read"])
+    expect(entry).to be_exhaustive
+    expect(entry.edges).to eq(["SuperEdge::BaseWriter#emit"])
+  end
+
+  it "records the edge for super(), for super(args), and for a super inside a block or a rescue" do
+    expect(table["SuperEdge::Parens#emit"].proven.to_a).to eq(["io.fs.read"])
+    expect(table["SuperEdge::Args#emit"].proven.to_a).to eq(["io.fs.write"])
+    expect(table["SuperEdge::InBlock#emit"].proven.to_a).to eq(["io.fs.read"])
+    expect(table["SuperEdge::InRescue#emit"].proven.to_a).to eq(["io.fs.read"])
+  end
+
+  it "resolves the singleton side of super through the superclass chain" do
+    expect(table["SuperEdge::Singleton.build"].proven.to_a).to eq(["io.output.stdout"])
+  end
+
+  # The honest answer where the ancestry answers nothing — a gem's base class, Ruby's own core, a module
+  # prepended at run time. Empty, and hedged; never empty and exhaustive.
+  it "taints a super the project's ancestry cannot resolve rather than reading it as effect-free" do
+    entry = table["SuperEdge::Unresolvable#to_s"]
+
+    expect(entry.proven).to be_empty
+    expect(entry).not_to be_exhaustive
+    expect(entry.causes).to eq([%w[unresolved-super to_s]])
+  end
+
+  # The parent lives in another file, so this is also the marshal round trip: a worker's collection carries
+  # the `super_call` bit back, and the fixpoint over the merged tables answers the same as a sequential run.
+  it "answers identically when the collections come back from a pool worker" do
+    pooled = analyze(configuration(workers: 2)).first
+
+    expect(pooled["SuperEdge::Bare#emit"].proven.to_a).to eq(["io.fs.read"])
+    expect(pooled["SuperEdge::Unresolvable#to_s"].causes).to eq([%w[unresolved-super to_s]])
+  end
+
+  it "carries both answers to a caller" do
+    expect(table["SuperEdge::Client#run"].proven.to_a).to eq(["io.fs.read"])
+    expect(table["SuperEdge::Client#describe"]).not_to be_exhaustive
+    expect(table["SuperEdge::Client#describe"].causes).to eq([%w[unresolved-super to_s]])
+  end
+
+  # The acceptance criterion that makes this a soundness fix rather than a precision one: the declared
+  # lane is the only half of the effect system that can fail a build, and an override that delegates
+  # upward must be judged on what the parent does.
+  describe "under an `effect: []` envelope over the same directory" do
+    let(:findings) do
+      _, diagnostics = analyze(
+        configuration(effects: { "envelopes" => [{ "match" => "lib/**/*.rb", "effect" => [] }] })
+      )
+      diagnostics.select { |d| d.rule == "effect.envelope-exceeded" }
+                 .map { |d| d.message[/Method (\S+) performs/, 1] }.sort
+    end
+
+    it "flags the delegating override as well as the parent" do
+      expect(findings).to include("SuperEdge::BaseWriter#emit", "SuperEdge::Bare#emit")
+    end
+
+    # A taint contributes no finding of its own: an unresolvable `super` says "and possibly more", which
+    # withholds the pass rather than manufacturing a failure.
+    it "does not fire on the method whose super it could not resolve" do
+      expect(findings).not_to include("SuperEdge::Unresolvable#to_s")
+    end
+  end
+end

--- a/spec/rigor/effects/taint_cause_spec.rb
+++ b/spec/rigor/effects/taint_cause_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Rigor::Effects::TaintCause do
       dynamic-send
       method-missing
       unresolved-self-call
+      unresolved-super
       opaque-callable
       unknown-ownership
       plugin-attribution


### PR DESCRIPTION
A `super` contributed **nothing** to a method's effect summary and left the row marked **exhaustive**, so a method whose whole body delegates upward read as provably effect-free — it passed `%a{pure}` and any envelope while its parent was correctly flagged. That is a soundness hole rather than a precision gap: ADR-103's promise is that an unresolved dispatch taints and the row then reads "and possibly more", which is what makes `effect.envelope-exceeded` safe to act on. Here the call was not merely unresolved but *unseen*, so nothing tainted and the summary asserted a completeness it had not earned. `def create; super; end` is a shape Rails code is made of.

## The mechanism

`Effects::UnitScan#visit_super` (`lib/rigor/effects/unit_scan.rb:248`) records `super` as an edge carrying the enclosing unit's own class and selector, marked `super_call:` on `FileCollection::Edge` (`lib/rigor/effects/file_collection.rb:38`). Which definition sits above that class is a whole-project question, so `Propagator::Index#super_targets` (`lib/rigor/effects/propagator.rb:247`) resolves it against the merged ancestry.

Two differences from an ordinary edge, both load-bearing:

- **The walk starts above the class** — its includes, then its superclass chain, with the class itself excluded, because a method never `super`s into itself (`Propagator::Index#resolve_super`, `lib/rigor/effects/propagator.rb:278`). Includes are consulted for the instance side only: `include M` puts `M#m` where `super` looks, while `M.m` is a singleton method `include` never contributes.
- **No closed-world override join.** `super` in `C#m` dispatches into `C`'s ancestors, and a subclass of `C` is never among them however the receiver was built, so joining `D#m` would put a proven label on `C#m` that no execution of it can produce. Ruby's lack of `final` is the argument for the join at an ordinary call site and says nothing here.

## When the parent cannot be resolved

A `super` the project's own ancestry does not answer — a gem's base class, Ruby's core, a module prepended at run time — taints `unresolved-super` (`Propagator.taint_unresolved_super`, `lib/rigor/effects/propagator.rb:91`), where an ordinary unresolved edge is dropped in silence. The asymmetry is the point: an inherited call the catalogue has no row for carries no information, while a `super` always dispatches to something. The taint is applied to the fixpoint's **seed** rather than to the direct summary, so it reaches this method's callers exactly as a collected cause does; a snapshot's `methods:` table records direct summaries and so does not show it, while `reach:`, the report and the judgment read the closure and do. A taint can only ever withhold a pass — it never manufactures a finding.

## Corpus measurement

Recorded in [`docs/notes/20260823-effect-super-edge-corpus.md`](https://github.com/rigortype/rigor/blob/claude/effects/super-edge/docs/notes/20260823-effect-super-edge-corpus.md). Private `rsync` copies of redmine `a12198ea0` and mastodon `163f96cee`, arms interleaved over seven cold iterations, both arms analysing the same positive file count (347 / 1,312) at every iteration.

| | redmine | mastodon |
| --- | --- | --- |
| units that gained a proven label | 28 (0.6 %) | 121 (1.4 %) |
| units that lost a proven label | 0 | 0 |
| exhaustive → hedged | 37 (0.8 %) | 28 (0.3 %) |
| units carrying an `unresolved-super` cause | 463 (9.9 %) | 792 (9.5 %) |
| …already hedged for another reason | 440 | 768 |

`rigor check`'s diagnostic stream is byte-identical between the arms on both projects (792 and 2,349 diagnostics, zero added, zero removed, at every iteration) — neither declares an envelope, and a taint never fires, so all of the movement lands in the report and in a judgment nobody there opted into. That is the expected shape of a false-negative fix: it can only fire where an author wrote a bound.

Cost, which ADR-103 WD13 budgets: redmine 9.33–9.69 s off against 9.41–9.61 s on, mastodon 13.89–14.53 s off against 13.65–14.37 s on; peak RSS overlapping in both. The ranges overlap completely and the medians differ by less than the spread within either arm, so **no cost is detectable at this sample size**. The host was shared with three other agent sessions throughout, which is why the arms are interleaved and the ranges carried rather than a single median; the note records that, and records the one excluded warm-up outlier rather than dropping it silently.

## Specs

`spec/rigor/effects/super_edge_spec.rb` runs the whole pipeline over a new fixture: the issue's own reproduction, `super()`, `super(args)`, `super` inside a block and inside a rescue, the singleton side, the unresolvable case, propagation to a caller, a pooled run (the parent lives in another file, so the `super_call` bit crosses the marshal boundary), and the acceptance criterion — an `effect: []` envelope over the directory now flags the delegating override as well as the parent, and stays silent on the method whose `super` could not be resolved. `spec/rigor/effects/propagator_spec.rb` pins the resolution rules over a synthetic table, including the guard rail that a sibling override is *not* joined.

15 of the new assertions fail on `master` with the fix reverted; the two negative ones pass vacuously and are regression guards.

## Deliberately left

- **Prepends are conflated with includes.** The collector records `include` and `prepend` into one table, so a `super` in `C#m` can resolve to a module prepended to `C` — which at run time sits *before* `C` rather than above it. Pre-existing in `resolve_owner`, rare in combination with a same-named `super`, and out of scope here.
- **No catalogue fallback for an unresolvable parent.** `def to_s; super; end` on a plain class taints rather than reading `Object`'s `value` posture. Reading the catalogue there is only sound when the class has no unresolvable includes anywhere in its chain, which is a bigger change; the taint is the honest answer meanwhile and costs no diagnostic.
- `CHANGELOG.md` is untouched — four branches are landing in parallel.

Fixes #446.
