### PR TITLE
Read the machine's own identity as io, not io.net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[effects]** `Socket.gethostname` and the other calls that read this machine's own identity are reported as `io` rather than `io.net`, so a method no longer reads as network traffic because something under it looked up a hostname ([#458](https://github.com/rigortype/rigor/issues/458)).
+  - On Redmine the label travelled a long way from its source: `Mailer` builds each Message-ID from the hostname, so **219 of 4,234 rows** — every model `save`, every `Mailer` method, and the IMAP and POP3 pollers, whose actual connections are invisible — claimed `io.net`. Three rows carry it now, all of them genuine DNS resolution. `Socket.gethostbyname`, `Socket.getaddrinfo` and every other socket call are unchanged.
+
 - **[effects]** An effect envelope written on a **class** or **module** as an rbs-inline comment — `# @rbs %a{pure}` above `class Memo` — is now checked, instead of being silently ignored while the identical bound in a `.rbs` file worked ([#452](https://github.com/rigortype/rigor/issues/452)).
   - It is the cheapest bound in the feature: one line, no per-method annotation, and it distributes over every method of the class. Before this, writing one and getting a clean run meant nothing had been checked. `%a{rigor:v1:effect …}` on a class or module was affected the same way and is fixed too; a method's own annotation still wins over the class bound, and an annotation a blank line separates from the declaration is still not attached to it — that is upstream's reading of the comment, and both lanes agree on it.
 

--- a/data/effects/core.yml
+++ b/data/effects/core.yml
@@ -531,7 +531,19 @@ classes:
   # ---------------------------------------------------------------------------------------------
   # Network.
   # ---------------------------------------------------------------------------------------------
-  Socket: { posture: net, why: "the BSD socket surface" }
+  Socket:
+    posture: net
+    why: "the BSD socket surface; the rows below read the machine's own identity and send nothing"
+    singleton_methods:
+      # `io.net` on these was a wrong label, not a conservative one, and it travelled: Redmine builds
+      # its Message-IDs from `Socket.gethostname`, so 215 of 4,234 rows — every model `save`, every
+      # `Mailer#*`, and `Redmine::IMAP.check`, whose actual IMAP connection is invisible — read as
+      # network traffic on the strength of a hostname lookup (#458). `io` is the honest bound: the
+      # call leaves the process to ask the kernel, and nothing goes over a wire.
+      gethostname: { effects: [io], why: "reads this machine's own name; no packet leaves the process" }
+      gethostbyname: { effects: [io.net], why: "resolves a name — the resolver, and possibly DNS" }
+      getifaddrs: { effects: [io], why: "reads this machine's own interfaces; local configuration, not resolution" }
+      ip_address_list: { effects: [io], why: "reads this machine's own addresses; local configuration, not resolution" }
   BasicSocket: { posture: net, why: "the shared socket surface" }
   TCPSocket: { posture: net, why: "a TCP stream" }
   TCPServer: { posture: net, why: "a listening TCP socket" }

--- a/spec/rigor/effects/catalog_data_spec.rb
+++ b/spec/rigor/effects/catalog_data_spec.rb
@@ -135,6 +135,25 @@ RSpec.describe "the shipped core effect catalogue" do
       expect(catalog.lookup("Kernel", "puts").labels.to_a).to eq(["io.output.stdout"])
     end
 
+    # Measured on Redmine (#458): `Socket.gethostname` read as `io.net` under the class's `net` posture,
+    # and Redmine builds its Message-IDs from it — so 219 of 4,234 rows, every model `save` and every
+    # `Mailer#*` among them, claimed network traffic on the strength of a hostname lookup. `io` is the
+    # honest bound for a call that leaves the process and sends nothing.
+    it "reads the machine's own identity as io rather than io.net" do
+      expect(catalog.lookup("Socket", "gethostname", singleton: true).labels.to_a).to eq(["io"])
+      expect(catalog.lookup("Socket", "ip_address_list", singleton: true).labels.to_a).to eq(["io"])
+      expect(catalog.lookup("Socket", "getifaddrs", singleton: true).labels.to_a).to eq(["io"])
+    end
+
+    # The other half of the same decision: resolution really does reach the network, and the class's
+    # posture still answers for every socket call the rows do not name.
+    it "keeps io.net for resolution and for the rest of the socket surface" do
+      expect(catalog.lookup("Socket", "gethostbyname", singleton: true).labels.to_a).to eq(["io.net"])
+      expect(catalog.lookup("Socket", "getaddrinfo", singleton: true).labels.to_a).to eq(["io.net"])
+      expect(catalog.lookup("Socket", "connect").labels.to_a).to eq(["io.net"])
+      expect(catalog.lookup("Addrinfo", "foreach", singleton: true).labels.to_a).to eq(["io.net"])
+    end
+
     it "contributes nothing at all for a class the catalogue does not list" do
       expect(catalog.lookup("Tracer::Reporter", "report")).to be_nil
     end


### PR DESCRIPTION
Closes #458.

## The decision

`Socket` carries a `net` posture, so any singleton call the catalogue does not row falls to `io.net`. `Socket.gethostname` asks the kernel for this machine's name and sends nothing, so that was a **wrong** label rather than a conservative one — and the catalogue's own rule is that a wrong label is worse than a missing one ([ADR-5](https://github.com/rigortype/rigor/blob/master/docs/adr/5-robustness-principle.md)).

`io` is the honest bound: the call leaves the process, and nothing goes over a wire. `Socket.ip_address_list` and `Socket.getifaddrs` read the same kind of local configuration and go with it. `Socket.gethostbyname` is now rowed explicitly at `io.net` so both halves of the decision sit side by side in the file, and the class posture still answers for every socket call the rows do not name.

## Corpus

`rigor-survey/redmine` @ `a12198ea0`, `rigor-survey/mastodon` @ `163f96cee`, fresh cache per arm.

| rows with `io.net` in the **proven** lane | before | after |
| --- | --- | --- |
| redmine (4,234 rows) | **219** | **3** |
| mastodon (7,474 rows) | 39 | 39 |

The label travelled because `Mailer` builds each Message-ID from the hostname:

```
Redmine::IMAP.check → MailHandler.safe_receive → … → Mailer#mail → Mailer.message_id_for
  → Mailer.token_for → Socket.gethostname [io.net]
```

Every model `save` / `create!` / `update!` on `Issue`, `Journal`, `News`, `Message`, `Document`, `WikiContent`, `User` and `EmailAddress` inherited it through the after-save notification. The three rows that keep `io.net` are `WebhookEndpointValidator#validate_each`, `.safe_webhook_uri?` and `.valid_host?`, all of them reaching `Addrinfo.foreach`, which really is DNS — the acceptance criterion the issue names.

**`rigor check`'s diagnostic stream is byte-identical on both applications.** Mastodon never calls these, so its figures do not move.

## What this deliberately does not fix

`Redmine::IMAP.check` now reads `io`, not `io.net`, and its real IMAP connection is still invisible. A catalogue row cannot reach it: `Net::IMAP` is not in the bundled stdlib RBS (rbs ships `net-http`, `net-protocol` and `net-smtp`, not `net-imap`, `net-pop` or `net-ftp`), so the receiver types `Dynamic` and the class posture is correctly withheld — the same reason the existing `Net::FTP` row cannot fire either. Verified on a fixture: `Net::HTTP.get` proves `io.net.http`, `Net::IMAP.new` proves nothing. Adding `Net::IMAP` and `Net::POP3` rows would be two lines that cannot fire, so they are not in this PR; the mechanism is filed separately.

## Verification

`make verify` and `make docs-check` green. Five new assertions in `spec/rigor/effects/catalog_data_spec.rb` pin both halves — the three identity rows at `io`, and resolution plus the surviving posture at `io.net`.