### PR TITLE
Cache rigor unused's per-file scans in a self-validating bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 - **[cli]** `rigor unused` now reuses the analysis cache for its RBS environment and its plugins' prepare work, and scans templates for class names against only the identifier-bearing fraction of each file — the report is byte-identical and 1.4–3.3× faster on the measured corpus (8.3 s → 2.5 s warm on Mastodon).
 
+- **[cli]** `rigor unused` also caches its per-file work — the reachability scan of every Ruby file and the template extraction — in one self-validating bundle under the cache directory, so a repeat run re-reads only the files that changed: warm runs are a further 1.9–2.6× faster on the mid-size corpus (Mastodon 2.7 s → 1.1 s, Redmine 1.5 s → 0.8 s) with a byte-identical report.
+
 - **[effects]** A warm `rigor effects` / `rigor effects check` / envelope-checked `rigor check` no longer re-runs the effect fixpoint: the propagated table rides the whole-run effects cache entry beside the per-file collections, under the same identities, so a cache hit adopts it whole (Redmine `rigor effects` warm 0.75 s → 0.61 s, output byte-identical cold vs warm).
 
 - **[engine]** A run whose only synthetic-method contributor registers trait registries (rigor-devise on a Rails app) no longer parses the whole project to build a provably empty index — the scan short-circuits before any I/O until the trait tier's environment threading is fixed ([#476](https://github.com/rigortype/rigor/issues/476); Mastodon `rigor effects` warm 1.12 s → 0.90 s).

