### PR TITLE
Resolve Foo.instance for the stdlib Singleton mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Changed
 
+- **[engine]** `Foo.instance` on a class that includes the stdlib `Singleton` mixin now types as `Foo` instead of untyped, so the methods you call on that instance are typed too ([#514](https://github.com/rigortype/rigor/pull/514)).
+
 - **[engine]** `x.nil?`, `x.is_a?(C)`, `x.respond_to?(:m)`, `!x`, `x.frozen?`, `x.equal?(y)`, `x.inspect`, `x.hash` and `x.object_id` now carry their own type even when Rigor cannot type `x` — their result never depended on the receiver — which is worth 2.3 points of type precision on Rigor's own `lib` and no new diagnostics ([#508](https://github.com/rigortype/rigor/pull/508), [#503](https://github.com/rigortype/rigor/issues/503)).
 
 ### Fixed

--- a/lib/rigor/inference/method_dispatcher.rb
+++ b/lib/rigor/inference/method_dispatcher.rb
@@ -31,6 +31,7 @@ require_relative "method_dispatcher/uri_folding"
 require_relative "method_dispatcher/set_folding"
 require_relative "method_dispatcher/kernel_dispatch"
 require_relative "method_dispatcher/universal_object_dispatch"
+require_relative "method_dispatcher/singleton_mixin_dispatch"
 require_relative "method_dispatcher/method_folding"
 
 module Rigor
@@ -144,6 +145,12 @@ module Rigor
         # lives in `Rigor::Builtins::StaticReturnRefinements::OVERRIDES`.
         static_refinement = try_static_refinement(receiver_type, method_name, arg_types)
         return static_refinement if static_refinement
+
+        # `Foo.instance` for a class that includes the stdlib `Singleton` mixin. Ruby grows that method through
+        # an `included` hook and the upstream RBS leaves `Singleton::SingletonClassMethods` empty, so nothing
+        # below can answer it. See {SingletonMixinDispatch} for why the value matters more than the site count.
+        singleton_mixin = SingletonMixinDispatch.try_dispatch(context)
+        return singleton_mixin if singleton_mixin
 
         rbs_result = RbsDispatch.try_dispatch(context)
         if rbs_result

--- a/lib/rigor/inference/method_dispatcher/singleton_mixin_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/singleton_mixin_dispatch.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative "../../type"
+
+module Rigor
+  module Inference
+    module MethodDispatcher
+      # `Foo.instance`, where `Foo` includes the stdlib `Singleton` mixin.
+      #
+      # Ruby grows that class method through a hook — `Singleton.included(klass)` extends the class with
+      # `Singleton::SingletonClassMethods` — so nothing static declares it, and the upstream RBS does not close
+      # the gap either: `stdlib/singleton/0/singleton.rbs` declares `def self.instance: () -> instance` on the
+      # module itself and leaves `module SingletonClassMethods` **empty**. `Singleton.instance` is not a call
+      # anyone makes; `Foo.instance` is the entire point of the mixin, and it typed `Dynamic[Top]`.
+      #
+      # That is expensive out of proportion to its site count, because the value is a whole object: every
+      # method called on the returned instance is then dispatched on `Dynamic` too. Mastodon has 365 such
+      # calls (`ActivityPub::TagManager.instance`, `FeedManager.instance`, `TagManager.instance`).
+      #
+      # The rule is exact rather than heuristic — the receiver must be a `Singleton[C]` whose `C` the project
+      # pre-pass recorded as including `Singleton` — so a class that does not include the mixin is untouched,
+      # and a project that defines its own `Singleton` module is the one case that would misfire. Guarded by
+      # {project_singleton_shadow?}: a project-declared `Singleton` class or module wins and the tier declines,
+      # because then the name means something else entirely.
+      module SingletonMixinDispatch
+        MIXIN_NAMES = Ractor.make_shareable(Set["Singleton", "::Singleton"])
+        private_constant :MIXIN_NAMES
+
+        SELECTOR = :instance
+        private_constant :SELECTOR
+
+        module_function
+
+        # @param context [CallContext]
+        # @return [Rigor::Type, nil] `Nominal[C]` for `C.instance`, or nil to decline.
+        def try_dispatch(context)
+          return nil unless context.method_name == SELECTOR
+          return nil unless context.args.empty?
+
+          receiver = context.receiver
+          return nil unless receiver.is_a?(Type::Singleton)
+
+          scope = context.scope
+          return nil if scope.nil?
+          return nil unless includes_singleton_mixin?(scope, receiver.class_name)
+          return nil if project_singleton_shadow?(scope)
+
+          Type::Combinator.nominal_of(receiver.class_name)
+        end
+
+        def includes_singleton_mixin?(scope, class_name)
+          scope.includes_of(class_name).any? { |name| MIXIN_NAMES.include?(name.to_s) }
+        end
+
+        # True when the project declares its OWN `Singleton` class / module, in which case `include Singleton`
+        # names that one and the stdlib rule does not apply.
+        def project_singleton_shadow?(scope)
+          MIXIN_NAMES.any? { |name| scope.discovery.discovered_classes.key?(name.to_s.delete_prefix("::")) }
+        end
+      end
+    end
+  end
+end

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -246,6 +246,39 @@ RSpec.describe Rigor::CLI do
       expect(out).to include("erased:  1")
     end
 
+    # `Foo.instance` for the stdlib Singleton mixin: Ruby grows it through an `included` hook and the
+    # upstream RBS leaves `Singleton::SingletonClassMethods` empty, so no other tier can answer it.
+    it "types `.instance` on a class that includes the Singleton mixin" do
+      path = write_fixture("registry.rb", <<~RUBY)
+        require "singleton"
+
+        class Registry
+          include Singleton
+
+          def label(key)
+            key.to_s
+          end
+        end
+
+        Registry.instance.label(:a)
+      RUBY
+
+      status, out, err = run_cli("type-of", "#{path}:11:10")
+
+      expect(err).to eq("")
+      expect(status).to eq(0)
+      expect(out).to include("type:    Registry")
+    end
+
+    it "leaves `.instance` alone on a class that does not include the mixin" do
+      path = write_fixture("plain.rb", "class Plain\nend\n\nPlain.instance\n")
+
+      status, out, _err = run_cli("type-of", "#{path}:4:7")
+
+      expect(status).to eq(0)
+      expect(out).to include("Dynamic[top]")
+    end
+
     it "accepts FILE LINE COL as separate arguments" do
       path = write_fixture("a.rb", "\"hi\"\n")
 

--- a/spec/rigor/inference/method_dispatcher/singleton_mixin_dispatch_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/singleton_mixin_dispatch_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# `Foo.instance` for the stdlib `Singleton` mixin. Ruby grows the method through an `included` hook and the
+# upstream RBS leaves `Singleton::SingletonClassMethods` empty, so no other tier can answer it.
+RSpec.describe Rigor::Inference::MethodDispatcher::SingletonMixinDispatch do
+  def scope_with(includes: {}, classes: {})
+    base = Rigor::Scope.empty
+    base.with_discovery(base.discovery.with(discovered_includes: includes, discovered_classes: classes))
+  end
+
+  def dispatch(receiver, scope, method_name: :instance, args: [])
+    described_class.try_dispatch(cc(receiver: receiver, method_name: method_name, args: args, scope: scope))
+  end
+
+  let(:registry) { Rigor::Type::Combinator.singleton_of("Registry") }
+
+  it "answers Nominal[C] for C.instance when C includes Singleton" do
+    result = dispatch(registry, scope_with(includes: { "Registry" => ["Singleton"] }))
+    expect(result).to eq(Rigor::Type::Combinator.nominal_of("Registry"))
+  end
+
+  it "accepts the ::-qualified spelling of the mixin" do
+    result = dispatch(registry, scope_with(includes: { "Registry" => ["::Singleton"] }))
+    expect(result).to eq(Rigor::Type::Combinator.nominal_of("Registry"))
+  end
+
+  it "declines for a class that includes something else" do
+    expect(dispatch(registry, scope_with(includes: { "Registry" => %w[Comparable] }))).to be_nil
+  end
+
+  it "declines when the project declares its own Singleton, where the name means something else" do
+    scope = scope_with(includes: { "Registry" => ["Singleton"] }, classes: { "Singleton" => "Singleton" })
+    expect(dispatch(registry, scope)).to be_nil
+  end
+
+  it "declines for an instance receiver — `instance` is a class method" do
+    nominal = Rigor::Type::Combinator.nominal_of("Registry")
+    scope = scope_with(includes: { "Registry" => ["Singleton"] })
+    expect(described_class.try_dispatch(cc(receiver: nominal, method_name: :instance, args: [], scope: scope)))
+      .to be_nil
+  end
+
+  it "declines for another selector, and for `instance` called with arguments" do
+    scope = scope_with(includes: { "Registry" => ["Singleton"] })
+    expect(dispatch(registry, scope, method_name: :new)).to be_nil
+    expect(dispatch(registry, scope, args: [Rigor::Type::Combinator.untyped])).to be_nil
+  end
+
+  it "declines without a scope — the internal dispatcher callers thread none" do
+    expect(described_class.try_dispatch(cc(receiver: registry, method_name: :instance, args: []))).to be_nil
+  end
+end


### PR DESCRIPTION
`Foo.instance`, where `Foo` includes the stdlib `Singleton` mixin, typed `Dynamic[Top]`.

Ruby grows that class method through a hook — `Singleton.included(klass)` extends the class with `Singleton::SingletonClassMethods` — so nothing static declares it. The upstream RBS does not close the gap either: `stdlib/singleton/0/singleton.rbs` declares `def self.instance: () -> instance` on the module itself and leaves `module SingletonClassMethods` **empty**. `Singleton.instance` is not a call anyone makes; `Foo.instance` is the entire point of the mixin.

```ruby
class Registry
  include Singleton
  def label(key) = key.to_s
end

Registry.instance          # was Dynamic[top], now Registry
Registry.instance.label(:a) # was Dynamic[top], now "a"
```

The second line is why this is worth more than its site count: the value is a whole object, so every method invoked on it dispatched on `Dynamic` too. Mastodon has **365** such calls (`ActivityPub::TagManager.instance`, `FeedManager.instance`, `TagManager.instance`).

## Exact, not heuristic

The receiver must be a `Singleton[C]` whose `C` the project pre-pass recorded as including `Singleton`, called with no arguments. A project that declares its **own** `Singleton` class or module shadows the stdlib name, and the tier declines — that is the one case where the rule could misfire, and it is guarded rather than argued.

Redmine and Mastodon both report **identical diagnostic sets** — 792 and 2,341, zero added, zero removed.

## One measurement that is not what it looks like

`rigor coverage` moves by **+3** sites on Mastodon, not 365. That is a gap in the measurement, not in the fix: the precision lens seeds only `discovered_classes` and `param_inferred_types` — not `discovered_includes` — so the tier cannot fire under it, while the `check` walk seeds the full eleven-slot bundle and does resolve all 365. Filed as #513, which measures the whole discrepancy (+0.77pp on mastodon from the tables alone, plus ~1.2pp on redmine from `coverage` building a plugin-less environment).

Worth stating plainly: **this change's value does not show up in the headline precision number, and the reason is a defect in that number.**

## Verification

- `make verify` green; `make check` / `check-plugins` clean.
- `spec/rigor/inference/method_dispatcher/singleton_mixin_dispatch_spec.rb` — the answer, the `::`-qualified spelling, and five declines (wrong mixin, project shadow, instance receiver, other selector, no scope).
- End-to-end proof is a CLI spec against `rigor type-of`, because the integration harness builds a single-file scope with no cross-file include table — the same limitation described above.