### PR TITLE
Make the precision-snapshot regeneration command actually work

### DIFF
--- a/spec/integration/precision_snapshot_spec.rb
+++ b/spec/integration/precision_snapshot_spec.rb
@@ -26,13 +26,20 @@ FIXTURE_DIR   = File.expand_path("fixtures",  __dir__)
 
 UPDATE_SNAPSHOTS = ENV.fetch("UPDATE_SNAPSHOTS", "0") == "1"
 
-# Enumerate fixture names: flat .rb files → name without extension, directory fixtures → directory name.
+# Enumerate fixture names: flat .rb files → name without extension, project fixtures → directory name.
+#
+# A directory qualifies only when it carries the harness entry file, because that is exactly what
+# `FixtureHarness#load_project` requires. `fixtures/` is a shared fixture root, not this spec's private one:
+# `fixtures/effects/` is a container of per-spec project trees (`effects/rails`, `effects/policy`, …) that the
+# effects specs address by absolute path, and neither it nor its children is loadable here. Discriminating on
+# the entry file keeps any future non-harness tree out of the gate without an exclusion list to maintain.
 SNAPSHOT_FIXTURE_NAMES = (
   Dir.children(FIXTURE_DIR).sort.filter_map do |entry|
     path = File.join(FIXTURE_DIR, entry)
     if File.file?(path) && entry.end_with?(".rb")
       entry.delete_suffix(".rb")
-    elsif File.directory?(path)
+    elsif File.directory?(path) &&
+          File.file?(File.join(path, Rigor::IntegrationSupport::FixtureHarness::DEFAULT_ENTRY))
       entry
     end
   end
@@ -51,14 +58,29 @@ end
 
 RSpec.describe "Precision snapshots (inference regression gate)" do
   if UPDATE_SNAPSHOTS
+    # One unloadable fixture MUST NOT cost the whole regeneration: every other snapshot is still written, and
+    # the failures are reported together at the end. Aborting on the first one leaves the tree half-regenerated
+    # and hides how many fixtures are actually broken.
     it "writes fresh snapshots for all fixtures" do
       FileUtils.mkdir_p(SNAPSHOTS_DIR)
-      SNAPSHOT_FIXTURE_NAMES.each do |name|
+
+      failures = SNAPSHOT_FIXTURE_NAMES.filter_map do |name|
         harness  = Rigor::IntegrationSupport::FixtureHarness.new(name)
         snapshot = build_snapshot(harness)
         File.write(snapshot_path(name), YAML.dump(snapshot))
+        nil
+      rescue StandardError => e
+        "  #{name}: #{e.class}: #{e.message}"
       end
-      expect(Dir.children(SNAPSHOTS_DIR).size).to eq(SNAPSHOT_FIXTURE_NAMES.size)
+
+      expect(failures).to be_empty,
+                          "#{failures.size} of #{SNAPSHOT_FIXTURE_NAMES.size} fixtures failed to regenerate " \
+                          "(the rest were written):\n#{failures.join("\n")}"
+
+      expected = SNAPSHOT_FIXTURE_NAMES.map { |name| File.basename(snapshot_path(name)) }
+      stale    = Dir.children(SNAPSHOTS_DIR) - expected
+      expect(stale).to be_empty,
+                       "Snapshot files with no matching fixture (delete them by hand):\n  #{stale.sort.join("\n  ")}"
     end
   else
     SNAPSHOT_FIXTURE_NAMES.each do |fixture_name|

--- a/spec/integration/support/fixture_harness.rb
+++ b/spec/integration/support/fixture_harness.rb
@@ -20,9 +20,14 @@ module Rigor
     class FixtureHarness
       FIXTURES_ROOT = File.expand_path("../fixtures", __dir__)
 
+      # The entry file a project fixture MUST carry. A directory under `fixtures/` without it is not a
+      # project fixture at all — `fixtures/effects/` is a container of per-spec project trees — so callers
+      # that enumerate fixtures discriminate on this name rather than on "is a directory".
+      DEFAULT_ENTRY = "demo.rb"
+
       attr_reader :name, :source, :tree, :scope, :index
 
-      def initialize(name, entry: "demo.rb")
+      def initialize(name, entry: DEFAULT_ENTRY)
         @name = name
         @entry = entry
         load_fixture
@@ -91,6 +96,11 @@ module Rigor
 
       def load_project(dir)
         entry_path = File.join(dir, @entry)
+        unless File.file?(entry_path)
+          raise ArgumentError, "fixture #{@name} is a directory but carries no #{@entry} " \
+                               "(a project fixture MUST have one; #{dir}/ looks like a plain fixture tree)"
+        end
+
         @source = File.read(entry_path)
         # `for_project` auto-detects `<dir>/sig` so the fixture's sig files are merged with the bundled stdlib.
         env = Rigor::Environment.for_project(root: dir)


### PR DESCRIPTION
The command the precision-snapshot gate prints in its own failure message — `UPDATE_SNAPSHOTS=1 bundle exec rspec spec/integration/precision_snapshot_spec.rb` — crashed with `Errno::ENOENT: spec/integration/fixtures/effects/demo.rb` partway through, leaving the snapshot tree half-regenerated. The same cause left the `fixtures/effects` example permanently pending ("No golden snapshot yet").

## Cause

`SNAPSHOT_FIXTURE_NAMES` enumerated every directory under `spec/integration/fixtures/` as a project fixture, but that directory is a **shared** fixture root, not this spec's private one. `fixtures/effects/` is a container of per-spec project trees (`effects/rails`, `effects/policy`, `effects/tracer`, …) that the effects specs address by absolute path. It carries no `demo.rb`, which `FixtureHarness#load_project` requires.

## The two decisions

**Exclude `effects/`, not enumerate its children.** Enumerating the children would not have worked either: every one of them is a `lib/` + `sig/` (or `app/`) project tree with no `demo.rb`, so each would have hit the same `Errno::ENOENT`. Rather than hard-code an exclusion list, the enumeration now discriminates on the entry file `FixtureHarness#load_project` actually requires. That needs no maintenance and keeps any future non-harness tree dropped under `fixtures/` out of the gate on its own. The entry name moves to `FixtureHarness::DEFAULT_ENTRY` so the enumeration cannot drift from the harness, and `load_project` raises a named `ArgumentError` instead of letting `File.read` surface a bare `Errno::ENOENT`.

**Tolerate a bad fixture, but do not go quiet about it.** The bulk-write example now writes every snapshot it can, collects the failures, and fails at the end with all of them listed. Aborting on the first one both cost the whole regeneration and hid how many fixtures were broken; silently skipping would turn a real authoring error into a fixture that quietly drops out of the gate. Its trailing count assertion becomes a set difference, so a stale snapshot file is named rather than inferred from two numbers disagreeing.

Verified by temporarily relaxing the guard so `effects/` was enumerated again — all 107 other snapshots still regenerated, and the report read `1 of 108 fixtures failed to regenerate (the rest were written): effects: ArgumentError: fixture effects is a directory but carries no demo.rb`.

## Verification

- `UPDATE_SNAPSHOTS=1 … rspec spec/integration/precision_snapshot_spec.rb` → 1 example, 0 failures; `git status` clean (no snapshot churn — the 107 loadable fixture names already matched the 107 snapshot files exactly).
- `… rspec spec/integration/precision_snapshot_spec.rb` → 107 examples, 0 failures, **0 pending** (was 106 + 1 permanently pending).
- `make verify` → exit 0. `git diff --check` → exit 0.

No `CHANGELOG.md` entry: `spec/` only, no shipped behaviour — this is a self-testing gate.