### PR TITLE
Arm the deferred YJIT deadline for every dispatched command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 - **[effects]** An effect annotation written in any of RBS's other bracket spellings — `%a(pure)`, `%a[rigor:v1:effect …]`, `%a|…|`, `%a<…>` — was invisible to the warm-run cache probe and to the annotations-unchecked notice, so its envelope was judged on cold runs and silently skipped on every cache hit; all five spellings now route identically, and a signature file with no effect annotation is no longer parsed by the envelope reader at all.
 
+- **[cli]** Every dispatched command now arms the deferred YJIT deadline, not just `check` and `coverage` — a cold `rigor effects` over Mastodon previously ran its whole 21 s interpreted where the identical analysis under `check` took 14.8 s; both now finish together, and commands that finish inside the deadline still never pay JIT compile cost.
+
 ## [0.3.5] - 2026-08-25
 
 v0.3.5 is about making the effect system usable rather than merely present. The `rigor effects` report went from 31,191 lines on a mid-size Rails application to 2,733 with nothing lost, gained `--label`, `--pure` and `--limit` so it can be asked a question, and can now print the label vocabulary itself. A larger group of fixes is about what the report *sees*: an optional receiver, a module a worker includes, a base class from a gem, a `super`, and a class-level annotation were each contributing nothing, several of them while the method still read as exhaustive. The manual gained a [chapter on effect labels](docs/manual/19-effect-labels.md), and [ADR-103](docs/adr/103-effect-labels.md) § WD17 records which labels a declared bound can actually fail on and where to enforce the rest.

--- a/lib/rigor/cli.rb
+++ b/lib/rigor/cli.rb
@@ -101,11 +101,24 @@ module Rigor
 
     def dispatch(command)
       handler = HANDLERS[command]
-      return send(handler) if handler
+      return arm_jit_deadline { send(handler) } if handler
 
       @err.puts("Unknown command: #{command}")
       @err.puts(help)
       EXIT_USAGE
+    end
+
+    # Deferred YJIT for EVERY dispatched command, not just `check` / `coverage` where PR #75 first
+    # calibrated it. The deadline makes the decision command-independent: a run that finishes inside
+    # the window never pays JIT compile, and a run that outlasts it JITs its dominant tail — measured
+    # on `rigor effects` cold over Mastodon, which ran its whole 21 s interpreted while the same
+    # analysis under `check` took 14.8 s (forcing YJIT on the effects run: 15.9 s; disabling it on
+    # check: 21.1 s). `lsp` / `mcp` still call `Runtime::Jit.enable_now` at boot, which makes the
+    # deadline thread armed here a no-op when it later fires.
+    def arm_jit_deadline
+      require_relative "runtime/jit"
+      Runtime::Jit.enable_after(Runtime::Jit.deadline_seconds)
+      yield
     end
 
     def run_check

--- a/lib/rigor/cli/check_command.rb
+++ b/lib/rigor/cli/check_command.rb
@@ -11,7 +11,6 @@ require_relative "../analysis/rule_catalog"
 # The baseline filter runs on EVERY exit path — including the ADR-87 WD4 cache-HIT fast path, which skips
 # `load_check_dependencies` — so it must be a load-time require. It pulls only YAML, never the engine.
 require_relative "../analysis/baseline"
-require_relative "../runtime/jit"
 require_relative "command"
 require_relative "options"
 require_relative "diagnostic_formats"
@@ -34,12 +33,10 @@ module Rigor
     # concerns that are clearer read together than split across micro-classes.
     class CheckCommand < Command # rubocop:disable Metrics/ClassLength
       # @return [Integer] CLI exit status.
-      def run # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-        # Arm deferred YJIT enablement before any analysis work: the deadline
-        # thread only fires once a run outlasts the amortization window, so a
-        # short check finishes before it ever pays JIT compile cost while a
-        # long run JITs its dominant tail (Runtime::Jit).
-        Runtime::Jit.enable_after(Runtime::Jit.deadline_seconds)
+      #
+      # Deferred YJIT enablement (Runtime::Jit) is armed by `CLI#dispatch` for every command, this
+      # one included, before any analysis work runs.
+      def run # rubocop:disable Metrics/AbcSize
         # ADR-87 WD4 — parse options + resolve config WITHOUT the inference engine, so the run-cache hit probe
         # can run first. The heavy engine (`load_check_dependencies`) loads only on a miss / non-cacheable run.
         options = parse_check_options

