### PR TITLE
Close the ActiveSupport overlay's drift from its plugin twin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[rbs]** `date.to_time(:utc)` and eleven other ordinary ActiveSupport calls — `String#dasherize`, `Object#in?`, `Time#all_day`, `ERB::Util.html_escape_once` among them — no longer draw a false diagnostic on a project that locks `activesupport` without opting into the `rigor-activesupport-core-ext` plugin ([#449](https://github.com/rigortype/rigor/issues/449)).
+
 - **[effects]** An effect annotation written in any of RBS's other bracket spellings — `%a(pure)`, `%a[rigor:v1:effect …]`, `%a|…|`, `%a<…>` — was invisible to the warm-run cache probe and to the annotations-unchecked notice, so its envelope was judged on cold runs and silently skipped on every cache hit; all five spellings now route identically, and a signature file with no effect annotation is no longer parsed by the envelope reader at all.
 
 - **[cli]** Every dispatched command now arms the deferred YJIT deadline, not just `check` and `coverage` — a cold `rigor effects` over Mastodon previously ran its whole 21 s interpreted where the identical analysis under `check` took 14.8 s; both now finish together, and commands that finish inside the deadline still never pay JIT compile cost.

--- a/data/gem_overlay/activesupport/core_ext.rbs
+++ b/data/gem_overlay/activesupport/core_ext.rbs
@@ -65,6 +65,9 @@ class Object
   # `acts_like?(:string)` / `acts_like?(:date)` / `acts_like?(:time)`
   # is ActiveSupport's "duck-typing helper" predicate.
   def acts_like?: (Symbol | String) -> bool
+
+  # `core_ext/object/inclusion` — `x.in?([a, b])` / `x.in?(1..10)`.
+  def in?: (untyped) -> bool
 end
 
 # `nil.blank?` / `nil.present?` / `nil.try` are the most frequent
@@ -108,6 +111,9 @@ class String
   def pluralize: (?Integer count, ?Symbol locale) -> String
   def singularize: (?Symbol locale) -> String
   def humanize: (?capitalize: bool, ?keep_id_suffix: bool) -> String
+  def titlecase: () -> String
+  def dasherize: () -> String
+  def upcase_first: () -> String
 
   # `core_ext/string/filters`
   def squish: () -> String
@@ -115,6 +121,8 @@ class String
   def truncate: (Integer truncate_at, ?omission: String, ?separator: String | Regexp | nil) -> String
   def truncate_bytes: (Integer truncate_at, ?omission: String) -> String
   def truncate_words: (Integer words_count, ?omission: String, ?separator: String | Regexp | nil) -> String
+  def remove: (*Regexp | String patterns) -> String
+  def remove!: (*Regexp | String patterns) -> String
 
   # `core_ext/string/output_safety` — `html_safe` returns an
   # `ActiveSupport::SafeBuffer` (a String subclass). The closest
@@ -282,6 +290,8 @@ class Time
   # Re-declaring it raised `RBS::DuplicatedMethodDefinitionError` and took the WHOLE `Time` definition
   # down with it (every `Time` call degraded to `Dynamic[top]`). This overlay only ADDS what
   # ActiveSupport adds.
+  def advance: (untyped options) -> Time
+  def all_day: () -> Range[Time]
   def acts_like_time?: () -> true
 end
 
@@ -323,6 +333,17 @@ class Date
   def at_beginning_of_day: () -> Time
   def end_of_day: () -> Time
   def at_end_of_day: () -> Time
+  def advance: (untyped options) -> Date
+  def all_day: () -> Range[Time]
+
+  # `Date#to_time` is an OVERLOAD CONTINUATION (`| ...`), not a plain declaration: stdlib `date`
+  # already types `to_time: () -> Time`, and re-declaring it raises
+  # `RBS::DuplicatedMethodDefinitionError`, which collapses `Date` to `Dynamic[top]` for every project
+  # this overlay reaches — the failure the `Time#utc?` note above records, and the one #437 hit on the
+  # plugin. The row cannot simply be omitted either: ActiveSupport genuinely widens the arity, so
+  # without it `date.to_time(:utc)` — correct Rails code — draws an arity diagnostic (#449). `| ...`
+  # appends this overload ahead of the stdlib one, so both arities resolve.
+  def to_time: (?Symbol form) -> Time | ...
 end
 
 # ---------------------------------------------------------------
