### PR TITLE
Route every RBS annotation spelling through the effect-envelope hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 - **[cli]** `rigor unused` now reuses the analysis cache for its RBS environment and its plugins' prepare work, and scans templates for class names against only the identifier-bearing fraction of each file — the report is byte-identical and 1.4–3.3× faster on the measured corpus (8.3 s → 2.5 s warm on Mastodon).
 
+### Fixed
+
+- **[effects]** An effect annotation written in any of RBS's other bracket spellings — `%a(pure)`, `%a[rigor:v1:effect …]`, `%a|…|`, `%a<…>` — was invisible to the warm-run cache probe and to the annotations-unchecked notice, so its envelope was judged on cold runs and silently skipped on every cache hit; all five spellings now route identically, and a signature file with no effect annotation is no longer parsed by the envelope reader at all.
+
 ## [0.3.5] - 2026-08-25
 
 v0.3.5 is about making the effect system usable rather than merely present. The `rigor effects` report went from 31,191 lines on a mid-size Rails application to 2,733 with nothing lost, gained `--label`, `--pure` and `--limit` so it can be asked a question, and can now print the label vocabulary itself. A larger group of fixes is about what the report *sees*: an optional receiver, a module a worker includes, a base class from a gem, a `super`, and a class-level annotation were each contributing nothing, several of them while the method still read as exhaustive. The manual gained a [chapter on effect labels](docs/manual/19-effect-labels.md), and [ADR-103](docs/adr/103-effect-labels.md) § WD17 records which labels a declared bound can actually fail on and where to enforce the rest.

--- a/lib/rigor/effects/signature_sources.rb
+++ b/lib/rigor/effects/signature_sources.rb
@@ -21,10 +21,21 @@ module Rigor
       DEFAULT_ROOTS = ["sig"].freeze
 
       # A cheap text pre-filter for "does this source carry an effect annotation at all". It matches
-      # the two spellings the envelope reader honours and nothing else, so a signature tree with no
+      # the two payloads the envelope reader honours and nothing else, so a signature tree with no
       # effect annotation is answered by one regex per file and never parsed. It is a ROUTING test,
       # not the grammar — `RbsExtended.parse_effect_annotation` is still what decides meaning.
-      ANNOTATION_HINT = /%a\{\s*(?:pure\s*\}|rigor:v1:effect\b)/
+      #
+      # RBS accepts five bracket pairs for an annotation, and the reader sees only the text inside
+      # them, so the hint must accept all five too: routing on `%a{` alone made a `%a(pure)` project
+      # invisible to the run-cache probe, which then served the fast path while a bound existed —
+      # the silent-lane shape the #428 family is about. Over-matching (a mismatched closer) is safe:
+      # the cost is one declined fast path or one parsed file, never a missed bound.
+      ANNOTATION_BRACKETS = { "{" => "}", "(" => ")", "[" => "]", "|" => "|", "<" => ">" }.freeze
+      ANNOTATION_HINT = Regexp.union(
+        ANNOTATION_BRACKETS.map do |opener, closer|
+          /%a#{Regexp.escape(opener)}\s*(?:pure\s*#{Regexp.escape(closer)}|rigor:v1:effect\b)/
+        end
+      )
 
       # A `virtual:<plugin-id>:<source path>` buffer is rbs-inline's (or a plugin's) synthesized RBS for
       # a Ruby file the author actually wrote in. Naming that file is what a reader can act on, so the

--- a/lib/rigor/rbs_extended/envelope_scanner.rb
+++ b/lib/rigor/rbs_extended/envelope_scanner.rb
@@ -2,6 +2,7 @@
 
 require "rbs"
 
+require_relative "../effects/signature_sources"
 require_relative "../rbs_extended"
 require_relative "reporter"
 
@@ -50,11 +51,19 @@ module Rigor
       #   `.rbs` files, plus the virtual entries rbs-inline and plugin `source_rbs` synthesis contribute.
       # @param registry [Rigor::Effects::Registry] the vocabulary an unknown label is judged against.
       # @return [Result]
+      #
+      # The `ANNOTATION_HINT` routing test runs here, before any parse: a source with no honoured
+      # payload can contribute neither an envelope nor an unresolved report, so a signature tree with
+      # no effect annotation is answered by one regex per file — which is what that hint's own
+      # documentation promises, and what every warm envelope-lane run was paying a full
+      # `RBS::Parser.parse_signature` per file for.
       def scan(sources:, registry:)
         reporter = Reporter.new
         methods = {}
         classes = {}
         sources.each do |name, content|
+          next unless Effects::SignatureSources::ANNOTATION_HINT.match?(content)
+
           declarations(name, content).each do |decl|
             walk(decl, [], methods, classes, registry, reporter)
           end

--- a/spec/rigor/effects/envelope_cache_spec.rb
+++ b/spec/rigor/effects/envelope_cache_spec.rb
@@ -168,6 +168,20 @@ RSpec.describe "effect envelope diagnostics across a cache hit" do
     end
   end
 
