### PR TITLE
Make a path argument to rigor effects a view, not a scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[cli]** A path argument to `rigor effects` now selects which methods are **printed** instead of narrowing the analysis, so `rigor effects app/controllers/issues_controller.rb` reports exactly what the whole-project run reports for those methods ([#439](https://github.com/rigortype/rigor/issues/439)).
+  - It used to narrow the analysed set, and an effect summary is transitive over whatever was analysed — so the narrowed run answered `IssuesController#create: [] …?` where the full run answered four proven labels and eight declared ones, and nothing distinguished that from a method which genuinely does nothing. A note on stderr now says how many of how many units you are looking at; a path that names no method says so instead of printing an empty report; and a path your configuration's `paths:` does not cover is analysed as well as them, so pointing the command at another tree still works. `rigor effects update` and the other subcommands have always refused a path and still do.
+
 - **[plugins]** A class you subclass from a gem no longer cuts off the effects Rigor knows about it: `class UserMailer < Devise::Mailer` and `class Auth::SessionsController < Devise::SessionsController` now get ActionMailer's and ActionPack's effects ([#465](https://github.com/rigortype/rigor/issues/465)).
   - Rigor reaches a framework's effects by following your own `class … <` and `include` lines, so a chain that leaves your source never came back — `Devise::Mailer < ActionMailer::Base` is a line in the devise gem, not in your application. A bundled plugin can now declare the ancestry its own gem introduces, and `rigor-devise` declares the six. On Mastodon that is 68 methods declaring `email.send` where 39 did, and 749 declaring `job.enqueue` where 737 did; `rigor check`'s diagnostics are unchanged.
 

--- a/docs/manual/02-cli-reference.md
+++ b/docs/manual/02-cli-reference.md
@@ -231,6 +231,14 @@ beyond `mutate.local` — mutation of objects its own frame
 allocated and never let out, which every effect envelope
 tolerates. `--full` lists every method instead.
 
+A `PATH` argument selects which methods are **printed**, never
+which are analysed: Rigor analyses your configured `paths:`
+either way, so a selected row carries exactly the labels the
+whole-project run gives it, and a note on stderr says how many
+of how many you are looking at. A path outside `paths:` is
+analysed as well as them, so pointing the command at a tree
+your configuration does not cover still works.
+
 `--format=text|json` selects the output format; the JSON
 payload additionally carries each method's *direct* summary
 broken down per origin. `--config=PATH` picks a config file.

--- a/docs/manual/19-effect-labels.md
+++ b/docs/manual/19-effect-labels.md
@@ -183,29 +183,29 @@ report hides.
 
 ### Making 31,000 lines tractable — with one caveat
 
-The report has no summary line, no pager and no filter. Two levers work, and
-the difference between them matters:
+The report has no summary line and no pager. Two levers work:
+
+**A path argument selects what is printed.**
+
+```
+$ rigor effects app/controllers/issues_controller.rb
+rigor: showing 20 of 4683 units, selected by app/controllers/issues_controller.rb;
+       a path narrows the printing and not the analysis, so every label is the one
+       the whole-project run reports
+IssuesController#create: [global.read, io, mutate.instance, mutate.local, mutate.self, mutate.static] ≤ [email.send, job.enqueue, …] …?
+```
+
+It is a **view**, not a scope. Rigor still analyses your configured `paths:`, so
+the twenty rows it prints are the same twenty lines the whole-project run
+prints. That costs a full analysis — the note on stderr is there so you know
+what you paid for and what you got — and it is the only honest way to do it: an
+effect summary is transitive, so analysing less would not filter this report, it
+would lower every answer in it. A path that names no method says so rather than
+printing an empty report.
 
 **Reading fewer rows is free.** `grep`, `sort`, `--format=json` piped into `jq`
-— the text is stable and sorted, and post-processing it costs you nothing.
-
-**Analysing fewer files is not.** `rigor effects app/models/change.rb` narrows
-the *analysis*, and the labels are transitive over what was analysed, so a
-narrowed run gives a **weaker answer for the same method**:
-
-```
-# rigor effects
-IssuesController#create: [global.read, mutate.local, mutate.self, mutate.static] ≤ [mutate, rails.flash.write, rails.i18n.translate, rails.response.write] …?
-
-# rigor effects app/controllers/issues_controller.rb
-IssuesController#create: [] …?
-```
-
-Both are honest — the second run genuinely could not see the models below the
-controller, so it says "possibly more" rather than guessing. But it is not a
-cheaper way to get the first answer. Use a path argument to read one file in
-isolation; run the whole project when you want the real footprint, and filter
-the output afterwards.
+— the text is stable and sorted, and post-processing it costs you nothing. The
+note goes to stderr, so a redirect or a pipe gets the report alone.
 
 ## Direct and transitive
 

--- a/lib/rigor/cli/effects_command.rb
+++ b/lib/rigor/cli/effects_command.rb
@@ -78,10 +78,36 @@ module Rigor
         return usage_error("unsupported format: #{options.fetch(:format)}") unless FORMATS.include?(options[:format])
 
         configuration = Configuration.load(options.fetch(:config)).with_effects_enabled
-        table = analyze(configuration)
-        report = EffectsReport.build(table, full: options.fetch(:full))
+        scope = @argv.dup
+        table, sources = analyze(configuration, scope)
+        report = EffectsReport.build(table, full: options.fetch(:full), sources: sources, scope: scope)
+        note_scope(scope, report, table)
         EffectsRenderer.new(out: @out).render(report, format: options.fetch(:format))
         0
+      end
+
+      # A path argument is a **view**, and the note says so (#439).
+      #
+      # It used to narrow the analysed set, and effect labels are transitive over whatever was analysed —
+      # so `rigor effects app/controllers/issues_controller.rb` reported `IssuesController#create: [] …?`
+      # where the whole-project run reported four labels and a declared lane. The weakened answer was
+      # indistinguishable from a genuinely effect-free method, and a path argument is the only tractability
+      # lever the report has, so it was the thing an adopter reached for first.
+      #
+      # The note goes to stderr rather than into the report: it is about the invocation, not about the
+      # code, and `--format json` and `rigor effects … > report.txt` both stay exactly what they were.
+      def note_scope(scope, report, table)
+        return if scope.empty?
+
+        if report.empty?
+          @err.puts("rigor: no effect unit is defined in #{scope.join(', ')} " \
+                    "(a path selects what is printed, not what is analysed)")
+          return
+        end
+
+        @err.puts("rigor: showing #{report.rows.length} of #{table.size} units, selected by " \
+                  "#{scope.join(', ')}; a path narrows the printing and not the analysis, so every " \
+                  "label is the one the whole-project run reports")
       end
 
       FORMATS = %w[text json].freeze
@@ -116,15 +142,28 @@ module Rigor
       # the diagnostics entry serves the run and the #382 effects sidecar serves the collections, leaving
       # only the fixpoint. Sequential is not a cache decision — the run-result cache declines pool mode —
       # but a collecting run is pinned to the fork backend anyway, so `workers: 0` costs nothing here.
-      def analyze(configuration)
+      # The analysed set is the configured `paths:` **plus** whatever the arguments name — never the
+      # arguments alone (#439). An effect summary is transitive over whatever was analysed, so analysing
+      # less does not filter the report, it lowers every answer in it: `rigor effects
+      # app/controllers/issues_controller.rb` used to report `IssuesController#create: [] …?` where the
+      # whole-project run reported four labels and a declared lane, with nothing marking the difference.
+      #
+      # The union rather than the configured paths alone, so that pointing the command at a tree the
+      # configuration does not cover — which is what every `rigor effects PATH` invocation from outside a
+      # project does — still analyses it. Inside a project the argument is already under `paths:` and the
+      # union is the configured set unchanged.
+      #
+      # @return [Array(Rigor::Effects::EffectTable, Hash{String=>Array<String>})] the table, and which
+      #   file each unit was defined in — the map {EffectsReport} needs to answer a path argument.
+      def analyze(configuration, scope)
         runner = Analysis::Runner.new(
           configuration: configuration,
           cache_store: Cache::Store.new(root: configuration.cache_path),
           collect_stats: false,
           workers: 0
         )
-        runner.run(@argv.empty? ? configuration.paths : @argv)
-        runner.effect_table
+        runner.run((configuration.paths + scope).uniq)
+        [runner.effect_table, runner.effect_sources]
       end
     end
   end

--- a/lib/rigor/cli/effects_report.rb
+++ b/lib/rigor/cli/effects_report.rb
@@ -28,10 +28,43 @@ module Rigor
 
       # Builds a report from an effect table. `full:` keeps the rows the report otherwise omits — an
       # exhaustive method proving nothing beyond `mutate.local`, which is the reading of `%a{pure}`.
-      def self.build(table, full: false)
-        rows = table.filter_map { |entry| row_for(entry) unless !full && entry.trivial? }
+      #
+      # `scope:` selects which units are **printed** and never which are analysed (#439). A path argument
+      # used to narrow the analysis, and a summary is transitive over whatever was analysed, so the
+      # narrowed run answered `[] …?` for a method the whole-project run answered four labels for — with
+      # nothing distinguishing that from a method which genuinely does nothing. `sources:` is
+      # `Runner#effect_sources`, `{ "Class#m" => [path, …] }`, which is how a key is traced back to the
+      # file it was written in.
+      def self.build(table, full: false, sources: nil, scope: [])
+        roots = normalize_scope(scope)
+        rows = table.filter_map do |entry|
+          next if !full && entry.trivial?
+          next unless roots.empty? || in_scope?(entry.key, sources, roots)
+
+          row_for(entry)
+        end
         new(rows: rows.freeze, full: full)
       end
+
+      # A path argument may name a file or a directory, and either may be written relative or absolute —
+      # so both sides are expanded and a directory matches by prefix. Deliberately not the `reach:` glob
+      # syntax: this is the argument a shell just tab-completed, and `rigor effects app/models` meaning
+      # "that directory" is the only reading a reader would guess.
+      def self.normalize_scope(scope)
+        Array(scope).map { |path| File.expand_path(path.to_s.chomp("/")) }.freeze
+      end
+      private_class_method :normalize_scope
+
+      def self.in_scope?(key, sources, roots)
+        paths = sources && sources[key]
+        return false if paths.nil? || paths.empty?
+
+        paths.any? do |path|
+          absolute = File.expand_path(path)
+          roots.any? { |root| absolute == root || absolute.start_with?("#{root}/") }
+        end
+      end
+      private_class_method :in_scope?
 
       def self.row_for(entry)
         Row.new(

--- a/spec/rigor/cli/effects_command_spec.rb
+++ b/spec/rigor/cli/effects_command_spec.rb
@@ -46,6 +46,57 @@ RSpec.describe Rigor::CLI::EffectsCommand do
     expect(out).to include("Tracer::Gateway#probe: [] …?\n    dynamic-receiver (inferred_return_untyped)\n")
   end
 
+  # #439 — a path argument used to narrow the ANALYSIS, and an effect summary is transitive over
+  # whatever was analysed, so the narrowed run answered `[] …?` for methods the whole-project run
+  # answered labels for. Nothing distinguished that from a method which genuinely does nothing, and a
+  # path argument was the only tractability lever the report had, so it was the first thing an adopter
+  # reached for.
+  describe "a path argument (#439)" do
+    # A configuration whose `paths:` is the fixture, so the argument under test is a *narrowing* of an
+    # already-analysed set — which is what a path argument is inside a real project.
+    def config_file
+      path = File.join(Dir.pwd, ".rigor.yml")
+      File.write(path, "paths:\n  - #{fixture}\n")
+      path
+    end
+
+    # `app.rb` is the discriminating selection: `Tracer::Dispatcher#run` reaches `Tracer::Loud#emit`,
+    # which lives in `loud.rb` precisely so that a per-file view cannot see it. Under the old behaviour
+    # this run analysed `app.rb` alone and answered a weaker row for it.
+    it "selects which units are printed and leaves every label the whole-project one" do
+      _, whole, = run(["--config", config_file])
+      _, narrowed, = run(["--config", config_file, File.join(fixture, "app.rb")])
+
+      selected = narrowed.lines.grep(/\A\S/)
+      expect(selected).not_to be_empty
+      expect(selected).to all(satisfy { |line| whole.include?(line) })
+      expect(selected.length).to be < whole.lines.grep(/\A\S/).length
+    end
+
+    it "says how much it selected, and that the analysis was not narrowed" do
+      _, _, err = run(["--config", config_file, File.join(fixture, "app.rb")])
+
+      expect(err).to match(/showing \d+ of \d+ units, selected by/)
+      expect(err).to include("a path narrows the printing and not the analysis")
+    end
+
+    it "says so when a path names no unit, rather than printing an empty report" do
+      status, out, err = run(["--config", config_file, File.join(fixture, "nothing_here")])
+
+      expect(status).to eq(0)
+      expect(out).to be_empty
+      expect(err).to include("no effect unit is defined in")
+      expect(err).to include("a path selects what is printed, not what is analysed")
+    end
+
+    it "prints the whole report and no note when no path is given" do
+      _, out, err = run(["--config", config_file])
+
+      expect(out.lines.grep(/\A\S/)).not_to be_empty
+      expect(err).to be_empty
+    end
+  end
+
   # Omission rule: exhaustive AND proving nothing beyond `mutate.local`, which every envelope tolerates.
   it "omits a pure method by default and lists it under --full" do
     _, default, = run([fixture])


### PR DESCRIPTION
Closes #439. First of the report-surface batch; #434 + #457 come next, and this one goes first because #434's fix is what removes the reason to reach for a path argument in the first place.

## The defect

A path argument narrowed the **analysis**, and an effect summary is transitive over whatever was analysed. So it did not filter the report — it lowered every answer in it.

```
$ rigor effects                                              # whole project
IssuesController#create: [global.read, io, mutate.instance, mutate.local, mutate.self, mutate.static] ≤ [email.send, job.enqueue, mutate, rails.actionmailer.deliver, …] …?

$ rigor effects app/controllers/issues_controller.rb         # before
IssuesController#create: [] …?
```

Same method, same tree, same configuration. `[] …?` is exactly what a genuinely effect-free method with one unresolved call looks like, so nothing distinguished "does nothing" from "you did not let me look at what it calls" — and a path argument was the only tractability lever a 31,191-line report had, which is why the walkthrough note recommended it before anyone checked what it did.

## The change

The analysed set is the configured `paths:` **plus** whatever the arguments name; the arguments select what is **printed**.

```
$ rigor effects app/controllers/issues_controller.rb          # after
rigor: showing 20 of 4683 units, selected by app/controllers/issues_controller.rb; a path narrows
       the printing and not the analysis, so every label is the one the whole-project run reports
IssuesController#create: [global.read, io, mutate.instance, mutate.local, mutate.self, mutate.static] ≤ [email.send, job.enqueue, …] …?
```

Three decisions worth naming:

- **The union, not the configured paths alone.** Pointing the command at a tree the configuration does not cover — which is what every invocation from outside a project does, this suite's own fixtures included — must still analyse it. Inside a project the argument is already under `paths:`, so the union is the configured set unchanged.
- **The note goes to stderr.** It is about the invocation, not the code, so `--format json` and `rigor effects … > report.txt` stay exactly what they were.
- **A path naming no unit says so** rather than printing an empty report, which is the same silence in a smaller disguise.

Selecting now costs a full analysis. That is the honest price and the note is there so you know what you paid for; the cheap levers are `grep` and `jq` over stable sorted text, and the real query surface is #457.

## Verification

On `rigor-survey/redmine` @ `a12198ea0`: `rigor effects --config … app/controllers/issues_controller.rb` prints 20 rows, and **all 20 are byte-identical lines of the whole-project report** (`grep -F -x -f`). A directory argument (`app/models`) selects 2,131. `no/such/path` prints the no-unit note and nothing else.

`make verify` and `make docs-check` green. Four new examples in `spec/rigor/cli/effects_command_spec.rb`; **two of them fail on master** (the note, and the no-match message). The other two pin the contract but do not discriminate on this fixture — every unit in `spec/integration/fixtures/effects/tracer` happens to read the same narrowed or whole, which is a property of a four-file fixture rather than of the change, and the Redmine reproduction above is what actually measures it. Saying so here rather than claiming four.

Acceptance criterion 2 — "`rigor effects update` with a narrowed scope cannot silently write a weakened snapshot" — was already met and is unchanged: the verbs refuse a path with `rigor effects update takes no paths; it records the configured paths:`.

Manual: chapter 19's "Analysing fewer files is not [free]" passage is replaced by what a path argument now does, and chapter 02 gains the contract.