### PR TITLE
Make the warm self-check arm exercise what its gate is for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,12 +282,39 @@ jobs:
       # the gem-without-rbs count diverge between warm and cold, failing
       # the warm==cold diff gate even when the analysis is correct.
       - name: Restore Rigor analysis cache
+        id: restore-cache
         if: matrix.cache == 'warm'
         uses: actions/cache@v6
         with:
           path: .rigor/cache
           key: rigor-cache-${{ runner.os }}-${{ hashFiles('Gemfile.lock') }}-${{ hashFiles('lib/**/*.rb', 'sig/**/*.rbs', 'data/builtins/**/*.yml') }}
           restore-keys: rigor-cache-${{ runner.os }}-${{ hashFiles('Gemfile.lock') }}-
+
+      # Issue #427 — put the warm arm in the ONE state that exercises what this gate exists to catch,
+      # instead of leaving it to whatever the restore happened to produce.
+      #
+      # The hazard is the rbs `TypeName#hash` memoisation riding into the Marshal'd `rbs.environment`
+      # blob and coming back wrong in a fresh process.  Catching it needs a cross-process restore of
+      # that blob AND a real analysis against it.  The arm failed to meet that on two counts:
+      #
+      #   1. A lockfile change leaves nothing restorable — both keys are scoped to the Gemfile.lock
+      #      hash (deliberately; see the note above), so a gem bump starts the arm empty and the diff
+      #      compares two cold runs.  Observed green against nothing on #412.
+      #   2. Even a FULLY warm arm never loads the environment: measured, with the whole-run
+      #      `analysis.run-diagnostics` slot populated, `rigor check` is served straight from it and
+      #      `rbs.environment` is consulted zero times.  No analysis, so no hazard on show.
+      #
+      # So: prime when nothing exact was restored, then drop the whole-run slot.  What remains is the
+      # RBS slices, restored across a process boundary, with a real analysis on top — which is the
+      # comparison the job's name claims.  `cache-hit` is 'true' only on an exact key match, so a
+      # restore-key (prefix) match still primes, where priming is itself warm and costs a second.
+      - name: Prime the analysis cache when the restore missed
+        if: matrix.cache == 'warm' && steps.restore-cache.outputs.cache-hit != 'true'
+        run: bundle exec exe/rigor check lib > /dev/null || true
+
+      - name: Drop the whole-run slot so the warm arm actually analyses
+        if: matrix.cache == 'warm'
+        run: rm -rf .rigor/cache/analysis.run-diagnostics
 
       # Run once with --format json so we get both structured output for
       # the warm-vs-cold diff and a human-readable summary in the CI log.
@@ -309,6 +336,15 @@ jobs:
               | sort_by(.path, .line, .column, .rule)' \
             rigor-raw.json > rigor-diagnostics-${{ matrix.cache }}.json || true
           exit $rigor_exit
+
+      # Issue #427 — the anti-vacuity assertion, the shape `make check-mutation-cache` already uses on
+      # its own warm arm.  It asserts `rbs.environment` was SERVED this run, which is the difference
+      # between "a cache was read" and "the cache that can be wrong was read".  Runs after the
+      # self-check; it re-establishes the measured run's cache state itself, because that run writes the
+      # whole-run slot back.
+      - name: Assert the warm arm was served from cache
+        if: matrix.cache == 'warm'
+        run: bundle exec ruby tool/warm_cache_assertion.rb lib
 
       # Upload even when the check found errors so the diff job always
       # has both artifacts to compare.

