### PR TITLE
Calibrate the precision gate on drift, not headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,8 +362,9 @@ jobs:
           echo "rigor self-check found errors — see diagnostic output above"
           exit 1
 
-      # Precision gate: `rigor coverage --threshold 0.43 lib` fails when the
-      # type-inference precision ratio on Rigor's own source drops below 43 %.
+      # Precision gate: `rigor coverage --threshold 0.57 lib` fails when the
+      # type-inference precision ratio on Rigor's own source drops below 57 %.
+      # See the Makefile's `coverage` target for how that number is calibrated.
       # The cold variant runs this so the gate exercises the full analysis path
       # without any cached assistance; the warm variant skips it to avoid
       # double-counting in CI time.

--- a/Makefile
+++ b/Makefile
@@ -161,11 +161,29 @@ check-json:
 	bundle exec exe/rigor check --format=json lib
 
 # Report type-precision coverage for `lib/`.
-# Exits non-zero when precision ratio drops below 43 % (the calibrated
-# baseline measured against Rigor's own source on 2026-05-26).
+# Exits non-zero when the precision ratio drops below 57 %.
+#
+# Recalibrated 2026-08-31. The original 43 % was measured on 2026-05-26 and
+# never moved; by v0.3.6 `lib` read 58.96 %, so the gate carried ~16 points
+# of slack and could not fail on any regression a person would ship. The new
+# number is calibrated on the DRIFT, measured by running the current analyzer
+# against every 0.3.x tag's `lib` tree (a fixed analyzer, a moving codebase —
+# the volatility the threshold has to tolerate):
+#
+#   v0.2.9 59.88 · v0.3.0 59.62 · v0.3.1 59.55 · v0.3.2 59.39 · v0.3.3 59.37
+#   v0.3.4 59.02 · v0.3.5 58.94 · v0.3.6 58.96 · master 58.98
+#
+# A 0.94-point band over three months and +108 files, drifting down roughly
+# 0.1 points per release as the codebase grows. 57 % leaves ~2 points, about
+# two years of that drift, so ordinary development cannot trip it — a gate
+# that fires on correct input teaches people to route around it (AGENTS.md
+# § "Implementation Guidelines"). An engine change that legitimately LOWERS
+# precision (a soundness fix that widens a type) re-baselines this line
+# deliberately, which is the point of the gate.
+#
 # Use `rigor coverage lib/` without --threshold for a non-gating report.
 coverage:
-	bundle exec exe/rigor coverage --threshold 0.43 lib
+	bundle exec exe/rigor coverage --threshold 0.57 lib
 
 # ADR-50 WD4 perf-regression gate. Runs `rigor check --no-cache` over `lib`
 # in-process, measures wall / allocations / peak-RSS, and gates against

--- a/docs/CURRENT_WORK.md
+++ b/docs/CURRENT_WORK.md
@@ -67,8 +67,9 @@ Rigor is for.
   post-#508 tree (`def` parameters 17,246 + block parameters 3,490 of 68,336 opaque expressions),
   and both levers on them are the closed ones above. Re-measure against the note's attribution
   before proposing anything here.
-- **`make check-coverage --threshold 0.43`** now gates a different number: `lib` reads 58.98% and the
-  two corpus applications 47.8% / 48.9%. Whether to tighten it is an open, self-contained decision.
+- ~~The precision gate's threshold~~ — done 2026-08-31: `make coverage` moved 0.43 → 0.57, calibrated
+  on the measured drift (0.94 points across the whole 0.3.x line under a fixed analyzer), not on the
+  headroom. The two corpus applications read 47.8% / 48.9%, so the gate stays a `lib`-only number.
 - **A larger population the ivar census surfaced**: 13–15% of all instance-variable reads are of an
   ivar with **no static write anywhere in the scanned tree** (380 / 394 / 635 across the three).
   `attr_writer`, `instance_variable_set`, framework assignment, or a write outside `paths:`. Bigger

--- a/docs/notes/20260831-self-check-type-coverage-audit.md
+++ b/docs/notes/20260831-self-check-type-coverage-audit.md
@@ -84,7 +84,7 @@ was never applied to the precision path.**
 | + `param_inferred_types` (1,338) | 99,607 | 0.6007 | +4.87pp / +8,071 sites |
 
 The ratio is user-facing — `rigor coverage`, `rigor check --coverage`, and the
-`make check-coverage --threshold 0.43` gate all report it. The consequence for anyone measuring:
+`make coverage` threshold gate all report it. The consequence for anyone measuring:
 **a precision ratio and a protection ratio from the same run describe two different engines and
 must not be compared.**
 


### PR DESCRIPTION
`make coverage` gates Rigor's own `lib` precision ratio in CI (the cold self-check job). Its threshold, `0.43`, was measured on 2026-05-26 and never moved. By v0.3.6 `lib` read **58.96%** — about sixteen points of slack, so the gate could not fail on any regression a person would actually ship. It has been passing for three months by being unreachable.

## Calibrated on the measured drift

The question a threshold has to answer is not "how far below are we" but "how much does this number move when nothing but the codebase changes". Measured by running the **current** analyzer against every 0.3.x tag's `lib` tree — a fixed analyzer, a moving codebase:

| tag | files | precision |
| --- | --- | --- |
| v0.2.9 | 321 | 59.88% |
| v0.3.0 | 343 | 59.62% |
| v0.3.1 | 346 | 59.55% |
| v0.3.2 | 358 | 59.39% |
| v0.3.3 | 362 | 59.37% |
| v0.3.4 | 420 | 59.02% |
| v0.3.5 | 423 | 58.94% |
| v0.3.6 | 427 | 58.96% |
| master | 429 | 58.98% |

A **0.94-point band** across three months and +108 files, drifting down roughly 0.1 points per release as the codebase grows. `0.57` leaves ~2 points — about two years of that drift — so ordinary development cannot trip it. A gate that fires on correct input teaches people to route around it, which is the same false-positive argument AGENTS.md holds the engine to, applied to tooling.

An engine change that legitimately *lowers* precision (a soundness fix that widens a type) re-baselines this line deliberately. That is the point of the gate, and the Makefile comment says so.

## Verified in both directions

```
rigor coverage --threshold 0.57 lib  → exit 0
rigor coverage --threshold 0.60 lib  → exit 1
```

CI's cold self-check job runs `make coverage`, so this PR's own run is the Linux confirmation.

## Also

Fixes a target name I invented in two documents in the previous commit: it is `make coverage`; `make check-coverage` does not exist.

Context for the 58.98%: [`docs/notes/20260831-self-check-type-coverage-audit.md`](https://github.com/rigortype/rigor/blob/master/docs/notes/20260831-self-check-type-coverage-audit.md).