--- a/lib/rigor/analysis/reachability/scan_cache.rb
+++ b/lib/rigor/analysis/reachability/scan_cache.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+require "zlib"
+
+require_relative "../../version"
+
+module Rigor
+  module Analysis
+    module Reachability
+      # ADR-102 — the warm cache for `rigor unused`'s two per-file passes: the Prism reachability
+      # scan over `.rb` / `.rake` files, and the capital-run extraction over template files. Both
+      # passes are pure functions of one file's bytes, and both were measured re-running in full on
+      # every invocation (2.0 s of a 2.6 s warm run on Mastodon; the Marshal restore is 25× cheaper
+      # than the rescan, `docs/notes/20260825-feature-warm-cold-corpus-perf.md`).
+      #
+      # One self-validating zlib-Marshal blob under the cache root, the ADR-46 IncrementalSnapshot
+      # shape rather than an ADR-54 `Cache::Store` producer: the sound unit of reuse is the FILE
+      # (any subset of files may change between runs), so the payload carries a stat signature per
+      # entry and validates each on read, where a store entry validates all-or-nothing and a miss
+      # would throw away every unchanged file's work. The whole-project answer stays complete —
+      # every file is still consulted every run; an unchanged one contributes its cached product.
+      #
+      # Fail-soft everywhere: a missing, torn, or stale-schema blob is an empty cache, and a file
+      # whose signature cannot be taken is computed and never recorded. Nothing here can change
+      # what the report says — only whether a per-file product was recomputed to say it.
+      class ScanCache
+        SCHEMA = 1
+        FILE_NAME = "reachability-scan.bundle"
+
+        # The sources whose behaviour the cached products embody. Digested into the header so a
+        # checkout that edits the scan invalidates its survey targets' bundles without anyone
+        # remembering to bump {SCHEMA} — the `Cache::EngineSource` idea, scoped to this feature.
+        SOURCE_FILES = [
+          File.expand_path("scan.rb", __dir__),
+          File.expand_path(__FILE__)
+        ].freeze
+
+        # A file modified within this window of the recording instant is computed but never
+        # recorded — the FileDigest racy-write guard, one tier simpler because a refused signature
+        # costs one rescan on the next run, never a wrong answer.
+        RACY_WINDOW_NS = 2_000_000_000
+        private_constant :RACY_WINDOW_NS
+
+        # @param cache_path [String, nil] the configuration's cache root; nil or empty is an inert
+        #   cache (every fetch computes, nothing persists).
+        # @param target_ruby [String, nil] parse-affecting configuration, part of the identity.
+        def self.open(cache_path, target_ruby: nil)
+          return new(path: nil, header: nil) if cache_path.nil? || cache_path.to_s.empty?
+
+          new(path: File.join(cache_path.to_s, FILE_NAME),
+              header: "#{SCHEMA}:#{Rigor::VERSION}:#{target_ruby}:#{source_digest}")
+        end
+
+        def self.source_digest
+          Digest::SHA256.hexdigest(SOURCE_FILES.map { |path| File.read(path) }.join)
+        rescue StandardError
+          "unreadable"
+        end
+
+        def initialize(path:, header:)
+          @path = path
+          @header = header
+          @entries = load_entries
+          @live = {}
+          @dirty = false
+        end
+
+        # Serves the cached product for `(kind, path)` while the file's stat signature holds;
+        # otherwise computes via the block and records the fresh product.
+        def serve(kind, path)
+          key = [kind, path]
+          sig = signature(path)
+          cached = @entries[key]
+          if cached && sig && cached[0] == sig
+            @live[key] = cached
+            return cached[1]
+          end
+
+          value = yield
+          @live[key] = [sig, value] if sig
+          @dirty = true
+          value
+        end
+
+        # Best-effort persist, only when something changed. Carries forward entries this run never
+        # consulted (a path-argument run must not shrink the full-project bundle) but drops the ones
+        # whose file no longer exists; tmp-then-rename so a torn write is never read back.
+        def save
+          return if @path.nil? || !@dirty
+
+          keep = @entries.merge(@live).select { |(_, path), _| File.exist?(path) }
+          FileUtils.mkdir_p(File.dirname(@path))
+          tmp = "#{@path}.#{Process.pid}.tmp"
+          File.binwrite(tmp, Zlib::Deflate.deflate(Marshal.dump([@header, keep])))
+          File.rename(tmp, @path)
+          nil
+        rescue StandardError
+          FileUtils.rm_f(tmp) if tmp
+          nil
+        end
+
+        private
+
+        def load_entries
+          return {} if @path.nil?
+
+          # Same trust model as the ADR-45 store and the ADR-46 snapshot: the blob lives in the
+          # project's own cache directory and a corrupt one degrades to an empty cache.
+          header, entries = Marshal.load(Zlib::Inflate.inflate(File.binread(@path))) # rubocop:disable Security/MarshalLoad
+          header == @header && entries.is_a?(Hash) ? entries : {}
+        rescue StandardError
+          {}
+        end
+
+        def signature(path)
+          st = File.stat(path)
+          mtime_ns = (st.mtime.to_i * 1_000_000_000) + st.mtime.nsec
+          now_ns = Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)
+          return nil if mtime_ns >= now_ns - RACY_WINDOW_NS
+
+          [st.size, mtime_ns, (st.ctime.to_i * 1_000_000_000) + st.ctime.nsec, st.ino]
+        rescue SystemCallError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/rigor/cli/unused_command.rb
+++ b/lib/rigor/cli/unused_command.rb
@@ -6,6 +6,7 @@ require "json"
 require_relative "../configuration"
 require_relative "../analysis/path_expansion"
 require_relative "../analysis/reachability/scan"
+require_relative "../analysis/reachability/scan_cache"
 require_relative "../analysis/reachability/graph"
 require_relative "../analysis/reachability/plugin_roots"
 require_relative "../analysis/reachability/signature_scan"
@@ -23,7 +24,11 @@ module Rigor
     # measured precision of this signal is 7.0% on an adjudicated corpus target
     # (`docs/notes/20260813-unused-constant-fp-baseline.md`), so its output is a review queue, not a defect
     # list, and it never enters `rigor check`'s stream at any severity (WD1). Exits 0 whatever it finds.
-    class UnusedCommand < Command
+    #
+    # Like {CheckCommand}, it aggregates one command's concerns — the two scans, the graph, and both
+    # render formats — that read clearer together than split across micro-classes, so it carries the
+    # same ClassLength exemption.
+    class UnusedCommand < Command # rubocop:disable Metrics/ClassLength
       USAGE = "Usage: rigor unused [options] [paths]"
 
       # WD7 — the REFERENCE corpus is wider than the ANALYSIS corpus. `.rake` files sit inside `paths:` and