@@ -474,4 +495,16 @@ class DateTime
   def beginning_of_minute: () -> DateTime
   def end_of_minute: () -> DateTime
   def acts_like_time?: () -> true
+end
+
+# ---------------------------------------------------------------
+# ERB::Util — ActionView extends it with `html_escape_once`
+# ---------------------------------------------------------------
+
+# `ERB` is a CLASS in Ruby / RBS (not a module), so reopen it as a class — a `module ERB` wrapper
+# collides with upstream `class ERB` once the `erb` stdlib is in scope. `ERB::Util` itself is a module.
+class ERB
+  module Util
+    def self.html_escape_once: (untyped) -> String
+  end
 end

--- a/spec/rigor/environment/activesupport_overlay_parity_spec.rb
+++ b/spec/rigor/environment/activesupport_overlay_parity_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Drift guard for issue #449.
+#
+# ADR-72's Gemfile.lock-gated overlay (`data/gem_overlay/activesupport/core_ext.rbs`) and the opt-in
+# `rigor-activesupport-core-ext` plugin are two hand-maintained copies of one surface. The overlay's own
+# header says so and asks the author to "keep the two in sync when extending coverage" — and nothing
+# checked it, so they drifted by twelve selectors.
+#
+# The cost of the drift falls entirely on the overlay's side, and it is a FALSE POSITIVE on correct code,
+# which AGENTS.md ranks above the worst-case static reading: `Date#to_time` reached the plugin in #437 and
+# not the overlay, so `date.to_time(:utc)` — ordinary ActiveSupport — drew an arity error on every project
+# that locks activesupport without opting into the plugin. The other eleven were `call.undefined-method` on
+# `String#dasherize`, `Object#in?` and friends, by the same mechanism.
+#
+# The invariant is one-directional on purpose. The plugin is the authoring home, so a row lands there
+# first; what must never happen is that it STAYS there, because the overlay is the copy that applies
+# automatically and therefore reaches every project that has not opted in.
+RSpec.describe "ActiveSupport overlay / plugin parity" do
+  def overlay_path
+    File.expand_path("../../../data/gem_overlay/activesupport/core_ext.rbs", __dir__)
+  end
+
+  def plugin_path
+    File.expand_path("../../../plugins/rigor-activesupport-core-ext/sig/active_support/core_ext.rbs", __dir__)
+  end
+
+  # Parsed with RBS rather than by regex: a regex over `def` lines cannot see nesting, and `ERB::Util`
+  # is exactly the case it would get wrong — the first version of this guard reported parity while
+  # `Util.html_escape_once` was still missing, because it keyed the row on `Util` alone.
+  def selectors(path)
+    _, _, decls = RBS::Parser.parse_signature(RBS::Buffer.new(name: path, content: File.read(path)))
+    walk(decls, []).to_set
+  end
+
+  def walk(decls, prefix)
+    decls.flat_map do |decl|
+      next [] unless decl.respond_to?(:members)
+
+      nested = prefix + [decl.name.to_s.sub(/\A::/, "")]
+      decl.members.flat_map do |member|
+        next walk([member], nested) unless member.is_a?(RBS::AST::Members::MethodDefinition)
+
+        member.kind == :singleton ? ["#{nested.join('::')}.#{member.name}"] : ["#{nested.join('::')}##{member.name}"]
+      end
+    end
+  end
+
+  it "declares in the overlay every selector the plugin declares" do
+    missing = selectors(plugin_path) - selectors(overlay_path)
+
+    expect(missing).to be_empty, lambda {
+      "the plugin declares #{missing.size} selector(s) the auto-applied overlay does not, so a project " \
+        "that locks activesupport without the plugin sees a false positive on each:\n  " \
+        "#{missing.sort.join("\n  ")}\nAdd them to #{OVERLAY.sub("#{Dir.pwd}/", '')} (declarations only — " \
+        "the overlay carries no effect annotations)."
+    }
+  end
+
+  # The guard's own non-vacuity: a parity assertion passes trivially if the extractor returns nothing,
+  # which is precisely how the first version of it passed while twelve rows were missing.
+  it "extracts a plausible surface from both files, so parity is not vacuous" do
+    expect(selectors(plugin_path).size).to be > 200
+    expect(selectors(overlay_path).size).to be > 200
+    expect(selectors(plugin_path)).to include("Date#to_time", "ERB::Util.html_escape_once", "String#dasherize")
+  end
+
+  # The overlay is deliberately annotation-free: effect envelopes on gem-shipped RBS are read by the
+  # accepted-signature lane (ADR-103 WD6), and the overlay applies to projects that never opted into the
+  # plugin. Porting a row must not port its `%a{pure}`.
+  it "keeps the overlay free of effect annotations" do
+    expect(File.read(overlay_path)).not_to include("%a{")
+    expect(File.read(plugin_path)).to include("%a{pure}")
+  end
+end