--- a/lib/rigor/cli/coverage_command.rb
+++ b/lib/rigor/cli/coverage_command.rb
@@ -14,7 +14,6 @@ require_relative "../inference/parameter_inference_collector"
 require_relative "../protection/mutation_scanner"
 require_relative "../protection/test_suite_oracle"
 require_relative "../language_server/project_context"
-require_relative "../runtime/jit"
 require_relative "../scope"
 require_relative "coverage_report"
 require_relative "coverage_renderer"
@@ -55,11 +54,11 @@ module Rigor
       DEFAULT_TEST_COMMAND = %w[bundle exec rake].freeze
 
       # @return [Integer] CLI exit status.
-      def run # rubocop:disable Metrics/AbcSize
-        # Arm deferred YJIT enablement (Runtime::Jit): a scan long enough to
-        # amortize JIT compile cost enables mid-flight; a short one finishes
-        # first and never pays it. Same seam as `rigor check`.
-        Runtime::Jit.enable_after(Runtime::Jit.deadline_seconds)
+      #
+      # Deferred YJIT enablement (Runtime::Jit) is armed by `CLI#dispatch` for every command, this
+      # one included: a scan long enough to amortize JIT compile cost enables mid-flight; a short one
+      # finishes first and never pays it.
+      def run
         options = parse_options
         return mutation_misuse_error if options[:mutation] && !options[:protection]
         return with_tests_misuse_error if options[:with_tests] && !options[:mutation]

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -36,6 +36,30 @@ RSpec.describe Rigor::CLI do
     expect(err).to include("Unknown command: nope")
   end
 
+  # The deadline makes the decision command-independent — a run that finishes inside the window never
+  # pays JIT compile — so dispatch arms it for EVERY command. `rigor effects` cold over Mastodon ran
+  # its whole 21 s interpreted while the same analysis under `check` (which armed the deadline) took
+  # 14.8 s; pinning the arm at the dispatch seam is what keeps the next command from repeating that.
+  describe "deferred YJIT" do
+    before do
+      require "rigor/runtime/jit"
+      allow(Rigor::Runtime::Jit).to receive(:enable_after)
+    end
+
+    it "arms the deadline for a dispatched command" do
+      run_cli("effects", "--help")
+
+      expect(Rigor::Runtime::Jit).to have_received(:enable_after)
+        .with(Rigor::Runtime::Jit.deadline_seconds)
+    end
+
+    it "leaves the trivial built-ins unarmed" do
+      run_cli("version")
+
+      expect(Rigor::Runtime::Jit).not_to have_received(:enable_after)
+    end
+  end
+
   # #433 — a mistake in `.rigor.yml` used to abort with an uncaught exception and a ~30-frame backtrace
   # naming a file inside `lib/rigor/`, which reads as a crash rather than as "fix this key". The message
   # was always right; only its delivery was not. These examples assert what the user SEES — the rendered


### PR DESCRIPTION
## What

`Runtime::Jit.enable_after` (PR #75) was called from `check` and `coverage` alone (`lsp`/`mcp` enable at boot), so **every other command ran interpreted however long it took**. This surfaced as a reproducible cold gap in the 2026-08-25 feature perf campaign: `rigor effects` cold over Mastodon took ~21 s against `check`'s ~14.8 s for the *identical* analysis (same config, same collection work, same cache writes — the primed cache directories are byte-for-byte the same size), across three interleaved pairs.

Perturbing the mechanism confirms it in both directions: forcing YJIT on at boot for the effects run gives **15.9 s**; disabling it on check gives **21.1 s**. The numbers swap exactly.

## Fix

Arm the deadline once in `CLI#dispatch`, for every command. The deadline already makes the decision command-independent — a run that finishes inside the window never pays JIT compile cost, a run that outlasts it JITs its dominant tail — so per-command arming was only an opportunity to forget, and `effects`, `unused`, `sig-gen`, `type-scan`, `annotate` and `trace` had all been forgotten. The per-command arms in `check`/`coverage` are removed; `version`/`help` return before dispatch and stay unarmed.

## Measured

Same corpus, same interleaved-pair method, with the fix: effects cold **17.8 s** beside check's **17.4 s** (the absolute seconds moved with host load between sessions; the parity is the result — the gap went from +41–47 % to +2 %).

## Gates

`make verify` green (exit read unpiped), changelog conformance green, new specs pin the dispatch-level arm (any dispatched command) and the unarmed trivial built-ins. Full `spec/rigor/cli_spec.rb` (147 examples) and `jit_spec` (23) green.