@@ -44,23 +49,31 @@ module Rigor
 
         configuration = Configuration.load(options.fetch(:config))
         paths = @argv.empty? ? configuration.paths : @argv
-        declarations, references, dynamic_uses = scan(paths, configuration)
+        scan_cache = Analysis::Reachability::ScanCache.open(configuration.cache_path,
+                                                            target_ruby: configuration.target_ruby)
+        declarations, references, dynamic_uses = scan(paths, configuration, scan_cache)
         references.concat(signature_references(configuration))
-        dynamic_uses.concat(template_mentions(declarations))
+        dynamic_uses.concat(template_mentions(declarations, scan_cache))
 
         contribution = Analysis::Reachability::PluginRoots.collect(configuration: configuration,
                                                                    cache_store: cache_store(configuration))
         references.concat(plugin_references(contribution.references))
-        graph = Analysis::Reachability::Graph.new(
-          declarations: declarations, references: references, dynamic_uses: dynamic_uses,
-          root_fqns: root_fqns(declarations, options.fetch(:entry_points)) + contribution.roots,
-          foreign: foreign_predicate(configuration)
-        )
+        graph = build_graph(configuration, options, contribution,
+                            declarations: declarations, references: references, dynamic_uses: dynamic_uses)
         emit(graph.report, options, supply: root_supply(contribution.roots, declarations))
+        scan_cache.save
         0
       end
 
       private
+
+      def build_graph(configuration, options, contribution, declarations:, references:, dynamic_uses:)
+        Analysis::Reachability::Graph.new(
+          declarations: declarations, references: references, dynamic_uses: dynamic_uses,
+          root_fqns: root_fqns(declarations, options.fetch(:entry_points)) + contribution.roots,
+          foreign: foreign_predicate(configuration)
+        )
+      end
 
       def parse_options
         options = { config: nil, format: "text", entry_points: [], limit: nil }
@@ -93,13 +106,15 @@ module Rigor
       end
 
       # Declarations come from the analysed paths; references additionally from the wider corpus (WD7).
-      def scan(paths, configuration)
+      # Every file is consulted every run — an unchanged one contributes its cached scan, so the
+      # whole-project completeness the `--incremental` refusal protects is unaffected.
+      def scan(paths, configuration, cache)
         declaration_files = Analysis::PathExpansion.ruby_files(paths, configuration.exclude_patterns).to_set
         declarations = []
         references = []
         dynamic_uses = []
         (declaration_files + reference_files(paths, configuration)).sort.each do |file|
-          result = read_and_scan(file, configuration)
+          result = cache.serve(:scan, file) { read_and_scan(file, configuration) }
           next if result.nil?
 
           declarations.concat(result.declarations) if declaration_files.include?(file)
@@ -157,12 +172,13 @@ module Rigor
         end
       end
 
-      def template_mentions(declarations)
+      def template_mentions(declarations, cache)
         names = declarations.map(&:fqn)
         return [] if names.empty?
 
         Analysis::Reachability::ProjectFiles.own(Dir.glob(TEMPLATE_GLOB, base: Dir.pwd), Dir.pwd).flat_map do |rel|
-          haystack = constant_bearing_text(File.read(File.expand_path(rel)).scrub)
+          absolute = File.expand_path(rel)
+          haystack = cache.serve(:runs, absolute) { constant_bearing_text(File.read(absolute).scrub) }
           names.filter_map do |fqn|
             next unless haystack.include?(fqn)
 

--- a/spec/rigor/cli/unused_command_spec.rb
+++ b/spec/rigor/cli/unused_command_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe Rigor::CLI::UnusedCommand do
     File.write(File.join(dir, ".rigor.yml"), "paths:\n  - lib\n")
     File.write(File.join(dir, "lib/loner.rb"), "class Loner\nend\n")
     File.write(File.join(dir, "lib/extra.rb"), extra_source) if extra_source
+    backdate(dir)
+  end
+
+  # The scan cache refuses to record a file modified within its racy window, so fixtures written
+  # milliseconds before the run must be aged or nothing would be cached to serve.
+  def backdate(dir)
+    aged = Time.now - 10
+    Dir.glob(File.join(dir, "**/*")).each { |f| File.utime(aged, aged, f) if File.file?(f) }
   end
 
   describe "template mentions (ADR-102 WD4)" do