### PR DESCRIPTION
Fixes [#449](https://github.com/rigortype/rigor/issues/449), and the eleven siblings it turned out to have.

## What the issue actually was

`date.to_time(:utc)` — ordinary Rails code — drew `wrong number of arguments to 'to_time' on Date (given 1, expected 0)` on any project that locks `activesupport` without opting into `rigor-activesupport-core-ext`. Reproduced on master before touching anything.

The cause is not a wrong row but a **missing** one. [#437](https://github.com/rigortype/rigor/issues/437) fixed `Date#to_time` on the plugin; the ADR-72 auto-applied overlay was not kept in sync, although `data/gem_overlay/activesupport/core_ext.rbs`'s own header asks the author to "keep the two in sync when extending coverage". So I compared the two surfaces mechanically rather than fixing the one row, and found **twelve** selectors, all missing in the same direction:

`Date#advance` · `Date#all_day` · `Date#to_time` · `Object#in?` · `String#dasherize` · `String#remove` · `String#remove!` · `String#titlecase` · `String#upcase_first` · `Time#advance` · `Time#all_day` · `ERB::Util.html_escape_once`

Each is a false positive on the overlay's population, by one of two mechanisms: a method ActiveSupport *adds* reads as `call.undefined-method`, one it *widens* as an arity error. AGENTS.md ranks that above the worst-case static reading, which makes all twelve defects rather than gaps.

## What landed

All twelve ported, **declarations only**. The overlay carries no effect annotations at all (222 `%a{pure}` in the plugin, 0 here) and that stays true: ADR-103 WD6 reads gem-shipped envelopes on the accepted-signature lane, and this file applies to projects that never opted into the effect system.

`Date#to_time` is an overload continuation (`| ...`) for the reason the file's own `Time#utc?` note records — re-declaring a stdlib-typed method raises `RBS::DuplicatedMethodDefinitionError` and collapses the whole class to `Dynamic[top]`, which is a far worse bug than the FP being fixed.

A spec pins the invariant, one-directional (the plugin is the authoring home; what must not happen is that a row *stays* there). It parses both files with **RBS rather than a regex** — a regex over `def` lines cannot see nesting, and `ERB::Util` is exactly the row it gets wrong: my first version of the guard reported parity while `html_escape_once` was still missing.

## Verification

**Targeted A/B**, on a fixture that locks `activesupport` and does not load the plugin:

| | master | branch |
| --- | --- | --- |
| `d.to_time(:utc)` | arity error | — |
| `"a b".dasherize` | undefined method | — |
| `d.no_such_method` (control) | fires | **fires** |

The control is the load-bearing half: if `| ...` had collapsed `Date` to `Dynamic[top]`, it would have gone silent. It does not.

**Corpus**: redmine + mastodon, `--no-cache`, plugin removed and overlay live in both arms — **zero new firings** across 3,141 diagnostics, zero suppressed. Honest reading: the twelve selectors are not exercised by these two projects, so this is a safety result, not a demonstration of value; the fixture A/B is the demonstration.

**Two traps I walked into and the controls that caught them**, both worth recording because both produced a confident wrong answer first:

1. My first repro had no `Gemfile.lock`, so the overlay was never loaded and I was measuring a different thing than the issue described. The tell was `dasherize` — a row I had just added — still firing.
2. My first corpus A/B used configs that load `rigor-activesupport-core-ext`, which makes the overlay **stand down** by design. Both arms were byte-identical because neither loaded the overlay at all. Confirmed vacuous, rebuilt with the plugin removed, and verified the overlay was genuinely live by a positive control: redmine has 732 `blank?` / `present?` call sites and zero FPs on them.

`make verify` and `make docs-check` green, each as its own call with the exit code read unpiped. The parity gate was confirmed to **fail** against master's overlay and pass on this branch.
