### PR TITLE
Merge CHANGELOG.md by union instead of by hand

### DIFF
--- a/.claude/skills/rigor-release-prep/SKILL.md
+++ b/.claude/skills/rigor-release-prep/SKILL.md
@@ -169,7 +169,12 @@ shortcut it:
    its change genuinely had no PR (a Markdown-only push to `master`).
 5. Watch for **merge artefacts**: two entries accidentally glued into one
    bullet (a stray second `**[label]**` mid-sentence, an env-var description
-   hanging off an unrelated entry). Split them.
+   hanging off an unrelated entry). Split them. `CHANGELOG.md` is `merge=union`
+   (`.gitattributes`), which trades insertion-order conflicts for one artefact
+   you must look for here: a **duplicated `###` heading**, where two branches
+   each opened the same section. Merge the two, keeping Keep a Changelog's
+   order. `spec/docs/changelog_conformance_spec.rb` fails on it, so a missed one
+   is caught rather than shipped — but catching it at the cut is cheaper.
 6. Re-read the sealed section top-to-bottom as a user would. If any top-level
    bullet still has two sentences or an em-dash clause, it is not done.
 
@@ -458,7 +463,11 @@ gh pr merge <pr> --rebase --delete-branch
   explained.
 - **Rebase- or merge-commit, never squash.** Keep the `Bump up version to
   x.y.z` commit intact so the tag in "Publish" lands on it. If `master`
-  advanced, rebase the branch first and re-push.
+  advanced, rebase the branch first and re-push — and **re-read the sealed
+  section afterwards**. `merge=union` means a `[Unreleased]` entry that landed
+  on `master` during release prep is folded in silently rather than raising a
+  conflict, so it can arrive under the wrong heading or after the section was
+  already sealed.
 - The PR merge **is** the merge-back to `master`; publish runs from `master`
   afterward, so there is no separate merge-back step.
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# `## [Unreleased]` is a single hot region that nearly every branch appends to: across v0.3.4-v0.3.6,
+# 18-29 of each cycle's commits touched this file. Two branches adding an entry therefore conflict on
+# insertion order alone, and the only correct resolution has always been "keep both" — 22 such
+# resolutions sit in the history, the largest of them parallel-agent worktree merges. `union` applies
+# that resolution automatically. See AGENTS.md § "Release Cadence".
+#
+# Residual risk: when both sides open the SAME `###` heading, union keeps both copies and merges
+# without complaint. `spec/docs/changelog_conformance_spec.rb` gates exactly that ("declares each
+# section at most once per release") and it covers `[Unreleased]`, so the artefact fails the suite
+# instead of reaching a release. Merging the two headings is the whole fix.
+CHANGELOG.md merge=union

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,11 +92,17 @@ flow is the `rigor-release-prep` skill.
   - **The link is the half that gets more expensive to add later.** You know your own PR number now;
     recovering it at the cut costs a cycle-wide enumeration plus a per-entry match against it. v0.3.6
     reached its release with 21 entries and zero links, and reconstructing the 18 dominated the prep.
-- **Running agents in parallel: only the orchestrator writes `CHANGELOG.md`.** Tell each agent to skip
-  its `[Unreleased]` entry and to report instead what its change means for a user; write the entries
-  yourself once the branches are merged, in that same session. Otherwise every branch edits the same few
-  lines, and every PR after the first needs a hand-resolved conflict in the one file whose wording you
-  were going to review anyway.
+- **Parallel agents each write their own entry; `CHANGELOG.md` merges by union.** `.gitattributes`
+  marks the file `merge=union`, so two branches appending to `## [Unreleased]` no longer conflict on
+  insertion order. That resolution was always "keep both" — git now applies it instead of stopping to
+  ask. Do **not** tell agents to skip their entry: the link is cheapest at landing (above), and a
+  deferred entry is one somebody has to reconstruct.
+  - The one artefact union can produce is a **duplicated `###` heading**, when two branches each open a
+    section `[Unreleased]` did not have. It merges silently, so it is gated instead:
+    `spec/docs/changelog_conformance_spec.rb` fails on a section declared twice in a release, and
+    merging the two headings is the whole fix. Prefer adding under a heading that already exists.
+  - Reviewing the wording is still yours, but it belongs **at the cut**, where release prep consolidates
+    across the whole cycle anyway — not serialised through one session while branches wait.
 
 ## Implementation Guidelines
 


### PR DESCRIPTION
`## [Unreleased]` is a single hot region that nearly every branch appends to, so two branches adding an entry conflict on insertion order alone. This marks the file `merge=union` in `.gitattributes` so git applies the resolution that was always correct — keep both — instead of stopping to ask.

## The conflict is real and recurring

| cycle | commits touching `CHANGELOG.md` | commits total |
| --- | --- | --- |
| v0.3.4 | 29 | 75 |
| v0.3.5 | 25 | 44 |
| v0.3.6 | 18 | 36 |

22 merge commits in the history carry a hand-resolved `CHANGELOG.md` conflict. The largest are exactly the parallel-agent case — the `worktree-agent-*` merges of 2026-05-02 (41–77 lines each) and the `rule/*` → `feature/phpstan-tier1-rules` merges of 2026-07-15 (6–7 colliding entries apiece) — but ordinary long-lived branches hit it too, most recently [#491](https://github.com/rigortype/rigor/pull/491) and `plugin-docs-example-drift` in the v0.3.6 cycle.

Every one of them is the same shape: two independent bullets inserted at the same anchor in one `###` section. There is no judgement in ordering them.

## Verified, not assumed

Two branches inserting into one `### Fixed` **conflict** without the attribute and **merge clean** with it, both entries preserved. `git check-attr merge` confirms the driver binds to `CHANGELOG.md` only — the frozen archives under `docs/` and every source file stay `unspecified`.

## The trade, and why it is safe

When both sides open a `###` heading the section did not have, union keeps both copies and merges **silently**. That artefact is already gated: `spec/docs/changelog_conformance_spec.rb` fails on a section declared twice in a release, and it covers `[Unreleased]`. Injecting the duplicate produces `## [Unreleased] → Fixed` and exit 1 — confirmed against the real spec, not a reimplementation. Merging the two headings is the whole fix, and the release skill's sealing step now looks for it.

The release-branch rebase note also gains a warning: union hides an `[Unreleased]` entry that lands on `master` mid-prep, so the sealed section gets re-read after a rebase.

## The AGENTS.md rule this replaces

The old rule told parallel agents to skip their `[Unreleased]` entry so the orchestrator could write them all afterwards. Its sole rationale was the conflict this PR removes. It had also become self-contradictory: the landing-time rule directly above it asks for the entry *and its PR link* at landing, which is where they are cheapest ([ab04360c](https://github.com/rigortype/rigor/commit/ab04360c)). Agents write their own entry again; wording review moves to the cut, where release prep consolidates across the cycle regardless.

## Notes

No `[Unreleased]` entry: a merge driver is invisible to anyone installing the gem.

`make verify` exit 0 locally.