### PR TITLE
Seed the precision lens with the full discovery bundle and plugin-aware environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[cli]** `rigor coverage` and `rigor check --coverage` now measure the same engine `rigor check` runs: the precision ratio sees your project's cross-file methods, ancestry, and plugin-contributed types instead of under-reporting them as untyped, and precisely-folded `Data` / `Struct` values count as typed ([#535](https://github.com/rigortype/rigor/pull/535), [#513](https://github.com/rigortype/rigor/issues/513), [#523](https://github.com/rigortype/rigor/issues/523)).
+
 - **[engine]** A collection handed out by one method and filled through that reference — `(bucket_for(entry)[key] ||= {})[name] = row` — is no longer read as still empty, so `empty?` and `size` on it stop folding to a constant in every other method of the class ([#507](https://github.com/rigortype/rigor/pull/507), [#506](https://github.com/rigortype/rigor/issues/506)).
 
 - **[engine]** A collection filled through `h[k] ||= v`, `h[k] &&= v` or `h[k] += v` is no longer read as still carrying the literal shape it was initialized with, so `empty?` and `size` on it stop folding to a constant and a guard like `return nil if x.nil? || @rows.empty?` stops drawing a false "condition is always truthy" ([#504](https://github.com/rigortype/rigor/pull/504), [#501](https://github.com/rigortype/rigor/issues/501)).

--- a/Makefile
+++ b/Makefile
@@ -174,16 +174,22 @@ check-json:
 #   v0.3.4 59.02 · v0.3.5 58.94 · v0.3.6 58.96 · master 58.98
 #
 # A 0.94-point band over three months and +108 files, drifting down roughly
-# 0.1 points per release as the codebase grows. 57 % leaves ~2 points, about
-# two years of that drift, so ordinary development cannot trip it — a gate
+# 0.1 points per release as the codebase grows. The margin leaves ~2 points,
+# about two years of that drift, so ordinary development cannot trip it — a gate
 # that fires on correct input teaches people to route around it (AGENTS.md
 # § "Implementation Guidelines"). An engine change that legitimately LOWERS
 # precision (a soundness fix that widens a type) re-baselines this line
 # deliberately, which is the point of the gate.
 #
+# Re-pinned 2026-09-01 for #513 + #523: the lens now seeds the full
+# check-walk discovery bundle, runs plugin-aware, and classifies the
+# Data / Struct / BoundMethod carriers, moving `lib` 58.98 % → 59.81 %.
+# The threshold shifts by the same ~0.8 points to keep the calibrated
+# margin unchanged.
+#
 # Use `rigor coverage lib/` without --threshold for a non-gating report.
 coverage:
-	bundle exec exe/rigor coverage --threshold 0.57 lib
+	bundle exec exe/rigor coverage --threshold 0.58 lib
 
 # ADR-50 WD4 perf-regression gate. Runs `rigor check --no-cache` over `lib`
 # in-process, measures wall / allocations / peak-RSS, and gates against

--- a/lib/rigor/cli/coverage_command.rb
+++ b/lib/rigor/cli/coverage_command.rb
@@ -244,11 +244,11 @@ module Rigor
 
       # The protection scan must see the same receiver types `rigor check` does — including plugin-contributed
       # `dynamic_return` types (a controller's `params` → `ActionController::Parameters`, a `Model.where` →
-      # `ActiveRecord::Relation[Model]`). The bare `CoverageScan.project_environment` carries only the RBS environment
-      # (no plugin registry), so every plugin-typed receiver reads `Dynamic` and its dispatch site is miscounted as
-      # *unprotected* — a systematic undercount of what Rigor actually types on a plugin-using project.
-      # `ProjectContext` builds the plugin-aware environment (registry materialised + the per-run prepare pass that
-      # primes producers like the controller / model index) exactly as the LSP and the runner do.
+      # `ActiveRecord::Relation[Model]`). A bare RBS environment carries no plugin registry, so every plugin-typed
+      # receiver reads `Dynamic` and its dispatch site is miscounted as *unprotected* — a systematic undercount of
+      # what Rigor actually types on a plugin-using project. `ProjectContext` builds the plugin-aware environment
+      # (registry materialised + the per-run prepare pass that primes producers like the controller / model index)
+      # exactly as the LSP, the runner, and — since #513 — the precision path all do.
       def plugin_aware_environment(configuration)
         LanguageServer::ProjectContext.new(configuration: configuration).environment
       end

--- a/lib/rigor/cli/coverage_scan.rb
+++ b/lib/rigor/cli/coverage_scan.rb
@@ -7,6 +7,8 @@ require_relative "../environment"
 require_relative "../inference/parameter_inference_collector"
 require_relative "../inference/precision_scanner"
 require_relative "../inference/scope_indexer"
+require_relative "../language_server/project_context"
+require_relative "../protection/discovery_seed"
 require_relative "../scope"
 require_relative "coverage_report"
 
@@ -22,11 +24,17 @@ module Rigor
       # @param files [Array<String>] explicit `.rb` file paths to scan.
       # @param configuration [Rigor::Configuration]
       # @return [Rigor::CLI::CoverageReport]
+      #
+      # Issue #513 — the environment is PLUGIN-AWARE (`LanguageServer::ProjectContext`, the same builder
+      # `--protection` uses), not the bare RBS environment this path carried until 2026-09-01. Without the
+      # plugin registry every plugin-typed receiver read `Dynamic` and the precision ratio understated the
+      # engine by ~1.2 points on a Rails target — the defect the protection path documented and fixed for
+      # itself on 2026-07-04, never applied here.
       def precision_report(files:, configuration:)
         scope = discovery_seeded_scope(
           files: files,
           configuration: configuration,
-          environment: project_environment(configuration),
+          environment: LanguageServer::ProjectContext.new(configuration: configuration).environment,
           parameter_inference: configuration.parameter_inference
         )
         scanner = Inference::PrecisionScanner.new(scope: scope)
@@ -36,18 +44,14 @@ module Rigor
       end
 
       # The cross-file facts a scan must see to report the types the engine actually infers, rather than the types a
-      # file-at-a-time walk can reach on its own:
+      # file-at-a-time walk can reach on its own.
       #
-      # - `discovered_classes` — a project constant naming a class defined in a SIBLING file (`Account`, `User`) types
-      #   as `singleton(Account)` instead of `Dynamic`. Without it a single-file scan cannot see a class it does not
-      #   itself declare (the model-constant undercount found 2026-07-04).
-      # - `param_inferred_types` (ADR-67 WD3) — an undeclared parameter seeded with the union of its call sites'
-      #   argument types.
-      #
-      # Both spanned the `--protection` scan only until 2026-08-31, so the PRECISION ratio — the number `rigor
-      # coverage`, `rigor check --coverage` and the `check-coverage` threshold gate all report — was measured on a
-      # stripped scope and understated the engine by 4.87 points on this repository's own `lib`. The two surfaces now
-      # build the same seed set, so their ratios describe the same engine.
+      # Issue #513 — the seed is the FULL check-walk bundle (`Protection::DiscoverySeed.discovery_tables`: classes,
+      # def nodes and sources for both kinds, superclasses, includes, visibilities, methods, and the Data / Struct
+      # member layouts), not just `discovered_classes`. The two-table seed #505 introduced closed the biggest part of
+      # the gap and left the rest: without the def-node / ancestry tables every cross-file call to a source-inferred
+      # project method measured as unresolved while `rigor check` resolves it — +0.27pp on redmine, +0.77pp on
+      # mastodon from the tables alone.
       #
       # `parameter_inference` is a parameter rather than a config read because the two callers want different answers:
       # the precision lens must mirror the walk it describes (`check` leaves the table empty unless
@@ -57,10 +61,7 @@ module Rigor
       # @return [Rigor::Scope]
       def discovery_seeded_scope(files:, configuration:, environment:, parameter_inference:, workers: nil)
         base = Scope.empty(environment: environment)
-        seed = {}
-
-        discovered = Inference::ScopeIndexer.discovered_classes_for_paths(files)
-        seed[:discovered_classes] = discovered unless discovered.empty?
+        seed = Protection::DiscoverySeed.discovery_tables(files).dup
 
         if parameter_inference
           table = Inference::ParameterInferenceCollector.collect(
@@ -73,13 +74,6 @@ module Rigor
         return base if seed.empty?
 
         base.with_discovery(base.discovery.with(**seed))
-      end
-
-      def project_environment(configuration)
-        Environment.for_project(
-          libraries: configuration.libraries,
-          signature_paths: configuration.signature_paths
-        )
       end
 
       # Parses one file and feeds the scan result (or a parse-error record) into `accumulator`. `scanner` /

--- a/lib/rigor/inference/precision_scanner.rb
+++ b/lib/rigor/inference/precision_scanner.rb
@@ -153,9 +153,12 @@ module Rigor
         when Type::Bot                          then :bot
         when Type::Top                          then :top
         when Type::Constant                     then :constant
-        when Type::Nominal, Type::Singleton     then :nominal
+        when Type::Nominal, Type::Singleton,
+             Type::DataClass, Type::StructClass then :nominal
         when Type::Tuple, Type::HashShape,
-             Type::IntegerRange, Type::App      then :shaped
+             Type::IntegerRange, Type::App,
+             Type::DataInstance, Type::StructInstance,
+             Type::BoundMethod                  then :shaped
         when Type::Refined                      then :refined
         when Type::Dynamic                      then classify_dynamic(type)
         when Type::Union                        then worst_of(type.members)

--- a/spec/rigor/cli/coverage_command_spec.rb
+++ b/spec/rigor/cli/coverage_command_spec.rb
@@ -41,6 +41,21 @@ RSpec.describe Rigor::CLI::CoverageCommand do
       expect(use.fetch("precise_ratio")).to eq(1.0)
     end
 
+    # Issue #513 — the seed is the full check-walk discovery bundle, not just `discovered_classes`: without
+    # the def-node / def-source tables a cross-file call to a source-inferred project method measured as
+    # unresolved while `rigor check` resolves it (redmine's `l` / `render_404`, +0.27–0.77pp on the apps).
+    it "resolves a cross-file call to a source-inferred project method, instead of counting it opaque" do
+      File.write("util.rb", "class Util\n  def self.greeting\n    \"hi\"\n  end\nend\n")
+      File.write("use_util.rb", "Util.greeting.upcase\n")
+
+      status, out, = run(["--format", "json", "util.rb", "use_util.rb"])
+
+      expect(status).to eq(0)
+      use = JSON.parse(out).fetch("by_file").find { |f| f.fetch("file") == "use_util.rb" }
+      expect(use.fetch("dynamic_opaque_count")).to eq(0)
+      expect(use.fetch("precise_ratio")).to eq(1.0)
+    end
+
     it "seeds inferred parameter types only when `parameter_inference:` is on, mirroring the check walk" do
       File.write("app.rb", <<~RUBY)
         class Greeter

--- a/spec/rigor/inference/precision_scanner_spec.rb
+++ b/spec/rigor/inference/precision_scanner_spec.rb
@@ -107,6 +107,32 @@ RSpec.describe Rigor::Inference::PrecisionScanner do
     end
   end
 
+  # Issue #523 — every precisely-folded carrier must land in a precise tier. These five fell through
+  # `classify`'s `else` arm to `:dynamic_top`, so 810 ADR-48 Data / Struct and bound-method sites on this
+  # repository's own `lib` were counted OPAQUE by the ratio `rigor coverage` and the `make coverage`
+  # gate report. The spec enumerates them so a future carrier addition fails loud instead of silently
+  # diluting the ratio.
+  describe "carrier classification" do
+    let(:scanner) { described_class.new }
+
+    it "classifies DataClass and StructClass as nominal (class-side carriers, like Singleton)" do
+      data_class = Rigor::Type::Combinator.data_class_of(members: %i[x y], class_name: "Point")
+      struct_class = Rigor::Type::Combinator.struct_class_of(members: %i[a], class_name: "Row")
+      expect(scanner.send(:classify, data_class)).to eq(:nominal)
+      expect(scanner.send(:classify, struct_class)).to eq(:nominal)
+    end
+
+    it "classifies DataInstance, StructInstance, and BoundMethod as shaped" do
+      int = Rigor::Type::Combinator.constant_of(1)
+      data_instance = Rigor::Type::Combinator.data_instance_of(members: { x: int }, class_name: "Point")
+      struct_instance = Rigor::Type::Combinator.struct_instance_of(members: { a: int }, class_name: "Row")
+      bound = Rigor::Type::Combinator.bound_method_of(Rigor::Type::Combinator.nominal_of("String"), :upcase)
+      expect(scanner.send(:classify, data_instance)).to eq(:shaped)
+      expect(scanner.send(:classify, struct_instance)).to eq(:shaped)
+      expect(scanner.send(:classify, bound)).to eq(:shaped)
+    end
+  end
+
   describe "union and intersection classification" do
     it "classifies a mixed union by its worst member" do
       # `x || 1` — the || result is a union of the unknown `x` (dynamic_top)


### PR DESCRIPTION
Closes #513, closes #523. Wave 0 of the 2026-09-01 corpus opacity sweep (`docs/notes/20260901-corpus-opacity-attribution.md`): the measurement fixes that have to land before the engine fixes are sized, because the lens was reporting engine gaps the engine does not have.

**Full-bundle seeding.** `CoverageScan.discovery_seeded_scope` now seeds `Protection::DiscoverySeed.discovery_tables` — the same eleven-table bundle the check walk and the Tier-2 mutation path build — instead of `discovered_classes` alone. A cross-file call to a source-inferred project method (redmine's `l`, `render_404`, `User.current`) previously measured unresolved while `rigor check` resolved it; the sweep reproduced this in a minimal two-file project and measured +0.27pp (redmine) / +0.77pp (mastodon) from the tables alone.

**Plugin-aware environment.** `precision_report` builds `LanguageServer::ProjectContext`'s environment, exactly as `--protection` has since 2026-07-04 — a plugin-typed receiver (`params`, `Model.where`) no longer reads Dynamic under the precision ratio. Worth ~1.2pp on redmine per #513's measurement.

**Carrier classification.** `PrecisionScanner#classify` gains arms for DataClass/StructClass (nominal) and DataInstance/StructInstance/BoundMethod (shaped); they previously fell through `else` to `dynamic_top`, miscounting 810 precisely-folded sites on our own `lib` as opaque. A spec enumerates the five so the next carrier addition fails loud.

**Gate recalibration.** `lib` moves 58.98% → 59.81%; `make coverage` re-pins 0.57 → 0.58, preserving PR #510's calibrated drift-band margin.

Lens-only: no dispatch or diagnostic behavior changes (`make verify`, `make coverage`, `git diff --check` all green; diagnostics cannot move by construction).