### PR TITLE
Share one validation stat per file across a run's cache slots

### DIFF
--- a/lib/rigor/cache/file_digest.rb
+++ b/lib/rigor/cache/file_digest.rb
@@ -30,9 +30,10 @@ module Rigor
     # identical to a bare `Digest::SHA256.file`.
     module FileDigest
       MEMO_KEY = :rigor_cache_file_digest_memo
+      STAT_KEY = :rigor_cache_file_stat_memo
       INSTANT_KEY = :rigor_cache_recording_instant
       STRICT_KEY = :rigor_cache_strict_validation
-      private_constant :MEMO_KEY, :INSTANT_KEY, :STRICT_KEY
+      private_constant :MEMO_KEY, :STAT_KEY, :INSTANT_KEY, :STRICT_KEY
 
       # Set in the environment to force the strict digest-always validation path for a single run, regardless
       # of the `cache.validation` config setting (the env wins). The escape hatch for a filesystem whose stat
@@ -47,14 +48,17 @@ module Rigor
       # digest-always path for `cache.validation: digest`.
       def self.with_run(strict: false)
         previous_memo = Thread.current[MEMO_KEY]
+        previous_stat = Thread.current[STAT_KEY]
         previous_instant = Thread.current[INSTANT_KEY]
         previous_strict = Thread.current[STRICT_KEY]
         Thread.current[MEMO_KEY] = {}
+        Thread.current[STAT_KEY] = {}
         Thread.current[INSTANT_KEY] = now_ns
         Thread.current[STRICT_KEY] = strict
         yield
       ensure
         Thread.current[MEMO_KEY] = previous_memo
+        Thread.current[STAT_KEY] = previous_stat
         Thread.current[INSTANT_KEY] = previous_instant
         Thread.current[STRICT_KEY] = previous_strict
       end
@@ -102,10 +106,24 @@ module Rigor
         digest = parsed[0]
         return hexdigest(path) == digest if strict_validation?
 
-        st = File.stat(path)
+        st = validation_stat(path)
         return true if !racy?(parsed) && tuple_matches?(st, parsed)
 
         hexdigest(path) == digest
+      end
+
+      # The VALIDATION-side stat, served from the per-run table when one is installed — a collecting run
+      # validates the effects entry and the diagnostics entry against the same ~thousands-of-files
+      # dependency descriptor, and the second pass is pure repetition under the run's own stable-filesystem
+      # premise (see the module doc). The RECORDING side ({.pack_stat}) deliberately keeps its direct
+      # `File.stat`: it packs the tuple a *future* run validates, after the content was read, and must
+      # describe that moment rather than an earlier probe's. A stat failure propagates un-memoised, exactly
+      # as {.hexdigest} treats a read failure.
+      def self.validation_stat(path)
+        memo = Thread.current[STAT_KEY]
+        return File.stat(path) if memo.nil?
+
+        memo[path] ||= File.stat(path)
       end
 
       def self.recording_instant_ns

--- a/spec/rigor/cache/file_digest_spec.rb
+++ b/spec/rigor/cache/file_digest_spec.rb
@@ -90,4 +90,44 @@ RSpec.describe Rigor::Cache::FileDigest do
       end
     end
   end
+
+  # A collecting run validates the effects entry and the diagnostics entry against the same
+  # dependency descriptor; under the run's stable-filesystem premise the second stat pass is pure
+  # repetition, so the validation side shares one stat per path per run scope.
+  describe "the validation stat memo" do
+    def packed
+      described_class.pack_stat(path, expected)
+    end
+
+    it "stats a path once across repeated validations inside one run scope" do
+      entry = packed
+      allow(File).to receive(:stat).and_call_original
+      described_class.with_run do
+        expect(described_class.stat_fresh?(path, entry)).to be(true)
+        expect(described_class.stat_fresh?(path, entry)).to be(true)
+      end
+      expect(File).to have_received(:stat).with(path).once
+    end
+
+    it "stats directly when no run scope is active" do
+      entry = packed
+      allow(File).to receive(:stat).and_call_original
+      described_class.stat_fresh?(path, entry)
+      described_class.stat_fresh?(path, entry)
+      expect(File).to have_received(:stat).with(path).twice
+    end
+
+    # The recording side packs the tuple a FUTURE run validates, after the content was read — it must
+    # describe that moment, never an earlier probe's, or a mid-run edit could pair a pre-edit tuple
+    # with post-edit content in the stored entry.
+    it "keeps the recording side un-memoised even after a validation warmed the table" do
+      entry = packed
+      described_class.with_run do
+        described_class.stat_fresh?(path, entry)
+        allow(File).to receive(:stat).and_call_original
+        described_class.pack_stat(path, expected)
+        expect(File).to have_received(:stat).with(path).once
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

A collecting run validates the effects sidecar entry and the diagnostics entry against the same post-run dependency descriptor — two full `File.stat` passes over the same multi-thousand-file list (≈5k files each on mastodon), because the per-run `FileDigest` memo covers content digests only and the happy stat-tier path returns before ever reaching it. Plugin producers' glob validations repeat more stats over the same trees inside the same `FileDigest.with_run` scope.

## Change

`with_run` installs a stat table beside the digest table; `stat_fresh?` reads through it (`validation_stat`). Two deliberate exclusions, both about the recording/validation duality:

- **`pack_stat` keeps its direct `File.stat`** — it packs the tuple a *future* run validates, after the content was read, and must describe that moment rather than an earlier probe's; reusing a validation-time stat there could pair a pre-edit tuple with post-edit content in a stored entry (the one non-fail-soft failure mode in this file).
- **`GlobEntry.signature_for` is untouched** — it computes the recorded value and the live one with the same code, so a memo there would mix the two sides.

## Verification

Specs pin both directions: repeated validations in one scope stat once; `pack_stat` stats the live file even after a validation warmed the table; no scope means no memo. `rigor effects --format json` on mastodon byte-identical cold vs warm and against the previous branch's output. `make verify` green.

The wall win is small per run (~tens of ms at mastodon scale, growing with file count and with the number of validated slots) — this is the mechanism cleanup the fresh?-attribution profile pointed at, taken because it is provably safe, not because it is the headline number.