@@ -61,6 +69,54 @@ RSpec.describe Rigor::CLI::UnusedCommand do
 
         expect(report.fetch("candidates").map { |c| c.fetch("name") }).to include("Loner")
         expect(report.fetch("undecidable")).to be_empty
+      end
+    end
+  end
+
+  describe "the per-file scan cache" do
+    it "serves the second run without re-scanning an unchanged file, with an identical report" do
+      Dir.mktmpdir do |dir|
+        write_project(dir)
+        File.write(File.join(dir, "config.yml"), "widget: LonerRegistry\n")
+        backdate(dir)
+        scans = 0
+        allow(Rigor::Analysis::Reachability::Scan).to receive(:call).and_wrap_original do |original, **kwargs|
+          scans += 1
+          original.call(**kwargs)
+        end
+
+        _, first, = run_in(dir)
+        after_first = scans
+        _, second, = run_in(dir)
+
+        expect(second).to eq(first)
+        expect(after_first).to be_positive
+        expect(scans).to eq(after_first)
+        expect(File.exist?(File.join(dir, ".rigor/cache/reachability-scan.bundle"))).to be(true)
+      end
+    end
+
+    it "re-scans an edited file and the report reflects the edit" do
+      Dir.mktmpdir do |dir|
+        write_project(dir)
+        run_in(dir)
+
+        File.write(File.join(dir, "lib/loner.rb"), "class Loner\nend\nclass Newcomer\nend\n")
+        _, report, = run_in(dir)
+
+        expect(report.fetch("candidates").map { |c| c.fetch("name") }).to include("Loner", "Newcomer")
+      end
+    end
+
+    it "recovers from a corrupt bundle by recomputing everything" do
+      Dir.mktmpdir do |dir|
+        write_project(dir)
+        _, first, = run_in(dir)
+
+        File.write(File.join(dir, ".rigor/cache/reachability-scan.bundle"), "not a bundle")
+        _, second, = run_in(dir)
+
+        expect(second).to eq(first)
       end
     end
   end


### PR DESCRIPTION
## What

After #473, a warm `rigor unused` still recomputed both per-file passes in full: the Prism reachability scan over every `.rb`/`.rake` file (0.66 s on Mastodon) and the template capital-run extraction (1.29 s of read+scrub+regex over 21.5 MB — measurement showed the #473 narrowing moved the template cost from matching into extraction, which now dominated). Both are pure functions of one file's bytes, and the measured Marshal restore clears the ADR-54 beats-recompute bar by 25× (1.8 MB blob, 0.03 s load vs 0.66 s rescan).

`Analysis::Reachability::ScanCache` is one self-validating zlib-Marshal bundle under the cache root — the ADR-46 IncrementalSnapshot shape rather than an ADR-54 `Cache::Store` producer, because the sound unit of reuse is the **file**: the payload carries a stat signature per entry and validates each on read, where a store entry validates all-or-nothing and one changed file would discard every unchanged file's work.

Guard rails: every file is still consulted every run (the whole-project completeness the `--incremental` refusal protects is unchanged); the header digests the scan sources themselves, so a checkout that edits the scan invalidates its survey targets' bundles; a file modified within the racy window is computed but never recorded; a subset (path-argument) run merges forward rather than shrinking the bundle; a missing, torn, or stale-schema blob degrades to an empty cache.

## Measured

A/B over kramdown, liquid, mail, redmine, mastodon (in-tree toggle, same bundle): `--format json` **byte-identical on all five**; warm wall Mastodon **2.74 → 1.07 s**, Redmine **1.53 → 0.81 s**, mail 0.59 → 0.42 s; kramdown/liquid at parity (the bundle round-trip is the size of the scan it replaces). Cumulative with #473, Mastodon `rigor unused` went 8.3 s → 1.07 s (7.8×).

## Gates

`make verify` green (exit read unpiped), changelog conformance green. New specs pin: second run serves with **zero** re-scans and an identical report; an edited file is re-scanned and the report reflects it; a corrupt bundle recomputes everything.
