### PR TITLE
Answer the receiver-independent Object methods on a Dynamic receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ## [Unreleased]
 
+### Changed
+
+- **[engine]** `x.nil?`, `x.is_a?(C)`, `x.respond_to?(:m)`, `!x`, `x.frozen?`, `x.equal?(y)`, `x.inspect`, `x.hash` and `x.object_id` now carry their own type even when Rigor cannot type `x` — their result never depended on the receiver — which is worth 2.3 points of type precision on Rigor's own `lib` and no new diagnostics ([#508](https://github.com/rigortype/rigor/pull/508), [#503](https://github.com/rigortype/rigor/issues/503)).
+
 ### Fixed
 
 - **[engine]** A collection handed out by one method and filled through that reference — `(bucket_for(entry)[key] ||= {})[name] = row` — is no longer read as still empty, so `empty?` and `size` on it stop folding to a constant in every other method of the class ([#507](https://github.com/rigortype/rigor/pull/507), [#506](https://github.com/rigortype/rigor/issues/506)).

--- a/lib/rigor/inference/method_dispatcher.rb
+++ b/lib/rigor/inference/method_dispatcher.rb
@@ -30,6 +30,7 @@ require_relative "method_dispatcher/cgi_folding"
 require_relative "method_dispatcher/uri_folding"
 require_relative "method_dispatcher/set_folding"
 require_relative "method_dispatcher/kernel_dispatch"
+require_relative "method_dispatcher/universal_object_dispatch"
 require_relative "method_dispatcher/method_folding"
 
 module Rigor
@@ -217,6 +218,15 @@ module Rigor
         # tier. Sits below every real resolution tier so a genuine signature always wins.
         stub_result = try_synthesized_stub_type(receiver_type, environment)
         return stub_result if stub_result
+
+        # The receiver-independent `BasicObject` / `Object` / `Kernel` selectors, for a receiver no tier
+        # above could name. `x.nil?` is `bool` whatever `x` is; without this tier it was `Dynamic[Top]`
+        # like every other call on an untyped receiver. Sits here, below every real resolution tier, so a
+        # nameable receiver always answers from its own signature first — this only ever replaces a
+        # `Dynamic[Top]` the typer was about to produce. See {UniversalObjectDispatch} for the table and
+        # for the selectors deliberately left out of it.
+        universal_result = UniversalObjectDispatch.try_dispatch(context)
+        return universal_result if universal_result
 
         # Slice 7 phase 10 — user-class ancestor fallback. When the receiver is `Nominal[T]` or
         # `Singleton[T]` for a class not in the RBS environment (typically a user-defined class),

--- a/lib/rigor/inference/method_dispatcher/universal_object_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/universal_object_dispatch.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require_relative "../../type"
+
+module Rigor
+  module Inference
+    module MethodDispatcher
+      # The last resolution tier for a `Dynamic` receiver: the handful of `BasicObject` / `Object` / `Kernel`
+      # methods whose return type does not depend on who the receiver is.
+      #
+      # `x.nil?` is `bool` whatever `x` is. Until this tier existed it was `Dynamic[Top]`, because every
+      # preceding tier needs a receiver it can name and the typer then fell through to the Dynamic-origin
+      # propagation. The same held for `is_a?`, `respond_to?`, `!` and the rest of the set below — a
+      # measurable share of the opaque expressions on a real codebase, closed by a fixed table rather than
+      # by knowing anything about the receiver
+      # (`docs/notes/20260831-self-check-type-coverage-audit.md` § Finding 2: +2.27 points of precision on this
+      # repository's own `lib`, with zero new diagnostics).
+      #
+      # **Where it sits.** After every real tier has declined, so a receiver Rigor can name always resolves
+      # through RBS first — `"".frozen?` is answered by `String`'s signature, not by this table. It only ever
+      # replaces a `Dynamic[Top]` that the engine was about to produce anyway.
+      #
+      # **What is deliberately NOT here**, each measured rather than argued (same note):
+      #
+      # - `class` — `Nominal[Class]` erases the singleton. `p.class.dynamic_returns` on a plugin instance is
+      #   real code in this repository; folding the receiver's class to the bare `Class` nominal produced 13
+      #   `call.undefined-method` false positives on `lib` alone. An ADR-5 violation bought for +0.14 points.
+      # - `==` / `!=` / `eql?` — the same failure at a much larger blast radius. `==` is the most commonly
+      #   overridden method in Ruby, and an overridden one is free to return anything.
+      # - `to_s` — receiver-independent in principle, but enabling it surfaces the RBS
+      #   `Array#[](Range) -> Array[T]?` optional-return noise on `x.to_s.split("::")[0...-1]` (7
+      #   `call.possible-nil-receiver` on `lib`). Not this tier's defect, but not this tier's to ship either:
+      #   it goes in once that noise has an answer.
+      # - `freeze` / `dup` / `clone` / `itself` / `tap` — receiver-independent in a different way (they
+      #   return the receiver), so on a `Dynamic` receiver they gain nothing.
+      module UniversalObjectDispatch
+        # `bool` as the engine spells it — `Constant[true] | Constant[false]`, the union
+        # `RbsTypeTranslator` folds RBS's `bool` to. Spelling it `Nominal[TrueClass] | Nominal[FalseClass]`
+        # instead type-checks but is not the same value: it fails to match a `-> bool` declaration and
+        # produced 17 spurious `def.return-type-mismatch` warnings when this tier was first prototyped.
+        BOOL = Type::Combinator.union(
+          Type::Combinator.constant_of(true),
+          Type::Combinator.constant_of(false)
+        ).freeze
+        private_constant :BOOL
+
+        # Selector => return type, for selectors defined on `BasicObject` / `Object` / `Kernel` whose result
+        # is a function of the language, not of the receiver's class:
+        #
+        # - the type predicates (`nil?`, `is_a?` and its aliases, `respond_to?`, `frozen?`) and the identity
+        #   comparison `equal?`, which `BasicObject` defines as object identity;
+        # - `!`, which Ruby's own semantics constrain to `true` / `false`;
+        # - `inspect`, whose `Object` contract is a `String` representation;
+        # - `hash` and `object_id`, both `Integer` by contract — `hash` because `Hash` requires it.
+        RETURN_TYPES = Ractor.make_shareable({
+                                               :nil? => BOOL,
+                                               :is_a? => BOOL,
+                                               :kind_of? => BOOL,
+                                               :instance_of? => BOOL,
+                                               :respond_to? => BOOL,
+                                               :equal? => BOOL,
+                                               :frozen? => BOOL,
+                                               :! => BOOL,
+                                               :inspect => Type::Combinator.nominal_of("String"),
+                                               :hash => Type::Combinator.nominal_of("Integer"),
+                                               :object_id => Type::Combinator.nominal_of("Integer")
+                                             })
+
+        module_function
+
+        # @param context [CallContext]
+        # @return [Rigor::Type, nil] the receiver-independent return type, or nil to decline.
+        def try_dispatch(context)
+          return nil unless context.receiver.is_a?(Type::Dynamic)
+
+          RETURN_TYPES[context.method_name]
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/fixtures/universal_object_methods.rb
+++ b/spec/integration/fixtures/universal_object_methods.rb
@@ -1,0 +1,39 @@
+require "rigor/testing"
+include Rigor::Testing
+
+# `x.nil?` is `bool` whatever `x` is. With `x` an undeclared parameter it
+# used to be `Dynamic[top]`, like every other call on an untyped receiver,
+# because every dispatch tier needs a receiver it can name. The
+# receiver-independent `BasicObject` / `Object` / `Kernel` selectors are
+# answered from a fixed table instead.
+class Probe
+  def predicates(x)
+    assert_type("bool", x.nil?)
+    assert_type("bool", x.is_a?(String))
+    assert_type("bool", x.respond_to?(:call))
+    assert_type("bool", !x)
+    assert_type("bool", x.frozen?)
+    assert_type("bool", x.equal?(1))
+  end
+
+  def contracts(x)
+    assert_type("String", x.inspect)
+    assert_type("Integer", x.hash)
+    assert_type("Integer", x.object_id)
+  end
+
+  # The exclusions. `x.class` must stay opaque: folding it to `Nominal[Class]`
+  # erases the singleton, and `x.class.some_class_method` is ordinary Ruby.
+  # `==` is the most commonly overridden method in the language, and `to_s`
+  # waits on the `Array#[](Range)` optional-return noise it makes reachable.
+  def excluded(x, y)
+    assert_type("Dynamic[top]", x.class)
+    assert_type("Dynamic[top]", x == y)
+    assert_type("Dynamic[top]", x.to_s)
+  end
+end
+
+# A named receiver still answers from its own signature — this tier sits
+# below every real resolution tier and only replaces a `Dynamic[Top]`.
+folded_nil = nil.nil?
+folded_inspect = :sym.inspect

--- a/spec/integration/snapshots/universal_object_methods.yml
+++ b/spec/integration/snapshots/universal_object_methods.yml
@@ -1,0 +1,4 @@
+---
+locals:
+  folded_inspect: '":sym"'
+  folded_nil: 'true'

--- a/spec/integration/type_construction_spec.rb
+++ b/spec/integration/type_construction_spec.rb
@@ -110,6 +110,22 @@ RSpec.describe "Rigor type construction (integration)" do
     end
   end
 
+  describe "fixtures/universal_object_methods.rb — receiver-independent Object/Kernel selectors" do
+    let(:harness) { harness_for("universal_object_methods") }
+
+    # Every `assert_type` in the fixture — the predicates on an untyped receiver, the Object contract methods, and
+    # the three deliberate exclusions (`class`, `==`, `to_s`), which must still read `untyped`.
+    it "produces no assert_type mismatches" do
+      mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
+      expect(mismatches).to be_empty
+    end
+
+    it "still folds through a receiver the dispatcher can name" do
+      expect(harness.local(:folded_nil)).to eq(constant(true))
+      expect(harness.local(:folded_inspect)).to eq(constant(":sym"))
+    end
+  end
+
   describe "fixtures/index_write_mutation_widening.rb — `h[k] ||= v` and siblings widen like `h[k] = v`" do
     let(:harness) { harness_for("index_write_mutation_widening") }
 

--- a/spec/rigor/inference/method_dispatcher/universal_object_dispatch_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/universal_object_dispatch_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# The last resolution tier for a `Dynamic` receiver. What it does NOT answer is as load-bearing as what it does —
+# every exclusion below was measured on this repository's own `lib` before being made one, so each has its own
+# example rather than living in a comment.
+RSpec.describe Rigor::Inference::MethodDispatcher::UniversalObjectDispatch do
+  def untyped = Rigor::Type::Combinator.untyped
+
+  def bool
+    Rigor::Type::Combinator.union(Rigor::Type::Combinator.constant_of(true),
+                                  Rigor::Type::Combinator.constant_of(false))
+  end
+
+  def dispatch(method_name, receiver: untyped, args: [])
+    described_class.try_dispatch(cc(receiver: receiver, method_name: method_name, args: args))
+  end
+
+  describe "the type predicates" do
+    it "answers bool for every predicate whose result is a function of the language, not the receiver" do
+      %i[nil? is_a? kind_of? instance_of? respond_to? equal? frozen? !].each do |selector|
+        expect(dispatch(selector)).to eq(bool), "expected #{selector} to answer bool"
+      end
+    end
+  end
+
+  describe "the Object contract methods" do
+    it "answers String for inspect" do
+      expect(dispatch(:inspect)).to eq(Rigor::Type::Combinator.nominal_of("String"))
+    end
+
+    it "answers Integer for hash and object_id" do
+      expect(dispatch(:hash)).to eq(Rigor::Type::Combinator.nominal_of("Integer"))
+      expect(dispatch(:object_id)).to eq(Rigor::Type::Combinator.nominal_of("Integer"))
+    end
+  end
+
+  describe "declines" do
+    it "declines for a receiver the dispatcher can name, so RBS and the folders keep answering" do
+      expect(dispatch(:nil?, receiver: Rigor::Type::Combinator.nominal_of("String"))).to be_nil
+      expect(dispatch(:nil?, receiver: Rigor::Type::Combinator.constant_of(nil))).to be_nil
+    end
+
+    it "declines `class`: Nominal[Class] erases the singleton, and `p.class.dynamic_returns` is real code" do
+      expect(dispatch(:class)).to be_nil
+    end
+
+    it "declines the `==` family: an overridden `==` is free to return anything" do
+      expect(dispatch(:==, args: [untyped])).to be_nil
+      expect(dispatch(:!=, args: [untyped])).to be_nil
+      expect(dispatch(:eql?, args: [untyped])).to be_nil
+    end
+
+    it "declines `to_s` while the Array#[](Range) optional-return noise it exposes has no answer" do
+      expect(dispatch(:to_s)).to be_nil
+    end
+
+    it "declines the self-returners, which gain nothing on a Dynamic receiver" do
+      %i[freeze dup clone itself tap].each { |selector| expect(dispatch(selector)).to be_nil }
+    end
+
+    it "declines an ordinary selector" do
+      expect(dispatch(:upcase)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Closes #503. Depends on #506 (merged) — three of the four diagnostics this surfaced were that bug, not this change.

`x.nil?` is `bool` whatever `x` is. With `x` untyped it was `Dynamic[Top]`, because every dispatch tier needs a receiver it can name and `ExpressionTyper` then fell through to Dynamic-origin propagation. The same held for `is_a?`, `kind_of?`, `instance_of?`, `respond_to?`, `equal?`, `frozen?`, `!`, `inspect`, `hash` and `object_id`.

## Measured on `lib`

| | master | this PR |
| --- | --- | --- |
| precision ratio | 56.71% | **58.98%** (+2.27pp, +3,830 sites) |
| protection | 45.6% (14421/31627) | 45.8% (14502/31640) |
| `make check` diagnostics | 0 | **0** |
| `make check-plugins` diagnostics | 0 | **0** |

Protection moves as a side effect: a chained call on one of these results now has a receiver Rigor can name.

## Where it sits

Below every real resolution tier, so a receiver Rigor *can* name still answers from its own signature — `nil.nil?` stays `Constant[true]`, `:sym.inspect` stays `Constant[":sym"]`, both pinned by the fixture. It only ever replaces a `Dynamic[Top]` the engine was about to produce.

## What is left out is the load-bearing half

Each exclusion was measured before it was made one, and each has its own spec example rather than living in a comment:

- **`class`** — `Nominal[Class]` erases the singleton. `p.class.dynamic_returns` on a plugin instance is real code in `lib/rigor/plugin/registry.rb`; the fold cost **13** `call.undefined-method` false positives on `lib` for +0.14 points. Textbook ADR-5.
- **`==` / `!=` / `eql?`** — the same failure at a larger blast radius. `==` is the most commonly overridden method in Ruby and an override may return anything.
- **`to_s`** — receiver-independent in principle, but enabling it makes the RBS `Array#[](Range) -> Array[T]?` optional-return noise reachable through `x.to_s.split("::")[0...-1]` (7 `call.possible-nil-receiver` on `lib`). Not this tier's defect, but not its to ship either.
- **`freeze` / `dup` / `clone` / `itself`** — receiver-independent in a different way (they return the receiver), so on a `Dynamic` receiver they gain nothing.

## One implementation note

`bool` MUST be spelled as the canonical `Constant[true] | Constant[false]`. The `Nominal[TrueClass] | Nominal[FalseClass]` spelling type-checks but is a different value — it fails to match a `-> bool` declaration and produced 17 spurious `def.return-type-mismatch` warnings when this was first prototyped. That is why the constant carries the reason.

## Verification

- `make verify` green; rubocop clean.
- `spec/rigor/inference/method_dispatcher/universal_object_dispatch_spec.rb` — the answers, the named-receiver decline, and one example per exclusion.
- `spec/integration/fixtures/universal_object_methods.rb` — `assert_type` on every selector including the three that must stay `Dynamic[top]`, plus a golden snapshot.

Found while auditing Rigor's own `lib`: [`docs/notes/20260831-self-check-type-coverage-audit.md`](https://github.com/rigortype/rigor/blob/master/docs/notes/20260831-self-check-type-coverage-audit.md) § Finding 2, which also carries the full arm-by-arm table this PR's set was chosen from.