### PR TITLE
Record why an Object-typed raise operand stays silent

### DIFF
--- a/docs/notes/20260827-raise-object-instance-polarity.md
+++ b/docs/notes/20260827-raise-object-instance-polarity.md
@@ -1,0 +1,93 @@
+# `call.raise-non-exception` — why an `Object`-typed instance stays silent (#420)
+
+Status: adjudication, no behaviour change. Taken on master `35ac976b`.
+
+[#420](https://github.com/rigortype/rigor/issues/420) asked whether the rule's singleton / instance
+asymmetry is a real bound or a vestigial exclusion:
+
+```ruby
+raise Object       # => call.raise-non-exception
+raise Object.new   # => silent
+```
+
+Both raise `TypeError` at run time, so the silence looks like a missed diagnostic. It is not. The
+answer, and the evidence for it, is below; the pin in
+`spec/rigor/analysis/check_rules/raise_non_exception_spec.rb` now carries the short form so the next
+differential run finds it rather than re-filing this.
+
+## The rule never sees the expression, it sees the carrier
+
+`raise Object.new` really is a `TypeError`. But `raise_instance_operand_verdict` is handed a type, not
+a syntax node, and that type is shared with values that are **not** exact:
+
+| expression | carrier |
+| --- | --- |
+| `Object.new` | `Object` |
+| a method declared `# @rbs () -> Object` | `Object` |
+| `[Object.new, ArgumentError.new].first` | `Object` |
+
+Measured with `dump_type` under a real `rigor check` run, not under `type-of` (which resolves a
+different environment — see `feedback_rigor_probe_pitfalls`).
+
+Every Ruby object is an `Object`, so a value carrying `Object` may be an `Exception` at run time.
+There is no reading of this carrier under which `Object.new` fires and a declared `Object` stays
+silent, because they are the same carrier.
+
+## What convergence actually does
+
+Two independent guards produce the silence, and each is sufficient on its own — removing one changes
+nothing, which is worth knowing before concluding that either is vestigial:
+
+1. `RAISE_UNEXACT_INSTANCE_CLASSES` lists `Object` / `BasicObject`, bailing before the ordering; and
+2. the `:superclass` ordering falls through to `:unknown`.
+
+With **both** removed, the rule fires on this, which is correct code that raises an `ArgumentError`:
+
+```ruby
+class Factory
+  # @rbs () -> Object
+  def build = ArgumentError.new("boom")
+end
+
+def go = raise Factory.new.build   # fires under convergence; silent today
+```
+
+AGENTS.md puts false-positive cost above the worst-case static reading, which settles it.
+
+## The corpus could not decide this, and says so
+
+The FP gate a widening normally needs was run anyway, over redmine, mastodon, mail and kramdown,
+cold, against the fully converged rule:
+
+| project | baseline firings | converged | new |
+| --- | --- | --- | --- |
+| redmine | 0 | 0 | 0 |
+| mastodon | 2 | 2 | 0 |
+| mail | 0 | 0 | 0 |
+| kramdown | 0 | 0 | 0 |
+
+**Zero new firings is an absence here, not a clearance.** The rule barely fires on this corpus at all,
+and none of the four projects contains a `raise <Object-typed value>` site — so the run cannot
+distinguish "the convergence is safe" from "the corpus has no instance of the shape". The deciding
+evidence is the carrier measurement and the constructed case above, both of which are mechanisms
+rather than absences.
+
+## What stays as it is
+
+The singleton path is not the same question and is unchanged: `raise Object` names one exact class
+object, `Object.exception` does not exist, and no subtype can intervene between the constant and the
+value. `raise Class` and `raise Comparable` fire for the same reason.
+
+## Two fixture traps this cost
+
+Both produced a confident wrong answer before the control caught them, and both are the same family:
+
+- A first FP fixture used an untyped parameter (`def go(f) = raise f.build`), so the operand typed
+  `Dynamic` and the example would have passed whatever the rule did.
+- `[Object.new, ArgumentError.new].first` types as `Object`, but at run time it **is** an `Object`, so
+  raising it is a genuine `TypeError` — it illustrates the carrier collapse, not a false positive, and
+  pinning it as one would have been wrong.
+
+Neither reached the spec file. The unit harness also cannot express an rbs-inline declared return —
+the fixture types `Dynamic` there — which is why the demonstration above is a project fixture run
+through the CLI and the spec carries the reasoning rather than a re-enactment.

--- a/spec/rigor/analysis/check_rules/raise_non_exception_spec.rb
+++ b/spec/rigor/analysis/check_rules/raise_non_exception_spec.rb
@@ -112,6 +112,25 @@ RSpec.describe "raise non-exception operand" do
       expect(raise_diagnostics("raise Comparable\n")).not_to be_empty
     end
 
+    # #420 asked whether this silence is a real bound or a vestigial exclusion, since `raise Object.new`
+    # does raise TypeError at run time. It is real, and the reason is that the rule never sees the
+    # expression — it sees the carrier, and this carrier is shared with values that are NOT exact.
+    # Measured: `Object.new` and a method declared `() -> Object` both type as exactly `Object`, so there
+    # is no reading under which the first fires and the second stays silent. Converging the instance path
+    # with the singleton one (allowing `:superclass`, AND dropping `Object` from
+    # RAISE_UNEXACT_INSTANCE_CLASSES — both guards had to go, each was sufficient on its own) was tried
+    # against a project fixture whose `() -> Object` method returns `ArgumentError.new`: it fires there,
+    # on code that raises an ArgumentError at run time. AGENTS.md puts that cost above the worst-case
+    # static reading. The demonstration is not an example here because this harness cannot express an
+    # rbs-inline declared return — the fixture types as `Dynamic` and would pass either way.
+    #
+    # The corpus could not decide this and is recorded as such: `call.raise-non-exception` fires 0 / 2 /
+    # 0 / 0 times on redmine, mastodon, mail and kramdown, and the convergence added zero firings to all
+    # four — an absence, not a clearance, because the corpus contains no `raise <Object-typed value>`
+    # site at all.
+    #
+    # The singleton path is different and stays as it is: `raise Object` names one exact class object,
+    # `Object.exception` does not exist, and no subtype can intervene.
     it "stays silent on `raise Object.new` — an Object-typed INSTANCE is not exact knowledge" do
       expect(raise_diagnostics("raise Object.new\n")).to be_empty
     end


### PR DESCRIPTION
Closes [#420](https://github.com/rigortype/rigor/issues/420) on its second acceptance branch: **it stays silent, and the pin's comment is replaced with the evidence** so the next differential run finds the reason rather than re-filing this. No behaviour change.

## The rule sees a carrier, not an expression

`raise Object.new` really is a `TypeError`. But `raise_instance_operand_verdict` is handed a type, and that type is shared with values that are *not* exact — measured with `dump_type` under a real `rigor check` run:

| expression | carrier |
| --- | --- |
| `Object.new` | `Object` |
| a method declared `# @rbs () -> Object` | `Object` |
| `[Object.new, ArgumentError.new].first` | `Object` |

Every Ruby object is an `Object`, so a value carrying `Object` may be an `Exception` at run time. There is no reading under which the first fires and the second stays silent, because they are the same carrier.

## The convergence was actually tried

Two guards produce the silence and **each is sufficient on its own** — removing one changes nothing, which is worth knowing before calling either vestigial: `RAISE_UNEXACT_INSTANCE_CLASSES` lists `Object`, and the `:superclass` ordering falls through to `:unknown`. With both removed, the rule fires on this:

```ruby
class Factory
  # @rbs () -> Object
  def build = ArgumentError.new("boom")
end

def go = raise Factory.new.build   # fires under convergence; correct code, raises ArgumentError
```

AGENTS.md puts false-positive cost above the worst-case static reading, which settles it.

## The corpus could not decide, and the note says so

| project | baseline | converged | new |
| --- | --- | --- | --- |
| redmine | 0 | 0 | 0 |
| mastodon | 2 | 2 | 0 |
| mail | 0 | 0 | 0 |
| kramdown | 0 | 0 | 0 |

**Zero new firings is an absence, not a clearance.** None of the four contains a `raise <Object-typed value>` site, so the run cannot distinguish "safe" from "the shape isn't there". Recorded that way rather than presented as a green gate — the deciding evidence is the carrier measurement and the constructed case, both mechanisms.

## Two fixture traps, recorded because both lied first

- A first FP fixture used an untyped parameter (`def go(f) = raise f.build`), so the operand typed `Dynamic` and it would have passed whatever the rule did.
- `[Object.new, ArgumentError.new].first` types as `Object` but at run time **is** an `Object`, so raising it is a genuine `TypeError`. It illustrates the carrier collapse, not a false positive; pinning it as one would have been wrong.

Neither reached the spec file. The unit harness also cannot express an rbs-inline declared return, so the demonstration is a project fixture through the CLI and the spec carries the reasoning rather than a re-enactment that would pass vacuously.

`make verify` and `make docs-check` green, each as its own call with the exit code read unpiped.
