### PR TITLE
Widen the receiver on index or/and/operator-writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Fixed
+
+- **[engine]** A collection filled through `h[k] ||= v`, `h[k] &&= v` or `h[k] += v` is no longer read as still carrying the literal shape it was initialized with, so `empty?` and `size` on it stop folding to a constant and a guard like `return nil if x.nil? || @rows.empty?` stops drawing a false "condition is always truthy" ([#504](https://github.com/rigortype/rigor/pull/504), [#501](https://github.com/rigortype/rigor/issues/501)).
+
 ## [0.3.6] - 2026-08-30
 
 v0.3.6 is a performance release for the commands you run repeatedly: a warm `rigor unused` is several times faster, and a warm `rigor effects` or `rigor effects check` now answers without loading the analysis engine at all ([ADR-104](docs/adr/104-effects-boot-slim-probe.md)). The effect snapshot is sized for an application rather than a fixture, so the committed file shrank by a third, stopped churning when an unrelated call moves, and a drift report now names where each method is defined instead of listing everything behind it. Machine-readable output is a valid document again under `--cache-stats`, and every diagnostic's text output carries the rule identifier you need to configure it. The documentation the gem ships also gained links that resolve for a reader who installed Rigor rather than cloning it.

--- a/lib/rigor/inference/index_write_widening.rb
+++ b/lib/rigor/inference/index_write_widening.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "prism"
+
+require_relative "mutation_widening"
+
+module Rigor
+  module Inference
+    # `h[k] ||= v`, `h[k] &&= v` and `h[k] += v` store through `[]=`, but Prism gives each its own node class rather
+    # than a `[]=` `CallNode`. None of them therefore reached {MutationWidening.widen_after_call}, and a literal-shape
+    # binding outlived its justification: an `@h = {}` written only through `@h[k] ||= {}` kept its empty `HashShape`,
+    # so `@h.empty?` folded to `Constant[true]` and `return nil if x.nil? || @h.empty?` drew a false
+    # `flow.always-truthy-condition` on a hash the class fills.
+    #
+    # Two consumers need the same recognition and neither had it: {StatementEvaluator} for the straight-line write, and
+    # {ScopeIndexer}'s class-ivar pre-pass for the cross-method one (an ivar written in `add` and read in `probe`).
+    # `||=` / `&&=` are conditional at runtime, but a widening may only LOSE precision, so answering on the branch that
+    # does not store is safe.
+    #
+    # `Prism::IndexTargetNode` is deliberately absent: it is a multi-assign TARGET, and the `MultiWriteNode` that owns
+    # it is where that write is observed.
+    module IndexWriteWidening
+      NODE_CLASSES = [Prism::IndexOrWriteNode, Prism::IndexAndWriteNode, Prism::IndexOperatorWriteNode].freeze
+
+      # The method these forms store through — the name the mutator tables are keyed on.
+      MUTATOR = :[]=
+
+      module_function
+
+      # @param node [Prism::Node]
+      def index_write?(node)
+        NODE_CLASSES.any? { |klass| node.is_a?(klass) }
+      end
+
+      # @param node          [Prism::Node] one of {NODE_CLASSES}
+      # @param current_scope [Rigor::Scope]
+      # @return              [Rigor::Scope]
+      def widen(node:, current_scope:)
+        MutationWidening.widen_receiver_aliases(node.receiver, MUTATOR, current_scope)
+      end
+    end
+  end
+end

--- a/lib/rigor/inference/mutation_widening.rb
+++ b/lib/rigor/inference/mutation_widening.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "prism"
+
 require_relative "../type"
 require_relative "../source/node_children"
 require_relative "receiver_alias"
@@ -117,11 +119,15 @@ module Rigor
       def widen_after_call(call_node:, current_scope:)
         return current_scope if pure_self_returner?(call_node.name)
 
-        receiver = call_node.receiver
+        widen_receiver_aliases(call_node.receiver, call_node.name, current_scope)
+      end
+
+      # Widens every variable `receiver` can evaluate to, against `method_name`'s mutator table.
+      def widen_receiver_aliases(receiver, method_name, current_scope)
         return current_scope if receiver.nil?
 
         ReceiverAlias.candidates(receiver).reduce(current_scope) do |acc, read|
-          widen_alias_read(call_node.name, read, acc)
+          widen_alias_read(method_name, read, acc)
         end
       end
 

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -9,6 +9,7 @@ require_relative "../source/node_children"
 require_relative "../cache/file_digest"
 require_relative "anonymous_meta_class"
 require_relative "def_handle"
+require_relative "index_write_widening"
 require_relative "mutation_widening"
 require_relative "narrowing"
 require_relative "statement_evaluator"
@@ -597,7 +598,7 @@ module Rigor
         # records — an unanalyzable multi-write means unknown, not nil).
         record_multi_write_ivars(node, scope, class_name, accumulator)
 
-        record_ivar_mutator_call(node, class_name, mutated_ivars) if mutated_ivars && node.is_a?(Prism::CallNode)
+        record_ivar_mutator_call(node, class_name, mutated_ivars) if mutated_ivars
 
         # Don't recurse into nested defs, classes, or modules; their ivars belong to their own enclosing class.
         return if IVAR_BARRIER_NODES.any? { |klass| node.is_a?(klass) }
@@ -618,14 +619,29 @@ module Rigor
       # {.widen_mutated_ivar_entries!}). Always-safe to over- collect: any name that the widening primitive declines is
       # ignored at finalization.
       def record_ivar_mutator_call(node, class_name, mutated_ivars)
+        method_name = ivar_mutator_name(node)
+        return if method_name.nil?
+
         receiver = node.receiver
         return unless receiver.is_a?(Prism::InstanceVariableReadNode)
-        return unless MutationWidening::ARRAY_MUTATORS.include?(node.name) ||
-                      MutationWidening::HASH_MUTATORS.include?(node.name)
+        return unless MutationWidening::ARRAY_MUTATORS.include?(method_name) ||
+                      MutationWidening::HASH_MUTATORS.include?(method_name)
 
         per_class = (mutated_ivars[class_name] ||= {})
         per_ivar = (per_class[receiver.name] ||= Set.new)
-        per_ivar << node.name
+        per_ivar << method_name
+      end
+
+      # The mutator a node applies to its receiver, or nil when the node is not a mutator form.
+      # `@h[k] ||= v` and its `&&=` / `+=` siblings store through `[]=` but are not `[]=` CallNodes
+      # (`IndexWriteWidening`); missing them left an `@h = {}` mutated only
+      # that way carrying its empty `HashShape` into every sibling method, so `@h.empty?` folded to
+      # `Constant[true]` on a hash the class fills.
+      def ivar_mutator_name(node)
+        return node.name if node.is_a?(Prism::CallNode)
+        return IndexWriteWidening::MUTATOR if IndexWriteWidening.index_write?(node)
+
+        nil
       end
 
       # Walk an `IfNode` / `UnlessNode` so writes inside the THEN body that look like defensive ivar initialisation gain

--- a/lib/rigor/inference/statement_evaluator.rb
+++ b/lib/rigor/inference/statement_evaluator.rb
@@ -16,6 +16,7 @@ require_relative "../analysis/check_rules/inferred_param_guard"
 require_relative "struct_fold_safety"
 require_relative "closure_escape_analyzer"
 require_relative "indexed_narrowing"
+require_relative "index_write_widening"
 require_relative "method_dispatcher"
 require_relative "method_parameter_binder"
 require_relative "multi_target_binder"
@@ -76,6 +77,8 @@ module Rigor
         Prism::GlobalVariableAndWriteNode => :eval_global_and_write,
         Prism::GlobalVariableOperatorWriteNode => :eval_global_operator_write,
         Prism::IndexOrWriteNode => :eval_index_or_write,
+        Prism::IndexAndWriteNode => :eval_index_write,
+        Prism::IndexOperatorWriteNode => :eval_index_write,
         Prism::MultiWriteNode => :eval_multi_write,
         Prism::IfNode => :eval_if,
         Prism::UnlessNode => :eval_unless,
@@ -433,9 +436,22 @@ module Rigor
         key_node = first_index_argument(node)
         address = key_node && IndexedNarrowing.stable_address(node.receiver, key_node)
         post = post_rhs
+        # Widen BEFORE recording the narrowing: rebinding the receiver drops the per-slot narrowings keyed on it, so
+        # the reverse order would trade this feature away for the widening. The two are complementary — the shape
+        # forgets that the collection is still empty, the narrowing remembers that THIS slot is now non-nil.
+        post = IndexWriteWidening.widen(node: node, current_scope: post)
         post = post.with_indexed_narrowing(*address, result_type) if address
 
         [result_type, post]
+      end
+
+      # `h[k] &&= v` / `h[k] += v`. Neither had a handler, so both fell to `evaluate`'s default — typed as a pure
+      # expression, scope untouched — and the receiver never widened. They store through `[]=` exactly as
+      # `eval_index_or_write` does, so they take the same widening; the value itself is still typed by the expression
+      # typer (`type_of_assignment_write`), which is what the default did.
+      def eval_index_write(node)
+        [scope.type_of(node, tracer: tracer),
+         IndexWriteWidening.widen(node: node, current_scope: scope)]
       end
 
       def first_index_argument(node)

--- a/spec/integration/fixtures/index_write_mutation_widening.rb
+++ b/spec/integration/fixtures/index_write_mutation_widening.rb
@@ -1,0 +1,50 @@
+require "rigor/testing"
+include Rigor::Testing
+
+# `h[k] ||= v`, `h[k] &&= v` and `h[k] += v` store through `[]=`
+# but Prism gives each its own node class, so none of them was a
+# `[]=` CallNode and none reached MutationWidening. A collection
+# written only that way kept the literal shape its seed gave it —
+# `@rows.empty?` folded to `Constant[true]` on a hash the class
+# fills — and the compound guard below drew a false
+# `flow.always-truthy-condition`.
+
+# Straight-line: the local keeps no empty-shape claim after the
+# or-write, so `empty?` stays `bool` rather than folding to true.
+local_or = {}
+local_or[:a] ||= 1
+local_or_empty = local_or.empty?
+
+local_op = {}
+local_op[:a] = 0
+local_op[:a] += 1
+local_op_empty = local_op.empty?
+
+local_array = []
+local_array[0] ||= :first
+local_array_empty = local_array.empty?
+
+# Cross-method: the class-ivar pre-pass observes the or-write in
+# `add` and widens the `initialize` seed for every other method
+# body, exactly as it already did for `@h[k] = v`.
+class Rows
+  def initialize
+    @rows = {}
+  end
+
+  def add(key)
+    @rows[key] ||= {}
+  end
+
+  def bump(key)
+    @rows[key] &&= 2
+  end
+
+  # The plugin_facts.rb worked site: a compound guard whose left
+  # operand is typed and whose right reads the mutated ivar.
+  def row(owner)
+    return nil if owner.nil? || @rows.empty?
+
+    @rows[owner]
+  end
+end

--- a/spec/integration/snapshots/index_write_mutation_widening.yml
+++ b/spec/integration/snapshots/index_write_mutation_widening.yml
@@ -1,0 +1,8 @@
+---
+locals:
+  local_array: Array[Dynamic[top]]
+  local_array_empty: bool
+  local_op: Hash[Dynamic[top], Dynamic[top]]
+  local_op_empty: bool
+  local_or: Hash[Dynamic[top], Dynamic[top]]
+  local_or_empty: bool

--- a/spec/integration/snapshots/indexed_or_narrowing.yml
+++ b/spec/integration/snapshots/indexed_or_narrowing.yml
@@ -1,4 +1,4 @@
 ---
 locals:
-  indexed: "{}"
-  params: "{}"
+  indexed: Hash[Dynamic[top], Dynamic[top]]
+  params: Hash[Dynamic[top], Dynamic[top]]

--- a/spec/integration/type_construction_spec.rb
+++ b/spec/integration/type_construction_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe "Rigor type construction (integration)" do
     Rigor::Type::Combinator.constant_of(value)
   end
 
+  # `bool` as the engine spells it — the `Constant[true] | Constant[false]` union
+  # `RbsTypeTranslator` folds RBS's `bool` to, not a `TrueClass | FalseClass` nominal pair.
+  def bool_type
+    Rigor::Type::Combinator.union(constant(true), constant(false))
+  end
+
   describe "fixtures/parity.rb — even/odd predicate" do
     let(:harness) { harness_for("parity") }
 
@@ -101,6 +107,27 @@ RSpec.describe "Rigor type construction (integration)" do
     it "records a per-slot narrowing keyed on `(receiver_kind, receiver_name, literal_key)`" do
       key = Rigor::Scope::IndexedKey.new(receiver_kind: :local, receiver_name: :params, key: :f)
       expect(harness.post_scope.indexed_narrowings).to have_key(key)
+    end
+  end
+
+  describe "fixtures/index_write_mutation_widening.rb — `h[k] ||= v` and siblings widen like `h[k] = v`" do
+    let(:harness) { harness_for("index_write_mutation_widening") }
+
+    it "is diagnostic-clean — the compound `x.nil? || @rows.empty?` guard no longer folds to a constant" do
+      messages = harness.diagnostics.map(&:message)
+      expect(messages.grep(/always-(truthy|falsey)|condition is always/)).to be_empty
+    end
+
+    it "widens a local through IndexOrWriteNode, so `empty?` stays undecided" do
+      expect(harness.local(:local_or_empty)).to eq(bool_type)
+    end
+
+    it "widens a local through IndexOperatorWriteNode" do
+      expect(harness.local(:local_op_empty)).to eq(bool_type)
+    end
+
+    it "widens an Array-receiver or-write, not only a Hash one" do
+      expect(harness.local(:local_array_empty)).to eq(bool_type)
     end
   end
 

--- a/spec/rigor/inference/index_write_widening_spec.rb
+++ b/spec/rigor/inference/index_write_widening_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "prism"
+
+require "rigor/inference/index_write_widening"
+require "rigor/scope"
+require "rigor/type"
+
+# `h[k] ||= v` and its `&&=` / `+=` siblings are not `[]=` CallNodes, so they bypassed
+# {Rigor::Inference::MutationWidening.widen_after_call} entirely and a literal-shape binding survived a
+# mutation that invalidated it. The straight-line consumer is `StatementEvaluator`; the cross-method
+# one is `ScopeIndexer`'s class-ivar pre-pass. Both are exercised end-to-end by
+# `spec/integration/fixtures/index_write_mutation_widening.rb`; this file pins the primitive.
+RSpec.describe Rigor::Inference::IndexWriteWidening do
+  describe ".index_write?" do
+    def parse_last(source)
+      Prism.parse(source).value.statements.body.last
+    end
+
+    it "recognises the three write forms" do
+      expect(described_class.index_write?(parse_last("h[:a] ||= 1\n"))).to be true
+      expect(described_class.index_write?(parse_last("h[:a] &&= 1\n"))).to be true
+      expect(described_class.index_write?(parse_last("h[:a] += 1\n"))).to be true
+    end
+
+    it "declines a plain `[]=` CallNode (already covered by widen_after_call) and an index READ" do
+      expect(described_class.index_write?(parse_last("h[:a] = 1\n"))).to be false
+      expect(described_class.index_write?(parse_last("h[:a]\n"))).to be false
+    end
+  end
+
+  describe ".widen" do
+    def parse_first(source)
+      Prism.parse(source).value.statements.body.last
+    end
+
+    let(:scope) { Rigor::Scope.empty.with_local(:h, Rigor::Type::HashShape.new) }
+
+    it "widens the receiver of an IndexOrWriteNode, which is not a `[]=` CallNode" do
+      node = parse_first("h = {}\nh[:a] ||= 1\n")
+      expect(node).to be_a(Prism::IndexOrWriteNode)
+      widened = described_class.widen(node: node, current_scope: scope).local(:h)
+      expect(widened).to be_a(Rigor::Type::Nominal)
+      expect(widened.class_name).to eq("Hash")
+    end
+
+    it "widens an IndexAndWriteNode receiver" do
+      node = parse_first("h = {}\nh[:a] &&= 1\n")
+      expect(node).to be_a(Prism::IndexAndWriteNode)
+      expect(described_class.widen(node: node, current_scope: scope).local(:h))
+        .to be_a(Rigor::Type::Nominal)
+    end
+
+    it "widens an IndexOperatorWriteNode receiver" do
+      node = parse_first("h = {}\nh[:a] += 1\n")
+      expect(node).to be_a(Prism::IndexOperatorWriteNode)
+      expect(described_class.widen(node: node, current_scope: scope).local(:h))
+        .to be_a(Rigor::Type::Nominal)
+    end
+
+    it "leaves an Array-typed local alone when the binding carries no literal shape" do
+      nominal = Rigor::Type::Combinator.nominal_of("Hash")
+      unshaped = Rigor::Scope.empty.with_local(:h, nominal)
+      node = parse_first("h = {}\nh[:a] ||= 1\n")
+      expect(described_class.widen(node: node, current_scope: unshaped).local(:h))
+        .to eq(nominal)
+    end
+
+    it "declines when the write has no receiver variable to widen" do
+      node = parse_first("foo[:a] ||= 1\n")
+      expect(described_class.widen(node: node, current_scope: scope).local(:h))
+        .to be_a(Rigor::Type::HashShape)
+    end
+  end
+end


### PR DESCRIPTION
Closes #501.

`h[k] = v` widens the receiver binding because Prism gives it a `[]=` `CallNode` and `MutationWidening` keys on the call name. `h[k] ||= v`, `h[k] &&= v` and `h[k] += v` store through the same `[]=` but get their own node classes, so none of them reached the widening. A collection written only that way kept the literal shape its seed gave it, and `empty?` / `size` constant-folded against a shape that mutation had already invalidated.

## Before / after — `rigor type-of` on `@h.empty?`, mutation in a sibling method

| mutation | before | after |
| --- | --- | --- |
| `@h[k] = 1` | `bool` | `bool` |
| `@h.store(k, 1)` | `bool` | `bool` |
| `@a << x` | `bool` | `bool` |
| `@h[k] \|\|= 1` | `true` | `bool` |
| `@h[k] += 1` | `true` | `bool` |
| `@h[k] &&= 2` (reading `@h.size`) | `1` | `non-negative-int` |

The straight-line local form (`h = {}; h[:a] ||= 1; h.empty?`) was wrong the same way and is fixed too.

## Shape of the change

Two consumers needed the same recognition and neither had it, so it lives in one place — `Inference::IndexWriteWidening`:

- `StatementEvaluator` for the straight-line write. Two of the three node classes had **no handler at all** and fell through to `evaluate`'s default ("pure expression, scope unchanged"), which is why `&&=` and `+=` were invisible even within one method.
- `ScopeIndexer`'s class-ivar pre-pass for the cross-method case, which is where the `plugin_facts.rb` shape actually sits (`@class_rows[entry.singleton] ||= {}` in one method, `@class_rows.empty?` in four others).

Ordering inside `eval_index_or_write` matters and is commented at the call site: rebinding the receiver drops the per-slot narrowings keyed on it, so the widening runs **first** and the `IndexedNarrowing` record is applied after. The two are complementary — the shape forgets that the collection is still empty, the narrowing remembers that this slot is now non-nil. With the reverse order the landed `receiver[key] ||= default` narrowing feature would have been traded away for the widening.

## The one snapshot change

`spec/integration/snapshots/indexed_or_narrowing.yml` moves `params` and `indexed` from `{}` to `Hash[Dynamic[top], Dynamic[top]]`. That is the correction the fix is about, not a regression: `h[:a] = 1` already widens the same local to exactly that, and a conditional write must not leave the receiver more precise than an unconditional one. The fixture's own diagnostic-clean assertion is unaffected — the narrowing still carries `params[:f]`, so `params[:f] << :status` still dispatches through `Array`.

## Verification

- `make verify` green (10,000+ examples, rubocop clean); `make check` and `make check-plugins` report zero diagnostics.
- New: `spec/rigor/inference/index_write_widening_spec.rb` (the primitive, including the deliberate declines) and `spec/integration/fixtures/index_write_mutation_widening.rb` with a golden snapshot, pinning all three node classes on both a Hash and an Array receiver plus the compound-guard shape that fires the false positive.
- `rigor coverage lib` is 55.28% against 55.27% before — the shape precision this gives up is bounded, and it is precision the engine was not entitled to.

Found while auditing Rigor's own `lib` — [`docs/notes/20260831-self-check-type-coverage-audit.md`](https://github.com/rigortype/rigor/blob/master/docs/notes/20260831-self-check-type-coverage-audit.md) has the method and the two sibling findings (#502, #503).