### PR TITLE
Cut rigor unused warm cost with cached env and narrowed template scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Changed
+
+- **[cli]** `rigor unused` now reuses the analysis cache for its RBS environment and its plugins' prepare work, and scans templates for class names against only the identifier-bearing fraction of each file — the report is byte-identical and 1.4–3.3× faster on the measured corpus (8.3 s → 2.5 s warm on Mastodon).
+
 ## [0.3.5] - 2026-08-25
 
 v0.3.5 is about making the effect system usable rather than merely present. The `rigor effects` report went from 31,191 lines on a mid-size Rails application to 2,733 with nothing lost, gained `--label`, `--pure` and `--limit` so it can be asked a question, and can now print the label vocabulary itself. A larger group of fixes is about what the report *sees*: an optional receiver, a module a worker includes, a base class from a gem, a `super`, and a class-level annotation were each contributing nothing, several of them while the method still read as exhaustive. The manual gained a [chapter on effect labels](docs/manual/19-effect-labels.md), and [ADR-103](docs/adr/103-effect-labels.md) § WD17 records which labels a declared bound can actually fail on and where to enforce the rest.

--- a/lib/rigor/analysis/reachability/plugin_roots.rb
+++ b/lib/rigor/analysis/reachability/plugin_roots.rb
@@ -86,12 +86,16 @@ module Rigor
         # @param configuration [Rigor::Configuration] the loaded project configuration.
         # @param plugin_requirer [#call] how a plugin gem is brought into the process. The same seam
         #   `Analysis::Runner` exposes, so a spec can register a plugin class without publishing a gem.
+        # @param cache_store [Rigor::Cache::Store, nil] when given, each plugin's `#prepare` producers read
+        #   and write the same ADR-60 record-and-validate slots they use under `rigor check`, instead of
+        #   recomputing from scratch — a routes parse or a factory discovery is a validated cache read on
+        #   every invocation after the first. Nil keeps the historical recompute-always behaviour.
         # @return [Contribution] sorted and de-duplicated. Empty whenever the project declares no plugins, no
         #   plugin contributes anything, or anything at all goes wrong.
-        def collect(configuration:, plugin_requirer: ->(name) { require name })
+        def collect(configuration:, plugin_requirer: ->(name) { require name }, cache_store: nil)
           return Contribution.empty if configuration.plugins.empty?
 
-          services = build_services(configuration)
+          services = build_services(configuration, cache_store)
           registry = Plugin::Loader.load(configuration: configuration, services: services,
                                          requirer: plugin_requirer)
           return Contribution.empty if registry.nil? || registry.empty?
@@ -102,16 +106,15 @@ module Rigor
           Contribution.empty
         end
 
-        # Mirrors `CLI::ProbeEnvironment.load_plugin_registry`: a `Plugin::Services` with no cache store
-        # (this is a one-shot report, so a producer recomputes rather than reading and writing cache slots)
-        # driving `Plugin::Loader.load`. Holding the `Services` is what gives access to the fact store the
-        # loaded plugins share — the loader hands the same instance to every plugin.
-        def build_services(configuration)
+        # Mirrors `Analysis::WorkerSession`'s services: the shared fact store plus whatever cache store the
+        # caller holds. Holding the `Services` is what gives access to the fact store the loaded plugins
+        # share — the loader hands the same instance to every plugin.
+        def build_services(configuration, cache_store)
           Plugin::Services.new(
             reflection: Reflection,
             type: Type::Combinator,
             configuration: configuration,
-            cache_store: nil
+            cache_store: cache_store
           )
         end
 

--- a/lib/rigor/cli/unused_command.rb
+++ b/lib/rigor/cli/unused_command.rb
@@ -10,6 +10,7 @@ require_relative "../analysis/reachability/graph"
 require_relative "../analysis/reachability/plugin_roots"
 require_relative "../analysis/reachability/signature_scan"
 require_relative "../analysis/reachability/project_files"
+require_relative "../cache/store"
 require_relative "options"
 require_relative "command"
 require_relative "probe_environment"
@@ -47,7 +48,8 @@ module Rigor
         references.concat(signature_references(configuration))
         dynamic_uses.concat(template_mentions(declarations))
 
