### PR TITLE
Seed the precision scan with the same cross-file facts as --protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Fixed
+
+- **[cli]** `rigor coverage` and `rigor check --coverage` report the type precision the engine actually reaches rather than what a file-at-a-time walk can see on its own — a class defined in a sibling file now counts as typed, which is worth 1.4 points on Rigor's own `lib`, and turning `parameter_inference:` on is worth 3.4 more ([#505](https://github.com/rigortype/rigor/pull/505), [#502](https://github.com/rigortype/rigor/issues/502)).
+
 ## [0.3.6] - 2026-08-30
 
 v0.3.6 is a performance release for the commands you run repeatedly: a warm `rigor unused` is several times faster, and a warm `rigor effects` or `rigor effects check` now answers without loading the analysis engine at all ([ADR-104](docs/adr/104-effects-boot-slim-probe.md)). The effect snapshot is sized for an application rather than a fixture, so the committed file shrank by a third, stopped churning when an unrelated call moves, and a drift report now names where each method is defined instead of listing everything behind it. Machine-readable output is a valid document again under `--cache-stats`, and every diagnostic's text output carries the rule identifier you need to configure it. The documentation the gem ships also gained links that resolve for a reader who installed Rigor rather than cloning it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,9 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
-- **[cli]** `rigor coverage` and `rigor check --coverage` report the type precision the engine actually reaches rather than what a file-at-a-time walk can see on its own — a class defined in a sibling file now counts as typed, which is worth 1.4 points on Rigor's own `lib`, and turning `parameter_inference:` on is worth 3.4 more ([#505](https://github.com/rigortype/rigor/pull/505), [#502](https://github.com/rigortype/rigor/issues/502)).
-
-### Fixed
-
 - **[engine]** A collection filled through `h[k] ||= v`, `h[k] &&= v` or `h[k] += v` is no longer read as still carrying the literal shape it was initialized with, so `empty?` and `size` on it stop folding to a constant and a guard like `return nil if x.nil? || @rows.empty?` stops drawing a false "condition is always truthy" ([#504](https://github.com/rigortype/rigor/pull/504), [#501](https://github.com/rigortype/rigor/issues/501)).
+
+- **[cli]** `rigor coverage` and `rigor check --coverage` report the type precision the engine actually reaches rather than what a file-at-a-time walk can see on its own — a class defined in a sibling file now counts as typed, which is worth 1.4 points on Rigor's own `lib`, and turning `parameter_inference:` on is worth 3.4 more ([#505](https://github.com/rigortype/rigor/pull/505), [#502](https://github.com/rigortype/rigor/issues/502)).
 
 ## [0.3.6] - 2026-08-30
 

--- a/lib/rigor/cli/coverage_command.rb
+++ b/lib/rigor/cli/coverage_command.rb
@@ -217,20 +217,10 @@ module Rigor
       # class. Tier 1 seeds unconditionally because it only reclassifies sites it already counted; Tier 2 adds
       # sites to a denominator `--threshold` gates CI on, which is why only the latter is gated on a feature id.
       def scope_with_inferred_params(paths, configuration, environment, workers)
-        base = Scope.empty(environment: environment)
-        seed = {}
-
-        discovered = Inference::ScopeIndexer.discovered_classes_for_paths(paths)
-        seed[:discovered_classes] = discovered unless discovered.empty?
-
-        table = Inference::ParameterInferenceCollector.collect(
-          files: paths, environment: environment, target_ruby: configuration.target_ruby, workers: workers
+        CoverageScan.discovery_seeded_scope(
+          files: paths, configuration: configuration, environment: environment,
+          parameter_inference: true, workers: workers
         )
-        seed[:param_inferred_types] = table unless table.empty?
-
-        return base if seed.empty?
-
-        base.with_discovery(base.discovery.with(**seed))
       end
 
       def determine_protection_exit(report, options)

--- a/lib/rigor/cli/coverage_scan.rb
+++ b/lib/rigor/cli/coverage_scan.rb
@@ -4,7 +4,9 @@ require "prism"
 
 require_relative "../configuration"
 require_relative "../environment"
+require_relative "../inference/parameter_inference_collector"
 require_relative "../inference/precision_scanner"
+require_relative "../inference/scope_indexer"
 require_relative "../scope"
 require_relative "coverage_report"
 
@@ -21,11 +23,56 @@ module Rigor
       # @param configuration [Rigor::Configuration]
       # @return [Rigor::CLI::CoverageReport]
       def precision_report(files:, configuration:)
-        scope = Scope.empty(environment: project_environment(configuration))
+        scope = discovery_seeded_scope(
+          files: files,
+          configuration: configuration,
+          environment: project_environment(configuration),
+          parameter_inference: configuration.parameter_inference
+        )
         scanner = Inference::PrecisionScanner.new(scope: scope)
         accumulator = CoverageAccumulator.new
         files.each { |path| scan_into(path, scanner, accumulator, configuration) }
         accumulator.to_report(files, {})
+      end
+
+      # The cross-file facts a scan must see to report the types the engine actually infers, rather than the types a
+      # file-at-a-time walk can reach on its own:
+      #
+      # - `discovered_classes` — a project constant naming a class defined in a SIBLING file (`Account`, `User`) types
+      #   as `singleton(Account)` instead of `Dynamic`. Without it a single-file scan cannot see a class it does not
+      #   itself declare (the model-constant undercount found 2026-07-04).
+      # - `param_inferred_types` (ADR-67 WD3) — an undeclared parameter seeded with the union of its call sites'
+      #   argument types.
+      #
+      # Both spanned the `--protection` scan only until 2026-08-31, so the PRECISION ratio — the number `rigor
+      # coverage`, `rigor check --coverage` and the `check-coverage` threshold gate all report — was measured on a
+      # stripped scope and understated the engine by 4.87 points on this repository's own `lib`. The two surfaces now
+      # build the same seed set, so their ratios describe the same engine.
+      #
+      # `parameter_inference` is a parameter rather than a config read because the two callers want different answers:
+      # the precision lens must mirror the walk it describes (`check` leaves the table empty unless
+      # `parameter_inference:` is on, ADR-67 WD6a), while `--protection` seeds it unconditionally by ADR-67's own
+      # wiring — it only ever reclassifies sites it already counted.
+      #
+      # @return [Rigor::Scope]
+      def discovery_seeded_scope(files:, configuration:, environment:, parameter_inference:, workers: nil)
+        base = Scope.empty(environment: environment)
+        seed = {}
+
+        discovered = Inference::ScopeIndexer.discovered_classes_for_paths(files)
+        seed[:discovered_classes] = discovered unless discovered.empty?
+
+        if parameter_inference
+          table = Inference::ParameterInferenceCollector.collect(
+            files: files, environment: environment, target_ruby: configuration.target_ruby,
+            workers: workers || configuration.parallel_workers
+          )
+          seed[:param_inferred_types] = table unless table.empty?
+        end
+
+        return base if seed.empty?
+
+        base.with_discovery(base.discovery.with(**seed))
       end
 
       def project_environment(configuration)

--- a/spec/rigor/cli/coverage_command_spec.rb
+++ b/spec/rigor/cli/coverage_command_spec.rb
@@ -24,6 +24,44 @@ RSpec.describe Rigor::CLI::CoverageCommand do
     Dir.mktmpdir { |dir| Dir.chdir(dir) { example.run } }
   end
 
+  # The precision lens used to build a bare `Scope.empty` while `--protection` seeded `discovered_classes` +
+  # `param_inferred_types`, so the two surfaces reported on different engines and the precision ratio — the number
+  # `rigor coverage`, `rigor check --coverage` and the `check-coverage` gate all print — understated what the engine
+  # infers. Both build the same seed set now; the gating difference that remains is deliberate and pinned below.
+  describe "cross-file discovery seeding" do
+    it "types a class constant defined in a sibling file, instead of counting it opaque" do
+      File.write("account.rb", "class Account\nend\n")
+      File.write("use.rb", "Account\n")
+
+      status, out, = run(["--format", "json", "account.rb", "use.rb"])
+
+      expect(status).to eq(0)
+      use = JSON.parse(out).fetch("by_file").find { |f| f.fetch("file") == "use.rb" }
+      expect(use.fetch("dynamic_opaque_count")).to eq(0)
+      expect(use.fetch("precise_ratio")).to eq(1.0)
+    end
+
+    it "seeds inferred parameter types only when `parameter_inference:` is on, mirroring the check walk" do
+      File.write("app.rb", <<~RUBY)
+        class Greeter
+          def shout(word)
+            word.upcase
+          end
+        end
+
+        Greeter.new.shout("hi")
+      RUBY
+      File.write("off.yml", %(target_ruby: "4.0"\nparameter_inference: false\n))
+      File.write("on.yml", %(target_ruby: "4.0"\nparameter_inference: true\n))
+
+      _, off, = run(["--format", "json", "--config", "off.yml", "app.rb"])
+      _, on, = run(["--format", "json", "--config", "on.yml", "app.rb"])
+
+      expect(JSON.parse(on).dig("summary", "precise_count"))
+        .to be > JSON.parse(off).dig("summary", "precise_count")
+    end
+  end
+
   it "rejects --mutation without --protection (usage error)" do
     File.write("a.rb", "x = 1\n")
     status, _out, err = run(["--mutation", "a.rb"])


### PR DESCRIPTION
Closes #502.

`CLI::CoverageScan.precision_report` built a bare `Scope.empty` while `CoverageCommand#scope_with_inferred_params` (the `--protection` path) seeded `discovered_classes` and `param_inferred_types`. The protection path's own comment records why those seeds are needed — a file-at-a-time walk cannot see a class it does not itself declare, which had systematically miscounted every cross-file class-constant dispatch — but that fix, made 2026-07-04, only ever reached the protection surface. The two lenses therefore reported on two different engines, and the one that under-reported is the user-facing one: the precision ratio is what `rigor coverage`, `rigor check --coverage` and the `make check-coverage` threshold gate all print.

## Measured on this repository's own `lib`

| | precise ratio |
| --- | --- |
| before | 55.27% |
| after, `parameter_inference: false` (the default) | 56.70% |
| after, `parameter_inference: true` | 60.13% |

## The gating difference is deliberate

Seeding both tables unconditionally would make `coverage` report precision no `rigor check` run actually has: the check walk leaves `param_inferred_types` empty unless `parameter_inference:` is on (ADR-67 WD6a). So the shared helper takes `parameter_inference:` as a parameter rather than reading the config itself —

- the **precision** lens passes `configuration.parameter_inference`, mirroring the walk it describes;
- **`--protection`** passes `true`, unchanged from ADR-67's own wiring: it only ever reclassifies sites it already counted.

## The protection surface is unchanged — measured, not argued

`rigor coverage --protection --workers 8 lib/rigor/inference` (a subtree this PR does not touch) reads **4945 / 10407 (47.5%)** on master and identically on this branch.

## The threshold

`make check-coverage` stays at `--threshold 0.43`. It now gates a different number, and how much headroom that gate should carry is a decision on its own rather than a side effect of this fix.

## Verification

- `make verify` green; rubocop clean.
- Two new specs in `spec/rigor/cli/coverage_command_spec.rb`: a sibling-file class constant now counts as precise rather than opaque (`dynamic_opaque_count == 0` for the referring file), and the `parameter_inference:` gating is pinned in both directions.

Found while auditing Rigor's own `lib` — [`docs/notes/20260831-self-check-type-coverage-audit.md`](https://github.com/rigortype/rigor/blob/master/docs/notes/20260831-self-check-type-coverage-audit.md) § Finding 1. The `param_inferred_types` half of that table is also the ADR-67 WD6 default-on data point, taken on a codebase whose call graph is entirely in-project.