### PR TITLE
Short-circuit the synthetic scan when trait registries cannot emit

### DIFF
--- a/lib/rigor/inference/synthetic_method_scanner.rb
+++ b/lib/rigor/inference/synthetic_method_scanner.rb
@@ -65,6 +65,13 @@ module Rigor
         registries = collect_trait_registries(plugin_registry)
         nested_templates = collect_nested_class_templates(plugin_registry)
         return SyntheticMethodIndex::EMPTY if templates.empty? && registries.empty? && nested_templates.empty?
+        # Tier B alone cannot emit without an environment: every trait entry — the direct route and the
+        # concern-re-targeted one — funnels through `module_instance_method_names`, whose first line
+        # answers `[]` for a nil environment. The production pre-pass passes `environment: nil` (#476),
+        # so a project whose only contributing plugin registers trait registries (rigor-devise on a
+        # Rails app) would otherwise pay a whole-project parse to build a provably empty index. This
+        # gate mirrors that nil guard and MUST be removed in the change that threads a real environment.
+        return SyntheticMethodIndex::EMPTY if environment.nil? && templates.empty? && nested_templates.empty?
 
         asts = parse_paths(paths, buffer: buffer)
         hierarchy = build_hierarchy(asts)

--- a/spec/rigor/inference/synthetic_method_scanner_spec.rb
+++ b/spec/rigor/inference/synthetic_method_scanner_spec.rb
@@ -211,6 +211,23 @@ RSpec.describe Rigor::Inference::SyntheticMethodScanner do
       env
     end
 
+    # The #476 interim gate: every trait entry funnels through `module_instance_method_names`, whose
+    # first line answers [] for a nil environment, so a registry-only scan with no environment is
+    # provably empty — and must not pay a whole-project read + parse to say so. The example above is
+    # this one's positive control: the same registry with an environment emits.
+    it "reads no file when only trait registries contribute and there is no environment" do
+      registry = Rigor::Plugin::Registry.new(plugins: [devise_plugin.new(services: services)])
+      _, paths = write_files(
+        "user.rb" => "class User < ApplicationRecord\n  devise :database_authenticatable\nend\n"
+      )
+      allow(Prism).to receive(:parse)
+
+      index = described_class.scan(plugin_registry: registry, paths: paths, environment: nil)
+
+      expect(index).to be_empty
+      expect(Prism).not_to have_received(:parse)
+    end
+
     it "explodes always_included + per-symbol modules' instance methods into the index" do
       registry = Rigor::Plugin::Registry.new(plugins: [devise_plugin.new(services: services)])
       _, paths = write_files(


### PR DESCRIPTION
## What

The production pre-pass calls `SyntheticMethodScanner.scan` with `environment: nil` (the only production call site; carried verbatim through the Runner decomposition). With no environment, `module_instance_method_names` answers `[]` on its first line, so every trait-registry (Tier B) entry — the direct route and the concern-re-targeted one, which funnels into the same collector — emits nothing.

A project whose only contributing plugin registers trait registries therefore paid a whole-project `File.read` + `Prism.parse` to build a **provably empty index**: 0.45 s per run on mastodon (rigor-devise is its single contributor), on every run, warm included — the only whole-project parse left on a warm effects/envelope run since PR #77 deferred discovery.

## Change

`scan` returns `EMPTY` before any I/O when `environment` is nil and neither heredoc nor nested-class templates contribute (both of those tiers emit without an environment and are unaffected — rigor-dry-struct and rigor-mangrove keep their behaviour). The gate mirrors the `module_instance_method_names` nil guard, and its comment ties it to #476 — the issue for the genuinely dead Tier B lane and the chicken-and-egg between the scanner and `Environment.for_project` — so the change that threads a real environment removes it.

## Measured

Mastodon `rigor effects` warm: **1.12 s → 0.90 s**; report byte-identical cold vs warm and against the pre-change output. Redmine-shaped projects (no trait contributor) are untouched — they already short-circuited on the empty-slots check.

## Gates

`make verify` green. New spec: a registry-only nil-environment scan reads no file (`Prism.parse` spy), with the existing with-environment example as its positive control.