--- a/tool/warm_cache_assertion.rb
+++ b/tool/warm_cache_assertion.rb
@@ -1,0 +1,93 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Issue #427 — the anti-vacuity assertion for the `Self-check diff (warm == cold)` gate.
+#
+# That gate is our detector for cache-identity regressions, most importantly the rbs `TypeName#hash` /
+# `Namespace#hash` memoisation hazard that `lib/rigor/cache/rbs_environment_marshal_patch.rb` exists to
+# neutralise: a memoised hash rides into the Marshal'd `rbs.environment` blob and comes back wrong in a
+# FRESH process, so every analysis built on it is quietly different. Catching that needs one specific
+# condition — a cross-process restore of that blob, followed by a real analysis against it.
+#
+# The gate could not meet that condition on the pull requests that matter most, for two separate reasons:
+#
+# 1. **A lockfile change leaves nothing restorable.** The cache key and both restore-keys are scoped to
+#    `hashFiles('Gemfile.lock')` — correctly, since a stale-lockfile restore makes the gem-without-rbs
+#    count diverge — so a gem bump starts the warm arm empty and the diff compares two cold runs. Observed
+#    on #412 (rbs 4.1.1 → 4.1.3, sole changed file `Gemfile.lock`), green against nothing.
+# 2. **A fully warm arm never loads the environment at all.** Measured: with the whole-run
+#    `analysis.run-diagnostics` slot populated, `rigor check` is served from it and `rbs.environment` is
+#    consulted ZERO times — the analysis does not happen, so a broken env cannot show. The warm arm only
+#    exercises the hazard when the whole-run slot misses and the RBS slices hit.
+#
+# The workflow now puts the arm in exactly that state (prime when the restore missed, then drop the
+# whole-run slot), and this asserts the state was reached: `rbs.environment` served this run, so the
+# diagnostics the diff compares were computed against a cross-process-restored environment.
+#
+# The whole-run slot's own correctness is not this gate's job and is not left uncovered — it is pinned
+# in-suite by the ADR-45 specs and `spec/rigor/effects/persistence_spec.rb`, both of which assert a
+# cache-served run against a computed one.
+#
+# Usage: bundle exec ruby tool/warm_cache_assertion.rb [PATH...]
+
+require "English"
+require "fileutils"
+require "open3"
+
+require_relative "../lib/rigor/configuration"
+
+# The producer whose cross-process restore the hazard rides in. Asserting on THIS rather than on any
+# hit at all is the difference between "a cache was read" and "the cache that can be wrong was read".
+PRODUCER = "rbs.environment"
+
+# `    rbs.environment: 1 hit, 0 misses, 0 writes`. Parsed narrowly on purpose: a pattern that cannot
+# find its line must FAIL rather than pass quietly, which is the same trap one level up from the one
+# this gate is about.
+def run_line(producer)
+  /^\s+#{Regexp.escape(producer)}:\s+(\d+)\s+hits?,\s+(\d+)\s+miss(?:es)?,\s+(\d+)\s+writes?$/
+end
+
+def fail_with(message)
+  warn("warm-cache assertion FAILED: #{message}")
+  warn("")
+  warn("The `Self-check diff (warm == cold)` gate compares this arm's diagnostics against the cold")
+  warn("arm's. Unless this arm analysed against a cross-process-restored `#{PRODUCER}`, the gate cannot")
+  warn("see a cache-identity regression — the rbs Marshal-hash hazard among them (issue #427).")
+  exit 1
+end
+
+paths = ARGV.empty? ? ["lib"] : ARGV
+
+# The tool establishes its own measurement state, the way `tool/mutation_cache_gate.rb` runs its own
+# three arms rather than trusting the caller to have set one up.
+#
+# The state it needs is the one the workflow puts the MEASURED run in: RBS slices present, whole-run
+# slot absent. That slot has to be dropped here and not merely by the workflow beforehand, because the
+# measured `rigor check` between the two WRITES it back — the first version of this gate asserted
+# against the state the check left rather than the state it ran in, and failed for that reason.
+slot = File.join(Rigor::Configuration.load(nil).cache_path, "analysis.run-diagnostics")
+FileUtils.rm_rf(slot)
+
+command = ["bundle", "exec", "exe/rigor", "check", "--cache-stats", *paths]
+stdout, stderr, status = Open3.capture3(*command)
+
+# A check that finds diagnostics exits 1; that is not this gate's business. Only a crash is.
+fail_with("`#{command.join(' ')}` did not run (exit #{status.exitstatus})\n#{stderr}") if
+  status.exitstatus.nil? || status.exitstatus > 1
+fail_with("the run printed no `this run:` cache statistics at all") unless stdout.include?("this run:")
+
+match = stdout.match(run_line(PRODUCER))
+if match.nil?
+  fail_with(
+    "the run printed cache statistics, but nothing for `#{PRODUCER}` — the environment was never " \
+    "consulted, which means either nothing was restored or the whole-run slot served this run without " \
+    "analysing at all"
+  )
+end
+
+hits, misses, = match.captures.map(&:to_i)
+fail_with("`#{PRODUCER}` reports #{hits} hits — it was rebuilt, not restored") if hits.zero?
+fail_with("`#{PRODUCER}` reports #{misses} miss(es) alongside #{hits} hit(s)") unless misses.zero?
+
+puts "warm-cache assertion OK: #{PRODUCER} served this run from cache (#{hits} hit(s), 0 misses), so the " \
+     "diagnostics were computed against a cross-process-restored environment."


