### PR TITLE
Keep stdout a valid document under every machine-readable format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[cli]** `rigor check --cache-stats` no longer corrupts machine-readable output. The cache block was appended to stdout after the document, so `--format json`, `sarif` and `gitlab` failed to parse and the XML formats grew prose after the closing tag — a SARIF upload to code scanning would reject the artifact while the run itself looked fine. The block now goes to stderr for every format but `text`, as do `--clear-cache`'s and `--verify-incremental`'s notes ([#493](https://github.com/rigortype/rigor/issues/493)).
+
 - **[docs]** Relative links from the shipped manual and handbook into documents the gem does not package — ADRs, the type specification, the internal spec, `examples/`, plugin READMEs — were dead for everyone who installed Rigor rather than cloning it. All 284 of them now name their canonical URL, and `rigor help` no longer cites ADRs a reader cannot open ([#430](https://github.com/rigortype/rigor/issues/430)).
 
 - **[cli]** `rigor unused` no longer reports a class as having no production caller when a data file also names it — a job listed in `config/recurring.yml` and referenced from its spec was landing under "live test, dead production path" while it ran every three minutes. A data-file mention now also demotes to *cannot decide*, and it demotes only the name it matched rather than everything beneath it: the word "Administrasie" in a locale file was demoting 18 unrelated `Admin::*` rows ([#370](https://github.com/rigortype/rigor/issues/370)).

--- a/lib/rigor/cli/check_command.rb
+++ b/lib/rigor/cli/check_command.rb
@@ -47,7 +47,7 @@ module Rigor
         configuration = apply_bleeding_edge_override(configuration, options)
         config_warnings = warn_unresolved_config(configuration)
         cache_root = configuration.cache_path
-        handle_clear_cache(cache_root) if options.fetch(:clear_cache)
+        handle_clear_cache(cache_root, options.fetch(:format)) if options.fetch(:clear_cache)
 
         # ADR-87 WD4 — try to serve the whole run from the ADR-45 cache before booting the engine. A hit boots
         # only CLI + config + cache + digest code (no `rigor/inference`), skipping the plugin prepass + env
@@ -73,7 +73,7 @@ module Rigor
         write_run_stats(result.stats) if result.stats
         write_trace_appendices
         runner.cache_store&.evict!
-        write_cache_stats(cache_root, runner.cache_store) if options.fetch(:cache_stats)
+        write_cache_stats(cache_root, runner.cache_store, options.fetch(:format)) if options.fetch(:cache_stats)
 
         exit_code = result.success? ? 0 : 1
         exit_code = 1 if baseline_strict_violation?(raw_result.diagnostics, configuration, options)
@@ -192,7 +192,8 @@ module Rigor
         incremental = normalize_diagnostics(session.reanalyze_subset(subset))
         full = normalize_diagnostics(verify_full_diagnostics(configuration, paths))
 
-        report_verify_incremental(incremental, full, subset_size: subset.size, total: analyzed.size)
+        report_verify_incremental(incremental, full, subset_size: subset.size, total: analyzed.size,
+                                                     format: options.fetch(:format))
       end
 
       # ADR-46 — cross-process incremental analysis (`--incremental`). Derives the global fingerprint cheaply (no RBS
@@ -227,7 +228,8 @@ module Rigor
         @err.puts("rigor: --incremental #{warm ? 'warm — reused cached diagnostics' : 'cold — full analysis'} " \
                   "(#{session.analyzed_files.size} files)")
         emit_incremental_fact_surface_notes(session)
-        write_incremental_cache_stats(session, cache_root, store) if options.fetch(:cache_stats)
+        write_incremental_cache_stats(session, cache_root, store, options.fetch(:format)) if
+          options.fetch(:cache_stats)
 
         result = apply_baseline_filter(Analysis::Result.new(diagnostics: diagnostics, stats: nil), configuration,
                                        options)
@@ -283,8 +285,8 @@ module Rigor
       # does) plus the fact-surface status line, so an operator can see whether a full run was fact-surface
       # driven. The plain `check` cache-stats path is bypassed by the incremental short-circuit, so it is
       # emitted here.
-      def write_incremental_cache_stats(session, cache_root, store)
-        write_cache_stats(cache_root, store)
+      def write_incremental_cache_stats(session, cache_root, store, format)
+        write_cache_stats(cache_root, store, format)
         status =
           if !session.opaque_plugin_ids.empty?
             "opaque (#{session.opaque_plugin_ids.sort.join(', ')})"
@@ -293,7 +295,7 @@ module Rigor
           else
             "unchanged"
           end
-        @out.puts("  plugin fact surface: #{status}")
+        side_output(format).puts("  plugin fact surface: #{status}")
       end
 
       def verify_full_diagnostics(configuration, paths)
@@ -307,11 +309,14 @@ module Rigor
         end
       end
 
-      def report_verify_incremental(incremental, full, subset_size:, total:)
+      # The OK line follows the same rule as the other side outputs (#493) — stdout under `text`, stderr
+      # under a machine format. The FAILED branch below has always gone to stderr: it is a failure
+      # report, and a run that produced one has no valid document to protect anyway.
+      def report_verify_incremental(incremental, full, subset_size:, total:, format: "text")
         if incremental == full
-          @out.puts("rigor: --verify-incremental OK — incremental " \
-                    "(#{subset_size}/#{total} files re-analyzed, rest from cache) " \
-                    "matches full (#{full.size} diagnostics)")
+          side_output(format).puts("rigor: --verify-incremental OK — incremental " \
+                                   "(#{subset_size}/#{total} files re-analyzed, rest from cache) " \
+                                   "matches full (#{full.size} diagnostics)")
           return 0
         end
 
@@ -596,12 +601,13 @@ module Rigor
         }]
       end
 
-      def handle_clear_cache(cache_root)
+      def handle_clear_cache(cache_root, format)
+        out = side_output(format)
         if File.directory?(cache_root)
           FileUtils.rm_rf(cache_root)
-          @out.puts("Cleared cache: #{cache_root}")
+          out.puts("Cleared cache: #{cache_root}")
         else
-          @out.puts("Cache already empty: #{cache_root}")
+          out.puts("Cache already empty: #{cache_root}")
         end
       end
 
@@ -769,42 +775,43 @@ module Rigor
         Kernel.format("%.1f MB", bytes / 1_048_576.0)
       end
 
-      def write_cache_stats(cache_root, runtime_store)
+      def write_cache_stats(cache_root, runtime_store, format)
         inv = Cache::Store.disk_inventory(root: cache_root)
+        out = side_output(format)
 
-        @out.puts("")
-        @out.puts("Cache (root: #{inv.fetch(:root)})")
+        out.puts("")
+        out.puts("Cache (root: #{inv.fetch(:root)})")
         schema = inv.fetch(:schema_version)
-        @out.puts("  schema_version: #{schema.nil? ? 'absent' : schema}")
-        write_disk_inventory(inv)
-        write_runtime_stats(runtime_store) if runtime_store
+        out.puts("  schema_version: #{schema.nil? ? 'absent' : schema}")
+        write_disk_inventory(inv, out)
+        write_runtime_stats(runtime_store, out) if runtime_store
       end
 
-      def write_disk_inventory(inv)
+      def write_disk_inventory(inv, out)
         if inv.fetch(:total_entries).zero?
-          @out.puts("  (empty)")
+          out.puts("  (empty)")
           return
         end
 
-        @out.puts("  #{inv.fetch(:total_entries)} entries, #{format_bytes(inv.fetch(:total_bytes))}")
+        out.puts("  #{inv.fetch(:total_entries)} entries, #{format_bytes(inv.fetch(:total_bytes))}")
         inv.fetch(:producers).each do |producer|
           bytes = format_bytes(producer.fetch(:bytes))
-          @out.puts("    #{producer.fetch(:id)}: #{producer.fetch(:entries)} entries, #{bytes}")
+          out.puts("    #{producer.fetch(:id)}: #{producer.fetch(:entries)} entries, #{bytes}")
         end
       end
 
-      def write_runtime_stats(store)
+      def write_runtime_stats(store, out)
         stats = store.stats
         hits = stats.fetch(:hits)
         misses = stats.fetch(:misses)
         writes = stats.fetch(:writes)
-        @out.puts("  this run: #{hits} #{plural(hits, 'hit')}, " \
-                  "#{misses} #{plural(misses, 'miss', 'misses')}, " \
-                  "#{writes} #{plural(writes, 'write')}")
+        out.puts("  this run: #{hits} #{plural(hits, 'hit')}, " \
+                 "#{misses} #{plural(misses, 'miss', 'misses')}, " \
+                 "#{writes} #{plural(writes, 'write')}")
         stats.fetch(:by_producer).each do |id, counts|
-          @out.puts("    #{id}: #{counts.fetch(:hits)} #{plural(counts.fetch(:hits), 'hit')}, " \
-                    "#{counts.fetch(:misses)} #{plural(counts.fetch(:misses), 'miss', 'misses')}, " \
-                    "#{counts.fetch(:writes)} #{plural(counts.fetch(:writes), 'write')}")
+          out.puts("    #{id}: #{counts.fetch(:hits)} #{plural(counts.fetch(:hits), 'hit')}, " \
+                   "#{counts.fetch(:misses)} #{plural(counts.fetch(:misses), 'miss', 'misses')}, " \
+                   "#{counts.fetch(:writes)} #{plural(counts.fetch(:writes), 'write')}")
         end
       end
 
@@ -817,6 +824,21 @@ module Rigor
         return format("%.1f KiB", bytes / 1024.0) if bytes < 1024 * 1024
 
         format("%.1f MiB", bytes / (1024.0 * 1024.0))
+      end
+
+      # Where a human-readable side output goes (#493).
+      #
+      # `--format text` is prose already, so an extra block after the diagnostics is just more prose. Every
+      # other format is a machine contract — a SARIF document a code-scanning upload parses, a Checkstyle
+      # or JUnit XML tree, a GitLab Code Quality array — and appending `Cache (root: …)` to it produces a
+      # document the consumer rejects. Measured: all seven non-text formats were corrupted by
+      # `--cache-stats`, and JSON / SARIF / GitLab failed to parse at all.
+      #
+      # The information is not dropped, because it is what the user asked for by passing the flag; it moves
+      # to stderr, which is where this command already routes everything it says about a run rather than
+      # about the code.
+      def side_output(format)
+        format == "text" ? @out : @err
       end
 
       def write_result(result, format, coverage: nil, config_warnings: [])

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -558,6 +558,33 @@ RSpec.describe Rigor::CLI do
       path
     end
 
+    # #493 — `--format` other than text is a machine contract, and a human-readable block appended to it
+    # produces a document the consumer rejects. All seven non-text formats were corrupted; JSON, SARIF
+    # and GitLab Code Quality failed to parse outright, and the XML pair grew prose after the closing
+    # tag. The stats are not dropped — the user asked for them — they move to stderr, where this command
+    # already puts everything it says about a run rather than about the code.
+    %w[json sarif gitlab].each do |format|
+      it "keeps stdout a parseable document under --format #{format} --cache-stats" do
+        write_check_fixture("a.rb", "1\n")
+        Dir.chdir(tmpdir) do
+          _status, out, err = run_cli("check", "--cache-stats", "--format", format, "a.rb")
+
+          expect { JSON.parse(out) }.not_to raise_error
+          # Non-vacuity: the block the user asked for really was emitted, just not onto the contract.
+          expect(err).to include("Cache (root:")
+        end
+      end
+    end
+
+    it "still prints the stats on stdout under the text format" do
+      write_check_fixture("a.rb", "1\n")
+      Dir.chdir(tmpdir) do
+        _status, out, _err = run_cli("check", "--cache-stats", "a.rb")
+
+        expect(out).to include("Cache (root:")
+      end
+    end
+
     it "prints '(empty)' under --cache-stats when no cache directory exists" do
       write_check_fixture("a.rb", "1\n")
       Dir.chdir(tmpdir) do

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -546,6 +546,41 @@ RSpec.describe Rigor::CLI do
     end
   end
 
+  # #493 — the contract the fix protects, asserted across the surface rather than only where the bug
+  # was. `--format json` means stdout is a document; a command that also has something to say must say
+  # it on stderr. A sweep found `check --cache-stats` to be the only violator, and this is what keeps
+  # that true as commands gain side outputs.
+  describe "machine-readable stdout is a document, whatever else the command reports" do
+    let(:tmpdir) { Dir.mktmpdir }
+
+    after { FileUtils.remove_entry(tmpdir) }
+
+    def json_stdout(*argv)
+      Dir.chdir(tmpdir) do
+        File.write("a.rb", "class Demo\n  def run = 1\nend\n")
+        _status, out, = run_cli(*argv, "--format", "json")
+        out
+      end
+    end
+
+    # `check --cache-stats` is the regression case; the rest are the neighbours a future side output
+    # would most likely land in, so the sweep is pinned rather than remembered.
+    {
+      "check --cache-stats" => %w[check --cache-stats a.rb],
+      "check --clear-cache" => %w[check --clear-cache a.rb],
+      "check --explain" => %w[check --explain a.rb],
+      "triage" => %w[triage a.rb],
+      "type-scan" => %w[type-scan a.rb]
+    }.each do |label, argv|
+      it "keeps stdout parseable for `#{label}`" do
+        out = json_stdout(*argv)
+
+        expect(out).not_to be_empty
+        expect { JSON.parse(out) }.not_to raise_error
+      end
+    end
+  end
+
   describe "check --cache-stats / --clear-cache" do
     let(:tmpdir) { Dir.mktmpdir }
 


### PR DESCRIPTION
Fixes [#493](https://github.com/rigortype/rigor/issues/493), which I found while building [#427](https://github.com/rigortype/rigor/issues/427)'s warm-cache gate — it needed to parse `--cache-stats` output and could not.

## What was wrong

`--cache-stats` appended its human-readable block to stdout **after** the document. Measured across every format `--format` accepts:

| format | result |
| --- | --- |
| `json` / `sarif` / `gitlab` | **fails to parse** |
| `checkstyle` / `junit` | prose after the closing tag |
| `github` / `teamcity` | prose after the last service message |
| `text` | unaffected — it is prose already |

**The failure is silent where it happens.** The exit code is unchanged and every diagnostic is present, so the run looks fine and only the artifact is unusable — a SARIF upload to code scanning rejects it, having been told the analysis succeeded.

Two neighbouring flags wrote to stdout the same way and corrupted the same formats: `--clear-cache`'s line and `--verify-incremental`'s OK line.

## The fix

One `side_output(format)` decides: **stdout under `text`, stderr otherwise**. Nothing is dropped — the user asked for it by passing the flag — and stderr is where this command already routes everything it says *about a run* rather than about the code, `RunStats` included.

The `--verify-incremental` **FAILED** branch stays on stderr as it always was: it is a failure report, and a run that produced one has no valid document to protect anyway. Its **OK** line follows the same rule as the rest — which an existing spec caught when my first pass moved it to stderr unconditionally.

## Verified in both directions

- The three parseable formats **fail on master** with `unexpected token at end of stream 'Cache'` and pass here.
- Each example also asserts the block is **present on stderr**, so it cannot pass by simply losing the output the user asked for.
- `text` still prints it on stdout, pinned separately.

`make verify` and `make docs-check` green, each as its own call with the exit code read unpiped.
