### PR TITLE
Make shipped documentation links resolvable for a reader who has the gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[docs]** Relative links from the shipped manual and handbook into documents the gem does not package — ADRs, the type specification, the internal spec, `examples/`, plugin READMEs — were dead for everyone who installed Rigor rather than cloning it. All 284 of them now name their canonical URL, and `rigor help` no longer cites ADRs a reader cannot open ([#430](https://github.com/rigortype/rigor/issues/430)).
+
 - **[cli]** `rigor unused` no longer reports a class as having no production caller when a data file also names it — a job listed in `config/recurring.yml` and referenced from its spec was landing under "live test, dead production path" while it ran every three minutes. A data-file mention now also demotes to *cannot decide*, and it demotes only the name it matched rather than everything beneath it: the word "Administrasie" in a locale file was demoting 18 unrelated `Admin::*` rows ([#370](https://github.com/rigortype/rigor/issues/370)).
 
 - **[cli]** Every diagnostic's text output now ends with its rule identifier in brackets — `[call.undefined-method]` — so the ID you need for `# rigor:disable`, `disable:` and `severity_profile:` is the one you are already looking at, and a run can be grepped for a rule. Previously only plugin and RBS-sourced diagnostics carried it, which was exactly the wrong half: built-in rules are the ones the manual tells you to configure by ID ([#431](https://github.com/rigortype/rigor/issues/431)).

--- a/README.md
+++ b/README.md
@@ -183,11 +183,11 @@ plugins:
   - rigor-rspec
 ```
 
-The full catalogue is in [`plugins/README.md`](plugins/README.md); the
+The full catalogue is in [`plugins/README.md`](https://github.com/rigortype/rigor/blob/master/plugins/README.md); the
 `rigor-project-init` Skill picks the right set for you. To teach Rigor
-your own DSL, the [`rigor-plugin-author`](skills/rigor-plugin-author/)
+your own DSL, the [`rigor-plugin-author`](https://github.com/rigortype/rigor/tree/master/skills/rigor-plugin-author)
 Skill authors a plugin step-by-step, and
-[`rigor-baseline-reduce`](skills/rigor-baseline-reduce/) drives the
+[`rigor-baseline-reduce`](https://github.com/rigortype/rigor/tree/master/skills/rigor-baseline-reduce) drives the
 baseline down once you are running.
 
 ## Going deeper
@@ -234,18 +234,18 @@ rigor docs --list                 # list every bundled page
 Current release: **`v0.3.5`** (2026-08-25) — on the
 `0.3.x` line, continuing the evaluation era opened by `v0.2.0`, the first
 publicly-announced (general / evaluation) release. The line publishes
-an enumerated [compatibility surface](docs/compatibility.md) as a
+an enumerated [compatibility surface](https://github.com/rigortype/rigor/blob/master/docs/compatibility.md) as a
 minor-non-break trial, rehearsing the contract that hard-freezes at
 `v1.0.0`. Rigor analyses real Ruby today: it has been hardened against
 Mastodon, Redmine, and GitLab FOSS, and the deliberately conservative
 rule catalogue grows only as fast as the zero-false-positive bar
-allows. Release history: [`CHANGELOG.md`](CHANGELOG.md) ·
+allows. Release history: [`CHANGELOG.md`](https://github.com/rigortype/rigor/blob/master/CHANGELOG.md) ·
 forward-looking commitments:
 [Roadmap](https://github.com/rigortype/rigor/milestones).
 
 ## Contributing
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the `git clone` →
+See [`CONTRIBUTING.md`](https://github.com/rigortype/rigor/blob/master/CONTRIBUTING.md) for the `git clone` →
 green-tests path and a map of the spec / ADR / skill documentation
 contributors should read.
 

--- a/docs/handbook/01-getting-started.md
+++ b/docs/handbook/01-getting-started.md
@@ -257,7 +257,7 @@ will need them:
    `.rigor.dist.yml` and Rigor will walk its `lib/` the same way
    it walks project source. Returns are wrapped in
    `Dynamic[T]` so the call site retains the provenance.
-   See [ADR-10](../adr/10-dependency-source-inference.md)
+   See [ADR-10](https://github.com/rigortype/rigor/blob/master/docs/adr/10-dependency-source-inference.md)
    for the trade-offs (per-gem opt-in by design — broad
    defaults would inflate budgets and make `bundle update`
    noisy).

--- a/docs/handbook/02-everyday-types.md
+++ b/docs/handbook/02-everyday-types.md
@@ -111,9 +111,9 @@ sym = "foo".to_sym        #=> dump_type: Constant<:foo>
 Folding extends to a long list of "pure" methods on Numeric,
 String, Symbol, Array, and Hash. The list is not in this
 handbook (it would fill several pages); see
-[`docs/types.md`](../types.md) and the per-class catalogues
+[`docs/types.md`](https://github.com/rigortype/rigor/blob/master/docs/types.md) and the per-class catalogues
 under
-[`data/builtins/ruby_core/`](../../data/builtins/ruby_core/).
+[`data/builtins/ruby_core/`](https://github.com/rigortype/rigor/tree/master/data/builtins/ruby_core).
 
 When folding is **not** safe (because a method has side
 effects, depends on the environment, or is not in a

--- a/docs/handbook/04-tuples-and-shapes.md
+++ b/docs/handbook/04-tuples-and-shapes.md
@@ -85,7 +85,7 @@ configurable union budget, when an unknown-shape array is
 concatenated to it, or when it crosses an RBS-declared
 parameter typed as `Array[T]`. The widening is deterministic
 and documented in
-[`docs/type-specification/inference-budgets.md`](../type-specification/inference-budgets.md).
+[`docs/type-specification/inference-budgets.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/inference-budgets.md).
 
 Widening is safe (`Array[T]` is a strictly less precise view
 of the same value), but you lose the per-position information.
@@ -275,7 +275,7 @@ the underlying RBS sig advertises.
 
 If you prefer the TS spellings (`Pick<T, K>` etc.) in
 directives, opt into the
-[`rigor-typescript-utility-types`](../../plugins/rigor-typescript-utility-types/)
+[`rigor-typescript-utility-types`](https://github.com/rigortype/rigor/tree/master/plugins/rigor-typescript-utility-types)
 plugin. The plugin registers a `Plugin::TypeNodeResolver` that
 translates each TS name onto the canonical projection:
 
@@ -301,7 +301,7 @@ information (`HashShape` and, for `pick_of` / `omit_of`,
 `Tuple`). Applying them to a plain `Hash[K, V]` or any other
 non-shape input is **lossy** — the projection silently
 degrades to the input type and Rigor records a
-[`dynamic.shape.lossy-projection`](../type-specification/diagnostic-policy.md)
+[`dynamic.shape.lossy-projection`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/diagnostic-policy.md)
 `:info` diagnostic so you can audit the call site.
 
 ```rbs

--- a/docs/handbook/07-rbs-and-extended.md
+++ b/docs/handbook/07-rbs-and-extended.md
@@ -115,14 +115,14 @@ payloads, the parameterised and bounded forms, and where `~T`
 negation is and is not allowed) — is
 [manual — RBS::Extended annotations](../manual/16-rbs-extended-annotations.md#per-method-directives);
 the normative rules for conflicts, merging and provenance are
-[`docs/type-specification/rbs-extended.md`](../type-specification/rbs-extended.md).
+[`docs/type-specification/rbs-extended.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/rbs-extended.md).
 The rest of this chapter works through the directives one
 example at a time.
 
 ## Refinement names
 
 The full catalogue is in
-[`docs/type-specification/imported-built-in-types.md`](../type-specification/imported-built-in-types.md).
+[`docs/type-specification/imported-built-in-types.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/imported-built-in-types.md).
 A short reference:
 
 | Family | Names |
@@ -191,7 +191,7 @@ objects the method itself allocated and never let out, so a
 The payload is a comma-separated list of bare labels
 (`%a{rigor:v1:effect io.db, nondet.time}`), from the vocabulary
 in
-[effect-labels.md](../type-specification/effect-labels.md).
+[effect-labels.md](https://github.com/rigortype/rigor/blob/master/docs/type-specification/effect-labels.md).
 Write the annotation on a `class` or `module` declaration
 instead and it applies to every method of that class —
 reopenings and `attr_writer`-generated methods included, but
@@ -235,7 +235,7 @@ you may be opening a root of your own.
 
 The whole feature — the label vocabulary, the committed effect
 snapshot, and `rigor effects` itself — is
-[ADR-103](../adr/103-effect-labels.md); start with
+[ADR-103](https://github.com/rigortype/rigor/blob/master/docs/adr/103-effect-labels.md); start with
 [`rigor effects`](../manual/02-cli-reference.md#rigor-effects).
 
 ## Worked example: an assertion gate
@@ -396,13 +396,13 @@ annotation object whichever buffer it arrived in — the effect
 envelopes above (`%a{pure}`, `%a{rigor:v1:effect …}`) included.
 Reading them requires the rbs-inline library, which Rigor
 ingests by default when it is installed
-([ADR-93](../adr/93-default-rbs-inline-ingestion.md)).
+([ADR-93](https://github.com/rigortype/rigor/blob/master/docs/adr/93-default-rbs-inline-ingestion.md)).
 
 What Rigor does **not** offer is a Rigor-only comment dialect —
 there is no `# rigor:effect` directive and no file pragma. The
 `# rigor:` comment family stays suppression-only (`disable`,
 `disable-file`). Application code never has to carry
-Rigor-specific syntax ([ADR-0](../adr/0-concept.md)); an
+Rigor-specific syntax ([ADR-0](https://github.com/rigortype/rigor/blob/master/docs/adr/0-concept.md)); an
 upstream annotation form you may use if you want one is a
 different thing from a requirement.
 
@@ -469,7 +469,7 @@ Notes:
 Full plugin documentation, configuration options (including
 the `require_magic_comment: false` host-context override the
 browser playground uses), and the caching contract:
-[`plugins/rigor-rbs-inline/README.md`](../../plugins/rigor-rbs-inline/README.md).
+[`plugins/rigor-rbs-inline/README.md`](https://github.com/rigortype/rigor/blob/master/plugins/rigor-rbs-inline/README.md).
 
 ## Falling back to `untyped`
 
@@ -494,7 +494,7 @@ arguments at runtime** (`Lisp.eval([:+, 1, 2])` returns
 Integer, but `Lisp.eval([:<, 1, 2])` returns bool), no RBS sig
 can express the relationship. That is what plugins are for —
 see [Chapter 9](09-plugins.md) and the
-[examples/](../../examples/README.md) directory.
+[examples/](https://github.com/rigortype/rigor/blob/master/examples/README.md) directory.
 
 ## What's next
 

--- a/docs/handbook/08-understanding-errors.md
+++ b/docs/handbook/08-understanding-errors.md
@@ -236,6 +236,6 @@ deprecations, …). Most projects will never write one; the
 chapter exists so you know the option is there.
 [Chapter 10 — Coexisting with Sorbet](10-sorbet.md) is for
 projects arriving from a Sorbet codebase: the
-[`rigor-sorbet`](../../plugins/rigor-sorbet/) adapter reads
+[`rigor-sorbet`](https://github.com/rigortype/rigor/tree/master/plugins/rigor-sorbet) adapter reads
 `sig { ... }` blocks, RBI files, and `T.let` / `T.cast` /
 `T.must` / `T.unsafe` assertions as type sources.

--- a/docs/handbook/09-plugins.md
+++ b/docs/handbook/09-plugins.md
@@ -6,10 +6,10 @@ RBS sig can express. This chapter helps you decide when that
 is worth a plugin, and when it is not.
 
 It does **not** teach plugin *authoring*. That lives in
-[`examples/`](../../examples/README.md) — six tutorial
+[`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) — six tutorial
 walkthroughs, each spotlighting one extension surface.
 Ready-to-install gems for real frameworks live in
-[`plugins/`](../../plugins/README.md), and activating one is
+[`plugins/`](https://github.com/rigortype/rigor/blob/master/plugins/README.md), and activating one is
 [manual — Using plugins](../manual/07-plugins.md). Read on to
 decide whether you need a plugin; go to `examples/` once you
 want to write one.
@@ -45,8 +45,8 @@ Other shapes that fit the plugin niche:
   lint time.
 
 Each of these has a worked example in
-[`examples/`](../../examples/README.md). The
-[`examples/README.md`](../../examples/README.md) page
+[`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md). The
+[`examples/README.md`](https://github.com/rigortype/rigor/blob/master/examples/README.md) page
 compares the six worked examples on architectural axes
 (config schema, file I/O, cache producers,
 engine-collaboration via `Scope#type_of`, cross-plugin facts,
@@ -66,7 +66,7 @@ authoring paths your DSL falls into.
 symbol arguments — a Rails-style `has_one_attached`, a
 dry-struct `attribute`, a Devise `devise :strategy`, a Sinatra
 `get "/foo" do … end` — the **macro-expansion substrate**
-([ADR-16](../adr/16-macro-expansion.md)) already knows that
+([ADR-16](https://github.com/rigortype/rigor/blob/master/docs/adr/16-macro-expansion.md)) already knows that
 shape. You write a manifest entry describing the call, and the
 substrate does the literal-symbol extraction, the name
 interpolation and the per-method synthesis. The three bundled
@@ -91,19 +91,19 @@ The two paths coexist — one plugin can declare substrate
 entries *and* walk files — and where you go next depends on
 which of them you need:
 
-- [`examples/README.md`](../../examples/README.md) — the six
+- [`examples/README.md`](https://github.com/rigortype/rigor/blob/master/examples/README.md) — the six
   walkthroughs, each spotlighting one contract surface, with a
   map of which example demonstrates which one.
-- [`docs/internal-spec/plugin.md`](../internal-spec/plugin.md)
+- [`docs/internal-spec/plugin.md`](https://github.com/rigortype/rigor/blob/master/docs/internal-spec/plugin.md)
   — the binding plugin contract: manifest, hooks, services,
   registry, load order. Its siblings
-  [`plugin-trust.md`](../internal-spec/plugin-trust.md) and
-  [`plugin-cache-producers.md`](../internal-spec/plugin-cache-producers.md)
+  [`plugin-trust.md`](https://github.com/rigortype/rigor/blob/master/docs/internal-spec/plugin-trust.md) and
+  [`plugin-cache-producers.md`](https://github.com/rigortype/rigor/blob/master/docs/internal-spec/plugin-cache-producers.md)
   cover the I/O and caching surfaces.
-- [`docs/internal-spec/macro-substrate.md`](../internal-spec/macro-substrate.md)
+- [`docs/internal-spec/macro-substrate.md`](https://github.com/rigortype/rigor/blob/master/docs/internal-spec/macro-substrate.md)
   — the substrate's tiers, the manifest field each one
   declares, and how much return-type precision each recovers.
-- [The macro-expansion library survey](../notes/20260515-macro-expansion-library-survey.md)
+- [The macro-expansion library survey](https://github.com/rigortype/rigor/blob/master/docs/notes/20260515-macro-expansion-library-survey.md)
   — which real Ruby libraries fit which tier, and which fall
   outside the substrate entirely.
 
@@ -120,9 +120,9 @@ Reach for a plugin only when:
 - The team can read the plugin's source — it is not a black
   box anyone can ignore.
 
-If those are true, [`examples/README.md`](../../examples/README.md)
+If those are true, [`examples/README.md`](https://github.com/rigortype/rigor/blob/master/examples/README.md)
 is your starting point. The
-[`rigor-deprecations`](../../examples/rigor-deprecations/)
+[`rigor-deprecations`](https://github.com/rigortype/rigor/tree/master/examples/rigor-deprecations)
 example is the smallest fully-shaped plugin — manifest +
 single per-file walk + a couple of diagnostic emissions —
 and is the recommended template for "I want to author my
@@ -144,10 +144,10 @@ From here:
   return to specific chapters as questions arise.
 - The [Handbook index](README.md) has the cross-references
   to deeper material in
-  [`docs/type-specification/`](../type-specification/README.md),
-  [`docs/internal-spec/`](../internal-spec/README.md), and
-  [`docs/adr/`](../adr/).
-- The [`CHANGELOG.md`](../../CHANGELOG.md) is the per-release
+  [`docs/type-specification/`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/README.md),
+  [`docs/internal-spec/`](https://github.com/rigortype/rigor/blob/master/docs/internal-spec/README.md), and
+  [`docs/adr/`](https://github.com/rigortype/rigor/tree/master/docs/adr).
+- The [`CHANGELOG.md`](https://github.com/rigortype/rigor/blob/master/CHANGELOG.md) is the per-release
   truth for what shipped when.
 
 Welcome to the small, growing community of static-Ruby

--- a/docs/handbook/10-sorbet.md
+++ b/docs/handbook/10-sorbet.md
@@ -1,7 +1,7 @@
 # Coexisting with Sorbet
 
 If your project already uses [Sorbet](https://sorbet.org/),
-the [`rigor-sorbet`](../../plugins/rigor-sorbet/) plugin
+the [`rigor-sorbet`](https://github.com/rigortype/rigor/tree/master/plugins/rigor-sorbet) plugin
 lets Rigor read your existing `sig` blocks, RBI files, and
 `T.let` / `T.cast` / `T.must` / `T.unsafe` assertions as type
 sources. You do not have to rewrite anything in RBS to start
@@ -290,7 +290,7 @@ wins. Sorbet sigs sit at Rigor's plugin tier:
 5. **User-class fallback** (`Object` / `Class` ancestors).
 
 The contribution merger (a v0.1.0 substrate documented in
-[`docs/internal-spec/flow-contribution-merger.md`](../internal-spec/flow-contribution-merger.md))
+[`docs/internal-spec/flow-contribution-merger.md`](https://github.com/rigortype/rigor/blob/master/docs/internal-spec/flow-contribution-merger.md))
 keeps RBS authoritative on conflict — the Sorbet sig is
 allowed to refine but not contradict it. Users who want
 their Sorbet sig to override should remove the conflicting
@@ -337,11 +337,11 @@ unit tests).
 ## Where to go next
 
 - The full feature matrix and architectural surface live in
-  [`plugins/rigor-sorbet/README.md`](../../plugins/rigor-sorbet/README.md).
+  [`plugins/rigor-sorbet/README.md`](https://github.com/rigortype/rigor/blob/master/plugins/rigor-sorbet/README.md).
 - The design rationale + slice plan is at
-  [`docs/adr/11-sorbet-input-adapter.md`](../adr/11-sorbet-input-adapter.md).
+  [`docs/adr/11-sorbet-input-adapter.md`](https://github.com/rigortype/rigor/blob/master/docs/adr/11-sorbet-input-adapter.md).
 - The cross-checker triage report at
-  [`docs/notes/20260503-steep-cross-check-triage.md`](../notes/20260503-steep-cross-check-triage.md)
+  [`docs/notes/20260503-steep-cross-check-triage.md`](https://github.com/rigortype/rigor/blob/master/docs/notes/20260503-steep-cross-check-triage.md)
   shows how Rigor's analyzer routinely surfaces sig drift
   that other static checkers miss — useful when comparing
   what each tool finds in practice.

--- a/docs/handbook/11-sig-gen.md
+++ b/docs/handbook/11-sig-gen.md
@@ -11,7 +11,7 @@ sees what Rigor sees.
 This chapter is a walkthrough of the command's UX, the
 classification model, the three output modes, and the
 `--params` policy trade-off that comes straight out of
-[ADR-5](../adr/5-robustness-principle.md)'s asymmetric
+[ADR-5](https://github.com/rigortype/rigor/blob/master/docs/adr/5-robustness-principle.md)'s asymmetric
 "strict on returns, lenient on parameters" rule.
 
 ## When to reach for it
@@ -166,7 +166,7 @@ two are wired today, one is reserved.
 | `observed-strict` | Reserved. Will additionally widen to capability roles (`_ToStr`, `_ToS`, …) once the role catalog ships. Currently rejected with a usage error. |
 
 The default deliberately favours `untyped` because of
-[ADR-5](../adr/5-robustness-principle.md)'s clause 2: a
+[ADR-5](https://github.com/rigortype/rigor/blob/master/docs/adr/5-robustness-principle.md)'s clause 2: a
 method's parameter contract should be the **most permissive**
 shape the body's logic justifies, not the most specific
 shape the current callers happen to use. Locking in
@@ -319,4 +319,4 @@ inference, not a separate analysis.
   *inside* a touched declaration's range.
 
 These are the ADR-14 deferred items; the design rationale
-is in [`docs/adr/14-rbs-sig-generation.md`](../adr/14-rbs-sig-generation.md).
+is in [`docs/adr/14-rbs-sig-generation.md`](https://github.com/rigortype/rigor/blob/master/docs/adr/14-rbs-sig-generation.md).

--- a/docs/handbook/12-lightweight-hkt.md
+++ b/docs/handbook/12-lightweight-hkt.md
@@ -20,7 +20,7 @@ assert_type(
 
 The mechanism behind this — and the one that lets you wire the
 same shape for your own DSL or stdlib method — is **Lightweight
-HKT** ([ADR-20](../adr/20-lightweight-hkt.md)), Rigor's
+HKT** ([ADR-20](https://github.com/rigortype/rigor/blob/master/docs/adr/20-lightweight-hkt.md)), Rigor's
 defunctionalised encoding of higher-kinded types in the
 [Yallop & White 2014](https://www.cl.cam.ac.uk/~jdy22/papers/lightweight-higher-kinded-polymorphism.pdf) /
 [fp-ts `URItoKind`](https://github.com/gcanti/fp-ts/blob/master/src/HKT.ts)
@@ -326,7 +326,7 @@ machinery:
 
 If you want to author your own overlay end-to-end, the
 worked example in
-[`spec/rigor/environment_spec.rb`](../../spec/rigor/environment_spec.rb)
+[`spec/rigor/environment_spec.rb`](https://github.com/rigortype/rigor/blob/master/spec/rigor/environment_spec.rb)
 ("ADR-20 HKT registry scan" context) is the smallest viable
 reference — a fixture `.rbs` file with the directive pair, a
 class declaration to anchor them on, and an `Environment.for_project`

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -18,7 +18,7 @@ on `nil` more than once, and you want to know:
 
 The handbook answers those questions. It does **not** try to
 replace the [normative type
-specification](../type-specification/README.md) — that lives
+specification](https://github.com/rigortype/rigor/blob/master/docs/type-specification/README.md) — that lives
 in `docs/type-specification/` and is the binding source when
 this handbook disagrees.
 
@@ -62,11 +62,11 @@ up the flag, key, or command that *acts* on it.
    The catalogue itself is
    [manual — Diagnostics](../manual/04-diagnostics.md).
 9. [**Plugins**](09-plugins.md) — when to author one,
-   pointer to the [examples/](../../examples/README.md)
+   pointer to the [examples/](https://github.com/rigortype/rigor/blob/master/examples/README.md)
    landing page.
 10. [**Coexisting with Sorbet**](10-sorbet.md) — for users
     arriving from a Sorbet-using project: the
-    [`rigor-sorbet`](../../plugins/rigor-sorbet/) adapter
+    [`rigor-sorbet`](https://github.com/rigortype/rigor/tree/master/plugins/rigor-sorbet) adapter
     reads `sig { ... }` blocks, RBI files, and
     `T.let` / `T.cast` / `T.must` / `T.unsafe` assertions
     as type sources without rewriting in RBS.
@@ -78,7 +78,7 @@ up the flag, key, or command that *acts* on it.
     trade-off, RSpec-aware observations.
 12. [**Lightweight HKT (JSON.parse and friends)**](12-lightweight-hkt.md)
     — Rigor's defunctionalised higher-kinded type encoding
-    ([ADR-20](../adr/20-lightweight-hkt.md), Yallop & White
+    ([ADR-20](https://github.com/rigortype/rigor/blob/master/docs/adr/20-lightweight-hkt.md), Yallop & White
     2014 / fp-ts shape). Covers the bundled `json::value`
     registration backing `JSON.parse` / `YAML.safe_load`,
     the `symbolize_names: true` + `permitted_classes: [...]`
@@ -154,7 +154,7 @@ choices.
   success-typing / no-false-positives stance shared with
   Dialyzer. Covers pattern matching + guards ↔ narrowing (the
   `flow.unreachable-clause` rule was modelled on Elixir's
-  clause-reachability work, [ADR-47](../adr/47-narrowing-driven-clause-reachability.md)),
+  clause-reachability work, [ADR-47](https://github.com/rigortype/rigor/blob/master/docs/adr/47-narrowing-driven-clause-reachability.md)),
   set-theoretic types ↔ Rigor's unions + `~T` / `T - U`
   operators, atoms ↔ symbols, and protocols / behaviours ↔
   structural interfaces.
@@ -173,7 +173,7 @@ contract) — so you reach for the right one.
   — RBS `interface` ↔ `typing.Protocol`, inferred object
   shapes and capability roles, and how all of that differs
   from the plugin-declared, path-scoped protocol contracts of
-  [ADR-28](../adr/28-path-scoped-protocol-contracts.md).
+  [ADR-28](https://github.com/rigortype/rigor/blob/master/docs/adr/28-path-scoped-protocol-contracts.md).
   Includes the side-by-side "interface vs protocol contract"
   table and a "which one do I want?" guide.
 
@@ -249,13 +249,13 @@ When a chapter references a more formal document, the link
 takes you out of the handbook into the binding spec corpus or
 ADRs:
 
-- [`docs/types.md`](../types.md) — one-page mental model.
-- [`docs/type-specification/`](../type-specification/README.md)
+- [`docs/types.md`](https://github.com/rigortype/rigor/blob/master/docs/types.md) — one-page mental model.
+- [`docs/type-specification/`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/README.md)
   — normative spec corpus.
-- [`docs/internal-spec/`](../internal-spec/README.md) —
+- [`docs/internal-spec/`](https://github.com/rigortype/rigor/blob/master/docs/internal-spec/README.md) —
   analyzer-internal contracts (engine surface, type-object
   public API).
-- [`docs/adr/`](../adr/) — architecture decision records.
+- [`docs/adr/`](https://github.com/rigortype/rigor/tree/master/docs/adr) — architecture decision records.
 
 ## Non-goals
 
@@ -268,9 +268,9 @@ hours. To keep it short:
   the spec corpus.
 - It does **not** discuss internal contracts (engine surface,
   type-object public API). Those live in
-  [`docs/internal-spec/`](../internal-spec/README.md).
+  [`docs/internal-spec/`](https://github.com/rigortype/rigor/blob/master/docs/internal-spec/README.md).
 - It does **not** cover plugin **authoring** — that is the
-  job of [examples/](../../examples/README.md). Chapter 9 is
+  job of [examples/](https://github.com/rigortype/rigor/blob/master/examples/README.md). Chapter 9 is
   a one-page pointer.
 
 If a topic comes up that the handbook does not explain, the

--- a/docs/handbook/appendix-elixir.md
+++ b/docs/handbook/appendix-elixir.md
@@ -11,7 +11,7 @@ prove will fail; so does Rigor. That instinct (never frighten
 working code) is shared DNA, not coincidence.
 
 There is even a direct lineage: Rigor's clause-reachability rule
-([ADR-47](../adr/47-narrowing-driven-clause-reachability.md)) was
+([ADR-47](https://github.com/rigortype/rigor/blob/master/docs/adr/47-narrowing-driven-clause-reachability.md)) was
 modelled on Elixir's own work on detecting impossible `case`
 clauses. You are coming from one of Rigor's design influences.
 
@@ -90,7 +90,7 @@ And the lineage runs the other way too: Rigor's
 `flow.unreachable-clause` rule — which flags a `case`/`in` clause
 that can never match because earlier clauses already covered its
 type — was modelled directly on Elixir's clause-reachability
-work ([ADR-47](../adr/47-narrowing-driven-clause-reachability.md)).
+work ([ADR-47](https://github.com/rigortype/rigor/blob/master/docs/adr/47-narrowing-driven-clause-reachability.md)).
 It is the feature you may know from Elixir warning you about an
 impossible `case` clause, brought to Ruby.
 
@@ -100,7 +100,7 @@ Elixir's type system is *set-theoretic*: types are sets of
 values, and you compose them with union, intersection, and
 negation, with a `dynamic()` type marking the gradual boundary.
 Rigor is built on the same union-of-values intuition (the
-[value lattice](../type-specification/value-lattice.md)) and has
+[value lattice](https://github.com/rigortype/rigor/blob/master/docs/type-specification/value-lattice.md)) and has
 the operator vocabulary to match the common cases:
 
 | Elixir | Rigor |

--- a/docs/handbook/appendix-go.md
+++ b/docs/handbook/appendix-go.md
@@ -105,7 +105,7 @@ type switches. Rigor has direct analogues.
 | `if x != nil` | `if x` (strips `nil`), or `unless x.nil?` |
 | `v, ok := x.(string)` (comma-ok assertion) | `x.is_a?(String)` narrowing in an `if` |
 | `switch v := x.(type) { case string: … }` | `case x; in String => v` |
-| `x.(T)` (assertion, panics on fail) | (no panicking assertion) — `is_a?` guard, or `T.cast` via [`rigor-sorbet`](../../plugins/rigor-sorbet/) |
+| `x.(T)` (assertion, panics on fail) | (no panicking assertion) — `is_a?` guard, or `T.cast` via [`rigor-sorbet`](https://github.com/rigortype/rigor/tree/master/plugins/rigor-sorbet) |
 | user func returning `bool` | `%a{rigor:v1:predicate-if-true x is Foo}` directive |
 
 Go's type switch is *not* exhaustive — you can omit cases and
@@ -114,7 +114,7 @@ report what they can prove, not what you forgot. (Where Rigor
 adds value is the dual: if a `case`/`in` clause can *never*
 match because earlier clauses already covered its type, the
 `flow.unreachable-clause` rule from
-[ADR-47](../adr/47-narrowing-driven-clause-reachability.md) says
+[ADR-47](https://github.com/rigortype/rigor/blob/master/docs/adr/47-narrowing-driven-clause-reachability.md) says
 so.)
 
 ## Errors as values vs raising
@@ -173,7 +173,7 @@ non-nil branch exactly as you would expect.
 
 A Go `struct` used as an immutable value maps onto Ruby's
 `Data.define` — value-equal, member-shaped, frozen. Rigor models
-it natively ([ADR-48](../adr/48-data-struct-value-folding.md)).
+it natively ([ADR-48](https://github.com/rigortype/rigor/blob/master/docs/adr/48-data-struct-value-folding.md)).
 
 ```go
 type Point struct{ X, Y int }

--- a/docs/handbook/appendix-java-csharp.md
+++ b/docs/handbook/appendix-java-csharp.md
@@ -58,7 +58,7 @@ advisor that only speaks when it is sure.
 | `Set<T>` | `HashSet<T>` / `ISet<T>` | `Set[T]` | |
 | `record Point(int x, int y)` | `record Point(int X, int Y)` | `Point = Data.define(:x, :y)` | See [Records ↔ Data.define](#records--datadefine). |
 | `Optional<T>` | `T?` (nullable reference type) | `T?` (i.e. `T \| nil`) | Java models it as a *container*; C# as a *type modifier*. See [Nullability](#nullability). |
-| `enum Color { RED, GREEN }` | `enum Color { Red, Green }` | `Constant<:red> \| Constant<:green>` (Symbol union) | Ruby has no native enum; the [`rigor-mangrove`](../../plugins/) plugin types richer enum DSLs. |
+| `enum Color { RED, GREEN }` | `enum Color { Red, Green }` | `Constant<:red> \| Constant<:green>` (Symbol union) | Ruby has no native enum; the [`rigor-mangrove`](https://github.com/rigortype/rigor/tree/master/plugins) plugin types richer enum DSLs. |
 | `sealed interface Shape permits …` | `abstract` base + sealed hierarchy | union of the subtypes | See [Sealed types & exhaustiveness](#sealed-types-and-exhaustiveness). |
 | `<T>` (generic) | `<T>` (generic) | RBS `[T]` type parameter | |
 | `? extends T` (use-site) | `out T` (declaration-site) | covariant type parameter | See [Generics & variance](#generics-and-variance). |
@@ -107,7 +107,7 @@ When you DO need to write a sig — at a public boundary, when a
 body is too dynamic, when you want to *enforce* a parameter
 shape rather than observe it — it goes into `sig/<file>.rbs`,
 never into the `.rb` source. That separation is deliberate (see
-[ADR-1](../adr/1-types.md) and [ADR-5](../adr/5-robustness-principle.md));
+[ADR-1](https://github.com/rigortype/rigor/blob/master/docs/adr/1-types.md) and [ADR-5](https://github.com/rigortype/rigor/blob/master/docs/adr/5-robustness-principle.md));
 it is the analogue of keeping declarations out of your method
 bodies, except Rigor keeps them out of the *file*.
 
@@ -124,7 +124,7 @@ behaviour matches.
 | `x instanceof String` | `x is string` | `x.is_a?(String)` |
 | `x instanceof String s` (binding) | `x is string s` (binding) | `case x; in String => s` |
 | `switch (x) { case Foo f -> … }` | `switch (x) { case Foo f => … }` | `case x; in Foo => f` |
-| `(Foo) x` (cast) | `(Foo)x` (cast) | (no in-source cast) — `is_a?` guard, or `T.cast` via [`rigor-sorbet`](../../plugins/rigor-sorbet/) |
+| `(Foo) x` (cast) | `(Foo)x` (cast) | (no in-source cast) — `is_a?` guard, or `T.cast` via [`rigor-sorbet`](https://github.com/rigortype/rigor/tree/master/plugins/rigor-sorbet) |
 | `Objects.requireNonNull(x)` | `x!` (null-forgiving) | (no in-source assertion) — `unless x.nil?`, or `T.must` via `rigor-sorbet` |
 | user method returning `boolean` | user method returning `bool` | `%a{rigor:v1:predicate-if-true x is Foo}` directive on the predicate |
 
@@ -146,7 +146,7 @@ equivalents are:
 A Java `record` or a C# positional `record` maps almost exactly
 onto Ruby's `Data.define` — an immutable, value-equal, member-
 shaped aggregate. Rigor models it natively
-([ADR-48](../adr/48-data-struct-value-folding.md)).
+([ADR-48](https://github.com/rigortype/rigor/blob/master/docs/adr/48-data-struct-value-folding.md)).
 
 ```java
 // Java 21
@@ -258,7 +258,7 @@ it is not. Rigor approaches the same shape from the other side.
 
 A closed set of subtypes is a union in Rigor, and the flow
 engine tracks which `case`/`when` and `case`/`in` clauses can
-still match. [ADR-47](../adr/47-narrowing-driven-clause-reachability.md)'s
+still match. [ADR-47](https://github.com/rigortype/rigor/blob/master/docs/adr/47-narrowing-driven-clause-reachability.md)'s
 `flow.unreachable-clause` rule fires when a clause is provably
 dead — its subject has already been narrowed to `Bot` by the
 prior clauses (per-clause disjointness) or by prior exhaustion:

--- a/docs/handbook/appendix-liskov.md
+++ b/docs/handbook/appendix-liskov.md
@@ -22,7 +22,7 @@ SOLID, and the same one a careful duck-typer follows by instinct.
 
 > **A note on the acronym.** Everywhere else in this repository
 > "LSP" means the **Language Server Protocol**
-> ([ADR-19](../adr/19-language-server-packaging.md), `rigor lsp`).
+> ([ADR-19](https://github.com/rigortype/rigor/blob/master/docs/adr/19-language-server-packaging.md), `rigor lsp`).
 > On *this* page, and only this page, "LSP" means the **Liskov
 > Substitution Principle**. The collision is unfortunate and
 > entirely conventional; the rest of the corpus keeps the
@@ -30,14 +30,14 @@ SOLID, and the same one a careful duck-typer follows by instinct.
 
 This page is descriptive, not normative. When the language here
 disagrees with the [type
-specification](../type-specification/README.md), the spec binds.
+specification](https://github.com/rigortype/rigor/blob/master/docs/type-specification/README.md), the spec binds.
 
 ## Five-second pitch
 
 | LSP obligation | Ruby idiom that already honours it | Rigor surface |
 | --- | --- | --- |
 | A subtype may be substituted wherever the supertype is expected | Duck typing — "if it responds to the messages I send, I can use it" | Nominal-first typing + structural facets + capability roles |
-| **Signature rule** — parameters contravariant, returns covariant | "Accept the widest thing you can use; return the most specific thing you can promise" | The **robustness principle** ([ADR-5](../adr/5-robustness-principle.md)) — lenient parameters (clause 2), strict returns (clause 1) |
+| **Signature rule** — parameters contravariant, returns covariant | "Accept the widest thing you can use; return the most specific thing you can promise" | The **robustness principle** ([ADR-5](https://github.com/rigortype/rigor/blob/master/docs/adr/5-robustness-principle.md)) — lenient parameters (clause 2), strict returns (clause 1) |
 | **Preconditions may not be strengthened** in a subtype | An override should not reject inputs the parent accepted | Clause 2: parameters widened to the largest correctness-preserving carrier |
 | **Postconditions may not be weakened** in a subtype | An override should not return something less specific than the parent promised | Clause 1: returns tightened to the smallest correctness-preserving carrier; `def.return-type-mismatch` |
 | **Invariants must be preserved**; **history constraint** | Don't add state transitions that break the parent's invariants; respect `freeze` | Mutation-effect model + fact stability + `frozen?` narrowing (partial; see § "Invariants") |
@@ -179,7 +179,7 @@ the result as a `T`, so `S`'s method must return something every
 
 **Rigor's derivation is bottom-up.** ADR-5 starts from a Ruby-
 adoption problem, not a substitutability proof
-([`robustness-principle.md`](../type-specification/robustness-principle.md)):
+([`robustness-principle.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/robustness-principle.md)):
 
 - An over-strict **parameter** type forces callers to paste
   defensive coercions (`x.to_s`, `x || ""`, `Array(x)`) at every
@@ -299,14 +299,14 @@ manufacture a precondition ("this exact class") the runtime never
 required. Strengthening the precondition would mean firing a false
 positive on working duck-typed code — which collides head-on with
 the project's [false-positive
-discipline](../adr/8-steep-inspired-improvements.md). LSP and "never
+discipline](https://github.com/rigortype/rigor/blob/master/docs/adr/8-steep-inspired-improvements.md). LSP and "never
 frighten working code" point the same way.
 
 ## Postconditions: covariant returns and `self` types
 
 "**Postconditions may not be weakened**" is clause 1, and it has a
 concrete enforcement surface: **`def.return-type-mismatch`**
-([ADR-8](../adr/8-steep-inspired-improvements.md)). When a method
+([ADR-8](https://github.com/rigortype/rigor/blob/master/docs/adr/8-steep-inspired-improvements.md)). When a method
 carries a declared RBS return type and the body's inferred type
 *cannot satisfy* it, Rigor emits an error:
 
@@ -428,7 +428,7 @@ end
 ```
 
 A *sound* checker would flag the override. Rigor, by its
-[no-false-positives stance](../adr/8-steep-inspired-improvements.md),
+[no-false-positives stance](https://github.com/rigortype/rigor/blob/master/docs/adr/8-steep-inspired-improvements.md),
 does **not** bark at every override — because in Ruby, overriding
 with a changed shape is frequently *intentional and correct*
 (template-method refinements, `method_missing`, DSL-driven
@@ -459,7 +459,7 @@ its defaults rather than policing it through diagnostics.
 
 ## Cross-hierarchy override compatibility
 
-Since v0.1.15 ([ADR-35](../adr/35-override-signature-compatibility.md)),
+Since v0.1.15 ([ADR-35](https://github.com/rigortype/rigor/blob/master/docs/adr/35-override-signature-compatibility.md)),
 Rigor *does* compare an override against the contract it inherits —
 the signature rule applied across a project-defined class/module
 hierarchy. Three rules make up the `def.override-*` family:
@@ -504,7 +504,7 @@ enforce in v0.1.x — named here so you can stop looking:
   The shipped `def.override-*` family (§ "Cross-hierarchy override
   compatibility" above) gates on *both sides carrying an authored
   signature*. The complementary case — checking a child's *inferred*
-  return against an authored parent return ([ADR-35](../adr/35-override-signature-compatibility.md)
+  return against an authored parent return ([ADR-35](https://github.com/rigortype/rigor/blob/master/docs/adr/35-override-signature-compatibility.md)
   slice 5) — plus RBS-only-ancestor reach and singleton (`def self.`)
   method coverage remain deferred (demand-driven, higher
   false-positive surface).
@@ -554,8 +554,8 @@ model"](appendix-type-theory.md#what-rigor-does-not-model) records.
   "L" in SOLID — substitutability as a practical design test,
   no type theory required.
 - See also the companion [§ "Robustness principle (Postel's law for
-  types)"](../type-specification/robustness-principle.md) (normative)
-  and [ADR-5](../adr/5-robustness-principle.md) (rationale) — the
+  types)"](https://github.com/rigortype/rigor/blob/master/docs/type-specification/robustness-principle.md) (normative)
+  and [ADR-5](https://github.com/rigortype/rigor/blob/master/docs/adr/5-robustness-principle.md) (rationale) — the
   Rigor surface this page maps LSP onto.
 
 ## What's next

--- a/docs/handbook/appendix-mypy.md
+++ b/docs/handbook/appendix-mypy.md
@@ -296,7 +296,7 @@ draws the distinction in full.
   Pyright's "type alias narrowing" and mypy's overload stacks
   cover some cases; Rigor's plugin contract gives you full
   Ruby code at the dispatch point. The
-  [`rigor-lisp-eval`](../../examples/rigor-lisp-eval/) example
+  [`rigor-lisp-eval`](https://github.com/rigortype/rigor/tree/master/examples/rigor-lisp-eval) example
   is the canonical demo — `Lisp.eval([:+, 1, 2])` returns
   `Integer`, `Lisp.eval([:<, 1, 2])` returns `bool`.
 

--- a/docs/handbook/appendix-phpstan.md
+++ b/docs/handbook/appendix-phpstan.md
@@ -112,7 +112,7 @@ Rigor's analogue is a plugin's `narrowing_facts` / `dynamic_return` and
 | `DynamicFunctionReturnTypeExtension` | Same, for module-level methods |
 
 The plugin contract pinned at
-[`docs/internal-spec/plugin.md`](../internal-spec/plugin.md)
+[`docs/internal-spec/plugin.md`](https://github.com/rigortype/rigor/blob/master/docs/internal-spec/plugin.md)
 gives every shape PHPStan's extension API covers, with
 analogous lifecycle (manifest declaration, per-call dispatch,
 fact emission). Chapter 9 has the high-level orientation; the

--- a/docs/handbook/appendix-protocols-and-structural-typing.md
+++ b/docs/handbook/appendix-protocols-and-structural-typing.md
@@ -10,7 +10,7 @@ That instinct is right, but the *word* is a trap in Rigor. Rigor's
 structural-typing feature is not called "protocol" — it is the RBS
 **`interface`**. Meanwhile "protocol" *does* appear in Rigor, naming
 a **different** feature: a framework's path-scoped *behavioural
-contract* ([ADR-28](../adr/28-path-scoped-protocol-contracts.md)).
+contract* ([ADR-28](https://github.com/rigortype/rigor/blob/master/docs/adr/28-path-scoped-protocol-contracts.md)).
 This appendix untangles the two so you reach for the right one.
 
 > **The one-line version.** Rigor's `interface` is **structural** —
@@ -64,7 +64,7 @@ end
 A class that defines `close` with a compatible signature satisfies
 the interface **with no `include`, no superclass, and no runtime
 marker** — the match is structural. From the normative spec
-([`structural-interfaces-and-object-shapes.md`](../type-specification/structural-interfaces-and-object-shapes.md)):
+([`structural-interfaces-and-object-shapes.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/structural-interfaces-and-object-shapes.md)):
 
 > An RBS interface type … is a *named structural contract*. A
 > nominal type or object shape is assignable to an interface when
@@ -228,8 +228,8 @@ author):
 - The `missing-protocol-method` / `protocol-return-mismatch`
   diagnostics are **plugin diagnostics**, emitted under the
   plugin's `plugin.<id>.` provenance — not core Rigor rules. The
-  worked references are [`examples/rigor-web/`](../../examples/rigor-web/)
-  (the minimal tutorial) and [`plugins/rigor-hanami/`](../../plugins/rigor-hanami/)
+  worked references are [`examples/rigor-web/`](https://github.com/rigortype/rigor/tree/master/examples/rigor-web)
+  (the minimal tutorial) and [`plugins/rigor-hanami/`](https://github.com/rigortype/rigor/tree/master/plugins/rigor-hanami)
   (production Hanami 2 actions).
 
 ## Interface vs protocol contract
@@ -262,8 +262,8 @@ contract*, while Python's `typing.Protocol` reused the word for the
 - You want to **enforce that every class in a directory implements
   a framework method with given parameter/return types** → that is
   a **protocol contract**, and it is a *plugin-authoring* feature.
-  See [ADR-28](../adr/28-path-scoped-protocol-contracts.md) and the
-  [`examples/`](../../examples/README.md) walkthroughs.
+  See [ADR-28](https://github.com/rigortype/rigor/blob/master/docs/adr/28-path-scoped-protocol-contracts.md) and the
+  [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) walkthroughs.
 - You are an **application developer** using such a framework → you
   do neither explicitly. Write idiomatic Ruby; the framework's
   plugin supplies the contract, and Rigor checks your actions
@@ -276,12 +276,12 @@ contract*, while Python's `typing.Protocol` reused the word for the
 - [Chapter 7 — RBS and RBS::Extended](07-rbs-and-extended.md) — how
   to write the `.rbs` an interface lives in.
 - [Chapter 9 — Plugins](09-plugins.md) and the
-  [examples/ landing page](../../examples/README.md) — where
+  [examples/ landing page](https://github.com/rigortype/rigor/blob/master/examples/README.md) — where
   protocol contracts are authored.
-- [`docs/type-specification/structural-interfaces-and-object-shapes.md`](../type-specification/structural-interfaces-and-object-shapes.md)
+- [`docs/type-specification/structural-interfaces-and-object-shapes.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/structural-interfaces-and-object-shapes.md)
   — the normative spec for interfaces, object shapes, and
   capability roles.
-- [ADR-28](../adr/28-path-scoped-protocol-contracts.md) — the
+- [ADR-28](https://github.com/rigortype/rigor/blob/master/docs/adr/28-path-scoped-protocol-contracts.md) — the
   protocol-contract design decision and its rejected alternatives
   (including *why* an RBS interface bound by directory was not the
   route).

--- a/docs/handbook/appendix-rust.md
+++ b/docs/handbook/appendix-rust.md
@@ -91,7 +91,7 @@ The reflex to drop is `unwrap()`. In Rust you reach for
 `.unwrap()` / `.expect()` when you *know* it is `Some`. Rigor
 has no in-source assertion that lies to the checker; the
 equivalents are a `nil?` guard (checked, not asserted) or
-`T.must` via the [`rigor-sorbet`](../../plugins/rigor-sorbet/)
+`T.must` via the [`rigor-sorbet`](https://github.com/rigortype/rigor/tree/master/plugins/rigor-sorbet)
 plugin (see [Chapter 10](10-sorbet.md)).
 
 **`Result<T, E>` ↔ exceptions.** Here the models diverge. Ruby
@@ -175,7 +175,7 @@ end
 ```
 
 The crucial difference is *direction*.
-[ADR-47](../adr/47-narrowing-driven-clause-reachability.md)'s
+[ADR-47](https://github.com/rigortype/rigor/blob/master/docs/adr/47-narrowing-driven-clause-reachability.md)'s
 `flow.unreachable-clause` rule fires when a clause is provably
 *dead* — its subject already narrowed to `Bot` by prior clauses
 or prior exhaustion:
@@ -203,7 +203,7 @@ of Rust's `_ => unreachable!()`.
 
 A Rust `struct` maps onto Ruby's `Data.define` — an immutable,
 value-equal, member-shaped aggregate. Rigor models it natively
-([ADR-48](../adr/48-data-struct-value-folding.md)).
+([ADR-48](https://github.com/rigortype/rigor/blob/master/docs/adr/48-data-struct-value-folding.md)).
 
 ```rust
 struct Point { x: i32, y: i32 }

--- a/docs/handbook/appendix-steep.md
+++ b/docs/handbook/appendix-steep.md
@@ -83,7 +83,7 @@ expectation even if Rigor knows the result is
 `non-empty-lowercase-string` internally.
 
 This erasure contract is documented at
-[`docs/type-specification/rbs-erasure.md`](../type-specification/rbs-erasure.md).
+[`docs/type-specification/rbs-erasure.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/rbs-erasure.md).
 
 ## Annotations in `.rb` source
 
@@ -164,7 +164,7 @@ A practical implication: a project that runs both Steep and
 Rigor will see overlapping diagnostics on shape errors and
 complementary diagnostics on the things each tool catches that
 the other does not. The
-[`docs/notes/20260503-steep-cross-check-triage.md`](../notes/20260503-steep-cross-check-triage.md)
+[`docs/notes/20260503-steep-cross-check-triage.md`](https://github.com/rigortype/rigor/blob/master/docs/notes/20260503-steep-cross-check-triage.md)
 note is a worked example — Steep and Rigor were run against
 the same project and the diagnostic streams categorised.
 
@@ -325,7 +325,7 @@ section sequentially. Three useful pointers:
   [manual — Diagnostics](../manual/04-diagnostics.md) for the
   rule catalogue and severity profiles — the analogue to
   Steep's diagnostic config.
-- [`docs/notes/20260503-steep-cross-check-triage.md`](../notes/20260503-steep-cross-check-triage.md)
+- [`docs/notes/20260503-steep-cross-check-triage.md`](https://github.com/rigortype/rigor/blob/master/docs/notes/20260503-steep-cross-check-triage.md)
   for a worked side-by-side run of Steep and Rigor on the
   same project (the project itself).
 

--- a/docs/handbook/appendix-type-theory.md
+++ b/docs/handbook/appendix-type-theory.md
@@ -9,7 +9,7 @@ recognise the corresponding Rigor surface immediately.
 
 This page is descriptive, not normative. When the formal language
 here disagrees with the [type
-specification](../type-specification/README.md), the spec binds.
+specification](https://github.com/rigortype/rigor/blob/master/docs/type-specification/README.md), the spec binds.
 
 ## Five-second pitch
 
@@ -60,8 +60,8 @@ assert_type("\"a\" | 1", n)
 # Mostly arises during refinement combinations
 ```
 
-Spec: [`docs/type-specification/value-lattice.md`](../type-specification/value-lattice.md),
-[`docs/type-specification/special-types.md`](../type-specification/special-types.md).
+Spec: [`docs/type-specification/value-lattice.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/value-lattice.md),
+[`docs/type-specification/special-types.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/special-types.md).
 
 ## Set-theoretic foundations of the lattice
 
@@ -125,7 +125,7 @@ still tractable.
 Rigor's lattice **is** set-theoretic in spirit:
 
 - `T | U`, `T & U`, `T - U` are present at the surface
-  ([`docs/type-specification/type-operators.md`](../type-specification/type-operators.md)).
+  ([`docs/type-specification/type-operators.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/type-operators.md)).
 - Top / Bot behave as the universal / empty sets.
 - The difference operator `T - U` is what lets occurrence typing
   express "in the `else` branch of `if x.is_a?(String)`, the type
@@ -147,7 +147,7 @@ system in the Castagna sense. Three reasons:
 3. **Implementation cost.** Castagna's decision procedure is
    theoretically elegant but operationally heavy for an analyser
    that walks an AST per file under a per-file budget
-   ([`inference-budgets.md`](../type-specification/inference-budgets.md)).
+   ([`inference-budgets.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/inference-budgets.md)).
 
 Rigor's `T | U` / `T & U` / `T - U` operators are best read
 with the set-theoretic interpretation in mind, even though
@@ -188,7 +188,7 @@ add_one("a")  # certainty: no — call.argument-type-mismatch fires
 add_one(JSON.parse(input))  # certainty: maybe — silent
 ```
 
-Spec: [`docs/type-specification/relations-and-certainty.md`](../type-specification/relations-and-certainty.md).
+Spec: [`docs/type-specification/relations-and-certainty.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/relations-and-certainty.md).
 
 ## Nominal vs structural typing
 
@@ -233,7 +233,7 @@ end
 ```
 
 Spec:
-[`docs/type-specification/structural-interfaces-and-object-shapes.md`](../type-specification/structural-interfaces-and-object-shapes.md).
+[`docs/type-specification/structural-interfaces-and-object-shapes.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/structural-interfaces-and-object-shapes.md).
 
 ## Polymorphism
 
@@ -262,7 +262,7 @@ total([1, 2.0, 3])    # ns: Array[Numeric]
 [1, 2] * 3  # Array overload
 ```
 
-Spec: [`docs/type-specification/rbs-compatible-types.md`](../type-specification/rbs-compatible-types.md).
+Spec: [`docs/type-specification/rbs-compatible-types.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/rbs-compatible-types.md).
 
 ## F-bounded polymorphism and self types
 
@@ -389,7 +389,7 @@ overwhelmingly reason in nominal classes rather than structural
 rows.
 
 The [Rigor-perspective review of the
-paper](../notes/20260518-matsumoto-2008-poly-records-rigor-review.md)
+paper](https://github.com/rigortype/rigor/blob/master/docs/notes/20260518-matsumoto-2008-poly-records-rigor-review.md)
 records the retrospective: the experiment *worked* but it
 **retroactively justified Rigor's nominal-first design** rather
 than recommending row variables as the primary modeling tool.
@@ -482,7 +482,7 @@ it has not landed at the user surface in v0.1.x:
 - **Inference cost.** Garrigue-kinded inference is decidable but
   more expensive than Rigor's local walker; the analyser's
   per-file budget (see
-  [`inference-budgets.md`](../type-specification/inference-budgets.md))
+  [`inference-budgets.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/inference-budgets.md))
   would have to accommodate global row-constraint solving.
 - **Readability.** The Matsumoto experiment found that inferred
   row-polymorphic types for everyday Ruby code are dense and hard
@@ -549,8 +549,8 @@ end
 This is the practical payoff of refinement subtyping without
 asking the user to author the refinement.
 
-Spec: [`docs/type-specification/imported-built-in-types.md`](../type-specification/imported-built-in-types.md),
-[`docs/type-specification/rigor-extensions.md`](../type-specification/rigor-extensions.md).
+Spec: [`docs/type-specification/imported-built-in-types.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/imported-built-in-types.md),
+[`docs/type-specification/rigor-extensions.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/rigor-extensions.md).
 
 ## Occurrence typing (flow-sensitive narrowing)
 
@@ -591,8 +591,8 @@ def describe(x)
 end
 ```
 
-Spec: [`docs/type-specification/control-flow-analysis.md`](../type-specification/control-flow-analysis.md),
-[`docs/type-specification/rbs-extended.md`](../type-specification/rbs-extended.md).
+Spec: [`docs/type-specification/control-flow-analysis.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/control-flow-analysis.md),
+[`docs/type-specification/rbs-extended.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/rbs-extended.md).
 
 ## Pattern matching and exhaustiveness
 
@@ -709,7 +709,7 @@ Rigor maps onto this as:
 | Dynamic type `?` | **`Dynamic[T]`** — a carrier that *wraps* a "best-guess" type `T` while marking the value as not-statically-verified. `Dynamic[top]` is the maximally-dynamic form. |
 | Consistency `~` | The `maybe` arm of the trinary certainty — `Dynamic[T] ~ U` holds whenever `T ~ U` does. |
 | Static/dynamic boundary | Per-method, per-file, per-plugin contribution — Rigor records *why* a value became `Dynamic[T]` in its dynamic-origin algebra. |
-| Casts | No in-source cast operator. The opt-in [`rigor-sorbet`](../../plugins/rigor-sorbet/) plugin reads `T.let` / `T.cast` / `T.must` as cast forms; `RBS::Extended` `assert_type` directives serve the same role from `.rbs`. |
+| Casts | No in-source cast operator. The opt-in [`rigor-sorbet`](https://github.com/rigortype/rigor/tree/master/plugins/rigor-sorbet) plugin reads `T.let` / `T.cast` / `T.must` as cast forms; `RBS::Extended` `assert_type` directives serve the same role from `.rbs`. |
 
 Two Rigor-specific extensions matter:
 
@@ -721,10 +721,10 @@ Two Rigor-specific extensions matter:
 2. **The robustness principle (Postel's law for types)** —
    parameters are accepted leniently (closer to `Dynamic[T]`),
    returns are reported strictly. See
-   [ADR-5](../adr/5-robustness-principle.md).
+   [ADR-5](https://github.com/rigortype/rigor/blob/master/docs/adr/5-robustness-principle.md).
 
-Spec: [`docs/type-specification/special-types.md`](../type-specification/special-types.md),
-[`docs/type-specification/value-lattice.md`](../type-specification/value-lattice.md).
+Spec: [`docs/type-specification/special-types.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/special-types.md),
+[`docs/type-specification/value-lattice.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/value-lattice.md).
 
 ## Blame, the gradual guarantee, and trust boundaries
 
@@ -776,7 +776,7 @@ The **gradual guarantee** *is* a property Rigor can be measured
 against:
 
 - **In spirit**, the no-false-positives stance
-  ([ADR-5](../adr/5-robustness-principle.md)) is strictly
+  ([ADR-5](https://github.com/rigortype/rigor/blob/master/docs/adr/5-robustness-principle.md)) is strictly
   stronger than the gradual guarantee. If Rigor was silent on a
   call site before an annotation was added, it remains silent
   after — unless the annotation provably contradicts the runtime
@@ -787,14 +787,14 @@ against:
 - **In practice**, the gradual guarantee in Rigor reads as: a
   project's baseline of "passes without annotation" should never
   regress when an RBS file is added. This is exactly the property
-  the [PHPStan-shaped baseline mechanism](../adr/22-baseline-and-project-onboarding.md)
+  the [PHPStan-shaped baseline mechanism](https://github.com/rigortype/rigor/blob/master/docs/adr/22-baseline-and-project-onboarding.md)
   enforces — adding annotations shrinks the baseline; it never
   grows it on un-annotated code.
 
 ### What Rigor explicitly does NOT do
 
 - **Runtime contract insertion at the static / dynamic boundary.**
-  The opt-in [`rigor-sorbet`](../../plugins/rigor-sorbet/) plugin
+  The opt-in [`rigor-sorbet`](https://github.com/rigortype/rigor/tree/master/plugins/rigor-sorbet) plugin
   reads Sorbet's `T.let` / `T.cast` / `T.must` as cast forms, but
   the contract *enforcement* is `sorbet-runtime`'s job, not
   Rigor's. Rigor's static analysis uses the cast as a hint, not
@@ -837,7 +837,7 @@ inferred from the AST walk and consulted by the narrowing logic.
 Future plugin / annotation extensions to surface effects at the
 user level are tracked in the spec corpus but not part of v0.1.x.
 
-Spec: [`docs/type-specification/control-flow-analysis.md`](../type-specification/control-flow-analysis.md)
+Spec: [`docs/type-specification/control-flow-analysis.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/control-flow-analysis.md)
 ("Mutation effects" subsection).
 
 ## Soundness, completeness, and the no-false-positives stance
@@ -863,7 +863,7 @@ This is a deliberate design choice grounded in the project's
 audience: Ruby programmers who would otherwise not run a type
 checker at all. A noisy false-positive on the first day kills
 adoption faster than a missed bug on day 30. The robustness
-principle ([ADR-5](../adr/5-robustness-principle.md)) is the
+principle ([ADR-5](https://github.com/rigortype/rigor/blob/master/docs/adr/5-robustness-principle.md)) is the
 formal expression of this stance: lenient on parameters
 ("anyone could call this with anything"), strict on returns
 ("we will commit to what we actually return").
@@ -1101,7 +1101,7 @@ Rigor's walker performs the two modes without naming them:
 | Inferring `HashShape` for a hash literal | Synthesis |
 | Inferring `Tuple` for an array literal | Synthesis |
 | Walking the `then` / `else` branches of an `if` under a narrowed environment | Synthesis under each branch + join (no expected-type checking) |
-| Verifying a plugin protocol contract ([ADR-28](../adr/28-path-scoped-protocol-contracts.md)) — method exists + return-type matches | Checking |
+| Verifying a plugin protocol contract ([ADR-28](https://github.com/rigortype/rigor/blob/master/docs/adr/28-path-scoped-protocol-contracts.md)) — method exists + return-type matches | Checking |
 | Honouring an `RBS::Extended` `assert_type` directive | Checking |
 
 What Rigor does NOT do that a fully formalised bidirectional
@@ -1173,7 +1173,7 @@ problem, distinct from the decidability problem:
 | Problem class | Example | Rigor's response |
 | --- | --- | --- |
 | Theoretical undecidability of inference | Rank-3 polymorphism; subtyping + intersection | The trinary `maybe` |
-| Reach — the AST does not contain the semantics | `define_method`, Rails DSL, `attr_*` | Plugin contributions + `RBS::Extended` + the [ADR-16](../adr/16-macro-expansion.md) macro substrate |
+| Reach — the AST does not contain the semantics | `define_method`, Rails DSL, `attr_*` | Plugin contributions + `RBS::Extended` + the [ADR-16](https://github.com/rigortype/rigor/blob/master/docs/adr/16-macro-expansion.md) macro substrate |
 | Genuine runtime opacity | `eval(user_input)` | `Dynamic[top]`, then `maybe` at use sites |
 
 Plugins are written in Ruby because the reach problem cannot be
@@ -1181,10 +1181,10 @@ solved in the type language alone — it needs a Ruby-side
 recogniser that walks the AST, decides "this `has_many :posts`
 declares an accessor returning `Relation[Post]`," and contributes
 that fact to the walker's worldview.
-[ADR-2](../adr/2-extension-api.md),
-[ADR-16](../adr/16-macro-expansion.md),
-[ADR-25](../adr/25-plugin-contributed-rbs.md), and
-[ADR-28](../adr/28-path-scoped-protocol-contracts.md) define the
+[ADR-2](https://github.com/rigortype/rigor/blob/master/docs/adr/2-extension-api.md),
+[ADR-16](https://github.com/rigortype/rigor/blob/master/docs/adr/16-macro-expansion.md),
+[ADR-25](https://github.com/rigortype/rigor/blob/master/docs/adr/25-plugin-contributed-rbs.md), and
+[ADR-28](https://github.com/rigortype/rigor/blob/master/docs/adr/28-path-scoped-protocol-contracts.md) define the
 structured extension points where this knowledge enters.
 
 ### Precision: naive inference produces useless joins
@@ -1198,7 +1198,7 @@ produce types so wide they tell the user nothing useful:
 | `{user: u, count: 3, msg: "ok"}` | `Hash[Symbol, User \| Integer \| String]` | `HashShape{user: User, count: Integer, msg: String}` | `HashShape` carrier (built-in for hash literals) |
 | `[1, "a", :sym]` | `Array[Integer \| String \| Symbol]` | `Tuple[Integer, String, Symbol]` | `Tuple` carrier (built-in for array literals) |
 | A provably-constant value (e.g. `42`, `"ok"`) | `Integer`, `String` | `Constant<42>`, `Constant<"ok">` | `Constant<T>` carrier |
-| `JSON.parse(input)` | `Hash[String, untyped] \| Array[untyped] \| String \| Integer \| Float \| true \| false \| nil` | `App[json::value, K]` per option `K` | [ADR-20](../adr/20-lightweight-hkt.md) Lightweight HKT + `METHOD_RETURN_OVERRIDES` |
+| `JSON.parse(input)` | `Hash[String, untyped] \| Array[untyped] \| String \| Integer \| Float \| true \| false \| nil` | `App[json::value, K]` per option `K` | [ADR-20](https://github.com/rigortype/rigor/blob/master/docs/adr/20-lightweight-hkt.md) Lightweight HKT + `METHOD_RETURN_OVERRIDES` |
 | A method whose return depends on its arguments | A wide union of every observed exit | A per-call-site discriminated return | `RBS::Extended` `return_override` directive |
 | A DSL-managed accessor (`has_many`, `attribute`) | `Dynamic[top]` | `Relation[Model]`, a model-specific shape | Plugin `dynamic_return` + macro substrate |
 
@@ -1211,7 +1211,7 @@ anything with it without narrowing first; the union has erased
 exactly the information the type system existed to carry.
 
 The shared design principle is **strictness on returns** — the
-robustness principle ([ADR-5](../adr/5-robustness-principle.md))
+robustness principle ([ADR-5](https://github.com/rigortype/rigor/blob/master/docs/adr/5-robustness-principle.md))
 treats "the most specific type the analysis can justify" as the
 goal, not "the smallest type that covers every observed exit."
 Naive join-widening fails that test in nearly every case where
@@ -1269,19 +1269,19 @@ trades safety for flexibility.
 
 ### Rigor's plugin contract as the tool-side answer
 
-Rigor's plugin substrate ([ADR-2](../adr/2-extension-api.md),
-[ADR-16](../adr/16-macro-expansion.md),
-[ADR-25](../adr/25-plugin-contributed-rbs.md),
-[ADR-28](../adr/28-path-scoped-protocol-contracts.md), …) solves
+Rigor's plugin substrate ([ADR-2](https://github.com/rigortype/rigor/blob/master/docs/adr/2-extension-api.md),
+[ADR-16](https://github.com/rigortype/rigor/blob/master/docs/adr/16-macro-expansion.md),
+[ADR-25](https://github.com/rigortype/rigor/blob/master/docs/adr/25-plugin-contributed-rbs.md),
+[ADR-28](https://github.com/rigortype/rigor/blob/master/docs/adr/28-path-scoped-protocol-contracts.md), …) solves
 the **tool-level** version of the same problem:
 
 - **Adding new type knowledge** the engine can act on — new RBS
   bundles, new structural shapes via `signature_paths:`, new
-  TypeNode resolvers ([ADR-13](../adr/13-typenode-resolver-plugin.md))
+  TypeNode resolvers ([ADR-13](https://github.com/rigortype/rigor/blob/master/docs/adr/13-typenode-resolver-plugin.md))
   — **without modifying the engine**.
 - **Adding new analyses / operations** over existing types — new
   diagnostic rules, new flow contributions, new protocol
-  contracts ([ADR-28](../adr/28-path-scoped-protocol-contracts.md))
+  contracts ([ADR-28](https://github.com/rigortype/rigor/blob/master/docs/adr/28-path-scoped-protocol-contracts.md))
   — **without modifying the type language**.
 
 The plugin contract is therefore the **expression problem solved
@@ -1296,11 +1296,11 @@ A worked example:
 - `rigor-web` adds a *new analysis* over existing classes
   (every class under `lib/controller/` must define
   `#get(Rack::Request) -> Rack::Response`) — operation-extension
-  axis ([ADR-28](../adr/28-path-scoped-protocol-contracts.md)).
+  axis ([ADR-28](https://github.com/rigortype/rigor/blob/master/docs/adr/28-path-scoped-protocol-contracts.md)).
 
 Neither plugin requires modifying the Rigor engine, and they
 *compose* — a single plugin can do both axes ([ADR-12 dry-rb
-packaging](../adr/12-dry-rb-packaging.md) discusses the
+packaging](https://github.com/rigortype/rigor/blob/master/docs/adr/12-dry-rb-packaging.md) discusses the
 production examples).
 
 ### Connection to earlier appendix sections
@@ -1314,13 +1314,13 @@ This framing also retroactively explains several design choices:
   to. The expression problem framing prefers explicit `class`
   declarations precisely because the name is the extension
   handle.
-- **The macro substrate** ([ADR-16](../adr/16-macro-expansion.md)):
+- **The macro substrate** ([ADR-16](https://github.com/rigortype/rigor/blob/master/docs/adr/16-macro-expansion.md)):
   each tier (A: block-as-method, B: trait-inlining, C: heredoc
   template, D: external-file inclusion) is a different way to
   add knowledge about a class's behaviour without modifying the
   class — the type-extension axis made plural.
 - **Path-scoped protocol contracts**
-  ([ADR-28](../adr/28-path-scoped-protocol-contracts.md)): a
+  ([ADR-28](https://github.com/rigortype/rigor/blob/master/docs/adr/28-path-scoped-protocol-contracts.md)): a
   plugin can declare a behavioural contract for an entire
   directory of user-authored classes without the classes
   opting in — the operation-extension axis made tool-side.
@@ -1413,7 +1413,7 @@ On a concretely-typed receiver (e.g. `String`), Rigor uses the
 **closed-world** assumption — the RBS signature is taken as the
 authoritative method set, and an unknown method fires
 `call.undefined-method` (subject to the
-[ADR-26 `open_receivers:`](../adr/26-activerecord-relation-typing.md)
+[ADR-26 `open_receivers:`](https://github.com/rigortype/rigor/blob/master/docs/adr/26-activerecord-relation-typing.md)
 exemption for receivers whose method set is provably open at
 runtime, like `ActiveRecord::Relation`).
 
@@ -1506,7 +1506,7 @@ here so you can stop looking:
   enforcement.
 - **Session types, capabilities-as-types.** Out of scope.
 - **Mechanised soundness proof.** Deliberately deferred; see the
-  [Matsumoto & Minamide 2010 review](../notes/20260518-matsumoto-2010-cfa-rigor-review.md)
+  [Matsumoto & Minamide 2010 review](https://github.com/rigortype/rigor/blob/master/docs/notes/20260518-matsumoto-2010-cfa-rigor-review.md)
   for the upstream "prove soundness on a tiny core" approach
   Rigor has not yet adopted.
 
@@ -1629,13 +1629,13 @@ they map to the sections of this appendix:
   その健全性の証明." *IPSJ TPRO Vol.3 No.2*, 2010. The
   upstream Ruby-CFA soundness proof; Rigor-perspective review
   at
-  [`docs/notes/20260518-matsumoto-2010-cfa-rigor-review.md`](../notes/20260518-matsumoto-2010-cfa-rigor-review.md).
+  [`docs/notes/20260518-matsumoto-2010-cfa-rigor-review.md`](https://github.com/rigortype/rigor/blob/master/docs/notes/20260518-matsumoto-2010-cfa-rigor-review.md).
 - Matsumoto & Minamide. "多相レコード型に基づくRubyプログラム
   の型推論." *IPSJ TPRO Vol.49 No.SIG 3*, 2008. The
   Garrigue-kinded polymorphic-record experiment that
   retroactively justifies Rigor's nominal-first carrier choice;
   Rigor-perspective review at
-  [`docs/notes/20260518-matsumoto-2008-poly-records-rigor-review.md`](../notes/20260518-matsumoto-2008-poly-records-rigor-review.md).
+  [`docs/notes/20260518-matsumoto-2008-poly-records-rigor-review.md`](https://github.com/rigortype/rigor/blob/master/docs/notes/20260518-matsumoto-2008-poly-records-rigor-review.md).
 
 ## What's next
 

--- a/docs/handbook/appendix-typeprof.md
+++ b/docs/handbook/appendix-typeprof.md
@@ -92,7 +92,7 @@ keeps a richer carrier and only erases at the boundary.
 The practical upshot: feed the same file to both, and
 TypeProf's RBS and `rigor sig-gen`'s RBS will usually agree at
 the *declaration* level, because Rigor's
-[RBS erasure](../type-specification/rbs-erasure.md) deliberately
+[RBS erasure](https://github.com/rigortype/rigor/blob/master/docs/type-specification/rbs-erasure.md) deliberately
 discards exactly the extra precision (`Constant`, `Refined`,
 `IntegerRange`) that TypeProf never tracked. Inside the
 analyzer, Rigor is carrying more — which is what powers its
@@ -131,7 +131,7 @@ resolve become `Dynamic[top]` and stop there. This is less
 precise than TypeProf on a self-contained toy program — Rigor
 will not deduce a parameter type from a single call site the
 way TypeProf can — but it is bounded by
-[inference budgets](../type-specification/inference-budgets.md)
+[inference budgets](https://github.com/rigortype/rigor/blob/master/docs/type-specification/inference-budgets.md)
 and backed by per-file caching (ADR-6), so it stays usable on
 a whole codebase and across runs.
 
@@ -242,7 +242,7 @@ more. The tools split on what to do about that.
 - **TypeProf emits the observed-narrow parameter** — its job
   is to report what the type-level run saw.
 - **Rigor refuses to make that the default.** Under the
-  [robustness principle](../type-specification/robustness-principle.md)
+  [robustness principle](https://github.com/rigortype/rigor/blob/master/docs/type-specification/robustness-principle.md)
   (strict returns, lenient parameters), `--params=observed` is
   a deliberate opt-in and its output is a *suggestion to
   review*, not a frozen contract. The default `untyped` is the
@@ -404,7 +404,7 @@ section sequentially. Three useful pointers:
 - [Chapter 8 — Understanding errors](08-understanding-errors.md)
   for the diagnostic gate that is Rigor's product, the thing
   TypeProf does not set out to be.
-- [`docs/type-specification/inference-budgets.md`](../type-specification/inference-budgets.md)
+- [`docs/type-specification/inference-budgets.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/inference-budgets.md)
   for the budget model that lets local inference scale where
   whole-program interpretation does not.
 

--- a/docs/handbook/appendix-typescript.md
+++ b/docs/handbook/appendix-typescript.md
@@ -51,7 +51,7 @@ inference cannot see further).
 | `{ name: string; age: number }` | `HashShape{name: String, age: Integer}` | Same per-key model; Ruby uses Symbol keys idiomatically. |
 | `Array<T>` / `T[]` | `Array[T]` | Same. |
 | `Record<K, V>` | `Hash[K, V]` | Same. |
-| `Readonly<T>` | `readonly_of[T]` (via opt-in [`rigor-typescript-utility-types`](../../plugins/rigor-typescript-utility-types/) plugin) | View-level read-only marker on every entry of a `HashShape`. Does NOT prove the underlying object is frozen — ADR-13 § "Readonly". |
+| `Readonly<T>` | `readonly_of[T]` (via opt-in [`rigor-typescript-utility-types`](https://github.com/rigortype/rigor/tree/master/plugins/rigor-typescript-utility-types) plugin) | View-level read-only marker on every entry of a `HashShape`. Does NOT prove the underlying object is frozen — ADR-13 § "Readonly". |
 | `Partial<T>` / `Required<T>` | `partial_of[T]` / `required_of[T]` (same plugin) | Flips every entry's required-ness on a `HashShape`. `Partial` does NOT widen value types to `nil` — Rigor's `HashShape` distinguishes "key absent" from "key present with nil value" (ADR-13 WD on required-ness flips). |
 | `Pick<T, K>` / `Omit<T, K>` | `pick_of[T, K]` / `omit_of[T, K]` (same plugin) | Restrict / remove `HashShape` entries by literal-key union; Tuple receivers project by integer index. Non-shape carriers degrade conservatively and surface `dynamic.shape.lossy-projection`. |
 | Conditional types `T extends U ? A : B` | (none in core; plugin contributions) | A plugin can vary return type by argument shape. |
@@ -159,7 +159,7 @@ inferred call-site instantiation as routinely as TypeScript.
 | `Array<T>` | `Array[T]` |
 | `Map<K, V>` | `Hash[K, V]` |
 | `Promise<T>` | (no analogue — Ruby has no built-in Promise) |
-| `Pick<T, K>` / `Omit<T, K>` / `Partial<T>` / `Required<T>` / `Readonly<T>` | Opt-in [`rigor-typescript-utility-types`](../../plugins/rigor-typescript-utility-types/) plugin maps each onto `pick_of` / `omit_of` / `partial_of` / `required_of` / `readonly_of` over `HashShape` (and `pick_of` / `omit_of` over `Tuple`). |
+| `Pick<T, K>` / `Omit<T, K>` / `Partial<T>` / `Required<T>` / `Readonly<T>` | Opt-in [`rigor-typescript-utility-types`](https://github.com/rigortype/rigor/tree/master/plugins/rigor-typescript-utility-types) plugin maps each onto `pick_of` / `omit_of` / `partial_of` / `required_of` / `readonly_of` over `HashShape` (and `pick_of` / `omit_of` over `Tuple`). |
 | Conditional types | (no analogue — would need a plugin) |
 
 Rigor reads RBS generics through its dispatcher and instantiates
@@ -214,7 +214,7 @@ Be honest about what you give up:
   variation, not type-level expressions.
 - **Mapped types.** `Pick`, `Omit`, `Partial`, `Required`, and
   `Readonly` ship as opt-in plugin-supplied vocabulary via
-  [`rigor-typescript-utility-types`](../../plugins/rigor-typescript-utility-types/),
+  [`rigor-typescript-utility-types`](https://github.com/rigortype/rigor/tree/master/plugins/rigor-typescript-utility-types),
   which maps them onto the Rigor-canonical `pick_of` / `omit_of`
   / `partial_of` / `required_of` / `readonly_of` shape-projection
   type functions on `HashShape` (and `pick_of` / `omit_of` on
@@ -294,7 +294,7 @@ def pick: [K, V] (Hash[K, V] obj, Array[K] keys) -> Hash[K, V]
 
 The RBS sig stays generic. If you want `Pick<T, K>`'s exact-
 key-set tracking back, opt into the
-[`rigor-typescript-utility-types`](../../plugins/rigor-typescript-utility-types/)
+[`rigor-typescript-utility-types`](https://github.com/rigortype/rigor/tree/master/plugins/rigor-typescript-utility-types)
 plugin and annotate the return type with the `Pick` spelling:
 
 ```rbs

--- a/docs/manual/02-cli-reference.md
+++ b/docs/manual/02-cli-reference.md
@@ -241,7 +241,7 @@ row behind each declared label, which are collapsed to a count
 by default. The report closes with a footer counting the two
 lanes apart, because they have different powers: a proven label
 can fail a build and a declared one cannot
-([ADR-103](../adr/103-effect-labels.md) § WD17).
+([ADR-103](https://github.com/rigortype/rigor/blob/master/docs/adr/103-effect-labels.md) § WD17).
 
 A `PATH` argument selects which methods are **printed**, never
 which are analysed: Rigor analyses your configured `paths:`
@@ -259,7 +259,7 @@ subcommands and does nothing here: the report is an
 observation, and observations are undischarged.
 
 What is collected and how it propagates is
-[the effect-summaries internal spec](../internal-spec/effect-summaries.md).
+[the effect-summaries internal spec](https://github.com/rigortype/rigor/blob/master/docs/internal-spec/effect-summaries.md).
 `--list-labels` prints the vocabulary this project can name —
 every shipped label with its root's meaning, plus whatever your
 plugins and your `effects.labels:` opened — and exits without
@@ -818,7 +818,7 @@ Without `--strict` the command always exits `0`; with
 gate).
 
 `--capabilities` switches to the **extension-protocol
-catalogue** ([ADR-37](../adr/37-plugin-interface-segregation.md)):
+catalogue** ([ADR-37](https://github.com/rigortype/rigor/blob/master/docs/adr/37-plugin-interface-segregation.md)):
 a focused, machine-readable map of what each loaded plugin
 contributes — the AST node types its `node_rule`s match, the
 receiver classes its `dynamic_return`s gate on, the methods its
@@ -920,7 +920,7 @@ they now read as an unknown skill. Use the forms above.
 Top-level alias for [`rigor skill describe`](#rigor-skill) — the
 onboarding entry point that recommends the next skill for this project.
 A bare `rigor describe` is the intuitive guess most users reach for
-first, so it is surfaced as its own command ([ADR-73](../adr/73-skill-driven-user-experience.md)
+first, so it is surfaced as its own command ([ADR-73](https://github.com/rigortype/rigor/blob/master/docs/adr/73-skill-driven-user-experience.md)
 § WD2).
 
 ```sh
@@ -941,7 +941,7 @@ check first — slow, and it writes the cache.
 Print the documentation bundled inside the `rigortype` gem
 **offline**, so once Rigor is installed an AI coding agent (or you) can
 read the drive-Rigor guidance the SKILL-driven UX routes to without the
-network ([ADR-74](../adr/74-offline-doc-access-and-llms-txt.md)). It is
+network ([ADR-74](https://github.com/rigortype/rigor/blob/master/docs/adr/74-offline-doc-access-and-llms-txt.md)). It is
 the doc twin of [`rigor skill`](#rigor-skill): the gem ships
 `docs/install.md`, `docs/llms.txt`, and the full user-facing
 [manual](README.md) and [handbook](../handbook/README.md); the
@@ -971,7 +971,7 @@ pages from the installed gem with no HTTP request.
 ## `rigor show-bleedingedge`
 
 Print the **bleeding-edge overlay** — the Rigor-maintained set of
-the next major's queued changes ([ADR-50](../adr/50-release-engineering-and-stability-strategy.md)
+the next major's queued changes ([ADR-50](https://github.com/rigortype/rigor/blob/master/docs/adr/50-release-engineering-and-stability-strategy.md)
 § WD2) — and report which of them the project's
 [`bleeding_edge:`](03-configuration.md) configuration adopts. Read-only:
 it loads `.rigor.yml` to resolve the active selection but runs no
@@ -991,7 +991,7 @@ or `behaviour` — and whether your configuration adopts it. A `severity`
 feature also prints the rule → severity diff it imposes; a `behaviour`
 feature changes a measurement, an algorithm, or a default without moving
 any rule's severity, so it has no such diff and its summary is the whole
-description. See [`docs/compatibility.md`](../compatibility.md) for how
+description. See [`docs/compatibility.md`](https://github.com/rigortype/rigor/blob/master/docs/compatibility.md) for how
 bleeding-edge fits the stability model.
 
 Queued today:
@@ -1002,10 +1002,10 @@ Queued today:
 | `use-of-void-value` | severity | Using a value recovered from an author-declared `-> void` return in value context is reported as `static.value-use.void` (`warning`). |
 | `discovery-seeded-mutation-sites` | behaviour | [`rigor coverage --protection --mutation`](15-type-protection-coverage.md) measures against the same cross-file project discovery Tier 1 already uses — both when picking the sites and when deciding whether a breakage was caught — so a call on a project class declared in a *sibling* file is measured instead of dropped, and a breakage there can actually be caught. **Adds sites to the denominator, so the reported effectiveness ratio moves** — check it against any `--threshold` you pin in CI before adopting. |
 | `dependent-closure-kill-oracle` | behaviour | [`rigor coverage --protection --mutation`](15-type-protection-coverage.md) counts a breakage as caught when the diagnostic appears anywhere in the mutated file **or the files that depend on it**, instead of in the mutated file alone — so changing what a method returns counts as caught when the error lands in its callers. Can only **add** kills, so the ratio moves up or not at all; it costs about a third more wall time per mutant, and a ratio measured under it is not comparable with one measured without it. |
-| `effects-on-by-default` | behaviour | A project whose `.rigor.yml` carries no [`effects:`](03-configuration.md#effect-labels) key at all is treated as if it had written `effects: {}` — [effect collection](03-configuration.md#effect-labels), the `rigor effects` verbs' cache sharing, and `effects.check` all turn on with every sub-key at its default. Writing `effects: false` explicitly still opts out. **Scheduled to graduate at v0.4.0** ([ADR-103](../adr/103-effect-labels.md) § WD15) rather than at the next major — an owner ruling specific to this feature, ahead of the general v1.0.0 majors-only cadence below. |
+| `effects-on-by-default` | behaviour | A project whose `.rigor.yml` carries no [`effects:`](03-configuration.md#effect-labels) key at all is treated as if it had written `effects: {}` — [effect collection](03-configuration.md#effect-labels), the `rigor effects` verbs' cache sharing, and `effects.check` all turn on with every sub-key at its default. Writing `effects: false` explicitly still opts out. **Scheduled to graduate at v0.4.0** ([ADR-103](https://github.com/rigortype/rigor/blob/master/docs/adr/103-effect-labels.md) § WD15) rather than at the next major — an owner ruling specific to this feature, ahead of the general v1.0.0 majors-only cadence below. |
 
 Once a feature **graduates** — it becomes the default at a major
-([ADR-50](../adr/50-release-engineering-and-stability-strategy.md) § WD7)
+([ADR-50](https://github.com/rigortype/rigor/blob/master/docs/adr/50-release-engineering-and-stability-strategy.md) § WD7)
 — it leaves the queued list and appears under `Graduated`, an
 acknowledgement that naming it in `bleeding_edge:` no longer does
 anything: the behaviour is on for everyone. The section is absent while
@@ -1016,7 +1016,7 @@ its `kind`), `active`, and `unknown_selected`.
 ## `rigor doctor`
 
 Classify setup problems vs a clean run with routed next actions
-([ADR-77](../adr/77-doctor-and-upgrade-commands.md) WD1).
+([ADR-77](https://github.com/rigortype/rigor/blob/master/docs/adr/77-doctor-and-upgrade-commands.md) WD1).
 
 ```sh
 rigor doctor [--config PATH] [--format text|json]
@@ -1068,7 +1068,7 @@ Exits `1` when any check fails, `0` when all pass.
 
 ## `rigor upgrade`
 
-Migration command skeleton ([ADR-50](../adr/50-release-engineering-and-stability-strategy.md)
+Migration command skeleton ([ADR-50](https://github.com/rigortype/rigor/blob/master/docs/adr/50-release-engineering-and-stability-strategy.md)
 WD7). The real body lands when a concrete backwards-compatibility
 break gives it a target (e.g. re-running `baseline regenerate`
 against a strengthened default profile, surfacing renamed
@@ -1091,7 +1091,7 @@ operational knobs read the environment instead.
 | `NO_COLOR` | Disable coloured output (honoured by `rigor annotate`; `--no-color` does the same). |
 | `RIGOR_CI_DETECT=0` | Turn off CI auto-detection — the same as `--no-ci-detect`. See [Running Rigor in CI § auto-detection](11-ci.md). |
 | `RIGOR_RACTOR_WORKERS=N` | Worker count for parallel analysis. Sits between the CLI flag and the config key in precedence: `--workers=N` > `RIGOR_RACTOR_WORKERS` > `parallel.workers:` > `0` (sequential). |
-| `RIGOR_POOL_BACKEND=ractor` | Opt back into the (off-by-default) Ractor worker pool instead of the active fork-based pool ([ADR-15](../adr/15-ractor-concurrency.md)). Only relevant with a non-zero worker count; the fork pool is the supported backend. |
+| `RIGOR_POOL_BACKEND=ractor` | Opt back into the (off-by-default) Ractor worker pool instead of the active fork-based pool ([ADR-15](https://github.com/rigortype/rigor/blob/master/docs/adr/15-ractor-concurrency.md)). Only relevant with a non-zero worker count; the fork pool is the supported backend. |
 | `RIGOR_PLUGIN_ISOLATION=none\|process\|ruby_box` | How a plugin's direct calls into its target library are isolated. Default `process`. See [Using plugins § Isolation strategy](07-plugins.md). `RIGOR_BOX` is a legacy alias for `ruby_box`. |
 | `RIGOR_STRICT_VALIDATION=1` | Force full-content cache validation for one run (the same as `cache.validation: digest`, and winning over it) — re-hash every file's content instead of trusting its stat metadata. Use it if a filesystem's timestamps or inode numbers cannot be trusted. See [Caching § How a file is checked for changes](12-caching.md#how-a-file-is-checked-for-changes). |
 | `RIGOR_DISABLE_YJIT=1` | Opt out of Rigor's deferred YJIT enablement. Rigor turns YJIT on partway through a long `check` / `coverage` run so short runs never pay the JIT warm-up; this variable leaves it off entirely. Diagnostics and allocations are identical either way — the effect is wall-time only. |

--- a/docs/manual/03-configuration.md
+++ b/docs/manual/03-configuration.md
@@ -62,7 +62,7 @@ cache:
 | `exclude` | Array | `[]` | Glob patterns to skip. `vendor/bundle`, `.bundle`, and `node_modules` are always excluded. |
 | `includes` | Array | `[]` | Other config files to layer underneath this one. |
 | `fold_platform_specific_paths` | Boolean | `false` | Resolve Ruby-version-conditional load paths when discovering sources. |
-| `parameter_inference` | Boolean | `false` | Opt-in call-site parameter type inference on the `check` walk ([ADR-67](../adr/67-parameter-type-inference.md) WD6). When `true`, an undeclared `def` / `initialize` / setter parameter is typed to the union of its resolved call-site argument types, sharpening downstream ivar reads, folds, and protection coverage. Precision-additive only — the negative rules never fire against an inferred parameter. Cannot be combined with `--incremental`. |
+| `parameter_inference` | Boolean | `false` | Opt-in call-site parameter type inference on the `check` walk ([ADR-67](https://github.com/rigortype/rigor/blob/master/docs/adr/67-parameter-type-inference.md) WD6). When `true`, an undeclared `def` / `initialize` / setter parameter is typed to the union of its resolved call-site argument types, sharpening downstream ivar reads, folds, and protection coverage. Precision-additive only — the negative rules never fire against an inferred parameter. Cannot be combined with `--incremental`. |
 
 ### Type sources
 
@@ -116,7 +116,7 @@ statically and may resolve at run time. The same findings appear in the
 | `severity_profile` | String | `"balanced"` | `lenient`, `balanced`, or `strict` — see [Diagnostics](04-diagnostics.md). |
 | `severity_overrides` | Hash | `{}` | Per-rule / per-family severity, e.g. `{ call: warning, flow.always-truthy-condition: off }`. |
 | `baseline` | String / `false` | `nil` | Path to a `.rigor-baseline.yml`, or `false` to disable an inherited one. See [Baselines](06-baseline.md). |
-| `bleeding_edge` | Boolean / Array / Hash | `false` | Adopt the next major's queued changes early ([ADR-50](../adr/50-release-engineering-and-stability-strategy.md) § WD2). `false` adopts none; `true` adopts the whole overlay; a list of feature ids adopts only those; `{ all: true, except: [ids] }` adopts all but the named. Orthogonal to `severity_profile`. Override it for a single run with [`rigor check --bleeding-edge[=ids]`](02-cli-reference.md#rigor-check) / `--no-bleeding-edge`. Inspect with [`rigor show-bleedingedge`](02-cli-reference.md#rigor-show-bleedingedge). |
+| `bleeding_edge` | Boolean / Array / Hash | `false` | Adopt the next major's queued changes early ([ADR-50](https://github.com/rigortype/rigor/blob/master/docs/adr/50-release-engineering-and-stability-strategy.md) § WD2). `false` adopts none; `true` adopts the whole overlay; a list of feature ids adopts only those; `{ all: true, except: [ids] }` adopts all but the named. Orthogonal to `severity_profile`. Override it for a single run with [`rigor check --bleeding-edge[=ids]`](02-cli-reference.md#rigor-check) / `--no-bleeding-edge`. Inspect with [`rigor show-bleedingedge`](02-cli-reference.md#rigor-show-bleedingedge). |
 
 A queued feature is one of two kinds, and `bleeding_edge:` selects both the
 same way:
@@ -151,7 +151,7 @@ It deliberately does **not** read `BUNDLE_PATH` from rigor's own
 environment, and it cannot reach gems installed at the *default* shared
 location (the active Ruby's `GEM_HOME`, when no `path` is configured):
 rigor runs in its own isolated Ruby and reads your project as data
-([ADR-27](../adr/27-tool-distribution-model.md)), so it does not know the
+([ADR-27](https://github.com/rigortype/rigor/blob/master/docs/adr/27-tool-distribution-model.md)), so it does not know the
 project Ruby's gem home without running your toolchain. If `rigor check`'s
 `--stats` shows gems whose RBS it could not find, point it at the bundle
 explicitly with `bundler.bundle_path:`, or supply signatures another way:
@@ -181,7 +181,7 @@ snapshot, the CI gate — is [Effect labels](19-effect-labels.md).
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `effects` | Hash | absent | **Opt-in to effect labels ([ADR-103](../adr/103-effect-labels.md)).** The *presence* of this block is the switch — `effects: {}` enables collection with every sub-key at its default, and leaving it out keeps `rigor check` byte-identical and free. Nothing else turns collection on: an `%a{pure}` or `%a{rigor:v1:effect …}` annotation in your RBS does not, because an annotation must not silently make every run more expensive — such a project gets one `effect.annotations-unchecked` `:info` per run instead, saying the annotations are inert. `rigor effects` runs under an implicit empty block when the key is absent, so you can try the report before configuring anything. Effect summaries are cached under their own identity (Rigor's effect vocabulary, its built-in catalogue and this block), so `rigor effects` after `rigor check` in the same job is a cache hit plus the propagation, and turning this block on or off does not invalidate your diagnostics cache. The sub-keys are below. `views` is declared in the schema and reserved: accepted and **not yet read**. See [`rigor effects`](02-cli-reference.md#rigor-effects). |
+| `effects` | Hash | absent | **Opt-in to effect labels ([ADR-103](https://github.com/rigortype/rigor/blob/master/docs/adr/103-effect-labels.md)).** The *presence* of this block is the switch — `effects: {}` enables collection with every sub-key at its default, and leaving it out keeps `rigor check` byte-identical and free. Nothing else turns collection on: an `%a{pure}` or `%a{rigor:v1:effect …}` annotation in your RBS does not, because an annotation must not silently make every run more expensive — such a project gets one `effect.annotations-unchecked` `:info` per run instead, saying the annotations are inert. `rigor effects` runs under an implicit empty block when the key is absent, so you can try the report before configuring anything. Effect summaries are cached under their own identity (Rigor's effect vocabulary, its built-in catalogue and this block), so `rigor effects` after `rigor check` in the same job is a cache hit plus the propagation, and turning this block on or off does not invalidate your diagnostics cache. The sub-keys are below. `views` is declared in the schema and reserved: accepted and **not yet read**. See [`rigor effects`](02-cli-reference.md#rigor-effects). |
 | `effects.check` | Boolean | `true` | Whether the envelopes you declared — `%a{pure}` and `%a{rigor:v1:effect …}` in RBS, and the `effects.envelopes:` stanzas below — are checked against what Rigor proved, surfacing `effect.envelope-exceeded` and, for a label the vocabulary does not recognise, `effect.unknown-label`. Set it to `false` to keep the report and the snapshot while silencing both. Never on without an `effects:` block. |
 | `effects.snapshot.path` | String | `.rigor-effects.yml` | Where `rigor effects update` writes the committed record. |
 | `effects.snapshot.reach` | Array | `[]` | Entry points whose **transitive** footprint the snapshot records under `reach:`. The default is empty **deliberately**: Rigor could infer `[rails]` from your plugin list, but a snapshot is a record you agree to and review the diff of, and one whose contents moved because your plugin list moved would be the worse artefact. `rigor effects update` names the presets your plugins registered and leaves the same hint in the written file. Each entry is a project-relative file glob (the `unused --entry-point` semantics — `**` is the only way across a directory boundary) or the name of an entry-point **preset** a plugin registered. On a Rails app, `reach: [rails]` is the one you want — see below. A name nothing registered is an error when the snapshot is built (not when the configuration loads, because the plugins that name presets load *from* that configuration); the error lists the presets your plugins did register, so it names the fix. |
@@ -199,7 +199,7 @@ config with no `effects:` key at all behave as `effects: {}` — collection,
 defaults. It only fills an *absence*: write `effects: false` and you stay
 opted out regardless, and any `effects:` block you do write is left exactly
 as written. It previews what becomes the default at **v0.4.0**
-([ADR-103](../adr/103-effect-labels.md) § WD15).
+([ADR-103](https://github.com/rigortype/rigor/blob/master/docs/adr/103-effect-labels.md) § WD15).
 
 #### Entry-point presets
 
@@ -269,7 +269,7 @@ plugin modelling a framework Rigor did not read, and a claim about unread code m
 fail your build. The enforcement path for that half is the committed snapshot, whose `rigor effects
 check` marks a declared-lane addition with `≤+` — [Effect labels § What a bound can and cannot
 see](19-effect-labels.md#what-a-bound-can-and-cannot-see), and
-[ADR-103](../adr/103-effect-labels.md) § WD17 for why.
+[ADR-103](https://github.com/rigortype/rigor/blob/master/docs/adr/103-effect-labels.md) § WD17 for why.
 
 If a layer is not ready for a bound yet, leave `envelopes:` out and start with the committed snapshot
 ([`rigor effects update`](02-cli-reference.md#the-effect-snapshot)) — it needs no declaration at all,

--- a/docs/manual/06-baseline.md
+++ b/docs/manual/06-baseline.md
@@ -7,7 +7,7 @@ on an existing codebase: you do not have to reach zero
 diagnostics before the check becomes useful in CI. It is also
 what the [`rigor-project-init` skill](08-skills.md) snapshots
 for you at onboarding
-([ADR-22](../adr/22-baseline-and-project-onboarding.md) is the
+([ADR-22](https://github.com/rigortype/rigor/blob/master/docs/adr/22-baseline-and-project-onboarding.md) is the
 design).
 
 ## The baseline file

--- a/docs/manual/07-plugins.md
+++ b/docs/manual/07-plugins.md
@@ -4,7 +4,7 @@ A plugin teaches Rigor about a framework, a gem, or an
 application DSL that plain inference cannot see — Rails route
 helpers, RSpec `let` bindings, dry-rb struct attributes, and
 so on. This page is about *activating* plugins. Writing one is
-covered by [`examples/`](../../examples/README.md) and the
+covered by [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and the
 [`rigor-plugin-author` skill](08-skills.md).
 
 ## Activating a plugin
@@ -33,7 +33,7 @@ plugins:
 ## Available plugins
 
 Rigor ships a catalogue of production plugins under
-[`plugins/`](../../plugins/README.md). The set grows between
+[`plugins/`](https://github.com/rigortype/rigor/blob/master/plugins/README.md). The set grows between
 releases — consult that directory for the current list and
 each plugin's options — but the families today are:
 
@@ -43,7 +43,7 @@ each plugin's options — but the families today are:
   `rigor-activestorage`, `rigor-actioncable`. Enumerate the ones
   you want under `plugins:` — there is no umbrella entry that
   turns on the Rails set as a group
-  ([ADR-96](../adr/96-plugin-target-gems.md) WD3 proposes one).
+  ([ADR-96](https://github.com/rigortype/rigor/blob/master/docs/adr/96-plugin-target-gems.md) WD3 proposes one).
 - **Testing** — `rigor-rspec`, `rigor-rspec-rails`,
   `rigor-minitest`, `rigor-shoulda-matchers`,
   `rigor-factorybot`.
@@ -57,9 +57,9 @@ each plugin's options — but the families today are:
 
 ## `plugins/` versus `examples/`
 
-[`plugins/`](../../plugins/README.md) holds production plugins
+[`plugins/`](https://github.com/rigortype/rigor/blob/master/plugins/README.md) holds production plugins
 for real gems and frameworks — the ones you activate. The
-[`examples/`](../../examples/README.md) tree holds *tutorial*
+[`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) tree holds *tutorial*
 plugins over deliberately simplified DSLs; they are reading
 material for plugin authors, not for activation in a real
 project.

--- a/docs/manual/08-skills.md
+++ b/docs/manual/08-skills.md
@@ -2,7 +2,7 @@
 
 Rigor bundles a set of **Agent Skills** — structured workflows an AI
 coding agent (Claude Code and compatible tools) can run on your behalf.
-They live in [`skills/`](../../skills/) and are auto-discovered when an
+They live in [`skills/`](https://github.com/rigortype/rigor/tree/master/skills) and are auto-discovered when an
 agent works inside a project that has Rigor available.
 
 Skills are optional. Everything they do, you can do by hand with the

--- a/docs/manual/09-editor-integration.md
+++ b/docs/manual/09-editor-integration.md
@@ -8,11 +8,11 @@ type-aware completion.
 
 This page is the entry point for wiring it into your editor. The
 design + capability matrix lives in
-[`docs/design/20260517-language-server.md`](../design/20260517-language-server.md)
+[`docs/design/20260517-language-server.md`](https://github.com/rigortype/rigor/blob/master/docs/design/20260517-language-server.md)
 (v1) and
-[`docs/design/20260517-lsp-hover-completion.md`](../design/20260517-lsp-hover-completion.md)
+[`docs/design/20260517-lsp-hover-completion.md`](https://github.com/rigortype/rigor/blob/master/docs/design/20260517-lsp-hover-completion.md)
 (v2). Packaging rationale is in
-[`docs/adr/19-language-server-packaging.md`](../adr/19-language-server-packaging.md).
+[`docs/adr/19-language-server-packaging.md`](https://github.com/rigortype/rigor/blob/master/docs/adr/19-language-server-packaging.md).
 
 ## Features at a glance
 

--- a/docs/manual/11-ci.md
+++ b/docs/manual/11-ci.md
@@ -70,10 +70,10 @@ auto default.
 
 `rigor check --format` renders the same diagnostics in a format your CI
 platform reads to annotate the diff directly, instead of leaving them in
-the job log ([ADR-51](../adr/51-ci-diagnostic-output-formats.md)). These
+the job log ([ADR-51](https://github.com/rigortype/rigor/blob/master/docs/adr/51-ci-diagnostic-output-formats.md)). These
 layer on the generic `--format json` stream; they add no new diagnostics,
 only a platform-native rendering. Ready-to-copy template files live under
-[`ci-templates/`](ci-templates/).
+[`ci-templates/`](https://github.com/rigortype/rigor/tree/master/docs/manual/ci-templates).
 
 ### GitHub — inline annotations (the default)
 
@@ -176,7 +176,7 @@ rigor check --format junit > rigor-junit.xml
 
 ### Severity mapping
 
-Rigor's severities map per format ([ADR-51](../adr/51-ci-diagnostic-output-formats.md) WD2):
+Rigor's severities map per format ([ADR-51](https://github.com/rigortype/rigor/blob/master/docs/adr/51-ci-diagnostic-output-formats.md) WD2):
 
 | Rigor | SARIF | GitHub | GitLab | Checkstyle | JUnit | TeamCity |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -232,7 +232,7 @@ time. To pin a version — and keep CI reproducible — choose one of the
 options below. While the `0.2.x` line is an evaluation trial the
 surface is still settling, so pinning is recommended; what Rigor
 commits to keeping stable (and from which release) is enumerated in
-[`docs/compatibility.md`](../compatibility.md).
+[`docs/compatibility.md`](https://github.com/rigortype/rigor/blob/master/docs/compatibility.md).
 
 ### A CI-only `Gemfile` (recommended)
 
@@ -358,5 +358,5 @@ else on the runner:
 nix run github:rigortype/rigor#rigor -- check
 ```
 
-See [ADR-27](../adr/27-tool-distribution-model.md) for the
+See [ADR-27](https://github.com/rigortype/rigor/blob/master/docs/adr/27-tool-distribution-model.md) for the
 distribution model behind this page.

--- a/docs/manual/14-rails-quickstart.md
+++ b/docs/manual/14-rails-quickstart.md
@@ -210,7 +210,7 @@ value in your `Gemfile` or `.ruby-version`) and trim the
 > **ActiveSupport core_ext is covered automatically.** When
 > `activesupport` is in your `Gemfile.lock` but ships no RBS,
 > Rigor auto-loads a bundled core-ext RBS overlay
-> ([ADR-72](../adr/72-gemfile-lock-gated-rbs-overlays.md)), so
+> ([ADR-72](https://github.com/rigortype/rigor/blob/master/docs/adr/72-gemfile-lock-gated-rbs-overlays.md)), so
 > extension calls (`3.days`, `"x".squish`, `Time.current`, …)
 > resolve without any plugin or config — on a real Rails app this
 > is reliably the single largest false-positive cluster (a
@@ -234,7 +234,7 @@ Other plugins to consider depending on your stack:
 | `rigor-shoulda-matchers` | shoulda-matchers |
 | `rigor-minitest` | Minitest / Test::Unit |
 
-See [`plugins/README.md`](../../plugins/README.md) for the full
+See [`plugins/README.md`](https://github.com/rigortype/rigor/blob/master/plugins/README.md) for the full
 catalogue.
 
 Add the cache directory to `.gitignore`:
@@ -331,4 +331,4 @@ exact same tools without any project `Gemfile` changes.
   [Baselines](06-baseline.md).
 - **Plugins** — each plugin's documentation describes its config
   options in detail: [Using plugins](07-plugins.md) and
-  [`plugins/`](../../plugins/README.md).
+  [`plugins/`](https://github.com/rigortype/rigor/blob/master/plugins/README.md).

--- a/docs/manual/15-type-protection-coverage.md
+++ b/docs/manual/15-type-protection-coverage.md
@@ -53,7 +53,7 @@ Some `protected` sites are typed only through call-site
 — an undeclared parameter seeded from what its callers pass)
 rather than a declaration — a lower bound that can only widen, so
 none of Rigor's negative rules fire against it yet
-([ADR-67](../adr/67-parameter-type-inference.md) WD6b). The text
+([ADR-67](https://github.com/rigortype/rigor/blob/master/docs/adr/67-parameter-type-inference.md) WD6b). The text
 report calls these out as "lower-bound-typed" when there are any,
 and the JSON form always carries the count as `lower_bound_typed`.
 It is a sub-count *within* `protected`, never subtracted from it —

--- a/docs/manual/16-rbs-extended-annotations.md
+++ b/docs/manual/16-rbs-extended-annotations.md
@@ -38,13 +38,13 @@ end
 
 This needs the `rbs-inline` library installed; Rigor ingests
 inline annotations by default when it is
-([ADR-93](../adr/93-default-rbs-inline-ingestion.md)). There is
+([ADR-93](https://github.com/rigortype/rigor/blob/master/docs/adr/93-default-rbs-inline-ingestion.md)). There is
 no Rigor-only comment dialect: `# rigor:` comments remain
 suppression-only.
 This page is the *operational* reference — the directives you can
 write and their syntax. For the normative rules (conflict
 handling, merging, provenance) see
-[`docs/type-specification/rbs-extended.md`](../type-specification/rbs-extended.md);
+[`docs/type-specification/rbs-extended.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/rbs-extended.md);
 for the type-model walkthrough see
 [handbook chapter 7](../handbook/07-rbs-and-extended.md).
 
@@ -117,7 +117,7 @@ The right-hand side of `return:`, `param:`, `assert*`, and
 - an **RBS class name** — `String`, `::Foo::Bar`; or
 - a **refinement payload** — a kebab-case name from the
   imported-built-in catalogue
-  ([`imported-built-in-types.md`](../type-specification/imported-built-in-types.md)),
+  ([`imported-built-in-types.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/imported-built-in-types.md)),
   such as `non-empty-string` or `positive-int`.
 
 Refinement payloads support the parameterised forms
@@ -131,7 +131,7 @@ Negation with `~T` is allowed on **class-name** payloads (it is
 how the false branch of a predicate is usually written); it is
 **not** yet accepted on refinement-form payloads. For an explicit
 user-authored difference type, prefer `T - U` (see
-[type-operators.md](../type-specification/type-operators.md)).
+[type-operators.md](https://github.com/rigortype/rigor/blob/master/docs/type-specification/type-operators.md)).
 
 ## `conforms-to` — a checked structural contract
 
@@ -229,7 +229,7 @@ these annotations draw from.
 
 Two declaration-level directives register and define the
 defunctionalised type constructors behind Rigor's lightweight HKT
-mechanism ([ADR-20](../adr/20-lightweight-hkt.md)). Unlike the
+mechanism ([ADR-20](https://github.com/rigortype/rigor/blob/master/docs/adr/20-lightweight-hkt.md)). Unlike the
 per-method directives they attach to a `class` / `module` and
 take **space-separated `key=value` pairs** (RBS's annotation
 grammar does not accept nested punctuation):
@@ -264,14 +264,14 @@ This is an advanced authoring surface; the worked walkthrough is
   reported as diagnostics — Rigor never silently picks a winner.
 - Annotations under unrelated keys belong to other tools; Rigor
   preserves them untouched. Conversely, exported plain RBS
-  ([RBS erasure](../type-specification/rbs-erasure.md)) drops
+  ([RBS erasure](https://github.com/rigortype/rigor/blob/master/docs/type-specification/rbs-erasure.md)) drops
   Rigor-only annotations unless you ask to keep them.
 
 ## See also
 
-- [`docs/type-specification/rbs-extended.md`](../type-specification/rbs-extended.md)
+- [`docs/type-specification/rbs-extended.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/rbs-extended.md)
   — the normative grammar and merging rules.
-- [`imported-built-in-types.md`](../type-specification/imported-built-in-types.md)
+- [`imported-built-in-types.md`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/imported-built-in-types.md)
   — the reserved refinement-name catalogue.
 - [handbook chapter 7](../handbook/07-rbs-and-extended.md) — the
   type-model walkthrough.

--- a/docs/manual/19-effect-labels.md
+++ b/docs/manual/19-effect-labels.md
@@ -644,7 +644,7 @@ observed state rather than a declared policy — which is why `effects.snapshot.
 exists, and why this chapter puts the snapshot before this section.
 
 The rule and the evidence behind it are
-[ADR-103](../adr/103-effect-labels.md) § WD17.
+[ADR-103](https://github.com/rigortype/rigor/blob/master/docs/adr/103-effect-labels.md) § WD17.
 
 ## The diagnostics
 

--- a/docs/manual/README.md
+++ b/docs/manual/README.md
@@ -80,7 +80,7 @@ flag, key, or command that *acts* on it.
     Cline, …) via `rigor mcp`.
 11. [Running Rigor in CI](11-ci.md) — a clean CI job, inline
     PR/MR diagnostics (SARIF / GitHub Actions / GitLab Code
-    Quality), copy-paste [templates](ci-templates/), and
+    Quality), copy-paste [templates](https://github.com/rigortype/rigor/tree/master/docs/manual/ci-templates), and
     version pinning.
 12. [Caching](12-caching.md) — where the cache lives, what
     invalidates it, and how to clear it.
@@ -91,7 +91,7 @@ flag, key, or command that *acts* on it.
 
 - [The Rigor Handbook](../handbook/README.md) — the type-model
   walkthrough.
-- [`docs/types.md`](../types.md) — one-page type-system guide.
-- [`docs/type-specification/`](../type-specification/README.md)
+- [`docs/types.md`](https://github.com/rigortype/rigor/blob/master/docs/types.md) — one-page type-system guide.
+- [`docs/type-specification/`](https://github.com/rigortype/rigor/blob/master/docs/type-specification/README.md)
   — the normative spec corpus.
-- [`docs/adr/`](../adr/) — architecture decision records.
+- [`docs/adr/`](https://github.com/rigortype/rigor/tree/master/docs/adr) — architecture decision records.

--- a/docs/manual/ci-templates/README.md
+++ b/docs/manual/ci-templates/README.md
@@ -4,7 +4,7 @@ Copy-paste CI configuration for running Rigor in your project's pipeline.
 Each runs Rigor in its **own isolated job** on Ruby 4.0 (see
 [chapter 11, "Running Rigor in CI"](../11-ci.md) for why isolation is
 required) and surfaces diagnostics inline on the pull / merge request via a
-CI-native output format ([ADR-51](../../adr/51-ci-diagnostic-output-formats.md)).
+CI-native output format ([ADR-51](https://github.com/rigortype/rigor/blob/master/docs/adr/51-ci-diagnostic-output-formats.md)).
 
 `ruby/setup-ruby` provides **prebuilt** Ruby 4.0.x binaries for
 `ubuntu-latest` — setup is fast (~0.3 s), not a compile-from-source
@@ -13,10 +13,10 @@ to Ruby 4.0.5 from the runner tool cache.
 
 | File | Copy it to | What it does |
 | --- | --- | --- |
-| [`github-actions-annotations.yml`](github-actions-annotations.yml) | `.github/workflows/rigor.yml` | **The default.** Workflow commands → inline PR annotations. No upload step, no permissions, works on every repo. |
-| [`github-actions-sarif.yml`](github-actions-sarif.yml) | `.github/workflows/rigor.yml` | SARIF 2.1.0 → GitHub code scanning (Security tab + PR alerts). Needs code scanning — public repo, or private with GitHub Advanced Security. |
-| [`github-actions-reviewdog.yml`](github-actions-reviewdog.yml) | `.github/workflows/rigor.yml` | reviewdog → inline PR **review comments**. Needs `pull-requests: write`. |
-| [`gitlab-ci.yml`](gitlab-ci.yml) | `.gitlab-ci.yml` (or `include:` it) | GitLab Code Quality report → the merge-request widget. |
+| [`github-actions-annotations.yml`](https://github.com/rigortype/rigor/blob/master/docs/manual/ci-templates/github-actions-annotations.yml) | `.github/workflows/rigor.yml` | **The default.** Workflow commands → inline PR annotations. No upload step, no permissions, works on every repo. |
+| [`github-actions-sarif.yml`](https://github.com/rigortype/rigor/blob/master/docs/manual/ci-templates/github-actions-sarif.yml) | `.github/workflows/rigor.yml` | SARIF 2.1.0 → GitHub code scanning (Security tab + PR alerts). Needs code scanning — public repo, or private with GitHub Advanced Security. |
+| [`github-actions-reviewdog.yml`](https://github.com/rigortype/rigor/blob/master/docs/manual/ci-templates/github-actions-reviewdog.yml) | `.github/workflows/rigor.yml` | reviewdog → inline PR **review comments**. Needs `pull-requests: write`. |
+| [`gitlab-ci.yml`](https://github.com/rigortype/rigor/blob/master/docs/manual/ci-templates/gitlab-ci.yml) | `.gitlab-ci.yml` (or `include:` it) | GitLab Code Quality report → the merge-request widget. |
 
 Pick **one** GitHub template. **Default to annotations** — it is the only
 one that works on every repository with zero setup. Use SARIF when code

--- a/docs/manual/plugins/README.md
+++ b/docs/manual/plugins/README.md
@@ -4,12 +4,12 @@ User-facing documentation for each bundled Rigor plugin — what
 it checks, its configuration keys, what it infers, and its
 limitations. For *activating* plugins in general, see
 [Using plugins](../07-plugins.md); to *write* one, see the
-[examples/](../../../examples/README.md) walkthroughs and the
+[examples/](https://github.com/rigortype/rigor/blob/master/examples/README.md) walkthroughs and the
 [`rigor-plugin-author` skill](../08-skills.md).
 
 All plugins ship bundled in `rigortype` — no separate install.
 The full catalogue, with a one-line scope for every plugin, is
-[plugins/README.md](../../../plugins/README.md).
+[plugins/README.md](https://github.com/rigortype/rigor/blob/master/plugins/README.md).
 
 ## Available pages
 
@@ -78,9 +78,9 @@ The full catalogue, with a one-line scope for every plugin, is
 The browser **playground** (`rigor playground`) is infrastructure, not
 a checker plugin — it has no page here; see the
 [CLI reference](../02-cli-reference.md) and
-[ADR-29](../../adr/29-browser-playground.md).
+[ADR-29](https://github.com/rigortype/rigor/blob/master/docs/adr/29-browser-playground.md).
 
 _Every bundled checker plugin has a page above; each plugin's in-tree
-[`README.md`](../../../plugins/README.md) now covers its internals
+[`README.md`](https://github.com/rigortype/rigor/blob/master/plugins/README.md) now covers its internals
 (layout, architecture, the contract surfaces it exercises) and links
 back up to its page here._

--- a/docs/manual/plugins/rigor-actioncable.md
+++ b/docs/manual/plugins/rigor-actioncable.md
@@ -46,7 +46,7 @@ arguments pass through silently.
 
 ## `#receive(data)` parameter typing
 
-The plugin also carries an [ADR-28](../../adr/28-path-scoped-protocol-contracts.md)
+The plugin also carries an [ADR-28](https://github.com/rigortype/rigor/blob/master/docs/adr/28-path-scoped-protocol-contracts.md)
 path-scoped protocol contract: inside any `#receive(data)` defined
 under `channel_search_paths`, `data` types as `Hash` instead of
 `Dynamic[Top]`. `#receive` is ActionCable's framework-dispatched
@@ -105,6 +105,6 @@ default.
 
 The channel discoverer / index and the contract surfaces this plugin
 exercises are in the
-[plugin's README](../../../plugins/rigor-actioncable/README.md). To
-write a plugin, see [`examples/`](../../../examples/README.md) and the
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-actioncable/README.md). To
+write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and the
 [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-actionmailer.md
+++ b/docs/manual/plugins/rigor-actionmailer.md
@@ -74,6 +74,6 @@ plugins:
 
 The mailer/concern discoverer, the cached `:mailer_index` producer,
 the demo, and the contract surfaces this plugin exercises are in
-the [plugin's README](../../../plugins/rigor-actionmailer/README.md).
-To write a plugin, see [`examples/`](../../../examples/README.md)
+the [plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-actionmailer/README.md).
+To write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md)
 and the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-actionpack.md
+++ b/docs/manual/plugins/rigor-actionpack.md
@@ -75,6 +75,6 @@ plugins:
 The cross-plugin fact contract (`:helper_table` / `:model_index`),
 the controller/view discovery producers, the demo, and the
 contract surfaces this plugin exercises are in the
-[plugin's README](../../../plugins/rigor-actionpack/README.md). To
-write a plugin, see [`examples/`](../../../examples/README.md) and
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-actionpack/README.md). To
+write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and
 the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-activejob.md
+++ b/docs/manual/plugins/rigor-activejob.md
@@ -100,6 +100,6 @@ nothing loads Solid Queue.
 
 The job discoverer / index, the cached `:job_index` producer, the
 demo, and the contract surfaces this plugin exercises are in the
-[plugin's README](../../../plugins/rigor-activejob/README.md). To
-write a plugin, see [`examples/`](../../../examples/README.md) and
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-activejob/README.md). To
+write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and
 the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-activerecord.md
+++ b/docs/manual/plugins/rigor-activerecord.md
@@ -103,7 +103,7 @@ never surfaces a false `call.undefined-method`.
 Architecture (the cached schema-parser → model-index → analyzer
 chain), the source layout, how to run the demo, and the plugin
 contract surfaces this plugin exercises are documented in the
-[plugin's README](../../../plugins/rigor-activerecord/README.md).
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-activerecord/README.md).
 To write a plugin of your own, see the
-[`examples/`](../../../examples/README.md) walkthroughs and the
+[`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) walkthroughs and the
 [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-activestorage.md
+++ b/docs/manual/plugins/rigor-activestorage.md
@@ -69,6 +69,6 @@ discovered AR classes.
 
 The discovery pass, the `AttachmentIndex`, and the contract
 surfaces this plugin exercises are in the
-[plugin's README](../../../plugins/rigor-activestorage/README.md).
-To write a plugin, see [`examples/`](../../../examples/README.md)
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-activestorage/README.md).
+To write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md)
 and the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-activesupport-core-ext.md
+++ b/docs/manual/plugins/rigor-activesupport-core-ext.md
@@ -19,11 +19,11 @@ plugins:
 ```
 
 That is the whole setup — Rigor resolves the bundled `sig/`
-automatically ([ADR-25](../../adr/25-plugin-contributed-rbs.md)); no
+automatically ([ADR-25](https://github.com/rigortype/rigor/blob/master/docs/adr/25-plugin-contributed-rbs.md)); no
 path, no vendoring, no `signature_paths:` wiring.
 
 > **You may not need this plugin.** As of
-> [ADR-72](../../adr/72-gemfile-lock-gated-rbs-overlays.md), Rigor
+> [ADR-72](https://github.com/rigortype/rigor/blob/master/docs/adr/72-gemfile-lock-gated-rbs-overlays.md), Rigor
 > auto-loads a bundled core-ext RBS overlay whenever `activesupport` is
 > in your `Gemfile.lock` but ships no RBS — so the most common
 > ActiveSupport false positives are already suppressed with zero config.
@@ -73,7 +73,7 @@ listed under `plugins:`.
   return `untyped`.
 - **Project-private monkey-patches are not covered** — only real
   ActiveSupport extensions. For your own core-class patches see the
-  `pre_eval:` mechanism ([ADR-17](../../adr/17-monkey-patch-pre-evaluation.md)).
+  `pre_eval:` mechanism ([ADR-17](https://github.com/rigortype/rigor/blob/master/docs/adr/17-monkey-patch-pre-evaluation.md)).
 - **Top ~40 selectors, not exhaustive.** ActiveSupport ships hundreds of
   extensions; this covers the head of the real-world distribution.
 
@@ -81,6 +81,6 @@ listed under `plugins:`.
 
 The RBS layout, the per-class coverage, and the survey that picked the
 selectors are in the
-[plugin's README](../../../plugins/rigor-activesupport-core-ext/README.md).
-To write a plugin, see [`examples/`](../../../examples/README.md) and the
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-activesupport-core-ext/README.md).
+To write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and the
 [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-devise.md
+++ b/docs/manual/plugins/rigor-devise.md
@@ -63,10 +63,10 @@ whatever class includes the concern.
 The macro manifest (the trait registry mapping each strategy to its
 module), the concern re-targeting walk, the demo, and the
 contract surfaces this plugin exercises are in the
-[plugin's README](../../../plugins/rigor-devise/README.md);
-[`docs/internal-spec/macro-substrate.md`](../../internal-spec/macro-substrate.md)
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-devise/README.md);
+[`docs/internal-spec/macro-substrate.md`](https://github.com/rigortype/rigor/blob/master/docs/internal-spec/macro-substrate.md)
 specifies the Tier B trait registry generally, and
 [handbook chapter 9](../../handbook/09-plugins.md) is the
 orientation. To write a plugin, see
-[`examples/`](../../../examples/README.md) and the
+[`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and the
 [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-dry-schema.md
+++ b/docs/manual/plugins/rigor-dry-schema.md
@@ -51,6 +51,6 @@ info diagnostics and typed `result.to_h` synthesis.)
 
 The `prepare(services)` scan, the published `:dry_schema_table`
 shape, and the slice floor/ceiling are documented in the
-[plugin's README](../../../plugins/rigor-dry-schema/README.md). To
-write a plugin, see [`examples/`](../../../examples/README.md) and
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-dry-schema/README.md). To
+write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and
 the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-dry-struct.md
+++ b/docs/manual/plugins/rigor-dry-struct.md
@@ -55,6 +55,6 @@ attribute-reader calls type-check.
 The declarative `HeredocTemplate` manifest, the
 `returns_from_arg` precision path (ADR-18), and the
 synthetic-method substrate it rides on are documented in the
-[plugin's README](../../../plugins/rigor-dry-struct/README.md). To
-write a plugin, see [`examples/`](../../../examples/README.md) and
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-dry-struct/README.md). To
+write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and
 the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-dry-types.md
+++ b/docs/manual/plugins/rigor-dry-types.md
@@ -54,6 +54,6 @@ skipped — there's no single underlying class to publish.
 
 The `prepare(services)` scan, the published `:dry_type_aliases`
 table, and the slice floor/ceiling are documented in the
-[plugin's README](../../../plugins/rigor-dry-types/README.md). To
-write a plugin, see [`examples/`](../../../examples/README.md) and
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-dry-types/README.md). To
+write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and
 the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-dry-validation.md
+++ b/docs/manual/plugins/rigor-dry-validation.md
@@ -42,7 +42,7 @@ result.to_h                                # Hash[Symbol, untyped]
 The plugin bundles an RBS overlay (`sig/dry_validation.rbs`) that
 types the result API above, and **contributes it automatically** —
 the plugin's manifest declares `signature_paths: ["sig"]`
-([ADR-25](../../adr/25-plugin-contributed-rbs.md)), so activating
+([ADR-25](https://github.com/rigortype/rigor/blob/master/docs/adr/25-plugin-contributed-rbs.md)), so activating
 `rigor-dry-validation` is enough; no project-side `signature_paths:`
 wiring is required.
 
@@ -57,6 +57,6 @@ and per-contract `rule`-key diagnostics.)
 
 The `prepare(services)` scan, the `:dry_validation_contracts` fact,
 the RBS overlay, and the slice floor/ceiling are documented in the
-[plugin's README](../../../plugins/rigor-dry-validation/README.md).
-To write a plugin, see [`examples/`](../../../examples/README.md)
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-dry-validation/README.md).
+To write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md)
 and the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-factorybot.md
+++ b/docs/manual/plugins/rigor-factorybot.md
@@ -87,6 +87,6 @@ that finding.
 The factory discoverer / index, the cached producer, the
 `:model_index` consumption, the demo, and the contract surfaces
 this plugin exercises are in the
-[plugin's README](../../../plugins/rigor-factorybot/README.md). To
-write a plugin, see [`examples/`](../../../examples/README.md) and
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-factorybot/README.md). To
+write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and
 the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-graphql.md
+++ b/docs/manual/plugins/rigor-graphql.md
@@ -4,7 +4,7 @@ Recognises GraphQL-Ruby schema classes — `Schema::Object`,
 `Schema::Enum`, `Schema::InputObject`, `Schema::Mutation` subclasses —
 and walks their `field` / `value` / `argument` DSL declarations,
 publishing the resulting type tables as
-[ADR-9](../../adr/9-cross-plugin-api.md) cross-plugin facts that
+[ADR-9](https://github.com/rigortype/rigor/blob/master/docs/adr/9-cross-plugin-api.md) cross-plugin facts that
 downstream plugins can consume. graphql-ruby's `field` DSL is a pure
 metadata recorder (it synthesises no Ruby methods), so Rigor's value
 here is a static type table rather than method synthesis. It reads
@@ -84,6 +84,6 @@ walks every `paths:` entry's `.rb` files for the schema-class shapes.
 ## Plugin internals
 
 The type scanner and the contract surfaces this plugin exercises are in
-the [plugin's README](../../../plugins/rigor-graphql/README.md). To
-write a plugin, see [`examples/`](../../../examples/README.md) and the
+the [plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-graphql/README.md). To
+write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and the
 [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-hanami.md
+++ b/docs/manual/plugins/rigor-hanami.md
@@ -5,7 +5,7 @@ class under `app/actions/**/*.rb` must define `#handle(request,
 response)`, and inside those bodies Rigor types the two parameters as
 `Hanami::Action::Request` / `Hanami::Action::Response` so misuse is
 caught precisely. It is the reference production consumer of the
-[ADR-28](../../adr/28-path-scoped-protocol-contracts.md) path-scoped
+[ADR-28](https://github.com/rigortype/rigor/blob/master/docs/adr/28-path-scoped-protocol-contracts.md) path-scoped
 method-protocol contract — Rigor *provides* the parameter types and the
 plugin *checks* the method shape. It reads source only, with no
 `hanami` runtime dependency (it ships RBS stubs for the Request /
@@ -78,6 +78,6 @@ parameter-type provision and the `#handle` check.
 
 The `ProtocolContract` declaration, the action checker, the RBS stubs,
 and the ADR-28 provide-and-check split are in the
-[plugin's README](../../../plugins/rigor-hanami/README.md). To write a
-plugin, see [`examples/`](../../../examples/README.md) and the
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-hanami/README.md). To write a
+plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and the
 [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-mangrove.md
+++ b/docs/manual/plugins/rigor-mangrove.md
@@ -67,7 +67,7 @@ Shape::Circle.new(1.5).inner.no_such_float_method # error: undefined for Float
 
 The carrier-generic instantiation, the `NestedClassTemplate`
 variant synthesis, and the relationship to `rigor-sorbet` are in
-the [plugin's README](../../../plugins/rigor-mangrove/README.md);
-the synthesis tier is [ADR-36](../../adr/36-mangrove-enum-nested-class-emission.md).
-To write a plugin, see [`examples/`](../../../examples/README.md)
+the [plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-mangrove/README.md);
+the synthesis tier is [ADR-36](https://github.com/rigortype/rigor/blob/master/docs/adr/36-mangrove-enum-nested-class-emission.md).
+To write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md)
 and the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-minitest.md
+++ b/docs/manual/plugins/rigor-minitest.md
@@ -81,6 +81,6 @@ matches.
 The assertion recogniser and the contract surfaces this plugin
 exercises — the ADR-37 `narrowing_facts` narrowing gate and the ADR-38
 `additional_initializers` for `setup` — are in the
-[plugin's README](../../../plugins/rigor-minitest/README.md). To write a
-plugin, see [`examples/`](../../../examples/README.md) and the
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-minitest/README.md). To write a
+plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and the
 [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-pundit.md
+++ b/docs/manual/plugins/rigor-pundit.md
@@ -93,6 +93,6 @@ candidate rather than being guessed at.
 
 The policy discoverer / index and the contract surfaces this plugin
 exercises are in the
-[plugin's README](../../../plugins/rigor-pundit/README.md). To
-write a plugin, see [`examples/`](../../../examples/README.md) and
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-pundit/README.md). To
+write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and
 the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-rails-i18n.md
+++ b/docs/manual/plugins/rigor-rails-i18n.md
@@ -106,6 +106,6 @@ view templates containing lazy `t('.key')` calls.
 
 The locale loader / index, the cached `:locale_index` producer,
 the demo, and the contract surfaces this plugin exercises are in
-the [plugin's README](../../../plugins/rigor-rails-i18n/README.md).
-To write a plugin, see [`examples/`](../../../examples/README.md)
+the [plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-rails-i18n/README.md).
+To write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md)
 and the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-rails-routes.md
+++ b/docs/manual/plugins/rigor-rails-routes.md
@@ -139,6 +139,6 @@ routed. Helper-name recognition for all three is unaffected.
 
 The Prism routes-parser, the cached `:helper_table` producer, the
 demo, and the contract surfaces this plugin exercises are in the
-[plugin's README](../../../plugins/rigor-rails-routes/README.md).
-To write a plugin, see [`examples/`](../../../examples/README.md)
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-rails-routes/README.md).
+To write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md)
 and the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-rbs-inline.md
+++ b/docs/manual/plugins/rigor-rbs-inline.md
@@ -7,7 +7,7 @@ synthesised RBS into the analysis environment — so a `# @rbs`
 annotation Rigor would otherwise ignore becomes an enforced contract
 that fires the same `argument-type-mismatch` diagnostics as a
 hand-written `.rbs` file. The design is recorded in
-[ADR-32](../../adr/32-rbs-inline-comment-ingestion.md).
+[ADR-32](https://github.com/rigortype/rigor/blob/master/docs/adr/32-rbs-inline-comment-ingestion.md).
 
 It ships bundled in `rigortype`. Activate it under `plugins:`:
 
@@ -52,7 +52,7 @@ plugin id/version + config), so an unchanged second run skips the parse.
 There are two implementations of inline RBS: the
 [`rbs-inline` gem](https://github.com/soutaro/rbs-inline), which this plugin
 runs, and the `RBS::InlineParser` built into `rbs` 4.x. **Rigor reads the
-gem's dialect** ([ADR-32](../../adr/32-rbs-inline-comment-ingestion.md) WD11).
+gem's dialect** ([ADR-32](https://github.com/rigortype/rigor/blob/master/docs/adr/32-rbs-inline-comment-ingestion.md) WD11).
 They overlap almost entirely — `#:`, `@rbs` method types, `def self.`,
 instance-variable annotations, `@rbs skip` all behave identically — but they
 are not the same grammar, and one difference bites in practice:
@@ -81,7 +81,7 @@ plugins:
   carrying `# rbs_inline: enabled` are processed. Set `false` to treat
   every file as if it carried the magic comment — useful only when you
   own the whole analysis scope (a single-file CI run or the hosted
-  [browser playground](../../adr/29-browser-playground.md), which sets
+  [browser playground](https://github.com/rigortype/rigor/blob/master/docs/adr/29-browser-playground.md), which sets
   it so pasted snippets analyse without the magic line).
 
 ## Limitations
@@ -100,6 +100,6 @@ plugins:
 
 The synthesizer, the `source_rbs_synthesizer:` manifest hook, and the
 caching wiring are in the
-[plugin's README](../../../plugins/rigor-rbs-inline/README.md). To write
-a plugin, see [`examples/`](../../../examples/README.md) and the
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-rbs-inline/README.md). To write
+a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and the
 [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-rspec-rails.md
+++ b/docs/manual/plugins/rigor-rspec-rails.md
@@ -41,7 +41,7 @@ The accepted status symbols come from the **real**
 `Rack::Utils::SYMBOL_TO_STATUS_CODE` read at analysis time (the same
 authority `have_http_status` itself uses), not a vendored snapshot — so
 a newly-added Rack symbol is never mistaken for a typo
-([ADR-39](../../adr/39-plugin-target-library-invocation.md)). When Rack
+([ADR-39](https://github.com/rigortype/rigor/blob/master/docs/adr/39-plugin-target-library-invocation.md)). When Rack
 can't be loaded the plugin **declines** to flag any symbol (reduced
 coverage, never a false positive). The eight Rails status-group aliases
 (`:success`, `:successful`, `:missing`, `:redirect`, `:error`,
@@ -72,6 +72,6 @@ The plugin has no configuration knobs.
 
 The matcher recogniser, the Rack-table lookup, and the contract
 surfaces this plugin exercises are in the
-[plugin's README](../../../plugins/rigor-rspec-rails/README.md). To
-write a plugin, see [`examples/`](../../../examples/README.md) and the
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-rspec-rails/README.md). To
+write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and the
 [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-rspec.md
+++ b/docs/manual/plugins/rigor-rspec.md
@@ -89,6 +89,6 @@ diagnostics for them. The README covers that boundary in detail.
 The scope-walker / analyzer layout, how to run the demo, the
 contract surfaces this plugin exercises, and the future-direction
 slices are in the
-[plugin's README](../../../plugins/rigor-rspec/README.md). To
-write a plugin, see [`examples/`](../../../examples/README.md)
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-rspec/README.md). To
+write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md)
 and the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-shoulda-matchers.md
+++ b/docs/manual/plugins/rigor-shoulda-matchers.md
@@ -73,6 +73,6 @@ plugin falls silent; the cross-check is opt-in.
 The describe-walker / matcher recogniser and the contract surfaces this
 plugin exercises (the optional `:model_index` consume, `NodeContext`
 ancestor resolution) are in the
-[plugin's README](../../../plugins/rigor-shoulda-matchers/README.md). To
-write a plugin, see [`examples/`](../../../examples/README.md) and the
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-shoulda-matchers/README.md). To
+write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and the
 [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-sidekiq.md
+++ b/docs/manual/plugins/rigor-sidekiq.md
@@ -127,6 +127,6 @@ added it is 100.
 
 The worker discoverer / index and the contract surfaces this plugin
 exercises are in the
-[plugin's README](../../../plugins/rigor-sidekiq/README.md). To write a
-plugin, see [`examples/`](../../../examples/README.md) and the
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-sidekiq/README.md). To write a
+plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and the
 [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-sinatra.md
+++ b/docs/manual/plugins/rigor-sinatra.md
@@ -56,6 +56,6 @@ is fixed in the manifest).
 
 The declarative `BlockAsMethod` manifest and the macro-substrate
 `self`-narrowing it rides on are documented in the
-[plugin's README](../../../plugins/rigor-sinatra/README.md). To
-write a plugin, see [`examples/`](../../../examples/README.md) and
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-sinatra/README.md). To
+write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and
 the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-sorbet.md
+++ b/docs/manual/plugins/rigor-sorbet.md
@@ -58,6 +58,6 @@ documents the full vocabulary and these edges.
 The slice-by-slice implementation (sig parsing, assertion
 lifting, the RBI tree walker, mixin-chain resolution, the
 dispatcher tier ordering), the source layout, and the demo are in
-the [plugin's README](../../../plugins/rigor-sorbet/README.md).
+the [plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-sorbet/README.md).
 The design rationale is
-[ADR-11](../../adr/11-sorbet-input-adapter.md).
+[ADR-11](https://github.com/rigortype/rigor/blob/master/docs/adr/11-sorbet-input-adapter.md).

--- a/docs/manual/plugins/rigor-statesman.md
+++ b/docs/manual/plugins/rigor-statesman.md
@@ -70,6 +70,6 @@ Renaming these adapts the plugin to a different state-machine DSL
 collects the declared states once, and a `node_rule` validates each
 `transition_to` over the engine-owned walk. The layout, demo, and
 contract surfaces are in the
-[plugin's README](../../../plugins/rigor-statesman/README.md). To
-write a plugin, see [`examples/`](../../../examples/README.md) and
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-statesman/README.md). To
+write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and
 the [`rigor-plugin-author`](../08-skills.md) skill.

--- a/docs/manual/plugins/rigor-typescript-utility-types.md
+++ b/docs/manual/plugins/rigor-typescript-utility-types.md
@@ -4,7 +4,7 @@ Maps the TypeScript-canonical utility-type spellings onto Rigor's own
 shape-projection type functions, so a codebase migrating from
 TypeScript / Sorbet RBI can write the familiar names inside
 `RBS::Extended` annotations. It registers five
-[ADR-13](../../adr/13-typenode-resolver-plugin.md) `TypeNodeResolver`s
+[ADR-13](https://github.com/rigortype/rigor/blob/master/docs/adr/13-typenode-resolver-plugin.md) `TypeNodeResolver`s
 as a pure translation layer; the shape *semantics* live in core, where
 they have one spec-owned definition shared by every consumer.
 
@@ -66,6 +66,6 @@ registered at class load.
 
 The five resolver classes, the recursive resolution mechanism, and the
 ADR-13 `TypeNodeResolver` contract are in the
-[plugin's README](../../../plugins/rigor-typescript-utility-types/README.md).
-To write a plugin, see [`examples/`](../../../examples/README.md) and the
+[plugin's README](https://github.com/rigortype/rigor/blob/master/plugins/rigor-typescript-utility-types/README.md).
+To write a plugin, see [`examples/`](https://github.com/rigortype/rigor/blob/master/examples/README.md) and the
 [`rigor-plugin-author`](../08-skills.md) skill.

--- a/lib/rigor/cli.rb
+++ b/lib/rigor/cli.rb
@@ -380,13 +380,13 @@ module Rigor
           trace      Replay how the engine typed FILE as a terminal animation
           type-scan  Report Scope#type_of coverage across PATHs
           effects    Report each method's effect labels, and the committed effect snapshot
-                     (ADR-103, opt-in; effects update/check/diff/explain)
+                     (opt-in; effects update/check/diff/explain)
           explain    Print the description of one or all CheckRules
           diff       Compare current diagnostics to a saved baseline JSON
-          sig-gen    Emit RBS skeletons inferred from .rb sources (ADR-14)
+          sig-gen    Emit RBS skeletons inferred from .rb sources
           lsp        Run the Rigor Language Server (LSP) over stdio
-          mcp        Run the Rigor MCP server over stdio (ADR-33)
-          triage     Summarise diagnostics: distribution, hotspots, hints (ADR-23)
+          mcp        Run the Rigor MCP server over stdio
+          triage     Summarise diagnostics: distribution, hotspots, hints
           coverage   Report type-precision coverage (precise vs Dynamic ratio)
           plugins    Report activation status of every configured plugin
           plugin     Browse bundled plugin source as worked examples (list/path/print/root)
@@ -394,9 +394,9 @@ module Rigor
           describe   Recommend the next skill for this project (alias for `skill describe`)
           skill      Recommend the next skill + list/print bundled Agent Skills (skill describe, skill <name>)
           docs       Print the bundled docs offline (docs <name>, docs --list)
-          show-bleedingedge  Show the bleeding-edge overlay + what your config adopts (ADR-50)
-          doctor     Classify setup problems vs clean run with routed next actions (ADR-77)
-          upgrade    Migration command skeleton (ADR-50 WD7, queued)
+          show-bleedingedge  Show the bleeding-edge overlay + what your config adopts
+          doctor     Classify setup problems vs clean run with routed next actions
+          upgrade    Migration command skeleton (queued)
           version    Print the Rigor version
           help       Print this help
       HELP

--- a/lib/rigor/cli/check_command.rb
+++ b/lib/rigor/cli/check_command.rb
@@ -492,46 +492,46 @@ module Rigor
           end
           Options.add_editor_mode(opts, options)
           opts.on("--baseline=PATH",
-                  "ADR-22: load baseline from PATH (overrides .rigor.yml `baseline:`)") do |value|
+                  "load baseline from PATH (overrides .rigor.yml `baseline:`)") do |value|
             options[:baseline] = value
           end
           opts.on("--no-baseline",
-                  "ADR-22: ignore any configured baseline for this run") do
+                  "ignore any configured baseline for this run") do
             options[:baseline] = false
           end
           opts.on("--baseline-strict",
-                  "ADR-22: fail the run on any baseline drift (CI gate)") do
+                  "fail the run on any baseline drift (CI gate)") do
             options[:baseline_strict] = true
           end
           opts.on("--treat-all-as-inline-rbs",
-                  "ADR-32: force-load rigor-rbs-inline with require_magic_comment: false") do
+                  "force-load rigor-rbs-inline with require_magic_comment: false") do
             options[:treat_all_as_inline_rbs] = true
           end
           opts.on("--verify-incremental",
-                  "ADR-46: assert incremental analysis matches a full run, then exit") do
+                  "assert incremental analysis matches a full run, then exit") do
             options[:verify_incremental] = true
           end
           opts.on("--incremental",
-                  "ADR-46: re-analyze only files changed since the last run (cross-process cache)") do
+                  "re-analyze only files changed since the last run (cross-process cache)") do
             options[:incremental] = true
           end
           opts.on("--no-ci-detect",
-                  "ADR-51: do not auto-emit CI-native output when a CI environment is detected") do
+                  "do not auto-emit CI-native output when a CI environment is detected") do
             options[:ci_detect] = false
           end
           # ADR-50 § WD2 — `=[LIST]` (not ` [LIST]`) so a bare `--bleeding-edge` never swallows a following positional
           # path: `rigor check --bleeding-edge lib` adopts the whole overlay and checks `lib`.
           opts.on("--bleeding-edge=[LIST]",
-                  "ADR-50: adopt the bleeding-edge overlay for this run " \
+                  "adopt the bleeding-edge overlay for this run " \
                   "(all features, or a comma-separated feature-id list)") do |value|
             options[:bleeding_edge] = value.nil? || value.split(",").map(&:strip).reject(&:empty?)
           end
           opts.on("--no-bleeding-edge",
-                  "ADR-50: ignore any configured bleeding_edge: selection for this run") do
+                  "ignore any configured bleeding_edge: selection for this run") do
             options[:bleeding_edge] = false
           end
           opts.on("--no-tolerated-effects",
-                  "ADR-103: check effect envelopes as if effects.tolerated: were empty") do
+                  "check effect envelopes as if effects.tolerated: were empty") do
             options[:no_tolerated_effects] = true
           end
         end

--- a/spec/docs/packaged_link_integrity_spec.rb
+++ b/spec/docs/packaged_link_integrity_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Issue #430 — link integrity against the PACKAGED file list, not the repository tree.
+#
+# `spec/docs/link_integrity_spec.rb` checks that every relative link resolves in the checkout, where
+# every target exists. An installed gem is a different file set: `rigortype.gemspec` ships
+# `docs/manual/**` and `docs/handbook/**` and not `docs/adr/`, `docs/type-specification/`,
+# `docs/internal-spec/`, `examples/`, `plugins/*/README.md` or `docs/notes/`. A relative link from a
+# shipped page into any of those is dead for every reader who installed Rigor rather than cloning it —
+# which is all of them — and invisible in-repo. There were 284 such links across 66 shipped documents.
+#
+# So the rule is: a shipped document may link relatively only to another shipped document. Anything
+# outside the package is named by its canonical URL, which resolves for a reader who has the gem and for
+# one who has the repository. Shipping the missing trees was measured and rejected: `docs/adr/` alone is
+# 2.1 MB against a 7.1 MB gem, and it would still leave the 128 links that point at `examples/`,
+# `plugins/*/README.md`, `docs/notes/` and the like.
+RSpec.describe "packaged documentation links" do
+  def packaged
+    @packaged ||= Gem::Specification.load(File.expand_path("../../rigortype.gemspec", __dir__)).files.to_set
+  end
+
+  def repo_root
+    @repo_root ||= File.expand_path("../..", __dir__)
+  end
+
+  # `](target)` and `](target#anchor)`, skipping absolute URLs and bare anchors.
+  def relative_links(doc)
+    File.read(File.join(repo_root, doc))
+        .scan(/\]\(([^)#\s]+)(?:#[^)\s]*)?\)/)
+        .flatten
+        .reject { |target| target.start_with?("http://", "https://", "mailto:") }
+  end
+
+  def resolve(doc, target)
+    File.expand_path(target, File.dirname(File.join(repo_root, doc))).sub("#{repo_root}/", "")
+  end
+
+  def shipped_docs
+    packaged.select { |file| file.end_with?(".md") }.sort
+  end
+
+  it "packages a plausible number of documents, so these checks are not vacuous" do
+    expect(shipped_docs.length).to be >= 100
+    expect(shipped_docs).to include("docs/manual/04-diagnostics.md", "docs/handbook/01-getting-started.md")
+  end
+
+  # The other half of the same rule, and the coverage this change would otherwise have removed. A
+  # relative link into `docs/adr/` was at least validated in-repo by `link_integrity_spec`; rewriting it
+  # to a URL takes it out of that spec's reach, so a rename would rot it silently. The target is a path
+  # in THIS repository, so it can be checked without a network call.
+  it "points every canonical repository URL at a path that exists" do
+    prefix = %r{\Ahttps://github\.com/rigortype/rigor/(?:blob|tree)/master/}
+    offenders = shipped_docs.flat_map do |doc|
+      File.read(File.join(repo_root, doc))
+          .scan(%r{\]\((https://github\.com/rigortype/rigor/(?:blob|tree)/master/[^)#\s]+)(?:#[^)\s]*)?\)})
+          .flatten
+          .reject { |url| File.exist?(File.join(repo_root, url.sub(prefix, ""))) }
+          .map { |url| "#{doc} → #{url}" }
+    end
+
+    expect(offenders).to be_empty, "these URLs name a path this repository does not have:\n  " \
+                                   "#{offenders.first(20).join("\n  ")}"
+  end
+
+  it "never links relatively from a shipped document to an unshipped one" do
+    offenders = shipped_docs.flat_map do |doc|
+      relative_links(doc).filter_map do |target|
+        resolved = resolve(doc, target)
+        next if packaged.include?(resolved)
+
+        reason = File.exist?(File.join(repo_root, resolved)) ? "not packaged" : "does not exist"
+        "#{doc} → #{target} (#{reason})"
+      end
+    end
+
+    expect(offenders).to be_empty, lambda {
+      "a reader who installed the gem cannot follow these; name the target by its canonical URL " \
+        "(https://github.com/rigortype/rigor/blob/master/…) instead:\n  #{offenders.first(40).join("\n  ")}" \
+        "#{"\n  … and #{offenders.length - 40} more" if offenders.length > 40}"
+    }
+  end
+end


### PR DESCRIPTION
Fixes [#430](https://github.com/rigortype/rigor/issues/430).

## The number decides the option

`rigortype.gemspec` ships `docs/manual/**` and `docs/handbook/**` and not `docs/adr/`, `docs/type-specification/`, `docs/internal-spec/`, `examples/`, `plugins/*/README.md` or `docs/notes/`. A relative link from a shipped page into any of those is dead for everyone who installed Rigor rather than cloning it — and invisible in-repo, where `link_integrity_spec` checks against a tree in which every target exists.

Measured: **284 such links across 66 shipped documents**, an order of magnitude more than the issue estimated. That reshapes the choice between its three options:

| option | verdict |
| --- | --- |
| **Ship the specs** | `docs/adr/` alone is **2.1 MB against a 7.1 MB gem**, and it would still leave the **128** links pointing at `examples/`, plugin READMEs and `docs/notes/`, which cannot be packaged at all. Doesn't solve it, and costs 30 %+ of the gem. |
| **Replace each pointer with content** | The issue calls this the best answer, and at 284 links it is not a fix — it is a rewrite of the documentation. |
| **Canonical URLs** ✅ | Uniform across every target class, costs nothing in gem size, resolves for a reader with the gem *and* one with the repository, and is already the convention in a handful of these pages. |

So all 284 now name `https://github.com/rigortype/rigor/blob/master/…` (`/tree/` for directories), rewritten mechanically rather than by hand.

## `rigor help` cited ADRs the same way

Seventeen of them, across `rigor help` and `rigor check --help`. An option's help line is read by someone deciding whether to pass the flag, so `"ADR-22: load baseline from PATH"` spent the first words of the line on a destination the reader cannot open. All gone; the descriptions are unchanged otherwise.

## The gate, and the coverage it had to restore

A spec that resolves links against the **packaged file list** rather than the checkout — acceptance criterion 1, and the thing that keeps this true after the next doc is written.

It carries a second assertion because **this change would otherwise have removed coverage**: a relative link into `docs/adr/` was at least validated in-repo by `link_integrity_spec`, and rewriting it to a URL takes it out of that spec's reach, so a rename would rot it silently. The same file therefore asserts that every canonical repository URL names a path that exists — checkable without a network call, since the target is a path in this repo.

Verified in both directions:

- the packaged check reports real links against master's docs (34 named before the output cap);
- renaming one ADR target makes the URL check name it: `docs/manual/02-cli-reference.md → …/docs/adr/103-renamed-away.md`.

Plus a non-vacuity example, since a check over "every shipped `.md`" passes trivially if the packaged list comes back empty.

## Acceptance criteria

- [x] A link-integrity check that runs against the packaged file list
- [x] No relative link from a shipped doc to an unshipped one
- [x] `rigor help`'s pointers reach something the user has

`make verify` and `make docs-check` green, each as its own call with the exit code read unpiped.
