### PR TITLE
Defer the envelope judgment's discovery parse to the first finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 - **[cache]** Warm-run cache validation stats each dependency file once per run instead of once per cache slot — a collecting run validated the effects entry and the diagnostics entry against the same multi-thousand-file descriptor twice.
 
+- **[effects]** An envelope judgment that finds nothing no longer pays the whole-project discovery parse: the `def`-position tables are built on the first finding instead of up front, so a clean `rigor check` under `effects.envelopes:` skips them entirely (mail 1.03 s → 0.46 s warm).
+
 ### Fixed
 
 - **[effects]** An effect annotation written in any of RBS's other bracket spellings — `%a(pure)`, `%a[rigor:v1:effect …]`, `%a|…|`, `%a<…>` — was invisible to the warm-run cache probe and to the annotations-unchecked notice, so its envelope was judged on cold runs and silently skipped on every cache hit; all five spellings now route identically, and a signature file with no effect annotation is no longer parsed by the envelope reader at all.

--- a/lib/rigor/analysis/runner.rb
+++ b/lib/rigor/analysis/runner.rb
@@ -755,7 +755,8 @@ module Rigor
       # ADR-103 WD8 / #383 — the envelope check. Nothing at all without an `effects:` block, and nothing
       # under `effects.check: false`; with both, one walk of the project's own RBS for `%a{pure}` /
       # `%a{rigor:v1:effect …}`, and only if that finds an envelope does anything else run (the discovery
-      # tables the `def` positions come from are forced from inside the pass, lazily, for that reason).
+      # tables the `def` positions come from are forced from inside the judgment, on the first finding
+      # built — a judged-clean envelope forces no discovery at all).
       #
       # The environment is the one the cacheable path already resolved when there is one, so a warm run
       # reads the envelopes off the loader it built anyway rather than building a second.

--- a/lib/rigor/analysis/runner/effect_envelope_pass.rb
+++ b/lib/rigor/analysis/runner/effect_envelope_pass.rb
@@ -30,11 +30,13 @@ module Rigor
       #
       # 1. **Read the envelopes** off the project's own RBS ({RbsExtended::EnvelopeScanner}). A project
       #    with `effects:` but no envelope pays this walk and stops here.
-      # 2. **Force cross-file discovery**, but only when step 1 found something — the diagnostic is
-      #    positioned at the Ruby `def`, and the discovery tables are what map a method key to one.
-      # 3. **Judge** ({Effects::EnvelopeCheck}) and render, then run the findings through the ordinary
-      #    suppression filter so `# rigor:disable effect.envelope-exceeded` on the `def` line and
-      #    `disable:` in `.rigor.yml` work exactly as they do for a per-file rule.
+      # 2. **Judge** ({Effects::EnvelopeCheck}). Cross-file discovery — the diagnostic is positioned
+      #    at the Ruby `def`, and the discovery tables are what map a method key to one — is forced
+      #    from inside the judgment, on the first finding built, so an envelope nothing exceeds costs
+      #    no discovery parse at all.
+      # 3. **Render**, then run the findings through the ordinary suppression filter so
+      #    `# rigor:disable effect.envelope-exceeded` on the `def` line and `disable:` in `.rigor.yml`
+      #    work exactly as they do for a per-file rule.
       #
       # **Why this is not part of the cached run assembly.** ADR-103 WD12 says envelope diagnostics are
       # recomputed every run from the (possibly cached) summaries and never stored. The `effects:` block
@@ -80,7 +82,8 @@ module Rigor
         # @param rbs_loader [Rigor::Environment::RbsLoader, nil] the run's loader; nil disables the pass.
         # @param effect_table [Rigor::Effects::EffectTable] the propagated graph.
         # @param discovery [#call] forces and returns the cross-file discovery tables as
-        #   `[def_sources, singleton_def_sources, class_sources]`. Called only when an envelope exists.
+        #   `[def_sources, singleton_def_sources, class_sources]`. Called only when a finding needs a
+        #   position — a judged-clean envelope never forces it.
         # @param sources [Hash{String => String}] in-memory sources, for the buffer-backed run path.
         # @param unit_sources [Hash{String => Array<String>}] `Runner#effect_sources` — where each effect
         #   unit is defined, which is what an `effects.envelopes[].match:` path glob selects on. Its paths
@@ -272,9 +275,12 @@ module Rigor
           )
         end
 
-        # The discovery tables both judgments position their findings from, forced once.
+        # The discovery tables both judgments position their findings from — behind a deferred value,
+        # forced at most once, on the first finding either judgment builds. A clean run (an envelope
+        # nothing exceeds — the common CI case) therefore never calls `@discovery` at all, which on a
+        # warm run is the difference between a no-op and a Prism parse of every project file.
         def positions