+  # RBS accepts five bracket pairs for an annotation and the reader honours the payload whatever the
+  # brackets, so the probe's routing hint must too: with the hint reading `%a{` alone, this exact
+  # project shape served the fast path warm and the envelope diagnostic silently vanished — the #428
+  # silent-lane failure, reachable again through a spelling.
+  context "with an `%a(pure)` annotation in the parenthesis spelling" do
+    before do
+      write_project
+      write_config(annotation_config)
+      write_signature(pure_signature.sub("%a{pure}", "%a(pure)"))
+    end
+
+    it_behaves_like "a declared envelope that survives a cache hit"
+  end
+
   # `effect.annotations-unchecked` — the mirror-image pass, on the effects-OFF surface. It went the same way
   # for the same reason, and comes back by a different route: the probe reproduces it rather than declining,
   # because it was built to cost a glob and a regex.

--- a/spec/rigor/rbs_extended/envelope_scanner_spec.rb
+++ b/spec/rigor/rbs_extended/envelope_scanner_spec.rb
@@ -59,6 +59,26 @@ RSpec.describe Rigor::RbsExtended::EnvelopeScanner do
       expect(result.method_envelopes["Repo#slug"].tolerates?("mutate.local")).to be(true)
     end
 
+    # RBS accepts five bracket pairs for an annotation; the reader sees only the payload inside them,
+    # so every spelling binds — and the routing pre-filter below must not lose any of them.
+    it "reads the annotation whatever bracket pair RBS accepted it in" do
+      result = scan(<<~RBS)
+        class Repo
+          %a(pure)
+          def a: () -> String
+          %a[rigor:v1:effect io.db]
+          def b: () -> String
+          %a<rigor:v1:effect telemetry>
+          def c: () -> String
+          %a|pure|
+          def d: () -> String
+        end
+      RBS
+
+      expect(result.method_envelopes.keys).to contain_exactly("Repo#a", "Repo#b", "Repo#c", "Repo#d")
+      expect(result.method_envelopes["Repo#b"].bound.to_a).to eq(["io.db"])
+    end
+
     it "keys a singleton member on the `.` side and `def self?.` on both" do
       result = scan(<<~RBS)
         class Repo
@@ -84,6 +104,25 @@ RSpec.describe Rigor::RbsExtended::EnvelopeScanner do
       RBS
 
       expect(result.method_envelopes.keys).to eq(["App::Repo#find"])
+    end
+  end
+
+  describe "the routing pre-filter" do
+    # The positive controls are every example above: an annotated source IS parsed and read. This is
+    # the other half — a source with no honoured payload can contribute neither an envelope nor an
+    # unresolved report, so it is answered by one regex and never parsed.
+    it "never parses a source that carries no effect annotation" do
+      allow(RBS::Parser).to receive(:parse_signature)
+
+      result = scan(<<~RBS)
+        class Repo
+          %a{implicitly-returns-nil}
+          def find: (Integer) -> String?
+        end
+      RBS
+
+      expect(result).to be_empty
+      expect(RBS::Parser).not_to have_received(:parse_signature)
     end
   end
 


### PR DESCRIPTION
## What

RBS accepts five bracket pairs for an annotation (`%a{…}` `%a(…)` `%a[…]` `%a|…|` `%a<…>`) and hands every reader the payload inside them, so `%a(pure)` binds exactly as `%a{pure}` does. The `ANNOTATION_HINT` routing regex matched the brace spelling alone, which re-opened the #428 silent lane through an orthography: a project whose only bound is written `%a(pure)` declined nothing, the run-cache probe served the boot-slim fast path, and the envelope diagnostic fired cold and **silently vanished on every warm run**. The annotations-unchecked residual missed the same spellings by the same regex. This violates the standing rule from the #428/#441/#446/#452 family: every path by which a declared bound can fail to be read must end in a diagnostic, not in silence.

## Changes

- `Effects::SignatureSources::ANNOTATION_HINT` accepts all five bracket pairs. Over-matching a mismatched closer is safe — the cost is one declined fast path or one parsed file, never a missed bound.
- `RbsExtended::EnvelopeScanner.scan` now implements the routing the hint's documentation always promised: a source with no honoured payload can contribute neither an envelope nor an unresolved report, so it is answered by one regex instead of an `RBS::Parser.parse_signature` — which every warm envelope-lane run was paying per signature file. On an annotation-free signature tree the whole scan is now regex-only.

## Verification

- The new probe spec (`%a(pure)` declared-envelope-survives-a-cache-hit) **fails on the previous lib** — verified by toggling the two files back to master: the warm arm was cache-served while the bound existed.
- Scanner specs pin all five bracket spellings and the never-parses-unannotated-sources routing (with the existing annotated examples as positive controls).
- `make verify` green, changelog conformance green.