-        contribution = Analysis::Reachability::PluginRoots.collect(configuration: configuration)
+        contribution = Analysis::Reachability::PluginRoots.collect(configuration: configuration,
+                                                                   cache_store: cache_store(configuration))
         references.concat(plugin_references(contribution.references))
         graph = Analysis::Reachability::Graph.new(
           declarations: declarations, references: references, dynamic_uses: dynamic_uses,
@@ -160,9 +162,9 @@ module Rigor
         return [] if names.empty?
 
         Analysis::Reachability::ProjectFiles.own(Dir.glob(TEMPLATE_GLOB, base: Dir.pwd), Dir.pwd).flat_map do |rel|
-          text = File.read(File.expand_path(rel)).scrub
+          haystack = constant_bearing_text(File.read(File.expand_path(rel)).scrub)
           names.filter_map do |fqn|
-            next unless text.include?(fqn)
+            next unless haystack.include?(fqn)
 
             Analysis::Reachability::Scan::DynamicUse.new(name: nil, prefix: fqn, site: nil,
                                                          reason: "named as a string in #{rel}",
@@ -171,6 +173,19 @@ module Rigor
         rescue SystemCallError, ArgumentError
           []
         end
+      end
+
+      # A maximal run of constant-path characters carrying at least one capital — the only substrings a
+      # declaration FQN can occur inside, since an FQN starts with a capital and uses this charset alone.
+      # An occurrence cannot cross a non-charset character, so `include?` over the de-duplicated runs
+      # (joined by a character outside the charset) answers exactly what `include?` over the whole text
+      # did, on a fraction of the bytes: a locale YAML or fixture JSON is almost entirely lowercase prose,
+      # and scanning 21 MB of it per declaration name was 81% of this command's wall time on mastodon.
+      CONSTANT_BEARING_RUN = /[A-Za-z0-9_:]*[A-Z][A-Za-z0-9_:]*/
+      private_constant :CONSTANT_BEARING_RUN
+
+      def constant_bearing_text(text)
+        text.scan(CONSTANT_BEARING_RUN).uniq.join("\n")
       end
 
       def root_fqns(declarations, globs)
@@ -188,11 +203,29 @@ module Rigor
       # declaration, which produced three of redmine's artifacts from a single initializer. A name the bundled
       # (non-project) environment already knows is not ours to call unused. The project's own `sig/` is
       # deliberately excluded from this environment, so a project class that ships a signature stays owned.
+      #
+      # The cache store makes the environment a Marshal restore instead of a cold RBS build on every
+      # invocation — the same ADR-54 slot `rigor check` reads, keyed apart by this environment's own
+      # (sig-less) descriptor. The report only ever asks "is this name known", which the cached
+      # environment answers identically: the one thing the cache degrades is `RBS::Location`, and no
+      # location is read here.
       def foreign_predicate(configuration)
-        env = Environment.for_project(libraries: configuration.libraries, signature_paths: [])
+        env = Environment.for_project(libraries: configuration.libraries, signature_paths: [],
+                                      cache_store: cache_store(configuration))
         ->(fqn) { !env.singleton_for_name(fqn).nil? }
       rescue StandardError
         ->(_fqn) { false }
+      end
+
+      # One store per run, shared by the environment build and the plugin-roots collection. Nil when the
+      # store cannot be opened — both consumers already treat a nil store as "recompute", which was this
+      # command's only mode before it had a cache at all.
+      def cache_store(configuration)
+        return @cache_store if defined?(@cache_store)
+
+        @cache_store = Cache::Store.new(root: configuration.cache_path)
+      rescue StandardError
+        @cache_store = nil
       end
 
       # ADR-102 § Consequences — "a root source that OVER-supplies silently hides real dead code, which is

--- a/spec/rigor/analysis/reachability/plugin_roots_spec.rb
+++ b/spec/rigor/analysis/reachability/plugin_roots_spec.rb
@@ -89,6 +89,19 @@ RSpec.describe Rigor::Analysis::Reachability::PluginRoots do
       expect(described_class.collect(configuration: configuration_for)).to be_empty
     end
 
+    it "hands the caller's cache store to the plugins' services, so producers hit their check-time slots" do
+      store = instance_double(Rigor::Cache::Store)
+      allow(Rigor::Plugin::Services).to receive(:new).and_call_original
+
+      described_class.collect(
+        configuration: configuration_for("rigor-roots-a"),
+        plugin_requirer: requirer_for("rigor-roots-a" => root_publisher),
+        cache_store: store
+      )
+
+      expect(Rigor::Plugin::Services).to have_received(:new).with(hash_including(cache_store: store))
+    end
+
     it "degrades when a plugin gem cannot be resolved" do
       contribution = described_class.collect(
         configuration: configuration_for("rigor-does-not-exist"),

--- a/spec/rigor/cli/unused_command_spec.rb
+++ b/spec/rigor/cli/unused_command_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "stringio"
+require "tmpdir"
+
+require "rigor/cli/unused_command"
+
+# ADR-102 — the report end to end, pinned where the fast template scan must not drift from the
+# semantics it replaced: a template mention is a SUBSTRING test over the file's text, so a name
+# inside a longer identifier still demotes, and a capital-free file can demote nothing.
+RSpec.describe Rigor::CLI::UnusedCommand do
+  def run_in(dir, *argv)
+    out = StringIO.new
+    err = StringIO.new
+    status = Dir.chdir(dir) { described_class.new(argv: ["--format=json", *argv], out: out, err: err).run }
+    [status, JSON.parse(out.string), err.string]
+  end
+
+  def write_project(dir, extra_source: nil)
+    FileUtils.mkdir_p(File.join(dir, "lib"))
+    File.write(File.join(dir, ".rigor.yml"), "paths:\n  - lib\n")
+    File.write(File.join(dir, "lib/loner.rb"), "class Loner\nend\n")
+    File.write(File.join(dir, "lib/extra.rb"), extra_source) if extra_source
+  end
+
+  describe "template mentions (ADR-102 WD4)" do
+    it "demotes a declaration named inside a longer identifier — substring, not token, semantics" do
+      Dir.mktmpdir do |dir|
+        write_project(dir)
+        File.write(File.join(dir, "config.yml"), "widget: LonerRegistry\n")
+
+        status, report, = run_in(dir)
+
+        expect(status).to eq(0)
+        row = report.fetch("undecidable").find { |u| u.fetch("name") == "Loner" }
+        expect(row).not_to be_nil
+        expect(row.fetch("reason")).to include("config.yml")
+        expect(report.fetch("candidates").map { |c| c.fetch("name") }).not_to include("Loner")
+      end
+    end
+
+    it "spans a mention split around punctuation the way the raw text reads it" do
+      Dir.mktmpdir do |dir|
+        write_project(dir, extra_source: "module Ns\n  class Deep\n  end\nend\n")
+        File.write(File.join(dir, "config.yml"), %(entry: "Ns::Deep"\n))
+
+        _, report, = run_in(dir)
+
+        expect(report.fetch("undecidable").map { |u| u.fetch("name") }).to include("Ns::Deep")
+      end
+    end
+
+    it "keeps the candidate when the name never appears, even in capital-free prose that echoes it" do
+      Dir.mktmpdir do |dir|
+        write_project(dir)
+        File.write(File.join(dir, "config.yml"), "note: the loner registry stays lowercase\n")
+
+        _, report, = run_in(dir)
+
+        expect(report.fetch("candidates").map { |c| c.fetch("name") }).to include("Loner")
+        expect(report.fetch("undecidable")).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

`rigor unused` runs no analysis engine, and until now touched no cache either: every invocation rebuilt the full RBS environment cold, re-ran every plugin's `#prepare` producers uncached, and scanned every template byte once per declaration name. Phase attribution on Mastodon put the template scan at 7.0 s of an 8.7 s run — 1,498 names each swept across 21.5 MB of locale YAML and fixture JSON, of which only 108 ever match anything.

Three changes, none observable in the report:

- **`Environment.for_project` gets the run's cache store** — the sig-less ownership environment becomes an ADR-54 Marshal restore after the first run. The report only reads nil-ness of `singleton_for_name`, so the cache's `RBS::Location` sentinel is irrelevant on this path.
- **`PluginRoots.collect` accepts the same store** and threads it into the plugins' `Services`, so prepare producers hit the ADR-60 record-and-validate slots they already maintain under `rigor check` instead of recomputing routes parses and factory discoveries per run.
- **The template scan narrows its haystack**: `include?(fqn)` now runs against only the de-duplicated maximal `[A-Za-z0-9_:]` runs that carry a capital. An FQN starts with a capital and cannot cross a non-charset byte, so the answer is provably identical to the whole-text scan, on a fraction of the bytes.

## Measured

A/B over kramdown, liquid, mail, redmine, mastodon (survey checkouts, in-tree file toggle, same bundle): `--format json` output **byte-identical on all five**; warm wall 0.59→0.38 s / 0.66→0.43 s / 0.78→0.55 s / 2.21→1.43 s / **8.30→2.53 s**. Even the first (cache-priming) run beats the old cost on Mastodon (9.3→3.3 s) because the template narrowing alone is −5.5 s.

## Gates

`make verify` green; `spec/docs` (changelog conformance) green; new specs pin the substring semantics of the template scan (a name inside a longer identifier still demotes; a capital-free file demotes nothing) and the cache-store pass-through.