-          @positions ||= begin
+          @positions ||= Effects::EnvelopeCheck::DeferredPositions.new do
             def_sources, singleton_def_sources, class_sources = @discovery.call
             Effects::EnvelopeCheck::Positions.build(
               def_sources: def_sources, singleton_def_sources: singleton_def_sources,

--- a/lib/rigor/effects/envelope_check.rb
+++ b/lib/rigor/effects/envelope_check.rb
@@ -83,6 +83,21 @@ module Rigor
         end
       end
 
+      # {Positions} behind a thunk: the discovery tables — one Prism parse of every project file —
+      # are built on the first `.for`, which both judgments reach only once a finding is being
+      # constructed. A clean judgment, the common CI case, therefore forces no discovery and parses
+      # nothing; that is the whole point of this class existing rather than the pass forcing the
+      # tables up front.
+      class DeferredPositions
+        def initialize(&build)
+          @build = build
+        end
+
+        def for(key)
+          (@positions ||= @build.call).for(key)
+        end
+      end
+
       NO_FINDINGS = [].freeze
       private_constant :NO_FINDINGS
 
@@ -93,7 +108,9 @@ module Rigor
       # @param class_envelopes [Hash{String => Envelope}] class- / module-level envelopes, to distribute.
       # @param config_envelopes [Hash{String => Envelope}] `effects.envelopes:` entries already resolved
       #   to the classes they select ({ConfigEnvelopes.for_classes}), to distribute at the lowest precedence.
-      # @param positions [Positions] the discovery tables a finding's `def` position is read from.
+      # @param positions [Positions, DeferredPositions] the discovery tables a finding's `def`
+      #   position is read from — consulted only when a finding is built, so a deferred value's
+      #   discovery force is reached exactly as often as a finding exists.
       # @param apply_tolerated [Boolean] false judges against the undischarged-by-policy `proven` lane —
       #   the `--no-tolerated-effects` audit switch.
       # @return [Array<Finding>] sorted by position then key then label, so a run explains identically twice.

--- a/lib/rigor/effects/liskov_check.rb
+++ b/lib/rigor/effects/liskov_check.rb
@@ -112,11 +112,13 @@ module Rigor
 
         inherited = envelopes.fetch(ancestor_key)
         own = envelopes[key]
-        position = positions.for(key)
+        # The position is read inside the two collectors, after they know a finding exists: `.for` is
+        # what forces a deferred position table, and an inherited envelope nothing widens must not
+        # cost a whole-project discovery parse.
         if own && !own.top?
-          collect_declared(findings, key, ancestor_key, inherited, own, position)
+          collect_declared(findings, key, ancestor_key, inherited, own, positions)
         else
-          collect_proven(findings, table, key, ancestor_key, inherited, position, apply_tolerated)
+          collect_proven(findings, table, key, ancestor_key, inherited, positions, apply_tolerated)
         end
       end
 
@@ -135,16 +137,19 @@ module Rigor
         nil
       end
 
-      def collect_proven(findings, table, key, ancestor_key, inherited, position, apply_tolerated)
+      def collect_proven(findings, table, key, ancestor_key, inherited, positions, apply_tolerated)
         entry = table[key]
         return if entry.nil?
 
         exceeding = inherited.exceeded_by(apply_tolerated ? entry.undischarged : entry.proven)
+        return if exceeding.empty?
+
+        path, line = positions.for(key)
         exceeding.each do |label|
           trail = PathFinder.shortest(table, symbol: key, label: label)
           findings << Finding.new(
             key: key, label: label, ancestor_key: ancestor_key, ancestor_envelope: inherited,
-            own_envelope: nil, path: position.first, line: position.last,
+            own_envelope: nil, path: path, line: line,
             chain: trail&.chain || [key].freeze, origin: trail&.origin
           )
         end
@@ -152,11 +157,15 @@ module Rigor
 
       # Two authored bounds, compared by subsumption alone. `mutate.local` is tolerated here as it is
       # everywhere, so declaring it under an inherited `%a{pure}` is not a widening.
-      def collect_declared(findings, key, ancestor_key, inherited, own, position)
-        own.bound.to_a.reject { |label| inherited.tolerates?(label) }.each do |label|
+      def collect_declared(findings, key, ancestor_key, inherited, own, positions)
+        widened = own.bound.to_a.reject { |label| inherited.tolerates?(label) }
+        return if widened.empty?
+
+        path, line = positions.for(key)
+        widened.each do |label|
           findings << Finding.new(
             key: key, label: label, ancestor_key: ancestor_key, ancestor_envelope: inherited,
-            own_envelope: own, path: position.first, line: position.last, chain: nil, origin: nil
+            own_envelope: own, path: path, line: line, chain: nil, origin: nil
           )
         end
       end

--- a/spec/rigor/effects/envelope_check_spec.rb
+++ b/spec/rigor/effects/envelope_check_spec.rb
@@ -169,4 +169,85 @@ RSpec.describe Rigor::Effects::EnvelopeCheck do
       expect(findings.map { |f| [f.path, f.line] }).to eq([["lib/repo.rb", 1], ["lib/repo.rb", 1]])
     end
   end
+
+  # The tables behind a position are a whole-project discovery parse on the pass side, so both
+  # judgments read them through {EnvelopeCheck::DeferredPositions} and must reach `.for` exactly as
+  # often as a finding exists — a judged-clean envelope, the common CI case, forces nothing.
+  describe "deferred positions" do
+    def deferred(&)
+      described_class::DeferredPositions.new(&)
+    end
+
+    it "never builds the tables when nothing exceeds" do
+      forced = false
+      graph = table(entry("Repo#find", proven: %w[io.db.read]))
+
+      findings = described_class.run(
+        table: graph, method_envelopes: { "Repo#find" => envelope("Repo#find", "io.db") },
+        class_envelopes: {},
+        positions: deferred do
+          forced = true
+          described_class::Positions.empty
+        end
+      )
+
+      expect(findings).to be_empty
+      expect(forced).to be(false)
+    end
+
+    it "builds them exactly once, on the first finding, and positions every later one from the memo" do
+      count = 0
+      graph = table(entry("Repo#find", proven: %w[io.net]), entry("Repo#also", proven: %w[io.net]))
+      positions = deferred do
+        count += 1
+        described_class::Positions.build(def_sources: { "Repo" => { find: "lib/repo.rb:3", also: "lib/repo.rb:9" } })
+      end
+
+      findings = described_class.run(
+        table: graph,
+        method_envelopes: { "Repo#find" => envelope("Repo#find", "io.db"),
+                            "Repo#also" => envelope("Repo#also", "io.db") },
+        class_envelopes: {}, positions: positions
+      )
+
+      expect(findings.map { |f| [f.path, f.line] }).to contain_exactly(["lib/repo.rb", 3], ["lib/repo.rb", 9])
+      expect(count).to eq(1)
+    end
+
+    it "stays unforced through a Liskov judgment whose overrides all honour their inherited bounds" do
+      forced = false
+      graph = table(entry("Base#find", proven: %w[io.db.read]), entry("Repo#find", proven: %w[io.db.read]))
+
+      findings = Rigor::Effects::LiskovCheck.run(
+        table: graph, superclasses: { "Repo" => "Base" },
+        method_envelopes: { "Base#find" => envelope("Base#find", "io.db") },
+        class_envelopes: {},
+        positions: deferred do
+          forced = true
+          described_class::Positions.empty
+        end
+      )
+
+      expect(findings).to be_empty
+      expect(forced).to be(false)
+    end
+
+    it "forces for a Liskov widening — the positive control for the example above" do
+      forced = false
+      graph = table(entry("Base#find", proven: %w[io.db.read]), entry("Repo#find", proven: %w[io.net]))
+
+      findings = Rigor::Effects::LiskovCheck.run(
+        table: graph, superclasses: { "Repo" => "Base" },
+        method_envelopes: { "Base#find" => envelope("Base#find", "io.db") },
+        class_envelopes: {},
+        positions: deferred do
+          forced = true
+          described_class::Positions.build(def_sources: { "Repo" => { find: "lib/repo.rb:7" } })
+        end
+      )
+
+      expect(findings.map { |f| [f.path, f.line] }).to eq([["lib/repo.rb", 7]])
+      expect(forced).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
## What

`EffectEnvelopePass` built its `Positions` value eagerly when either judgment was invoked, and constructing it calls the discovery thunk — `ensure_project_discovery`, one Prism parse of every project file. A judged-clean envelope — the common CI case, and the exact shape the integrated after-sweep in `docs/notes/20260825-feature-warm-cold-corpus-perf.md` flagged with its mail † footnote — therefore paid the whole parse to position **zero** findings.

## Change

- `EnvelopeCheck` already read positions per finding; `LiskovCheck` read them per inherited-envelope key, *before* knowing whether a widening exists. Both now reach `.for` exactly as often as a finding is built.
- The pass hands them an `EnvelopeCheck::DeferredPositions` whose first `.for` forces the discovery once and memoises.

## Measured

Warm envelope-checked `rigor check` (`effects.envelopes:` stanza, nothing exceeded), output byte-identical on all three: **mail 1.03 s → 0.46 s (−55 %)** — mail's few-large-files shape makes the discovery parse half its warm run; redmine and mastodon timing-neutral (their parse is not the dominant term there). The lever's cost model is now proportional to findings, not to project size.

## Gates

`make verify` green. Unit specs pin the deferred/forced boundary in both directions (clean judgment and honoured Liskov bound force nothing; an exceedance and a widening force once, memoised across findings); the end-to-end envelope fixtures keep pinning that findings position identically.