### PR TITLE
Seed the type-of scan with the cross-file discovery tables

### DIFF
--- a/lib/rigor/cli/type_scan_command.rb
+++ b/lib/rigor/cli/type_scan_command.rb
@@ -12,6 +12,7 @@ require_relative "type_scan_renderer"
 require_relative "type_scan_report"
 require_relative "command"
 require_relative "probe_environment"
+require_relative "coverage_scan"
 
 module Rigor
   class CLI
@@ -70,7 +71,15 @@ module Rigor
 
       def scan_paths(paths, options)
         configuration = Configuration.load(options.fetch(:config))
-        scope = Scope.empty(environment: project_environment(configuration, paths))
+        # Same seed set as `rigor coverage` and `coverage --protection` (#502). Without it a cross-file class
+        # constant reads `Dynamic` and is counted as an unrecognised node, so the scan reports the engine as
+        # blinder than it is — on Mastodon that alone was most of a 14.7% unrecognised rate.
+        scope = CoverageScan.discovery_seeded_scope(
+          files: paths,
+          configuration: configuration,
+          environment: project_environment(configuration, paths),
+          parameter_inference: configuration.parameter_inference
+        )
         scanner = Inference::CoverageScanner.new(scope: scope)
         accumulator = ScanAccumulator.new
         paths.each { |path| scan_one(path, scanner, accumulator, configuration) }

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -1050,6 +1050,22 @@ RSpec.describe Rigor::CLI do
       expect(status).to eq(0)
     end
 
+    # #502's third surface. Without the discovery seed a class declared in a SIBLING file reads
+    # `Dynamic`, so the scan counted it unrecognised and reported the engine as blinder than it is —
+    # the same undercount already fixed for `coverage` and `coverage --protection`.
+    it "recognises a class constant declared in a sibling file" do
+      write_fixture("account.rb", "class Account\nend\n")
+      use = write_fixture("use.rb", "Account\n")
+
+      status, out, _err = run_cli("type-scan", "--format=json", File.join(tmpdir, "account.rb"), use)
+
+      expect(status).to eq(0)
+      payload = JSON.parse(out)
+      unrecognised_in_use = payload["events"].select { |e| e["file"] == use }
+      expect(unrecognised_in_use).to be_empty
+      expect(payload["by_class"].fetch("Prism::ConstantReadNode").fetch("unrecognized")).to eq(0)
+    end
+
     it "recurses into directories and aggregates files" do
       write_fixture("nested/one.rb", "1\n")
       write_fixture("nested/two.rb", "foo()\n")


### PR DESCRIPTION
The third surface with #502's hole, and the one where the wrong number was actively misleading.

`CLI::TypeScanCommand#scan_paths` built a bare `Scope.empty`, so a class constant declared in a sibling file read `Dynamic` and was counted as a node the engine does not recognise. `CoverageScan.discovery_seeded_scope` already existed — this wires `type-scan` to it, exactly as `coverage` and `coverage --protection` are.

## Measured

| | `ConstantReadNode` | `ConstantPathNode` | `CallNode` | overall |
| --- | --- | --- | --- | --- |
| this repo (`lib`) | 8.6% → **0.4%** | 20.9% → **6.7%** | 7.7% → 9.8% | 2.1% → **1.8%** |
| redmine (app+lib) | 58.3% → **5.5%** | 80.1% → **36.4%** | 36.1% → 47.4% | 10.1% → 10.5% |
| mastodon (app+lib) | 70.9% → **27.3%** | 82.2% → **42.0%** | 39.6% → 50.3% | 14.7% → 13.9% |

## Why `CallNode` rises, and why that is the point

The whole-file rate barely moves on the applications because `CallNode` climbs as the constants fall. That is not a regression — it is the scan finally counting what it was hiding.

A call on a `Dynamic` receiver returns through `ExpressionTyper#inherit_receiver_origin`, which by contract **records no tracer event** ("a recognised semantic outcome, not a fail-soft compromise"). While the receiver constant was unresolved, every call on it took that path and was invisible to the scan. Once the receiver resolves, the same call reaches the dispatcher, fails *there*, and is counted honestly.

So the pre-fix report said "constants are your biggest hole" when constants are mostly fine and **unresolved calls on resolved receivers are the hole** — 47.4% and 50.3% of all `CallNode`s on the two applications, against 9.8% on our own `lib`. A measurement that misdirects is worse than one that is merely low, which is why this is worth its own change rather than a footnote.

## Notes

- `parameter_inference` is threaded from the configuration for the same reason `coverage` does it: the scan should mirror the walk it describes, and the check walk leaves that table empty unless the gate is on.
- `type-scan` is not run by `make verify` or CI, so no gate number moves.
- New spec in `spec/rigor/cli_spec.rb` pins the sibling-file constant at zero unrecognised.
- `make verify` green; `make check` / `check-plugins` unaffected (the command is a probe, not an analysis path).

Found while re-testing this session's own conclusion against the corpus — [`docs/notes/20260831-self-check-type-coverage-audit.md`](https://github.com/rigortype/rigor/blob/master/docs/notes/20260831-self-check-type-coverage-audit.md).