### PR TITLE
Size the effects report for an application, and let it be asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Added
 
+- **[cli]** `rigor effects` can be asked a question. `--label=LABEL` prints only the methods carrying that label or one under it, `--pure` prints the methods proven to do nothing — the `%a{pure}` candidates, which the report omitted by construction — and `--limit=N` caps the output ([#457](https://github.com/rigortype/rigor/issues/457)).
+  - On Redmine, `rigor effects --label io.net` is five rows and `rigor effects --pure` is 436, where both questions previously needed `--full`, a `grep` and a guess about the row grammar.
+
 - **[docs]** [Effect labels](docs/manual/19-effect-labels.md) now says which labels a declared bound can actually fail on, and where to enforce the ones it cannot ([ADR-103](docs/adr/103-effect-labels.md) § WD17).
   - A bound is checked against a method's *proven* labels — what Rigor got by reading your code. On a Rails application `io.db.*`, `cache.*`, `telemetry`, `email.send`, `job.enqueue` and every `rails.*` come from a plugin modelling a framework Rigor did not read, so an envelope naming them is satisfied vacuously; the committed snapshot is what enforces them, and `rigor effects check` marks a new one with `≤+`. The chapter gained a section on the split, the surfaces table now says which question each one answers, and the configuration reference says it at `effects.envelopes:`.
 
@@ -25,6 +28,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
   - Rigor produces no `failure.*` label of its own — in Steins the family names why a failure arm exists rather than what a method does — so a bound that names one is satisfied vacuously, the same way `io.output.buffer` is already registered here without any Ruby method producing it.
 
 ### Fixed
+
+- **[cli]** `rigor effects` prints a report sized for an application instead of for a fixture: 2,733 lines on Redmine where it printed 31,191, with nothing lost ([#434](https://github.com/rigortype/rigor/issues/434)).
+  - Three changes get there. A row with no label in either lane says nothing at all and is now omitted — 1,953 of Redmine's 4,683. The unresolved-reason block, which was 30,000 of the 34,680 lines a full report prints, is collapsed to a count on the row, and `--why` expands it. And the report closes with a footer: how many units of how many are printed, and how many carry a **proven** label against a **declared** one — counted apart because only the first can ever fail a build. `--full` still prints exactly what the old default did, `--why` restores the reason blocks, and `--format json` carries the same totals.
+  - `--why` also names the plugin row behind each declared label (`plugin:ActionController::Base#redirect_to → [mutate.self, rails.response.write]`), which nothing did before: a bundled plugin's row is trusted and so leaves no taint line, which is why `plugin-attribution` appeared zero times in a whole Redmine run while 1,320 rows carried a `≤` clause.
 
 - **[cli]** A path argument to `rigor effects` now selects which methods are **printed** instead of narrowing the analysis, so `rigor effects app/controllers/issues_controller.rb` reports exactly what the whole-project run reports for those methods ([#439](https://github.com/rigortype/rigor/issues/439)).
   - It used to narrow the analysed set, and an effect summary is transitive over whatever was analysed — so the narrowed run answered `IssuesController#create: [] …?` where the full run answered four proven labels and eight declared ones, and nothing distinguished that from a method which genuinely does nothing. A note on stderr now says how many of how many units you are looking at; a path that names no method says so instead of printing an empty report; and a path your configuration's `paths:` does not cover is analysed as well as them, so pointing the command at another tree still works. `rigor effects update` and the other subcommands have always refused a path and still do.

--- a/docs/manual/02-cli-reference.md
+++ b/docs/manual/02-cli-reference.md
@@ -226,10 +226,22 @@ Gateways::Client#fetch: [] ≤ [io.net.http] …?
     plugin-attribution (Acme::Http.get)
 ```
 
-A method is omitted when it is exhaustive and proves nothing
-beyond `mutate.local` — mutation of objects its own frame
-allocated and never let out, which every effect envelope
-tolerates. `--full` lists every method instead.
+Two kinds of method are omitted: one that proves nothing
+beyond `mutate.local` and claims nothing — mutation of objects
+its own frame allocated and never let out, which every effect
+envelope tolerates — and one with no label in either lane,
+which exists only to record that something below it was
+unresolved. `--full` lists both. `--pure` asks for the first
+group by name, which is the set worth annotating `%a{pure}`.
+
+`--label=LABEL` prints only the methods carrying `LABEL` or a
+label under it, in either lane. `--limit=N` caps the rows.
+`--why` expands each row's unresolved reasons and the plugin
+row behind each declared label, which are collapsed to a count
+by default. The report closes with a footer counting the two
+lanes apart, because they have different powers: a proven label
+can fail a build and a declared one cannot
+([ADR-103](../adr/103-effect-labels.md) § WD17).
 
 A `PATH` argument selects which methods are **printed**, never
 which are analysed: Rigor analyses your configured `paths:`

--- a/docs/manual/19-effect-labels.md
+++ b/docs/manual/19-effect-labels.md
@@ -117,30 +117,36 @@ its own — the report is:
 
 | | count | share |
 | --- | --- | --- |
-| lines on stdout | 31,191 | |
-| method rows | 4,223 | 13.5% |
-| indented reason lines | 26,968 | 86.5% |
-| rows ending in ` …?` | 3,930 | **93.1% of rows** |
-| rows that are exhaustive | 293 | 6.9% |
-| rows reading exactly `Foo#bar: [] …?` | 1,627 | 38.5% of rows |
+| units analysed | 4,683 | |
+| rows printed by default | 2,730 | 58% of units |
+| rows omitted, because they say nothing at all | 1,953 | 42% |
+| lines on stdout | 2,733 | (the rows, plus a three-line footer) |
+| printed rows ending in ` …?` | 2,468 | **90% of rows** |
+| lines under `--full --why` | 34,680 | |
 
-**Ninety-three percent hedged is the normal, healthy state of a Rails
-application**, not a sign that something is broken. Rails resolves an enormous
-amount at runtime, and Rigor reports what it proved rather than what it feared.
-If you were expecting an exhaustive answer for every method, recalibrate here
-rather than at the end of the chapter.
+**Ninety percent hedged is the normal, healthy state of a Rails application**,
+not a sign that something is broken. Rails resolves an enormous amount at
+runtime, and Rigor reports what it proved rather than what it feared. If you
+were expecting an exhaustive answer for every method, recalibrate here rather
+than at the end of the chapter.
+
+The report closes with a footer, and it counts the two lanes apart on purpose:
+
+```
+──
+2730 of 4683 units printed; 1953 omitted (--full)
+2183 carry a proven label · 1555 carry a declared (≤) one · 262 are exhaustive
+```
+
+Those two numbers have different powers, and the rest of this chapter is about
+the difference. A **proven** label can fail a build. A **declared** one cannot —
+it is a claim by a plugin about a framework Rigor never read, and the snapshot
+is what enforces it.
 
 ### Reading a row
 
 ```
-IssuesController#create: [global.read, mutate.local, mutate.self, mutate.static] ≤ [mutate, rails.flash.write, rails.i18n.translate, rails.response.write] …?
-    dynamic-receiver
-    dynamic-receiver (explicit_untyped)
-    dynamic-receiver (inferred_return_untyped)
-    dynamic-receiver (unsupported_syntax)
-    dynamic-send
-    template-not-analysed (ActionController::Base#render)
-    … 15 more
+IssuesController#create: [global.read, io, mutate.instance, mutate.local, mutate.self, mutate.static] ≤ [email.send, job.enqueue, mutate, rails.flash.write, rails.i18n.translate, rails.response.write] …? (21 reasons, --why)
 ```
 
 Four fields, and they answer four different questions:
@@ -165,27 +171,57 @@ Four fields, and they answer four different questions:
    line naming the call; a row a bundled plugin contributed does not, because a
    trusted row discharges its own taint.
 4. **` …?`** — "these effects, and **possibly more**". Some call could not be
-   resolved. The indented lines say which kind; across the whole Redmine report
-   they break down as `unresolved-self-call` 15,652, `dynamic-receiver` 8,912,
-   `unknown-ownership` 1,340, `dynamic-send` 685, `template-not-analysed` 249,
-   `opaque-callable` 130.
+   resolved, and the count says how many kinds. `--why` expands them under the
+   row, along with the plugin row behind each declared label:
 
-A row is **omitted** when it is exhaustive and proves nothing beyond
-`mutate.local`. `--full` prints those too, which is the one good use for it:
+   ```
+   IssuesController#create: … …?
+       dynamic-receiver (inferred_return_untyped)
+       template-not-analysed (ActionController::Base#render)
+       plugin:ActionController::Base#redirect_to → [mutate.self, rails.response.write]
+   ```
+
+   They are collapsed by default because on Redmine they are 30,000 of the
+   34,680 lines a full report prints, and they answer a question you ask about
+   one row after having read many.
+
+Two kinds of row are **omitted** by default:
+
+- a method that proves nothing beyond `mutate.local` and claims nothing — the
+  reading of `%a{pure}`;
+- a method with no label in either lane, which exists only to record that
+  something below it was unresolved. That is 1,953 rows on Redmine, and the
+  footer counts them.
+
+`--full` prints both. But the first group is worth asking for by name:
 
 ```sh
-rigor effects --full | grep ': \[\]$'
+rigor effects --pure
 ```
 
-Those are the methods Rigor proved do nothing at all — 460 of them on Redmine.
-They are your `%a{pure}` candidates, and they are precisely the rows the default
-report hides.
+436 methods on Redmine, and they are your `%a{pure}` candidates — the on-ramp to
+the last section of this chapter.
 
-### Making 31,000 lines tractable — with one caveat
+### Asking it a question
 
-The report has no summary line and no pager. Two levers work:
+**By label.** The question this chapter opens with, in one command:
 
-**A path argument selects what is printed.**
+```sh
+$ rigor effects --label io.net
+Redmine::IMAP.check: [exit, global.read, io, io.fs.read, io.fs.write, io.net, …] ≤ [email.send, job.enqueue, …] …? (121 reasons, --why)
+Redmine::POP3.check: …
+WebhookEndpointValidator#validate_each: …
+──
+5 of 4683 units printed; 4678 not selected
+```
+
+`--label` matches a label and everything under it — `--label io` selects the
+`io.net` rows above and the `io.fs.read` ones too — and it looks in **both**
+lanes, because "what talks to the network" is a question about your code rather
+than about which lane happens to know it. The row's own rendering keeps the two
+apart.
+
+**By path.**
 
 ```
 $ rigor effects app/controllers/issues_controller.rb
@@ -203,9 +239,12 @@ effect summary is transitive, so analysing less would not filter this report, it
 would lower every answer in it. A path that names no method says so rather than
 printing an empty report.
 
-**Reading fewer rows is free.** `grep`, `sort`, `--format=json` piped into `jq`
-— the text is stable and sorted, and post-processing it costs you nothing. The
-note goes to stderr, so a redirect or a pipe gets the report alone.
+**By count.** `--limit N` prints the first N rows and the footer says how many
+it cut.
+
+And `grep`, `sort` and `--format=json` piped into `jq` all still work — the text
+is stable and sorted, the JSON payload carries the same totals the footer
+prints, and the path note goes to stderr so a redirect gets the report alone.
 
 ## Direct and transitive
 

--- a/lib/rigor/cli/effects_command.rb
+++ b/lib/rigor/cli/effects_command.rb
@@ -61,7 +61,16 @@ module Rigor
           #{USAGE}
 
           With no subcommand, prints one line per method: its proven effect labels and whether that
-          list is exhaustive.
+          list is exhaustive. A PATH selects which methods are printed, never which are analysed.
+
+          Options:
+            --config=PATH        Path to the Rigor configuration file
+            --format=FORMAT      Output format: text (default) or json
+            --full               List every method, including the ones with nothing to say
+            --label=LABEL        Only methods carrying LABEL (or a label under it), in either lane
+            --pure               Only methods proven to do nothing beyond mutate.local
+            --limit=N            Print at most N methods
+            --why                Expand each method's unresolved reasons and declared-lane sources
 
           Subcommands (the committed effect snapshot, ADR-103 WD7):
             update      Write the snapshot to effects.snapshot.path. Commit it; review its diff.
@@ -80,9 +89,12 @@ module Rigor
         configuration = Configuration.load(options.fetch(:config)).with_effects_enabled
         scope = @argv.dup
         table, sources = analyze(configuration, scope)
-        report = EffectsReport.build(table, full: options.fetch(:full), sources: sources, scope: scope)
+        report = EffectsReport.build(
+          table, full: options.fetch(:full), sources: sources, scope: scope,
+                 label: options.fetch(:label), pure: options.fetch(:pure), limit: options.fetch(:limit)
+        )
         note_scope(scope, report, table)
-        EffectsRenderer.new(out: @out).render(report, format: options.fetch(:format))
+        EffectsRenderer.new(out: @out, why: options.fetch(:why)).render(report, format: options.fetch(:format))
         0
       end
 
@@ -114,13 +126,24 @@ module Rigor
       private_constant :FORMATS
 
       def parse_options
-        options = { config: nil, format: "text", full: false, no_tolerated: false }
+        options = { config: nil, format: "text", full: false, no_tolerated: false, label: [], pure: false,
+                    limit: nil, why: false }
         OptionParser.new do |opts|
           opts.banner = USAGE
           Options.add_config(opts, options)
           opts.on("--format=FORMAT", "Output format: text (default) or json") { |value| options[:format] = value }
-          opts.on("--full", "List every method, including exhaustive ones with no effects beyond mutate.local") do
+          opts.on("--full", "List every method, including the ones with nothing to say") do
             options[:full] = true
+          end
+          opts.on("--label=LABEL", "Only methods carrying LABEL (or a label under it), in either lane") do |value|
+            options[:label].concat(value.split(",").map(&:strip).reject(&:empty?))
+          end
+          opts.on("--pure", "Only methods proven to do nothing beyond mutate.local — the %a{pure} set") do
+            options[:pure] = true
+          end
+          opts.on("--limit=N", Integer, "Print at most N methods") { |value| options[:limit] = value }
+          opts.on("--why", "Expand each method's unresolved reasons and declared-lane sources") do
+            options[:why] = true
           end
           # Accepted here and deliberately inert, exactly as it is on `update`: the report is an
           # observation, and observations are undischarged. Only a JUDGMENT reads `effects.tolerated:` —

--- a/lib/rigor/cli/effects_renderer.rb
+++ b/lib/rigor/cli/effects_renderer.rb
@@ -16,17 +16,53 @@ module Rigor
     class EffectsRenderer
       include Renderable
 
-      def initialize(out:)
+      def initialize(out:, why: false)
         @out = out
+        @why = why
       end
 
       private
 
+      # The reason block is **collapsed to a count** by default (#434). It was 86.5 % of the bytes of a
+      # 31,191-line Redmine run, and it answers a question a reader asks about one row after reading many
+      # — so `--why` expands it, and the count is what stays on the line that made them curious.
       def render_text(report)
         report.rows.each do |row|
-          @out.puts("#{row.key}: [#{row.effects.join(', ')}]#{declared(row)}#{' …?' unless row.exhaustive?}")
+          @out.puts("#{row.key}: [#{row.effects.join(', ')}]#{declared(row)}#{hedge(row)}")
+          next unless @why
+
           row.causes.each { |cause, detail| @out.puts("    #{cause}#{" (#{detail})" if detail}") }
+          row.attribution.each { |origin, labels| @out.puts("    #{origin} → [#{labels.join(', ')}]") }
         end
+        render_footer(report.totals)
+      end
+
+      def hedge(row)
+        return "" if row.exhaustive?
+        return " …?" if @why || row.causes.empty?
+
+        " …? (#{row.causes.length} #{row.causes.length == 1 ? 'reason' : 'reasons'}, --why)"
+      end
+
+      # The footer a 31,191-line report never had, and the reason it counts the two lanes apart: a
+      # declared label can never fail a build (ADR-103 § WD17), so a reader who sees one total cannot tell
+      # which half of the report is a policy surface and which half is a record to review the diff of.
+      def render_footer(totals)
+        return if totals.nil?
+
+        @out.puts("──")
+        @out.puts("#{totals.printed} of #{totals.units} units printed#{omitted(totals)}")
+        @out.puts("#{totals.proven} carry a proven label · #{totals.declared} carry a declared (≤) one " \
+                  "· #{totals.exhaustive} are exhaustive")
+      end
+
+      # Two ways a row can be missing, counted apart because `--full` answers only one of them.
+      def omitted(totals)
+        parts = []
+        parts << "#{totals.omitted} omitted (--full)" if totals.omitted.positive?
+        parts << "#{totals.unselected} not selected" if totals.unselected.positive?
+        parts << "#{totals.truncated} cut by --limit" if totals.truncated.positive?
+        parts.empty? ? "" : "; #{parts.join(', ')}"
       end
 
       # `≤` is the lane's spelling everywhere in the model — an upper bound, not an observation — so the
@@ -43,10 +79,12 @@ module Rigor
               "declared" => row.declared,
               "exhaustive" => row.exhaustive?,
               "causes" => row.causes.map { |cause, detail| [cause, detail] },
-              "direct" => row.direct
+              "direct" => row.direct,
+              "attribution" => row.attribution
             }]
           end
         }
+        payload["totals"] = report.totals.to_h.transform_keys(&:to_s) if report.totals
         @out.puts(JSON.pretty_generate(payload))
       end
     end

--- a/lib/rigor/cli/effects_report.rb
+++ b/lib/rigor/cli/effects_report.rb
@@ -7,7 +7,12 @@ module Rigor
     #
     # Rows are sorted by key and every collection inside one is sorted, so two runs over the same tree
     # print byte-identical output whether analysis ran sequentially or across the fork pool.
-    class EffectsReport < Data.define(:rows, :full)
+    class EffectsReport < Data.define(:rows, :full, :totals)
+      # `totals:` defaults so a caller that builds a report by hand keeps working.
+      def initialize(totals: nil, **rest)
+        super
+      end
+
       # One method's line in the report.
       #
       # `effects` is the transitive proven lane — this method's labels joined with every project method it
@@ -20,11 +25,40 @@ module Rigor
       # is printed apart from `effects` and never folded into it, because the two answer different
       # questions: one is proven, the other is asserted. A declared label the proven lane already admits
       # is dropped here, where output is rendered; the table keeps both lanes raw.
-      class Row < Data.define(:key, :effects, :declared, :exhaustive, :causes, :direct)
+      class Row < Data.define(:key, :effects, :declared, :exhaustive, :causes, :direct, :attribution)
+        # `attribution:` defaults so a caller that builds a row by hand keeps working.
+        def initialize(attribution: {}, **rest)
+          super
+        end
+
         def exhaustive?
           exhaustive
         end
+
+        # The reading `--pure` selects and the default report omits: nothing proven beyond what every
+        # envelope tolerates, nothing claimed, and no "possibly more".
+        def pure?
+          exhaustive && declared.empty? && (effects - TRIVIAL).empty?
+        end
+
+        # `mutate.local` is mutation of objects the frame allocated and never let out, which every
+        # envelope tolerates — so a method proving only it is what `%a{pure}` means here.
+        TRIVIAL = ["mutate.local"].freeze
+        private_constant :TRIVIAL
+
+        def carries_label?(labels)
+          labels.any? { |label| (effects + declared).any? { |own| own == label || own.start_with?("#{label}.") } }
+        end
       end
+
+      # The counts the footer prints and the JSON payload carries (#434). The two lanes are counted
+      # **separately** and deliberately: a declared label can never fail a build ([ADR-103](../adr/103-effect-labels.md)
+      # § WD17), and on a Rails application it is most of the mass — 709 `io.db.read` plus 644
+      # `io.db.write` on Redmine's 4,234 rows against zero of either proven. A single total tells a reader
+      # how big the report is; the split tells them which half is a policy surface and which half is a
+      # record whose diff they should be reviewing instead.
+      Totals = Data.define(:units, :printed, :omitted, :unselected, :proven, :declared, :exhaustive,
+                           :truncated)
 
       # Builds a report from an effect table. `full:` keeps the rows the report otherwise omits — an
       # exhaustive method proving nothing beyond `mutate.local`, which is the reading of `%a{pure}`.
@@ -35,16 +69,52 @@ module Rigor
       # nothing distinguishing that from a method which genuinely does nothing. `sources:` is
       # `Runner#effect_sources`, `{ "Class#m" => [path, …] }`, which is how a key is traced back to the
       # file it was written in.
-      def self.build(table, full: false, sources: nil, scope: [])
+      def self.build(table, full: false, sources: nil, scope: [], label: [], pure: false, limit: nil)
         roots = normalize_scope(scope)
-        rows = table.filter_map do |entry|
-          next if !full && entry.trivial?
-          next unless roots.empty? || in_scope?(entry.key, sources, roots)
-
-          row_for(entry)
+        in_scope = table.filter_map do |entry|
+          row_for(entry) if roots.empty? || in_scope?(entry.key, sources, roots)
         end
-        new(rows: rows.freeze, full: full)
+        selected = in_scope.select { |row| keep?(row, full: full, label: label, pure: pure) }
+        new(rows: (limit ? selected.first(limit) : selected).freeze, full: full,
+            totals: totals_for(table, in_scope, selected, limit, query: pure || !label.empty?))
       end
+
+      # What the default report drops, and why each is a separate question:
+      #
+      # - **`full:`** keeps a row the omission rule would drop. Two shapes qualify: a method proving
+      #   nothing beyond `mutate.local` and claiming nothing (the reading of `%a{pure}`), and a row with
+      #   no label in **either** lane, which is 35–38 % of a real application's rows and says literally
+      #   nothing — it exists only to record that something was unresolved, which the footer counts.
+      # - **`pure:`** is the complement of the first: exactly the rows the default omits for being
+      #   provably harmless, which is the set worth annotating and which nothing could ask for (#457).
+      # - **`label:`** is the question chapter 19 opens with. It matches **either** lane, because "which
+      #   controllers reach the network" is a question about the code and not about which lane knows it;
+      #   the row's own rendering keeps the two apart.
+      def self.keep?(row, full:, label:, pure:)
+        return row.pure? if pure
+        return row.carries_label?(label) unless label.empty?
+        return true if full
+
+        !row.pure? && !(row.effects.empty? && row.declared.empty?)
+      end
+      private_class_method :keep?
+
+      # Two ways a row can be missing, and only one of them `--full` answers: the **omission rule** drops
+      # a row that says nothing, and a **filter** — a path, `--label`, `--pure` — drops one that did not
+      # match. Telling a `--label io.net` reader that 4,678 more are behind `--full` would be false, so
+      # the two are counted apart.
+      def self.totals_for(table, in_scope, selected, limit, query:)
+        omitted = query ? 0 : in_scope.length - selected.length
+        Totals.new(
+          units: table.size, printed: limit ? [selected.length, limit].min : selected.length,
+          omitted: omitted, unselected: table.size - selected.length - omitted,
+          proven: selected.count { |row| !row.effects.empty? },
+          declared: selected.count { |row| !row.declared.empty? },
+          exhaustive: selected.count(&:exhaustive?),
+          truncated: limit ? [selected.length - limit, 0].max : 0
+        )
+      end
+      private_class_method :totals_for
 
       # A path argument may name a file or a directory, and either may be written relative or absolute —
       # so both sides are expanded and a directory matches by prefix. Deliberately not the `reach:` glob
@@ -73,7 +143,14 @@ module Rigor
           declared: entry.rendered_declared.to_a,
           exhaustive: entry.exhaustive?,
           causes: entry.causes,
-          direct: entry.direct.bundles.to_h { |origin, labels| [origin.to_s, labels.to_a] }.freeze
+          direct: entry.direct.bundles.to_h { |origin, labels| [origin.to_s, labels.to_a] }.freeze,
+          # The declared lane's provenance (#434). A *discharging* plugin row leaves no cause line by
+          # design — WD6: a row the engine bundles is trusted, so it does not taint — which is why
+          # `plugin-attribution` appeared zero times in a whole Redmine run while 1,320 rows carried a
+          # `≤` clause. The origins are where the answer actually lives, and this is the direct half; a
+          # label that arrived transitively is `rigor effects explain`'s question.
+          attribution: entry.direct.declared_bundles.to_h { |origin, labels| [origin.to_s, labels.to_a] }
+                            .freeze
         )
       end
       private_class_method :row_for

--- a/spec/rigor/cli/effects_command_spec.rb
+++ b/spec/rigor/cli/effects_command_spec.rb
@@ -39,11 +39,17 @@ RSpec.describe Rigor::CLI::EffectsCommand do
       .map { |line| line.split(":").first }.sort)
   end
 
-  it "suffixes a non-exhaustive method and lists the causes under it" do
-    _, out, = run([fixture])
+  # #434 — the reason block was 86.5 % of the bytes of a 31,191-line Redmine run, so the default keeps
+  # the count on the row that made a reader curious and `--why` expands it. These two rows carry no label
+  # in either lane, which is the other thing the default drops, so they need `--full` to be printed at all.
+  it "collapses a non-exhaustive method's causes to a count, and expands them under --why" do
+    _, collapsed, = run(["--full", fixture])
+    _, expanded, = run(["--full", "--why", fixture])
 
-    expect(out).to include("Tracer::Gateway#dispatch: [] …?\n    dynamic-send\n")
-    expect(out).to include("Tracer::Gateway#probe: [] …?\n    dynamic-receiver (inferred_return_untyped)\n")
+    expect(collapsed).to include("Tracer::Gateway#dispatch: [] …? (1 reason, --why)\n")
+    expect(collapsed).not_to include("    dynamic-send")
+    expect(expanded).to include("Tracer::Gateway#dispatch: [] …?\n    dynamic-send\n")
+    expect(expanded).to include("Tracer::Gateway#probe: [] …?\n    dynamic-receiver (inferred_return_untyped)\n")
   end
 
   # #439 — a path argument used to narrow the ANALYSIS, and an effect summary is transitive over
@@ -67,10 +73,10 @@ RSpec.describe Rigor::CLI::EffectsCommand do
       _, whole, = run(["--config", config_file])
       _, narrowed, = run(["--config", config_file, File.join(fixture, "app.rb")])
 
-      selected = narrowed.lines.grep(/\A\S/)
+      selected = narrowed.lines.grep(/: \[/)
       expect(selected).not_to be_empty
       expect(selected).to all(satisfy { |line| whole.include?(line) })
-      expect(selected.length).to be < whole.lines.grep(/\A\S/).length
+      expect(selected.length).to be < whole.lines.grep(/: \[/).length
     end
 
     it "says how much it selected, and that the analysis was not narrowed" do
@@ -84,7 +90,7 @@ RSpec.describe Rigor::CLI::EffectsCommand do
       status, out, err = run(["--config", config_file, File.join(fixture, "nothing_here")])
 
       expect(status).to eq(0)
-      expect(out).to be_empty
+      expect(out.lines.grep(/: \[/)).to be_empty
       expect(err).to include("no effect unit is defined in")
       expect(err).to include("a path selects what is printed, not what is analysed")
     end
@@ -92,7 +98,7 @@ RSpec.describe Rigor::CLI::EffectsCommand do
     it "prints the whole report and no note when no path is given" do
       _, out, err = run(["--config", config_file])
 
-      expect(out.lines.grep(/\A\S/)).not_to be_empty
+      expect(out.lines.grep(/: \[/)).not_to be_empty
       expect(err).to be_empty
     end
   end
@@ -108,6 +114,65 @@ RSpec.describe Rigor::CLI::EffectsCommand do
     expect(full).to include("Tracer::Reporter#label: []\n")
   end
 
+  # #457 — every question in the user-story note was answered with `grep` and a throwaway script, and
+  # the sharpest instance was that the report's own on-ramp — "find the methods you can safely declare
+  # pure" — is exactly the set the default omits.
+  describe "the query surface (#457)" do
+    it "selects by label, matching a label and everything under it, in either lane" do
+      _, out, = run(["--label", "io.output.stdout", fixture])
+
+      rows = out.lines.grep(/: \[/)
+      expect(rows).not_to be_empty
+      expect(rows).to all(include("io.output"))
+      expect(out).to include("Tracer::Reporter#report:")
+    end
+
+    it "selects a root and matches its leaves" do
+      _, leaf, = run(["--label", "io.output.stdout", fixture])
+      _, root, = run(["--label", "io", fixture])
+
+      expect(root.lines.grep(/: \[/).length).to be >= leaf.lines.grep(/: \[/).length
+      expect(root).to include("Tracer::Reporter#report:")
+    end
+
+    it "prints the pure set, which the default report omits by construction" do
+      _, default, = run([fixture])
+      _, pure, = run(["--pure", fixture])
+
+      expect(default).not_to include("Tracer::Reporter#collect")
+      expect(pure).to include("Tracer::Reporter#collect: [mutate.local]\n")
+      expect(pure).to include("Tracer::Reporter#label: []\n")
+      expect(pure.lines.grep(/: \[/)).to all(satisfy { |line| !line.include?("…?") && !line.include?("≤") })
+    end
+
+    # `--full` answers the omission rule and nothing else, so a filtered run must not offer it as the
+    # way to see what the filter dropped.
+    it "says rows were not selected rather than offering --full for them" do
+      _, filtered, = run(["--label", "io.output.stdout", fixture])
+      _, unfiltered, = run([fixture])
+
+      expect(filtered).to include("not selected")
+      expect(filtered).not_to include("--full")
+      expect(unfiltered).to include("omitted (--full)")
+    end
+
+    it "caps the printed rows with --limit and says how many it cut" do
+      _, out, = run(["--limit", "1", fixture])
+
+      expect(out.lines.grep(/: \[/).length).to eq(1)
+      expect(out).to include("cut by --limit")
+    end
+  end
+
+  # #434 — the report had no summary line at all, and the two lanes are counted apart because they have
+  # different powers: a declared label can never fail a build (ADR-103 § WD17).
+  it "closes with a footer counting the two lanes apart" do
+    _, out, = run([fixture])
+
+    expect(out).to match(/^\d+ of \d+ units printed/)
+    expect(out).to match(/^\d+ carry a proven label · \d+ carry a declared \(≤\) one · \d+ are exhaustive$/)
+  end
+
   it "emits the methods table under --format json" do
     status, out, = run(["--format", "json", fixture])
     payload = JSON.parse(out)
@@ -118,12 +183,24 @@ RSpec.describe Rigor::CLI::EffectsCommand do
       "declared" => [],
       "exhaustive" => true,
       "causes" => [],
-      "direct" => { "catalogue:Kernel#puts" => ["io.output.stdout"], "catalogue:Time.now" => ["nondet.time"] }
+      "direct" => { "catalogue:Kernel#puts" => ["io.output.stdout"], "catalogue:Time.now" => ["nondet.time"] },
+      "attribution" => {}
     )
   end
 
-  it "reports the taint causes as [cause, detail] pairs in JSON" do
+  # The footer's counts, for the reader that is a script (#434).
+  it "carries the totals in the JSON payload" do
     _, out, = run(["--format", "json", fixture])
+    totals = JSON.parse(out).fetch("totals")
+
+    expect(totals.keys).to contain_exactly("units", "printed", "omitted", "unselected", "proven",
+                                           "declared", "exhaustive", "truncated")
+    expect(totals.fetch("printed")).to be_positive
+    expect(totals.fetch("units")).to be >= totals.fetch("printed")
+  end
+
+  it "reports the taint causes as [cause, detail] pairs in JSON" do
+    _, out, = run(["--full", "--format", "json", fixture])
 
     expect(JSON.parse(out).dig("methods", "Tracer::Gateway#probe", "causes"))
       .to eq([%w[dynamic-receiver inferred_return_untyped]])

--- a/spec/rigor/effects/config_policy_spec.rb
+++ b/spec/rigor/effects/config_policy_spec.rb
@@ -173,7 +173,9 @@ RSpec.describe "the effects policy configuration" do
     it "prints the declared lane apart from the proven one, as a `≤` bound" do
       text = run(policy) do |_diagnostics, runner|
         out = StringIO.new
-        Rigor::CLI::EffectsRenderer.new(out: out)
+        # `why: true` keeps the plain `…?` suffix: the default collapses each row's reason count onto it
+        # (#434), and this example is about the `≤` spelling rather than about the hedge.
+        Rigor::CLI::EffectsRenderer.new(out: out, why: true)
                                    .render(Rigor::CLI::EffectsReport.build(runner.effect_table), format: "text")
         out.string
       end


### PR DESCRIPTION
Closes #457. Advances #434 — its report-side criteria are met here; its two snapshot-side fixes (the regeneration diff, and the `unresolved:` arrays that are half the snapshot's bytes) are a separate surface and follow in their own PR, so #434 stays open until then.

Second of the report-surface batch, after #439.

## What it was

31,191 lines on Redmine. 38.5 % of the rows said literally nothing — `Foo#bar: [] …?`, a row that exists only to record that something below it was unresolved — and 86.5 % of the bytes were the indented reason blocks under them. No summary, no filter, no way to ask it anything.

## Sizing it (#434)

| | before | after |
| --- | --- | --- |
| lines, default | 31,191 | **2,733** |
| lines, `--full --why` | — | 34,680 (nothing lost) |
| rows printed | 4,223 | 2,730 of 4,683 units |
| rows omitted for saying nothing | 0 | 1,953 |

- **A row with no label in either lane is omitted**, behind `--full`. Same call `effects update` already makes for taint-only snapshot rows (#411).
- **The reason block collapses to a count** — `…? (21 reasons, --why)` — and `--why` expands it. It was 30,000 of the 34,680 lines a full report prints, and it answers a question you ask about *one* row after reading many.
- **A footer**, and it counts the two lanes **apart**:

```
──
2730 of 4683 units printed; 1953 omitted (--full)
2183 carry a proven label · 1555 carry a declared (≤) one · 262 are exhaustive
```

That split is the acceptance criterion WD17 added to this issue: a proven label can fail a build and a declared one cannot, so one total cannot tell a reader which half of the report is a policy surface and which half is a record whose *diff* they should be reviewing.

- **`--why` names the plugin row behind each declared label** — `plugin:ActionController::Base#redirect_to → [mutate.self, rails.response.write]`, 1,544 such lines on Redmine. Nothing rendered these before, which is why `plugin-attribution` appeared **zero** times in a whole run while 1,320 rows carried a `≤` clause: a bundled plugin's row is trusted and so leaves no taint line (WD6). The origins were always in the summary.

## Asking it a question (#457)

```
$ rigor effects --label io.net
Redmine::IMAP.check: [exit, global.read, io, io.fs.read, io.fs.write, io.net, …] ≤ [email.send, job.enqueue, …] …? (121 reasons, --why)
…
──
5 of 4683 units printed; 4678 not selected
```

- **`--label`** matches a label and everything under it, in **both** lanes — "what talks to the network" is a question about the code rather than about which lane happens to know it, and the row's own rendering keeps the two apart.
- **`--pure`** prints the set the default omits by construction: 436 methods on Redmine, the `%a{pure}` candidates, which previously required `--full`, a `grep`, and a guess about the row grammar.
- **`--limit=N`** caps the rows and the footer says how many it cut.

**Omission and filtering are counted apart.** `--full` answers the omission rule and nothing else, so a `--label io.net` run says "4,678 not selected" rather than offering `--full` for them, which would be false.

Filtering never changes what was analysed — that contract is #439's, landed, and these flags inherit it.

## Verification

`make verify` and `make docs-check` green. Eleven new examples in `spec/rigor/cli/effects_command_spec.rb` covering each flag, the footer's shape, the JSON totals, and the omitted-versus-not-selected distinction. The existing examples that pinned the old default output are updated to `--full` / `--why`, which is the deliberate half of this change: `spec/rigor/effects/config_policy_spec.rb`'s `≤` example now renders with `why: true` so it keeps testing the spelling rather than the hedge.

Also closes item 1 of #435 in passing: `rigor effects --help` now lists its own options, which it had to since this adds five.