### PR TITLE
Project a union receiver to its class in effect summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[effects]** `rigor effects` now reads a call on an optional receiver — a `Foo | nil`, which is what every cross-method instance-variable read and every `find_by`-shaped return is — as a call on a `Foo`, instead of contributing nothing while the row still claimed to be exhaustive ([#455](https://github.com/rigortype/rigor/issues/455)).
+  - The idioms this covers are ordinary: `@record.save` read in a method other than the one that assigned `@record`, and `thing&.destroy!` after a `find_by`. On Redmine the entry points recorded as writing to the database go from 27 to 35 and on Mastodon from 114 to 169; three of Redmine's twenty-seven `#update` actions now record the write they perform, where none did before.
+  - A receiver whose arms disagree still contributes no label, and a receiver one of whose arms the analyzer could not name now marks the summary non-exhaustive rather than reading as effect-free. `rigor check`'s diagnostics are unchanged on both applications.
+
 - **[cli]** The `documentation_url` carried by every diagnostic in `rigor check --format json`, and printed by `rigor explain`, now resolves: it points at the catalogue page on the documentation site instead of a GitHub branch this project has never had, so following one no longer lands on a 404 ([#438](https://github.com/rigortype/rigor/issues/438)).
   - Three more links shipped with the same wrong branch and are fixed too: the plugins link in the `.rigor.yml` that `rigor init` writes, and the homepage and installation links of the VS Code extension.
 - **[plugins]** `rigor effects` reports the database write on an ActiveRecord model's own `save` row, where a model with a callback or a uniqueness validator used to read `AuthSource#save: ≤ io.db.read` — the validator's query and no write at all ([#440](https://github.com/rigortype/rigor/issues/440)).

--- a/docs/internal-spec/effect-summaries.md
+++ b/docs/internal-spec/effect-summaries.md
@@ -104,11 +104,19 @@ A `super` is a dispatch and contributes an **edge**, in every shape it takes —
 
 `UnitScan#delegates_upward?` reads the same node for an unrelated question — whether a class that wrote a body for a selector has *replaced* the framework's implementation or wrapped it (§ Framework units) — and the two must not be conflated: that bit is about the class, the edge is about what the parent does.
 
+### The receiver's class projection
+
+The tracer records one receiver class per call site, projected from the type the typer computed: a `Nominal` / `Singleton` names itself, a `Tuple` is an `Array`, a `HashShape` a `Hash`, a `Constant` its value's class, and a `Dynamic` whatever its static facet projects to. A type that projects to nothing costs an edge; it never produces a wrong one.
+
+A **union** projects to a class exactly when its non-`nil` arms all project to the same one. This is not a corner: [ADR-58](../adr/58-ivar-field-typing.md) contributes a declaration-sourced `nil` to every instance variable `initialize` does not write, so *every cross-method instance-variable read is a union*, as is every `find_by`-shaped return read through `&.`. Whether the `nil` arm means the call happens at all is `possible-nil-receiver`'s question and says nothing about what the call does when it does happen, which is the only question here.
+
+Arms that disagree project to nothing, because the record has room for one receiver class and answering with either arm would state an effect no single execution need perform. Arms that *cannot be named* — a union carrying a `Dynamic` — are the same knowledge as a bare `Dynamic` receiver in a different shape, and MUST taint accordingly: a summary whose receiver was admittedly unknown may not read exhaustive.
+
 ### Taints
 
 | Cause | When the tracer records it |
 | --- | --- |
-| `dynamic-receiver` | the typer's receiver type was `Dynamic`, and no envelope bounds the class its static facet named (§ The declared lane at call sites); the detail is the `DynamicOrigin` cause name, when one was recorded |
+| `dynamic-receiver` | the typer's receiver type was `Dynamic`, **or a union one of whose arms is** (§ The receiver's class projection), and no envelope bounds the class its static facet named (§ The declared lane at call sites); the detail is the `DynamicOrigin` cause name, when one was recorded |
 | `dynamic-send` | `send` / `public_send` / `__send__` with a non-literal selector (a literal one is an ordinary edge) |
 | `opaque-callable` | `.call` on a receiver that is neither a lambda literal nor the unit's own block parameter and whose class is unknown or `Proc` / `Method`; or a `&expr` block argument that is neither a symbol nor the unit's block parameter |
 | `unresolved-self-call` | an implicit-self call for which **every** dispatch tier declined, and whose selector the unit's own class carries no envelope for; the detail is the selector |

--- a/docs/notes/20260823-effect-user-stories-corpus.md
+++ b/docs/notes/20260823-effect-user-stories-corpus.md
@@ -262,8 +262,7 @@ The negative query. It fails, and it fails in the worst way: the answer looks co
 
 Redmine has twenty-seven `#update` actions and not one of them records a database write.
 
-**The mechanism, isolated to a two-method A/B inside one controller.** `GroupsController` — same
-class, same `@group.save` call:
+**The A/B, inside one controller.** `GroupsController` — same class, same `@group.save` call:
 
 ```ruby
 def create
@@ -276,16 +275,35 @@ def update
   … if @group.save                          # → reach records []
 ```
 
-The plugin's `ActiveRecord::Base#save` row matches through the *project's* superclass table, keyed on
-the receiver's type. An ivar assigned in the same method is typed; an ivar assigned by a
-`before_action` in a superclass (`ApplicationController#find_issue`, `#find_model_object`) is not, so
-the receiver is dynamic and the row never matches. `IssuesController#update` proves the point from
-the other side — its reach explains `mutate.self`, `mutate.local`, `mutate.static` and `global.read`
-through `save_issue_with_child_records`, and nothing at all about `@issue.save`.
+> **Correction, 2026-08-24 — this note first read that pair as "an ivar assigned by a `before_action`
+> is untyped", and that was wrong.** `find_group` is in `GroupsController` itself, not in a
+> superclass, so nothing here is a cross-class flow. Two separate mechanisms were being read as one:
+>
+> 1. **A union receiver projected to no class at all** ([#455](https://github.com/rigortype/rigor/issues/455), fixed
+>    2026-08-24). [ADR-58](../adr/58-ivar-field-typing.md) contributes a declaration-sourced `nil` to
+>    every ivar `initialize` does not write, so *every cross-method ivar read is a `T | nil`* — and the
+>    effect collector's receiver projection had no union arm. The call contributed no label and no edge
+>    **while the row still read exhaustive**. The same hole swallowed every `find_by` + `&.` site, which
+>    is why it was worth more than the ivar framing: `featured_tag&.destroy!` in Mastodon's
+>    `ActivityPub::Activity::Remove#remove_featured_tags` is an ivar-free instance of it.
+> 2. **`Group.visible.find(params[:id])` types `Dynamic`** — an ActiveRecord scope chain nothing models
+>    — so `GroupsController#update` is a plain `dynamic-receiver`, which the report *does* disclose. It
+>    is an ordinary inference gap, not a silent one, and the union fix does not touch it. What separated
+>    the two actions was never where the ivar was assigned but how it was *produced*: `Group.new` types,
+>    a scope chain does not.
+>
+> With #455 fixed, the table's after-figures are: redmine `io.db.write` reach entries **27 → 35** and
+> `#update` **0 / 27 → 3 / 27**; mastodon **114 → 169** and `#update` **8 / 41 → 21 / 43**,
+> `#destroy` **9 / 59 → 23 / 64**. `rigor check`'s diagnostic stream is byte-identical on both. The
+> verdict on the story does not change — a negative reading is still unlicensed — but its size does.
 
-**So the effect system's Rails value is bounded by cross-method ivar receiver typing** — which is
-[ADR-58](../adr/58-ivar-field-typing.md)'s subject, and the dominant Rails idiom is the case it does
-not cover. Every US-5 and US-8 number in this note moves when that moves.
+`IssuesController#update` shows the second mechanism from the other side: its reach explains
+`mutate.self`, `mutate.local`, `mutate.static` and `global.read` through
+`save_issue_with_child_records`, and (before #455) nothing at all about `@issue.save`.
+
+**So the effect system's Rails value is bounded by receiver typing** — the union projection above, and
+beyond it the ActiveRecord scope chains that type `Dynamic`. Every US-5 and US-8 number in this note
+moves when those move.
 
 Compounding it: `reach:` rows are exhaustive for **2.4 %** (redmine) / **8.7 %** (mastodon) of entry
 points, so a negative reading is unlicensed 91–98 % of the time — and the report says so only through
@@ -326,9 +344,12 @@ content-free.
    been stated: **on a Rails application, every effect a team would write a policy about is in the
    unjudgeable lane.** The snapshot's `≤+` marker is the escape hatch and is undocumented as such.
 
-2. **Rails effect visibility equals ivar receiver typing.** The `GroupsController#create` /
-   `#update` A/B is the whole story in nine lines of application code. This is the single highest-value
-   engine lever for the effect system, and it is not an effects issue.
+2. **Rails effect visibility equals receiver typing.** The `GroupsController#create` / `#update` A/B is
+   the whole story in nine lines of application code — but see the correction under US-8: it is two
+   mechanisms, not one. The first, a union receiver projecting to no class, was an effects bug and is
+   [#455](https://github.com/rigortype/rigor/issues/455), fixed 2026-08-24 (+8 / +55 write-recording
+   entry points). The second, an ActiveRecord scope chain typing `Dynamic`, is an inference gap and
+   remains the highest-value lever — and it is not an effects issue.
 
 3. **A negative reading is never licensed and nothing at the point of reading says so.** 2.4 % / 8.7 %
    exhaustive on `reach:`. The ` …?` hedge cannot carry that weight at 93 % density; a reader needs the
@@ -337,7 +358,7 @@ content-free.
 ## Filed
 
 - [#454](https://github.com/rigortype/rigor/issues/454) — every label a Rails policy would name lives in the lane no diagnostic can read (design call)
-- [#455](https://github.com/rigortype/rigor/issues/455) — a `before_action`-assigned ivar hides every ActiveRecord effect (the `GroupsController` A/B)
+- [#455](https://github.com/rigortype/rigor/issues/455) — a union-typed receiver projected to no class, so every cross-method ivar read and every `find_by` + `&.` contributed nothing while reading exhaustive (**fixed 2026-08-24**; filed under a mechanism that turned out to be wrong — see the correction under US-8)
 - [#456](https://github.com/rigortype/rigor/issues/456) — `job.*` and `email.*` have zero producers; the Rails plugins attribute neither
 - [#457](https://github.com/rigortype/rigor/issues/457) — `rigor effects` has no query surface; the pure set (449 methods on redmine) is the one answer nobody can ask for
 - [#458](https://github.com/rigortype/rigor/issues/458) — `Socket.gethostname` proves `io.net`, colouring 5 % of Redmine's rows as network

--- a/lib/rigor/effects/collector.rb
+++ b/lib/rigor/effects/collector.rb
@@ -128,7 +128,7 @@ module Rigor
         # {Accumulator#record} is what stops it paying for the `Data` and the origin lookup below.
         return if accumulator.recorded?(node)
 
-        dynamic = receiver.is_a?(Type::Dynamic)
+        dynamic = dynamic_receiver?(receiver)
         class_name, kind = descriptor_for(receiver)
         accumulator.record(
           node,
@@ -160,7 +160,44 @@ module Rigor
         when Type::HashShape then ["Hash", :instance]
         when Type::Constant then [receiver.value.class.name, :instance]
         when Type::Dynamic then descriptor_for(receiver.static_facet)
+        when Type::Union then union_descriptor(receiver)
         end
+      end
+
+      # Whether the typer's verdict on this receiver leaves its class a guess. A bare `Dynamic` is the
+      # original case; a union carrying a `Dynamic` arm is the same knowledge in a different shape, and
+      # before #455 it was the shape that said nothing — no class, no edge, and no taint, so the summary
+      # read *exhaustive* while an arm of its receiver was admittedly unknown.
+      def dynamic_receiver?(receiver)
+        return true if receiver.is_a?(Type::Dynamic)
+
+        receiver.is_a?(Type::Union) && receiver.members.any?(Type::Dynamic)
+      end
+
+      # A union projects to a class exactly when its non-nil arms all project to the SAME one (#455).
+      #
+      # `T?` is the case that pays, and it is not a corner: ADR-58 contributes a declaration-sourced
+      # `nil` to every instance variable not written in `initialize`, so **every cross-method ivar read
+      # is a union** — `@group.save` reads `Group | nil` where the same `Group.new.save` two lines up
+      # reads `Group`. Without this arm the receiver had no class, so the plugin row never matched, the
+      # edge was dropped, and the site contributed nothing *while the summary still read exhaustive*.
+      # Whether the nil arm means the call happens at all is a question for `possible-nil-receiver`; it
+      # says nothing about what the call does when it does happen, which is the only question here.
+      #
+      # Arms that disagree (`File | StringIO`) still project to nothing. Answering with either one would
+      # state an effect no single execution need perform, and answering with both is a shape the record
+      # has no room for — one call site carries one receiver class.
+      def union_descriptor(receiver)
+        descriptors = receiver.members.reject { |member| nil_member?(member) }.map { |member| descriptor_for(member) }
+        first = descriptors.first
+        return nil if first.nil?
+
+        descriptors.all? { |descriptor| descriptor == first } ? first : nil
+      end
+
+      def nil_member?(member)
+        (member.is_a?(Type::Constant) && member.value.nil?) ||
+          (member.is_a?(Type::Nominal) && member.class_name == "NilClass")
       end
 
       # Fail-soft (WD13): the scan raising drops this file's summaries and never reaches `rigor check`.

--- a/spec/integration/fixtures/effects/optional_receiver/lib/optional_receiver.rb
+++ b/spec/integration/fixtures/effects/optional_receiver/lib/optional_receiver.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Receivers whose type is a union rather than a single class (#455). Every one of these is an
+# ordinary Ruby idiom, and before the union arm existed each contributed nothing to its summary
+# while the row still read exhaustive.
+module OptionalReceiver
+  # The cross-method instance-variable read. ADR-58 contributes a declaration-sourced `nil` to any
+  # ivar `initialize` does not write, so the receiver here is `File | nil` where the same expression
+  # inside `open!` is a bare `File`.
+  class IvarReader
+    def open!
+      @io = File.open("data.txt")
+    end
+
+    def read_it
+      @io.read
+    end
+  end
+
+  # The same shape a `find_by` produces, read through safe navigation.
+  class SafeNavigator
+    def read_it(flag)
+      handle = flag ? File.open("data.txt") : nil
+      handle&.read
+    end
+  end
+
+  # An arm the typer could not name leaves the whole receiver a guess, exactly as a bare `Dynamic`
+  # receiver does — so the site taints rather than reading as effect-free. Neither body below opens
+  # anything itself: the only candidate label is the one the `.read` contributes.
+  class UnknownArm
+    def open!
+      @io = File.open("data.txt")
+    end
+
+    def read_it(other)
+      handle = @io || other
+      handle.read
+    end
+  end
+
+  # Arms that disagree project to nothing. Both of these perform `io.fs.read`, so the summary is a
+  # miss rather than a lie — one call site carries one receiver class, and answering with either
+  # arm would state an effect no single execution need perform.
+  class DisagreeingArms
+    def open!
+      @io = File.open("data.txt")
+      @dir = Dir.new(".")
+    end
+
+    def read_it(flag)
+      handle = flag ? @io : @dir
+      handle.read
+    end
+  end
+end

--- a/spec/rigor/effects/optional_receiver_spec.rb
+++ b/spec/rigor/effects/optional_receiver_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rigor"
+require "rigor/analysis/runner"
+
+# ADR-103 #455 — a receiver whose type is a union, end to end over the fixture app in
+# `spec/integration/fixtures/effects/optional_receiver`. The collector's receiver projection is a small
+# mirror of the dispatcher's, and it had no union arm: `T?` — which is what ADR-58 makes of every
+# cross-method instance-variable read, and what every `find_by` returns — projected to no class, so the
+# call contributed no label and no edge *while the row still read exhaustive*.
+RSpec.describe "an effect summary over a union-typed receiver" do
+  def fixture
+    File.expand_path("../../integration/fixtures/effects/optional_receiver", __dir__)
+  end
+
+  def configuration
+    data = { "paths" => ["lib"], "parallel" => { "workers" => 0 }, "effects" => {} }
+    Rigor::Configuration.new(Rigor::Configuration::DEFAULTS.merge(data))
+  end
+
+  let(:table) do
+    Dir.chdir(fixture) do
+      runner = Rigor::Analysis::Runner.new(configuration: configuration, cache_store: nil)
+      runner.run(["lib"])
+      runner.effect_table
+    end
+  end
+
+  # The issue's own reproduction: the same `.read`, once on a `File` and once on the `File | nil` a
+  # sibling method's write leaves behind.
+  it "reads a cross-method instance variable as its own class" do
+    entry = table["OptionalReceiver::IvarReader#read_it"]
+
+    expect(entry.proven.to_a).to eq(["io.fs.read"])
+    expect(entry).to be_exhaustive
+  end
+
+  it "reads a safe-navigated optional local as its own class" do
+    expect(table["OptionalReceiver::SafeNavigator#read_it"].proven.to_a).to eq(["io.fs.read"])
+  end
+
+  # A union carrying an arm the typer could not name is the same knowledge as a bare `Dynamic`
+  # receiver in a different shape. Empty is allowed; empty AND exhaustive is not.
+  it "taints a union with an unnameable arm rather than reading it as effect-free" do
+    entry = table["OptionalReceiver::UnknownArm#read_it"]
+
+    expect(entry.proven).to be_empty
+    expect(entry).not_to be_exhaustive
+    expect(entry.causes.map(&:first)).to include("dynamic-receiver")
+  end
+
+  # The residue, asserted so it changes deliberately: both arms perform `io.fs.read` and the record
+  # has room for one receiver class, so the site is a miss.
+  it "projects nothing when the arms name different classes" do
+    expect(table["OptionalReceiver::DisagreeingArms#read_it"].proven).to be_empty
+  end
+end


### PR DESCRIPTION
Closes #455 — though not by the mechanism the issue names. See **What the issue got wrong** below.

## The defect

`Effects::Collector.descriptor_for` is a deliberately small mirror of the dispatcher's receiver descriptor, and it had no `Type::Union` arm. A receiver typed `Foo | nil` therefore projected to **no class**: the plugin row never matched, the project edge was dropped, and the call contributed nothing — *while the row still read exhaustive*.

The minimal reproduction, catalogue-only, no plugins:

```ruby
class C
  def setup = (@io = File.open("x"))
  def use    = @io.read          # before: C#use: []      ← and exhaustive
  def direct = (io = File.open("x"); io.read)  # C#direct: [io.fs.read]
end
```

`T?` is not a corner shape. [ADR-58](https://github.com/rigortype/rigor/blob/master/docs/adr/58-ivar-field-typing.md) contributes a declaration-sourced `nil` to every instance variable `initialize` does not write, so **every cross-method instance-variable read is a union** — and so is every `find_by`-shaped return read through `&.`. Mastodon's `ActivityPub::Activity::Remove#remove_featured_tags` is the ivar-free instance: `featured_tag&.destroy!`, a database write that contributed nothing.

## The change

A union projects to a class exactly when its non-`nil` arms all project to the same one. Two deliberate non-answers:

- **Arms that disagree project to nothing.** The record has room for one receiver class per call site, and answering with either arm would state an effect no single execution need perform. This is a miss, and it is recorded as such in the fixture and in the follow-up issue.
- **Arms the typer could not name taint.** A union carrying a `Dynamic` arm is the same knowledge as a bare `Dynamic` receiver in a different shape, so the site now records `dynamic-receiver` rather than leaving a summary that was admittedly guessing to read exhaustive. That is the standing rule from the #428 / #441 / #446 batch applied to the one path in this file that still ended in silence.

## Corpus

`rigor-survey/redmine` @ `a12198ea0` and `rigor-survey/mastodon` @ `163f96cee`, each project's own config plus `rigor-railties` and `reach: [rails]`, fresh cache per arm.

| | redmine before → after | mastodon before → after |
| --- | --- | --- |
| `reach:` entries recording `io.db.write` | 27 → **35** | 114 → **169** |
| `#create` actions | 9/30 → 10/30 | 35/86 → 39/86 |
| `#update` actions | **0/27 → 3/27** | 8/41 → **21/43** |
| `#destroy` actions | 1/32 → 2/32 | 9/59 → **23/64** |
| report rows changed | 49 | 244 |
| exhaustive rows withdrawn by the new taint | −7 | −12 |

**`rigor check`'s diagnostic stream is byte-identical on both applications**, and the two envelope experiments from the user-story note are unchanged at 343 (redmine `app/helpers/**`, `effect: []`) and 56 (mastodon `app/serializers/**`).

Spot-checked gains: `IssuesController#create` now records `io.db.read`, `io.db.write` and `io.db.transaction`; `ActivityPub::Activity::Remove#remove_featured_tags` records `io.db.write` for its `featured_tag&.destroy!`.

## What the issue got wrong

#455 read the `GroupsController#create` / `#update` A/B as "an ivar assigned by a `before_action` in a superclass is untyped". `find_group` is in `GroupsController` itself, so nothing there is a cross-class flow, and ADR-58's per-class index was never the constraint. Two mechanisms were being read as one:

1. the union projection above — an effects bug, fixed here;
2. `Group.visible.find(params[:id])` types `Dynamic`, because nothing models an ActiveRecord scope chain — an ordinary inference gap, which the report *does* disclose as `dynamic-receiver`, and which this PR does not touch. It is why redmine's `#update` figure moves to 3/27 rather than to 27/27.

What actually separated the two actions was never where the ivar was assigned but how it was produced: `Group.new` types, a scope chain does not. `docs/notes/20260823-effect-user-stories-corpus.md` carries the correction in place.

## Also in this PR

- `spec/rigor/effects/optional_receiver_spec.rb` + its fixture app — the cross-method ivar read, the safe-navigated optional, the unnameable arm (asserted to taint, never to read effect-free), and the disagreeing arms (asserted so the residue changes deliberately).
- `docs/internal-spec/effect-summaries.md` gains § The receiver's class projection, and the `dynamic-receiver` taint row now names the union case.
- `CHANGELOG.md` `[Unreleased]`.

`make verify` and `make docs-check` green.