### PR DESCRIPTION
Fixes [#427](https://github.com/rigortype/rigor/issues/427) — and a second blindness that measuring the fix uncovered, which the issue did not anticipate and which applies on ordinary pull requests too.

## What the gate is for

`Self-check diff (warm == cold)` is our detector for cache-identity regressions, above all the rbs `TypeName#hash` / `Namespace#hash` memoisation hazard that [`lib/rigor/cache/rbs_environment_marshal_patch.rb`](https://github.com/rigortype/rigor/blob/master/lib/rigor/cache/rbs_environment_marshal_patch.rb) exists to neutralise. Catching it needs one specific condition: **a cross-process restore of the Marshal'd `rbs.environment` blob, and a real analysis on top of it.**

The warm arm failed to meet that condition for two independent reasons.

**1. A lockfile change leaves nothing restorable** — the issue's finding. Both keys are scoped to `hashFiles('Gemfile.lock')`, correctly (a stale-lockfile restore makes the gem-without-rbs count diverge and fails the diff even when the analysis is right), so a gem bump starts the arm empty and the diff compares two cold runs. Observed on [#412](https://github.com/rigortype/rigor/pull/412), green against nothing.

**2. A *fully warm* arm never loads the environment at all** — found while measuring the fix for (1). With the whole-run `analysis.run-diagnostics` slot populated, `rigor check` is served straight from it and `rbs.environment` is consulted **zero** times. Measured:

```
# slot present                          # slot absent, rbs.* present
this run: 426 hits, 0 misses            this run: 430 hits, 1 miss, 1 write
  plugin.source_rbs_synthesizer: 425      plugin.source_rbs_synthesizer: 425 hits
  analysis.run-diagnostics: 1 hit         rbs.environment: 1 hit          ← the hazard-bearing restore
                                          analysis.run-diagnostics: 0 hits, 1 miss
```

No analysis happens on the left, so a broken environment cannot show. **Priming alone would have moved the arm from one blind state to another** — which is why this PR is not just the priming step the issue proposed.

## What landed

The warm arm primes when nothing exact was restored, then **drops the whole-run slot**. What remains is the RBS slices, restored across a process boundary, with a real analysis on top — the comparison the job's name claims.

`tool/warm_cache_assertion.rb` then asserts `rbs.environment` was **served** this run: the difference between "a cache was read" and "the cache that can be wrong was read". It re-establishes that cache state itself, because the measured `rigor check` between the two writes the slot back — my first version asserted against the state the check *left* rather than the one it *ran in*, and failed for exactly that reason. Owning its own measurement state is the `tool/mutation_cache_gate.rb` shape, which runs its own three arms for the same reason.

## Verified

Locally, in all three states — and the middle one is the second finding as a live assertion:

| cache state | assertion |
| --- | --- |
| empty | **fails** — "reports 0 hits, it was rebuilt, not restored" |
| fully warm (slot present) | **fails** — "nothing for `rbs.environment` … the whole-run slot served this run without analysing at all" |
| slices warm, slot dropped | **passes** |

And the whole CI arm simulated end to end from an empty cache (the gem-bump case): prime → drop → self-check → assert. Assertion green, and warm == cold byte-identical against a `--no-cache` run.

This PR's own CI exercises the other path — it touches no `lib/` and no `Gemfile.lock`, so an exact key match is expected, priming is skipped, and the arm runs slot-dropped against a genuinely restored cache.

## Scope

The whole-run slot's own correctness is not this gate's job and is not left uncovered: the ADR-45 specs and `spec/rigor/effects/persistence_spec.rb` both compare a cache-served run against a computed one, in-suite. No changelog entry — CI infrastructure, not user-facing; `tool/` does not ship in the gem.
