### PR TITLE
Carry the rule identifier on every diagnostic's text output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[cli]** Every diagnostic's text output now ends with its rule identifier in brackets — `[call.undefined-method]` — so the ID you need for `# rigor:disable`, `disable:` and `severity_profile:` is the one you are already looking at, and a run can be grepped for a rule. Previously only plugin and RBS-sourced diagnostics carried it, which was exactly the wrong half: built-in rules are the ones the manual tells you to configure by ID ([#431](https://github.com/rigortype/rigor/issues/431)).
+
 - **[rbs]** `date.to_time(:utc)` and eleven other ordinary ActiveSupport calls — `String#dasherize`, `Object#in?`, `Time#all_day`, `ERB::Util.html_escape_once` among them — no longer draw a false diagnostic on a project that locks `activesupport` without opting into the `rigor-activesupport-core-ext` plugin ([#449](https://github.com/rigortype/rigor/issues/449)).
 
 - **[effects]** An effect annotation written in any of RBS's other bracket spellings — `%a(pure)`, `%a[rigor:v1:effect …]`, `%a|…|`, `%a<…>` — was invisible to the warm-run cache probe and to the annotations-unchecked notice, so its envelope was judged on cold runs and silently skipped on every cache hit; all five spellings now route identically, and a signature file with no effect annotation is no longer parsed by the envelope reader at all.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ s.lenght
 
 ```shell-session
 $ rigor check demo.rb
-demo.rb:7:3: error: undefined method `lenght' for "hello-world"
+demo.rb:7:3: error: undefined method `lenght' for "hello-world" [call.undefined-method]
 ```
 
 Note what the error says: not ``undefined method `lenght' for String``

--- a/docs/manual/03-configuration.md
+++ b/docs/manual/03-configuration.md
@@ -251,7 +251,7 @@ stanza it broke:
 ```
 app/presenters/user_presenter.rb:14:1: warning: Method Presenters::User#render performs io.fs.read
   (File.read), but is declared effect: [] at .rigor.yml effects.envelopes[0], so io.fs.read exceeds
-  the envelope.
+  the envelope. [effect.envelope-exceeded]
 ```
 
 When one method is a deliberate exception, write the narrower envelope on it in RBS — nearest wins,

--- a/docs/manual/04-diagnostics.md
+++ b/docs/manual/04-diagnostics.md
@@ -19,6 +19,18 @@ Every rule has a two-segment `family.rule` identifier:
 | `assert` | `assert_type` checks. |
 | `dump` | `dump_type` notices. |
 
+Every diagnostic carries its identifier in brackets at the end of the
+line, so the ID you need for `# rigor:disable`, for `disable:` and for
+`severity_profile:` is the one you are already looking at:
+
+```text
+app/user.rb:11:3: error: undefined method `lenght' for "hello" [call.undefined-method]
+```
+
+A diagnostic no rule produced — a parse error, a path error, an
+internal analyzer error — has nothing to suppress and carries no
+bracket.
+
 `rigor explain <rule>` prints the full catalogue entry for any
 built-in rule ID; `rigor explain` with no argument lists them all.
 

--- a/docs/manual/19-effect-labels.md
+++ b/docs/manual/19-effect-labels.md
@@ -520,7 +520,7 @@ A method that exceeds its bound gets one diagnostic per (method, label) pair, at
 its `def`, naming the route:
 
 ```
-app/helpers/application_helper.rb:59:1: warning: Method ApplicationHelper#link_to_principal performs io.fs.read (Dir.glob via IconsHelper#principal_icon → IconsHelper#sprite_icon → IconsHelper#sprite_source → Redmine::Themes::Helper#current_theme → Redmine::Themes.theme → Redmine::Themes.themes → Redmine::Themes.scan_themes), but is declared effect: [] at .rigor.yml effects.envelopes[0], so io.fs.read exceeds the envelope.
+app/helpers/application_helper.rb:59:1: warning: Method ApplicationHelper#link_to_principal performs io.fs.read (Dir.glob via IconsHelper#principal_icon → IconsHelper#sprite_icon → IconsHelper#sprite_source → Redmine::Themes::Helper#current_theme → Redmine::Themes.theme → Redmine::Themes.themes → Redmine::Themes.scan_themes), but is declared effect: [] at .rigor.yml effects.envelopes[0], so io.fs.read exceeds the envelope. [effect.envelope-exceeded]
 ```
 
 **Budget for a big first number.** That one stanza, on Redmine, is **343
@@ -610,7 +610,7 @@ app/serializers/rest/v1/instance_serializer.rb:89:1: warning: Method
   REST::V1::InstanceSerializer#invites_enabled performs mutate.self
   (receiver-mutation via UserRole.everyone → UserRole.create! → UserRole#set_position),
   but is declared effect: [] at .rigor.yml effects.envelopes[0], so mutate.self
-  exceeds the envelope.
+  exceeds the envelope. [effect.envelope-exceeded]
 ```
 
 Rigor walked *through* the database write and reported the ivar assignment beyond

--- a/lib/rigor/analysis/diagnostic.rb
+++ b/lib/rigor/analysis/diagnostic.rb
@@ -134,14 +134,25 @@ module Rigor
       end
 
       # Text rendering for `rigor check`. The qualified rule identifier (per ADR-2 § "Plugin Diagnostic
-      # Provenance" — `plugin.<id>.<rule>`, `rbs_extended.<rule>`, `generated.<provider>.<rule>`) is appended
-      # in brackets whenever the diagnostic carries a non-default `source_family`, so plugin / RBS::Extended
-      # / generated provenance is visible in the standard text output without changing the layout for
-      # built-in rules. Slice 5 (v0.1.0) wires this surface.
+      # Provenance" — `call.undefined-method`, `plugin.<id>.<rule>`, `rbs_extended.<rule>`,
+      # `generated.<provider>.<rule>`) is appended in brackets.
+      #
+      # Slice 5 (v0.1.0) introduced the bracket for non-builtin families only, "without changing the layout
+      # for built-in rules" — a layout-conservatism call made when provenance was the point, not a judgment
+      # that the identifier is noise. The consequence outlived the reason (#431): the exception covers the
+      # rules `docs/manual/04-diagnostics.md` tells the reader to suppress with `# rigor:disable <id>` and
+      # to key `severity_profile:` on, so the default output was the one place the identifier could not be
+      # read. A run could not be grepped for a rule either — the effect-system walkthrough grepped
+      # `effect\.` over a whole Redmine run, got nothing, and concluded the feature was broken.
+      #
+      # The cost is bounded and was measured before the change: on Redmine every diagnostic carries an
+      # identifier, only 13 distinct ones appear across the project, and the suffix adds 14 characters to a
+      # 165-character median line.
+      #
+      # `rule` is nil for diagnostics no rule produced — parse errors, path errors, internal analyzer
+      # errors — and those stay unsuffixed, because there is nothing to suppress or configure.
       def to_s
         base = "#{path}:#{line}:#{column}: #{severity}: #{message}"
-        return base if source_family == DEFAULT_SOURCE_FAMILY
-
         qualified = qualified_rule
         return base if qualified.nil?
 

--- a/spec/rigor/analysis/diagnostic_spec.rb
+++ b/spec/rigor/analysis/diagnostic_spec.rb
@@ -80,7 +80,25 @@ RSpec.describe Rigor::Analysis::Diagnostic do
       diagnostic = described_class.new(
         path: "f.rb", line: 1, column: 2, message: "boom", rule: "call.undefined-method"
       )
-      expect(diagnostic.to_s).to eq("f.rb:1:2: error: boom")
+      expect(diagnostic.to_s).to eq("f.rb:1:2: error: boom [call.undefined-method]")
+    end
+
+    # #431 — the identifier is what `# rigor:disable <id>` and `severity_profile:` are keyed on, and the
+    # default output was the one place it could not be read. A builtin rule now carries it like every
+    # other family; slice 5's exception for builtins was a layout call, not a judgment that it is noise.
+    it "appends the bare rule for a builtin diagnostic" do
+      diagnostic = described_class.new(
+        path: "f.rb", line: 1, column: 2, message: "boom", severity: :warning, rule: "flow.always-raises"
+      )
+      expect(diagnostic.to_s).to eq("f.rb:1:2: warning: boom [flow.always-raises]")
+    end
+
+    # The other half, and the reason `rule` is allowed to be nil: a parse error, a path error or an
+    # internal analyzer error is produced by no rule, so there is nothing to suppress or configure and
+    # nothing to print.
+    it "leaves a rule-less diagnostic unsuffixed" do
+      diagnostic = described_class.new(path: "f.rb", line: 1, column: 2, message: "cannot parse")
+      expect(diagnostic.to_s).to eq("f.rb:1:2: error: cannot parse")
     end
 
     it "appends the qualified rule for non-builtin source families" do


### PR DESCRIPTION
Fixes [#431](https://github.com/rigortype/rigor/issues/431). The issue asked for a **decision** rather than a patch, and investigating it corrected its own diagnosis — for the second time on this surface.

## The finding that reframes the options

**The text formatter was never id-less.** It has appended `[qualified.rule]` since v0.1.0 slice 5 — but only when `source_family` is not `:builtin`:

```
builtin: a.rb:1:1: warning: m
plugin : a.rb:1:1: warning: m [plugin.rigor-units.units.mismatch]
```

So the walkthrough's "neighbouring plugin warning carrying its id" was *that suffix*, not message text as the issue records. This makes option 1 not "add a convention most linters have" but **remove an exception from a convention we already ship** — a smaller change than the issue's re-scoping suggested, and one with a house precedent rather than an imported one.

And the exception covered exactly the wrong half. Built-in rules are the ones [`04-diagnostics.md`](https://github.com/rigortype/rigor/blob/master/docs/manual/04-diagnostics.md) tells the reader to suppress with `# rigor:disable <id>` and to key `severity_profile:` on, so the default output was the one place the identifier could not be read.

The stated reason for the exception — "without changing the layout for built-in rules" — was a layout call made when provenance was the point, not a judgment that the identifier is noise.

## The decision, and the cost measured before making it

**Option 1: always append.** Measured on Redmine first, because "an id on every line is noise" is the real objection and deserved a number rather than an opinion:

| | |
| --- | --- |
| diagnostics carrying an identifier | 792 / 792 (100 %) |
| **distinct** identifiers across the whole project | **13** |
| median line length | 165 chars |
| median suffix | **+14 chars** (+8.5 %) |

Nothing inside the repo parses the text output, so there is no breakage surface. A reader meets 13 identifiers across an entire Rails application, not 792 distinct ones.

## Verified

The issue's own failing test — grepping a run for a rule family — now works: `effect.` returns 0 hits on master and 1 on a fixture that earns an envelope diagnostic. A Redmine run carries 33 `[call.undefined-method]`, 17 `[flow.dead-assignment]`, 12 `[flow.always-truthy-condition]` and the rest.

A diagnostic **no rule produced** — a parse error, a path error, an internal analyzer error — still carries no bracket, because there is nothing to suppress or configure. Spec'd in both directions.

`make verify` needed exactly one existing assertion updated; `make docs-check` green. Both run as their own calls with the exit code read unpiped.

## Docs

Refreshed the four built-in examples (README, `03-configuration.md`, `19-effect-labels.md` ×2) and `04-diagnostics.md` now states that the identifier is on the line, which is the issue's second acceptance criterion.

**Deliberately not touched: the plugin manual pages.** Their examples were already stale before this change — `rigor-rails-i18n.md` shows `demo.rb:14` where the real output is `demo.rb:12`, and omits the `[plugin.rails-i18n.…]` suffix those diagnostics have always carried. That is pre-existing drift with its own cause (the examples were never regenerated), and folding it into this PR would mix an unrelated fix into a decision record. Worth its own issue if you want it filed.
