### PR TITLE
Answer several positions per type-of invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Changed
 
+- **[cli]** `rigor type-of` accepts several positions in one invocation and makes the column optional — `rigor type-of file.rb:42` lists every expression on line 42 — so walking a chain of expressions costs one process instead of one each (five positions on a Rails application: 10.3 s → 2.1 s) ([#515](https://github.com/rigortype/rigor/pull/515)).
+
 - **[engine]** `x.nil?`, `x.is_a?(C)`, `x.respond_to?(:m)`, `!x`, `x.frozen?`, `x.equal?(y)`, `x.inspect`, `x.hash` and `x.object_id` now carry their own type even when Rigor cannot type `x` — their result never depended on the receiver — which is worth 2.3 points of type precision on Rigor's own `lib` and no new diagnostics ([#508](https://github.com/rigortype/rigor/pull/508), [#503](https://github.com/rigortype/rigor/issues/503)).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Changed
 
-- **[cli]** `rigor type-of` accepts several positions in one invocation and makes the column optional — `rigor type-of file.rb:42` lists every expression on line 42 — so walking a chain of expressions costs one process instead of one each (five positions on a Rails application: 10.3 s → 2.1 s) ([#515](https://github.com/rigortype/rigor/pull/515)).
+- **[cli]** `rigor type-of` accepts several positions in one invocation and makes the column optional — `rigor type-of file.rb:42` lists up to 40 expressions on line 42 — so walking a chain of expressions costs one process instead of one each (five positions on a Rails application: 10.3 s → 2.1 s) ([#515](https://github.com/rigortype/rigor/pull/515)).
 
 - **[engine]** `Foo.instance` on a class that includes the stdlib `Singleton` mixin now types as `Foo` instead of untyped, so the methods you call on that instance are typed too ([#514](https://github.com/rigortype/rigor/pull/514)).
 

--- a/docs/manual/02-cli-reference.md
+++ b/docs/manual/02-cli-reference.md
@@ -114,16 +114,25 @@ missing file.
 
 ## `rigor type-of`
 
-Print the inferred type at one source position.
+Print inferred types at one or more source positions.
 
 ```sh
-rigor type-of FILE:LINE:COL
-rigor type-of FILE LINE COL
+rigor type-of [options] FILE:LINE[:COL] [FILE:LINE[:COL] ...]
+rigor type-of [options] FILE LINE COL
 ```
 
-Accepts the position as a single `file:line:col` triple or as
-three arguments. `--format=json` emits a machine-readable
-form; `--trace` records fail-soft fallbacks. The editor-mode
+The colon form is repeatable and keeps argument order while
+parsing and scope-indexing each file once. Omit `COL` to print a
+table of up to 40 expressions that start on that line, outermost
+first at each 1-based column; the table marks when further
+expressions were omitted. The legacy three-argument form accepts
+one exact position.
+
+`--format=json` keeps one result as the original flat object and
+wraps several results in a `results` array. Line queries add a
+`line_enumerations` array whose `shown` and `total` counts make
+truncation explicit. `--trace` records fail-soft fallbacks,
+after the rows of a line table in text output. The editor-mode
 `--tmp-file` / `--instead-of` pair is accepted as on `check`.
 
 ## `rigor trace`

--- a/docs/manual/05-inspecting-types.md
+++ b/docs/manual/05-inspecting-types.md
@@ -63,19 +63,31 @@ syntax-highlighted for a tty — through
 colorizer; `--no-color` (and the `NO_COLOR` environment
 variable) disable the colour.
 
-## `rigor type-of` — one position
+## `rigor type-of` — exact positions or a whole line
 
-When you only need one expression's type — typically while
-chasing down why a diagnostic did or did not fire — query a
-single position:
+When you need a few expression types — typically while chasing
+down why a diagnostic did or did not fire — query the exact
+positions together so Rigor loads the project and each source
+file once:
 
 ```sh
-rigor type-of lib/example.rb:12:8
+rigor type-of lib/example.rb:12:8 lib/example.rb:12:14
 ```
 
-`--format=json` emits a machine-readable result for tooling.
-This is the same query the editor integration answers on
-hover.
+Leave off the column to avoid counting it by hand. Rigor prints
+a table of the first 40 expressions starting on the line,
+outermost first at each 1-based column, and marks a truncated
+table:
+
+```sh
+rigor type-of lib/example.rb:12
+```
+
+`--format=json` emits a machine-readable result for tooling: one
+result stays a flat object, while several results use a `results`
+array. Line queries add `line_enumerations` metadata with the
+shown and total expression counts. An exact position is the same
+query the editor integration answers on hover.
 
 ## `rigor trace` — watch the inference happen
 

--- a/lib/rigor/cli.rb
+++ b/lib/rigor/cli.rb
@@ -376,7 +376,7 @@ module Rigor
           check      Analyze Ruby source files
           init       Create a starter .rigor.yml
           annotate   Print FILE with each line's last-expression type
-          type-of    Print the inferred type at FILE:LINE:COL
+          type-of    Print inferred types at FILE:LINE[:COL] positions
           trace      Replay how the engine typed FILE as a terminal animation
           type-scan  Report Scope#type_of coverage across PATHs
           effects    Report each method's effect labels, and the committed effect snapshot

--- a/lib/rigor/cli/type_of_command.rb
+++ b/lib/rigor/cli/type_of_command.rb
@@ -11,7 +11,7 @@ require_relative "../source/node_locator"
 require_relative "../inference/fallback_tracer"
 require_relative "../inference/scope_indexer"
 require_relative "../inference/precision_scanner"
-require_relative "../source/node_walker"
+require_relative "../source/node_children"
 require_relative "type_of_renderer"
 require_relative "command"
 require_relative "options"
@@ -30,15 +30,15 @@ module Rigor
     class TypeOfCommand < Command
       USAGE = "Usage: rigor type-of [options] FILE:LINE[:COL] [FILE:LINE[:COL] ...]"
 
-      # `enumerated` marks a result that came from a bare `FILE:LINE`, so the renderer can print the line as a
-      # compact table instead of a stanza per expression — a chain like `a.b(c).d` is forty lines otherwise.
-      Result = Data.define(:file, :line, :column, :node, :type, :tracer, :enumerated) do
-        def initialize(enumerated: false, **rest)
+      Result = Data.define(:file, :line, :column, :node, :type, :tracer, :enumeration) do
+        def initialize(enumeration: nil, **rest)
           super
         end
       end
 
-      # One requested position. A nil `column` means "every expression starting on this line" — the form that
+      LineEnumeration = Data.define(:total, :shown)
+
+      # One requested position. A nil `column` means "the first 40 expressions starting on this line" — the form that
       # exists because hand-computing a column is the single most error-prone part of using this command.
       Target = Data.define(:file, :line, :column)
 
@@ -84,13 +84,14 @@ module Rigor
         environment = project_environment(targets.map(&:file).uniq, configuration)
         base_scope = Scope.empty(environment: environment)
 
-        results = []
-        targets.group_by(&:file).each do |file, group|
-          file_results = resolve_file(file, group, configuration, base_scope, options, buffer)
+        results_by_target = Array.new(targets.length)
+        targets.each_with_index.group_by { |target, _index| target.file }.each do |file, indexed_targets|
+          file_results = resolve_file(file, indexed_targets, configuration, base_scope, options, buffer)
           return file_results if file_results.is_a?(Integer)
 
-          results.concat(file_results)
+          file_results.each { |index, resolved| results_by_target[index] = resolved }
         end
+        results = results_by_target.compact.flatten(1)
         return 1 if results.empty?
 
         TypeOfRenderer.new(out: @out).render(results, format: options.fetch(:format))
@@ -99,7 +100,7 @@ module Rigor
 
       # Every result for one file: parsed and indexed once, then each requested position resolved against that
       # index. Returns an Integer exit status instead when the file itself cannot be probed.
-      def resolve_file(file, targets, configuration, base_scope, options, buffer)
+      def resolve_file(file, indexed_targets, configuration, base_scope, options, buffer)
         # Under editor mode the logical `file` may not exist on disk (user editing a new file); the runtime check
         # is only that the BUFFER is readable, which `resolve_buffer_binding` has already enforced.
         physical = buffer ? buffer.resolve(file) : file
@@ -112,52 +113,85 @@ module Rigor
         # Built with no tracer attached — it would otherwise double-record fallback events with the per-node
         # `type_of` calls below.
         scope_index = Inference::ScopeIndexer.index(parse_result.value, default_scope: base_scope)
+        locator = Source::NodeLocator.new(source: source, root: parse_result.value)
+        lines = indexed_targets.filter_map { |target, _index| target.line if target.column.nil? }
+        line_nodes, line_totals = collect_line_nodes(parse_result.value, lines)
 
-        collected = []
-        targets.each do |target|
-          if target.column.nil?
-            collected.concat(enumerate_line(file, target.line, parse_result.value, scope_index, options))
-            next
-          end
-
-          node = locate_node(source: source, root: parse_result.value, file: file,
-                             line: target.line, column: target.column)
-          return CLI::EXIT_USAGE if node == :out_of_range
-          next if node.nil?
-
-          collected << type_result(file, target.line, target.column, node, scope_index, options)
-        end
-        collected
+        resolve_targets(file: file, indexed_targets: indexed_targets, locator: locator, line_nodes: line_nodes,
+                        line_totals: line_totals, scope_index: scope_index, options: options)
       end
 
-      # Every expression STARTING on `line`, outermost first at each column. This is the form that removes the
-      # column arithmetic: `rigor type-of file.rb:42` answers "what are the types on line 42" without the user
-      # having to guess which byte the receiver starts at.
-      def enumerate_line(file, line, root, scope_index, options)
-        nodes = []
-        Source::NodeWalker.each(root) do |node|
-          loc = node.location
-          next unless loc.start_line == line
+      def resolve_targets(file:, indexed_targets:, locator:, line_nodes:, line_totals:, scope_index:, options:)
+        indexed_targets.map do |target, index|
+          if target.column.nil?
+            resolved = enumerate_line(file, target.line, line_nodes.fetch(target.line),
+                                      line_totals.fetch(target.line), scope_index, options)
+            next [index, resolved]
+          end
+
+          node = locate_node(locator: locator, file: file, line: target.line, column: target.column)
+          return CLI::EXIT_USAGE if node == :out_of_range
+          next [index, []] if node.nil?
+
+          [index, [type_result(file, target.line, target.column, node, scope_index, options)]]
+        end
+      end
+
+      # Collect every requested line in one full syntax walk. Unlike `Source::NodeWalker`, this deliberately
+      # descends into `defined?`: the probe inventories source expressions, including operands Ruby inspects but
+      # does not evaluate. Candidate storage stays bounded while retaining the first 40 nodes in display order.
+      def collect_line_nodes(root, lines)
+        return [{}, {}] if lines.empty?
+
+        candidates = lines.uniq.to_h { |line| [line, []] }
+        totals = candidates.to_h { |line, _nodes| [line, 0] }
+        walk_syntax(root) do |node|
+          line = node.location.start_line
+          nodes = candidates[line]
+          next if nodes.nil?
           next if Inference::PrecisionScanner::NON_EXPRESSION_NODE_TYPES.include?(node.class.name)
 
+          totals[line] += 1
           nodes << node
+          trim_line_nodes(nodes) if nodes.length > LINE_ENUMERATION_CAP * 2
         end
+        candidates.each_value { |nodes| trim_line_nodes(nodes) }
+        [candidates, totals]
+      end
+
+      def walk_syntax(node, &block)
+        return unless node.is_a?(Prism::Node)
+
+        block.call(node)
+        node.rigor_each_child { |child| walk_syntax(child, &block) }
+      end
+
+      def trim_line_nodes(nodes)
+        nodes.sort_by! { |node| [node.location.start_column, -node.location.length] }
+        nodes.slice!(LINE_ENUMERATION_CAP, nodes.length)
+      end
+
+      # Up to 40 expressions STARTING on `line`, outermost first at each 1-based column. This form removes
+      # the column arithmetic: `rigor type-of file.rb:42` answers "what are the types on line 42" without the user
+      # having to guess which byte the receiver starts at.
+      def enumerate_line(file, line, nodes, total, scope_index, options)
         if nodes.empty?
           @err.puts("type-of: no expression found on #{file}:#{line}")
           return []
         end
 
-        nodes.sort_by! { |node| [node.location.start_column, -node.location.length] }
-        nodes.first(LINE_ENUMERATION_CAP).map do |node|
-          type_result(file, line, node.location.start_column, node, scope_index, options, enumerated: true)
+        enumeration = LineEnumeration.new(total: total, shown: nodes.length)
+        nodes.map do |node|
+          type_result(file, line, node.location.start_column + 1, node, scope_index, options,
+                      enumeration: enumeration)
         end
       end
 
-      def type_result(file, line, column, node, scope_index, options, enumerated: false)
+      def type_result(file, line, column, node, scope_index, options, enumeration: nil)
         tracer = options[:trace] ? Inference::FallbackTracer.new : nil
         type = scope_index[node].type_of(node, tracer: tracer)
         Result.new(file: file, line: line, column: column, node: node, type: type, tracer: tracer,
-                   enumerated: enumerated)
+                   enumeration: enumeration)
       end
 
       # Builds the plugin-aware environment relative to the probed file, so the reported type matches what `rigor
@@ -184,8 +218,8 @@ module Rigor
         true
       end
 
-      def locate_node(source:, root:, file:, line:, column:)
-        node = Source::NodeLocator.at_position(source: source, root: root, line: line, column: column)
+      def locate_node(locator:, file:, line:, column:)
+        node = locator.at_position(line: line, column: column)
         @err.puts("type-of: no expression found at #{file}:#{line}:#{column}") if node.nil?
         node
       rescue Source::NodeLocator::OutOfRangeError => e

--- a/lib/rigor/cli/type_of_command.rb
+++ b/lib/rigor/cli/type_of_command.rb
@@ -10,6 +10,8 @@ require_relative "../scope"
 require_relative "../source/node_locator"
 require_relative "../inference/fallback_tracer"
 require_relative "../inference/scope_indexer"
+require_relative "../inference/precision_scanner"
+require_relative "../source/node_walker"
 require_relative "type_of_renderer"
 require_relative "command"
 require_relative "options"
@@ -26,9 +28,23 @@ module Rigor
     # type-of UX (extra flags, watch mode, streaming output) without bloating the CLI shell. Output formatting is
     # delegated to {TypeOfRenderer}.
     class TypeOfCommand < Command
-      USAGE = "Usage: rigor type-of [options] FILE:LINE:COL"
+      USAGE = "Usage: rigor type-of [options] FILE:LINE[:COL] [FILE:LINE[:COL] ...]"
 
-      Result = Data.define(:file, :line, :column, :node, :type, :tracer)
+      # `enumerated` marks a result that came from a bare `FILE:LINE`, so the renderer can print the line as a
+      # compact table instead of a stanza per expression — a chain like `a.b(c).d` is forty lines otherwise.
+      Result = Data.define(:file, :line, :column, :node, :type, :tracer, :enumerated) do
+        def initialize(enumerated: false, **rest)
+          super
+        end
+      end
+
+      # One requested position. A nil `column` means "every expression starting on this line" — the form that
+      # exists because hand-computing a column is the single most error-prone part of using this command.
+      Target = Data.define(:file, :line, :column)
+
+      # Cap on the expressions one bare `FILE:LINE` prints, so a long line cannot bury the answer.
+      LINE_ENUMERATION_CAP = 40
+      private_constant :LINE_ENUMERATION_CAP
 
       # @return [Integer] CLI exit status.
       def run
@@ -36,10 +52,10 @@ module Rigor
         buffer = Options.resolve_buffer_binding(options, err: @err)
         return CLI::EXIT_USAGE if buffer == :usage_error
 
-        target = parse_position_argument(@argv)
-        return CLI::EXIT_USAGE if target.nil?
+        targets = parse_position_arguments(@argv)
+        return CLI::EXIT_USAGE if targets.nil?
 
-        execute(target: target, options: options, buffer: buffer)
+        execute(targets: targets, options: options, buffer: buffer)
       end
 
       private
@@ -59,38 +75,89 @@ module Rigor
         options
       end
 
-      def execute(target:, options:, buffer: nil)
-        file, line, column = target
-        # Under editor mode the logical `file` may not exist on disk (user editing a new file); the runtime check is
-        # only that the BUFFER is readable, which `resolve_buffer_binding` has already enforced. For non-editor mode
-        # `file` must exist.
+      # One process, N positions. Every invocation used to rebuild the plugin-aware environment and reparse the
+      # file for a single answer, so investigating a chain of expressions cost one process each — the dominant
+      # cost of using this command in anger. The environment is now built once for the whole request and each
+      # file is parsed and scope-indexed once, however many positions land in it.
+      def execute(targets:, options:, buffer: nil)
+        configuration = Configuration.load(options.fetch(:config))
+        environment = project_environment(targets.map(&:file).uniq, configuration)
+        base_scope = Scope.empty(environment: environment)
+
+        results = []
+        targets.group_by(&:file).each do |file, group|
+          file_results = resolve_file(file, group, configuration, base_scope, options, buffer)
+          return file_results if file_results.is_a?(Integer)
+
+          results.concat(file_results)
+        end
+        return 1 if results.empty?
+
+        TypeOfRenderer.new(out: @out).render(results, format: options.fetch(:format))
+        0
+      end
+
+      # Every result for one file: parsed and indexed once, then each requested position resolved against that
+      # index. Returns an Integer exit status instead when the file itself cannot be probed.
+      def resolve_file(file, targets, configuration, base_scope, options, buffer)
+        # Under editor mode the logical `file` may not exist on disk (user editing a new file); the runtime check
+        # is only that the BUFFER is readable, which `resolve_buffer_binding` has already enforced.
         physical = buffer ? buffer.resolve(file) : file
         return 1 unless file_exists?(buffer ? physical : file)
 
-        configuration = Configuration.load(options.fetch(:config))
         source = File.read(physical)
         parse_result = Prism.parse(source, filepath: file, version: configuration.target_ruby)
         return 1 if parse_errors?(parse_result, file)
 
-        node = locate_node(source: source, root: parse_result.value, file: file, line: line, column: column)
-        return CLI::EXIT_USAGE if node == :out_of_range
-        return 1 if node.nil?
-
-        tracer = options[:trace] ? Inference::FallbackTracer.new : nil
-        base_scope = Scope.empty(environment: project_environment(file, configuration))
-
-        # Build a per-node scope index so locals bound earlier in the file flow into the scope used to type the queried
-        # node. We build the index with no tracer attached (it would otherwise double-record fallback events with the
-        # second-pass type_of call below), then look up the scope visible at the queried node and run the actual probe
-        # under it.
+        # Built with no tracer attached — it would otherwise double-record fallback events with the per-node
+        # `type_of` calls below.
         scope_index = Inference::ScopeIndexer.index(parse_result.value, default_scope: base_scope)
-        node_scope = scope_index[node]
 
-        type = node_scope.type_of(node, tracer: tracer)
-        result = Result.new(file: file, line: line, column: column, node: node, type: type, tracer: tracer)
+        collected = []
+        targets.each do |target|
+          if target.column.nil?
+            collected.concat(enumerate_line(file, target.line, parse_result.value, scope_index, options))
+            next
+          end
 
-        TypeOfRenderer.new(out: @out).render(result, format: options.fetch(:format))
-        0
+          node = locate_node(source: source, root: parse_result.value, file: file,
+                             line: target.line, column: target.column)
+          return CLI::EXIT_USAGE if node == :out_of_range
+          next if node.nil?
+
+          collected << type_result(file, target.line, target.column, node, scope_index, options)
+        end
+        collected
+      end
+
+      # Every expression STARTING on `line`, outermost first at each column. This is the form that removes the
+      # column arithmetic: `rigor type-of file.rb:42` answers "what are the types on line 42" without the user
+      # having to guess which byte the receiver starts at.
+      def enumerate_line(file, line, root, scope_index, options)
+        nodes = []
+        Source::NodeWalker.each(root) do |node|
+          loc = node.location
+          next unless loc.start_line == line
+          next if Inference::PrecisionScanner::NON_EXPRESSION_NODE_TYPES.include?(node.class.name)
+
+          nodes << node
+        end
+        if nodes.empty?
+          @err.puts("type-of: no expression found on #{file}:#{line}")
+          return []
+        end
+
+        nodes.sort_by! { |node| [node.location.start_column, -node.location.length] }
+        nodes.first(LINE_ENUMERATION_CAP).map do |node|
+          type_result(file, line, node.location.start_column, node, scope_index, options, enumerated: true)
+        end
+      end
+
+      def type_result(file, line, column, node, scope_index, options, enumerated: false)
+        tracer = options[:trace] ? Inference::FallbackTracer.new : nil
+        type = scope_index[node].type_of(node, tracer: tracer)
+        Result.new(file: file, line: line, column: column, node: node, type: type, tracer: tracer,
+                   enumerated: enumerated)
       end
 
       # Builds the plugin-aware environment relative to the probed file, so the reported type matches what `rigor
@@ -99,8 +166,8 @@ module Rigor
       # closes). The probed file is threaded as the synthesizer's `source_files:`. Project-RBS auto-detection
       # roots at CWD today; future work will walk parent directories to find the enclosing `Gemfile`/`*.gemspec`
       # so probes against files outside the current process's CWD still see the right `sig/` tree.
-      def project_environment(file, configuration)
-        ProbeEnvironment.build(configuration: configuration, source_files: [file])
+      def project_environment(files, configuration)
+        ProbeEnvironment.build(configuration: configuration, source_files: files)
       end
 
       def file_exists?(file)
@@ -126,19 +193,66 @@ module Rigor
         :out_of_range
       end
 
-      def parse_position_argument(argv)
-        case argv.size
-        when 1
-          parse_colon_form(argv[0])
-        when 3
-          decode_position(*argv)
-        else
-          @err.puts("type-of: expected FILE:LINE:COL or FILE LINE COL")
+      def parse_position_arguments(argv)
+        if argv.empty?
+          @err.puts("type-of: expected FILE:LINE[:COL] or FILE LINE COL")
           @err.puts(USAGE)
-          nil
+          return nil
+        end
+
+        colon = argv.map { |arg| try_colon_form(arg) }
+        return colon if colon.all?
+        return legacy_triple(argv) if argv.size == 3 && colon.none?
+        # A single unparseable argument keeps its old, specific diagnosis ("must be integers", "expected
+        # FILE:LINE:COL") rather than the generic multi-position complaint below.
+        return single_colon_form(argv[0]) if argv.size == 1
+
+        @err.puts("type-of: expected FILE:LINE[:COL] (repeatable) or FILE LINE COL, got #{argv.inspect}")
+        @err.puts(USAGE)
+        nil
+      end
+
+      # `FILE:LINE:COL` or `FILE:LINE`, or nil when the argument is not in either form. Silent: the caller
+      # decides whether a nil means "try the three-argument form" or "report a usage error", and a probe should
+      # not print a complaint about a shape it is about to accept under a different reading.
+      def try_colon_form(arg)
+        parts = arg.split(":")
+        return nil if parts.size < 2 || !integer_literal?(parts[-1])
+
+        # Three or more segments is the `FILE:LINE:COL` reading; if its LINE is not a number the argument is a
+        # typo, not a column-less position, and must reach the specific "must be integers" diagnosis.
+        if parts.size >= 3
+          return nil unless integer_literal?(parts[-2])
+
+          Target.new(file: parts[0..-3].join(":"), line: Integer(parts[-2], 10), column: Integer(parts[-1], 10))
+        else
+          Target.new(file: parts[0], line: Integer(parts[-1], 10), column: nil)
         end
       end
 
+      def integer_literal?(value)
+        value.match?(/\A\d+\z/)
+      end
+
+      # The pre-batch single-argument path, kept for its error messages. Returns nil after printing one.
+      def single_colon_form(arg)
+        position = parse_colon_form(arg)
+        return nil if position.nil?
+
+        file, line, column = position
+        [Target.new(file: file, line: line, column: column)]
+      end
+
+      def legacy_triple(argv)
+        position = decode_position(*argv)
+        return nil if position.nil?
+
+        file, line, column = position
+        [Target.new(file: file, line: line, column: column)]
+      end
+
+      # The strict `FILE:LINE:COL` reading, used only to produce the specific error for a single unparseable
+      # argument. The permissive reading (which also accepts `FILE:LINE`) is {try_colon_form}.
       def parse_colon_form(arg)
         parts = arg.split(":")
         if parts.size < 3
@@ -149,8 +263,7 @@ module Rigor
 
         column = parts.pop
         line = parts.pop
-        file = parts.join(":")
-        decode_position(file, line, column)
+        decode_position(parts.join(":"), line, column)
       end
 
       def decode_position(file, line, column)

--- a/lib/rigor/cli/type_of_renderer.rb
+++ b/lib/rigor/cli/type_of_renderer.rb
@@ -21,23 +21,37 @@ module Rigor
       private
 
       # Takes the whole result list: one invocation can now answer several positions, and a bare `FILE:LINE`
-      # answers every expression on that line. Blocks are separated by a blank line so a multi-result run stays
-      # readable; a single result renders byte-identically to before.
+      # answers up to 40 expressions on that line. A single exact result renders byte-identically to before.
       def render_text(results)
         list = Array(results)
-        return render_enumeration(list) if list.any? && list.all?(&:enumerated)
-
-        list.each_with_index do |result, index|
-          @out.puts("") unless index.zero?
-          render_one_text(result)
+        index = 0
+        first = true
+        while index < list.length
+          @out.puts("") unless first
+          result = list[index]
+          enumeration = result.enumeration
+          if enumeration
+            finish = index + 1
+            finish += 1 while finish < list.length && list[finish].enumeration.equal?(enumeration)
+            render_enumeration(list[index...finish], enumeration)
+            index = finish
+          else
+            render_one_text(result)
+            index += 1
+          end
+          first = false
         end
       end
 
       # A bare `FILE:LINE` asks "what are the types on this line", and the answer is a table: one row per
       # expression, outermost first at each column, so a method chain reads top to bottom.
-      def render_enumeration(results)
+      def render_enumeration(results, enumeration)
         @out.puts("#{results.first.file}:#{results.first.line}")
         render_enumeration_rows(results)
+        if enumeration.total > results.length
+          omitted = enumeration.total - results.length
+          @out.puts("  ... #{omitted} additional expressions omitted (limit #{results.length})")
+        end
         # After the table, never interleaved with it: a `--trace` fallback list between two rows would break the
         # column alignment the whole form exists for.
         results.each { |result| render_text_fallbacks(result) }
@@ -79,7 +93,20 @@ module Rigor
       def render_json(results)
         list = Array(results)
         payload = list.size == 1 ? result_to_h(list.first) : { results: list.map { |r| result_to_h(r) } }
+        enumerations = line_enumerations(list)
+        payload[:line_enumerations] = enumerations unless enumerations.empty?
         @out.puts(JSON.pretty_generate(payload))
+      end
+
+      def line_enumerations(results)
+        seen = {}.compare_by_identity
+        results.filter_map do |result|
+          enumeration = result.enumeration
+          next if enumeration.nil? || seen.key?(enumeration)
+
+          seen[enumeration] = true
+          { file: result.file, line: result.line, shown: enumeration.shown, total: enumeration.total }
+        end
       end
 
       def result_to_h(result)

--- a/lib/rigor/cli/type_of_renderer.rb
+++ b/lib/rigor/cli/type_of_renderer.rb
@@ -20,7 +20,41 @@ module Rigor
 
       private
 
-      def render_text(result)
+      # Takes the whole result list: one invocation can now answer several positions, and a bare `FILE:LINE`
+      # answers every expression on that line. Blocks are separated by a blank line so a multi-result run stays
+      # readable; a single result renders byte-identically to before.
+      def render_text(results)
+        list = Array(results)
+        return render_enumeration(list) if list.any? && list.all?(&:enumerated)
+
+        list.each_with_index do |result, index|
+          @out.puts("") unless index.zero?
+          render_one_text(result)
+        end
+      end
+
+      # A bare `FILE:LINE` asks "what are the types on this line", and the answer is a table: one row per
+      # expression, outermost first at each column, so a method chain reads top to bottom.
+      def render_enumeration(results)
+        @out.puts("#{results.first.file}:#{results.first.line}")
+        render_enumeration_rows(results)
+        # After the table, never interleaved with it: a `--trace` fallback list between two rows would break the
+        # column alignment the whole form exists for.
+        results.each { |result| render_text_fallbacks(result) }
+      end
+
+      def render_enumeration_rows(results)
+        width = results.map { |result| node_label(result).length }.max
+        results.each do |result|
+          @out.puts(format("  %4d  %-#{width}s  %s", result.column, node_label(result), result.type.describe))
+        end
+      end
+
+      def node_label(result)
+        result.node.class.name.to_s.delete_prefix("Prism::")
+      end
+
+      def render_one_text(result)
         @out.puts("#{result.file}:#{result.line}:#{result.column}")
         @out.puts("node:    #{result.node.class}")
         @out.puts("type:    #{result.type.describe}")
@@ -40,7 +74,15 @@ module Rigor
         end
       end
 
-      def render_json(result)
+      # A single result keeps the flat object it has always emitted, so existing consumers are untouched; a
+      # multi-position request wraps them in `results` rather than printing several documents to one stream.
+      def render_json(results)
+        list = Array(results)
+        payload = list.size == 1 ? result_to_h(list.first) : { results: list.map { |r| result_to_h(r) } }
+        @out.puts(JSON.pretty_generate(payload))
+      end
+
+      def result_to_h(result)
         payload = {
           file: result.file,
           line: result.line,
@@ -50,7 +92,7 @@ module Rigor
           erased: result.type.erase_to_rbs
         }
         payload[:fallbacks] = result.tracer.map { |event| fallback_to_h(event) } if result.tracer
-        @out.puts(JSON.pretty_generate(payload))
+        payload
       end
 
       def format_fallback_text(event, file)

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -246,6 +246,66 @@ RSpec.describe Rigor::CLI do
       expect(out).to include("erased:  1")
     end
 
+    # Throughput: one invocation used to rebuild the plugin-aware environment and reparse the file for a
+    # single answer, so walking a method chain cost one process per position. On redmine, five positions went
+    # from 10.34 s (five processes) to 2.08 s.
+    it "answers several positions in one invocation" do
+      path = write_fixture("multi.rb", "a = 1\nb = \"s\"\nc = :sym\n")
+
+      status, out, err = run_cli("type-of", "#{path}:1:5", "#{path}:2:5", "#{path}:3:5")
+
+      expect(err).to eq("")
+      expect(status).to eq(0)
+      expect(out).to include("type:    1")
+      expect(out).to include('type:    "s"')
+      expect(out).to include("type:    :sym")
+    end
+
+    it "answers positions across several files in one invocation" do
+      one = write_fixture("one.rb", "1\n")
+      two = write_fixture("two.rb", ":two\n")
+
+      status, out, _err = run_cli("type-of", "#{one}:1:1", "#{two}:1:1")
+
+      expect(status).to eq(0)
+      expect(out).to include("type:    1")
+      expect(out).to include("type:    :two")
+    end
+
+    it "wraps a multi-position JSON payload in `results`, and keeps a single one flat" do
+      path = write_fixture("multi.rb", "a = 1\nb = :s\n")
+
+      _, multi, = run_cli("type-of", "--format=json", "#{path}:1:5", "#{path}:2:5")
+      _, single, = run_cli("type-of", "--format=json", "#{path}:1:5")
+
+      expect(JSON.parse(multi)["results"].map { |r| r["type"] }).to eq(%w[1 :s])
+      expect(JSON.parse(single)).to include("type" => "1")
+      expect(JSON.parse(single)).not_to have_key("results")
+    end
+
+    # The column is the most error-prone part of using this command by hand, so it is optional.
+    it "enumerates every expression on the line when the column is omitted" do
+      path = write_fixture("line.rb", "x = [1, 2].first\n")
+
+      status, out, err = run_cli("type-of", "#{path}:1")
+
+      expect(err).to eq("")
+      expect(status).to eq(0)
+      expect(out).to include("#{path}:1")
+      expect(out).to match(/\s+0\s+LocalVariableWriteNode/)
+      expect(out).to include("CallNode")
+      expect(out).to match(/ArrayNode|Tuple/)
+    end
+
+    it "reports a line with no expression on it" do
+      path = write_fixture("blank.rb", "x = 1\n\n")
+
+      status, _out, err = run_cli("type-of", "#{path}:2")
+
+      expect(status).to eq(1)
+      expect(err).to include("no expression found on")
+    end
+
     it "accepts FILE LINE COL as separate arguments" do
       path = write_fixture("a.rb", "\"hi\"\n")
 

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -305,6 +305,17 @@ RSpec.describe Rigor::CLI do
       expect(out).to include("type:    :two")
     end
 
+    it "keeps positions in argument order while reusing each file's analysis" do
+      one = write_fixture("one.rb", "1\n\"last\"\n")
+      two = write_fixture("two.rb", ":two\n")
+
+      status, out, err = run_cli("type-of", "#{one}:1:1", "#{two}:1:1", "#{one}:2:1")
+
+      expect(err).to eq("")
+      expect(status).to eq(0)
+      expect(out.scan(/^.+:\d+:\d+$/)).to eq(["#{one}:1:1", "#{two}:1:1", "#{one}:2:1"])
+    end
+
     it "wraps a multi-position JSON payload in `results`, and keeps a single one flat" do
       path = write_fixture("multi.rb", "a = 1\nb = :s\n")
 
@@ -325,9 +336,57 @@ RSpec.describe Rigor::CLI do
       expect(err).to eq("")
       expect(status).to eq(0)
       expect(out).to include("#{path}:1")
-      expect(out).to match(/\s+0\s+LocalVariableWriteNode/)
+      expect(out).to match(/\s+1\s+LocalVariableWriteNode/)
       expect(out).to include("CallNode")
       expect(out).to match(/ArrayNode|Tuple/)
+    end
+
+    it "renders each line enumeration as its own table alongside exact positions" do
+      path = write_fixture("mixed.rb", "x = 1\ny = :two\n")
+
+      status, out, err = run_cli("type-of", "#{path}:1", "#{path}:2:5", "#{path}:2")
+
+      expect(err).to eq("")
+      expect(status).to eq(0)
+      expect(out.scan(/^#{Regexp.escape(path)}:\d+(?::\d+)?$/)).to eq(
+        ["#{path}:1", "#{path}:2:5", "#{path}:2"]
+      )
+    end
+
+    it "enumerates expressions inside defined? without evaluating them" do
+      path = write_fixture("defined.rb", "defined?(receiver.call)\n")
+
+      status, out, err = run_cli("type-of", "#{path}:1")
+
+      expect(err).to eq("")
+      expect(status).to eq(0)
+      expect(out).to include("DefinedNode")
+      expect(out).to include("CallNode")
+    end
+
+    it "marks a line enumeration that reaches the output cap" do
+      path = write_fixture("long.rb", Array.new(41, "1").join("; "))
+
+      status, out, err = run_cli("type-of", "#{path}:1")
+
+      expect(err).to eq("")
+      expect(status).to eq(0)
+      expect(out.scan("IntegerNode").size).to eq(40)
+      expect(out).to include("additional expressions omitted")
+    end
+
+    it "reports line-enumeration truncation in JSON" do
+      path = write_fixture("long.rb", Array.new(41, "1").join("; "))
+
+      status, out, err = run_cli("type-of", "--format=json", "#{path}:1")
+
+      expect(err).to eq("")
+      expect(status).to eq(0)
+      payload = JSON.parse(out)
+      expect(payload.fetch("results").size).to eq(40)
+      expect(payload.fetch("line_enumerations")).to eq(
+        [{ "file" => path, "line" => 1, "shown" => 40, "total" => 41 }]
+      )
     end
 
     it "reports a line with no expression on it" do


### PR DESCRIPTION
`rigor type-of` is the tool for asking why an expression is untyped, and answering that means walking the expression: the receiver, then the call, then the next link. Each of those cost a process, and each process rebuilt the plugin-aware environment and reparsed the file to answer one question.

## Measured on redmine

| | before | after |
| --- | --- | --- |
| five positions | 10.34 s (five processes) | **2.08 s** |
| one line, no column arithmetic | n/a | **1.93 s** |

The environment is built once per invocation, and each file is parsed and scope-indexed once however many positions land in it.

## The column is the other half of the cost

It has to be counted by hand, it is the part that goes wrong, and a wrong column costs a whole round trip. So it is optional: `rigor type-of file.rb:42` answers every expression **starting** on line 42, outermost first at each column — which is how a method chain reads.

```
$ rigor type-of app/controllers/account_controller.rb:35
app/controllers/account_controller.rb:35
     6  IfNode            Dynamic[top]?
     9  CallNode          Dynamic[top]
     9  CallNode          Dynamic[top]
     9  ConstantReadNode  Dynamic[top]
```

A table rather than a stanza per expression, because a four-link chain is otherwise twenty lines. Capped at 40 expressions so a long line cannot bury the answer. `--trace` fallbacks print after the table, never between rows — that is why the two loops stay separate rather than being combined.

## Compatibility

- A single position renders **byte-identically**, and its JSON keeps the flat object it has always emitted; only a multi-position request wraps them in `results`.
- `FILE LINE COL` (three arguments) still works.
- The three existing usage errors keep their specific wording. `FILE:LINE:COL` with a non-numeric line is a **typo**, not a column-less position, so it still reaches "must be integers" rather than being read as a file named `path:abc` — pinned by the existing specs, which caught exactly that during development.

## Verification

`make verify` green, rubocop clean. Seven new specs in `spec/rigor/cli_spec.rb`: several positions in one file, positions across files, the JSON single/multi shapes, line enumeration, and a line with no expression on it.

Related but separate: #512 (the probe answers `Dynamic` for a cross-file constant, whose obvious fix costs 2× and needs a cached seed) and #147 (the `check` editor-mode throughput backlog, whose disk-backed `ProjectScan` snapshot cache would cut the remaining ~1.9 s floor here too).