### PR TITLE
Record inferred_return_untyped for unresolved calls that name a discovered project def

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[cli]** `rigor coverage --protection` no longer reports a call to your own method as an "unsupported syntax" hole when the real story is a return type Rigor could not infer — the cause table now routes those sites to the inference-gap bucket, so the report's engine-gap/add-RBS split reflects what would actually help ([#536](https://github.com/rigortype/rigor/pull/536), [#522](https://github.com/rigortype/rigor/issues/522)).
+
 - **[engine]** A collection handed out by one method and filled through that reference — `(bucket_for(entry)[key] ||= {})[name] = row` — is no longer read as still empty, so `empty?` and `size` on it stop folding to a constant in every other method of the class ([#507](https://github.com/rigortype/rigor/pull/507), [#506](https://github.com/rigortype/rigor/issues/506)).
 
 - **[engine]** A collection filled through `h[k] ||= v`, `h[k] &&= v` or `h[k] += v` is no longer read as still carrying the literal shape it was initialized with, so `empty?` and `size` on it stop folding to a constant and a guard like `return nil if x.nil? || @rows.empty?` stops drawing a false "condition is always truthy" ([#504](https://github.com/rigortype/rigor/pull/504), [#501](https://github.com/rigortype/rigor/issues/501)).

--- a/lib/rigor/inference/expression_typer.rb
+++ b/lib/rigor/inference/expression_typer.rb
@@ -957,10 +957,10 @@ module Rigor
         end
       end
 
-      def fallback_for(node, family:)
+      def fallback_for(node, family:, origin: DynamicOrigin::UNSUPPORTED_SYNTAX)
         inner = dynamic_top
-        record_fallback(node, family: family, inner_type: inner, origin: DynamicOrigin::UNSUPPORTED_SYNTAX)
-        scope.record_dynamic_origin(node, DynamicOrigin::UNSUPPORTED_SYNTAX)
+        record_fallback(node, family: family, inner_type: inner, origin: origin)
+        scope.record_dynamic_origin(node, origin)
         inner
       end
 
@@ -1201,7 +1201,26 @@ module Rigor
         record_unresolved_self_call(node, receiver) if Analysis::SelfCallResolutionRecorder.active?
         Effects::Collector.record_unresolved(node, scope.source_path) if Effects::Collector.active?
 
-        fallback_for(node, family: :prism)
+        fallback_for(node, family: :prism, origin: unresolved_call_origin(receiver, node.name))
+      end
+
+      # Issue #522 — the honest cause for a call the tiers exhausted. When the receiver's class HAS a
+      # discovered project def for the method, the miss is a return the engine could not infer (the
+      # discovered-method tier deliberately declined in favor of body inference, which then declined too —
+      # `MethodDispatcher#try_discovered_method`'s decline arms), which is ADR-82's
+      # `INFERRED_RETURN_UNTYPED`, not "unsupported syntax". Without this, every service-object `#call`
+      # whose body defeats inference reports to `coverage --protection` as a syntax gap. The generic cause
+      # stays for genuinely unresolved names (framework DSL sends, methods no scanned file defines).
+      def unresolved_call_origin(receiver, method_name)
+        class_name, kind = case receiver
+                           when Type::Nominal then [receiver.class_name, :instance]
+                           when Type::Singleton then [receiver.class_name, :singleton]
+                           else [nil, nil]
+                           end
+        return DynamicOrigin::UNSUPPORTED_SYNTAX if class_name.nil?
+        return DynamicOrigin::UNSUPPORTED_SYNTAX unless scope.discovered_method?(class_name, method_name, kind)
+
+        DynamicOrigin::INFERRED_RETURN_UNTYPED
       end
 
       # ADR-82 WD6 — carry the receiver's provenance onto the call it produces (returning the unchanged

--- a/spec/rigor/inference/protection_scanner_spec.rb
+++ b/spec/rigor/inference/protection_scanner_spec.rb
@@ -69,15 +69,17 @@ RSpec.describe Rigor::Inference::ProtectionScanner do
   # service-object `#call` carried the wrong label.
   it "routes a chain behind an unresolved call with a discovered project def to inferred_return_untyped" do
     # `call`'s own receiver is concrete (protected — not a site); the label shows on the DOWNSTREAM
-    # dispatch whose Dynamic receiver inherits the call node's provenance via ADR-82 WD6.
+    # dispatch whose Dynamic receiver inherits the call node's provenance via ADR-82 WD6. The def uses a
+    # trailing post parameter — the one shape the #524 per-parameter binder still declines — so the
+    # fixture keeps exercising the decline path on the integrated tree too.
     result = scan(<<~RUBY)
       class Service
-        def call(*args)
-          args
+        def call(first, *rest, last)
+          rest
         end
       end
 
-      Service.new.call(1).foo
+      Service.new.call(1, 2, 3).foo
     RUBY
     site = result.sites.find { |s| s.method_name == "foo" }
     expect(site).not_to be_nil

--- a/spec/rigor/inference/protection_scanner_spec.rb
+++ b/spec/rigor/inference/protection_scanner_spec.rb
@@ -63,6 +63,41 @@ RSpec.describe Rigor::Inference::ProtectionScanner do
     expect(result.sites.first.dynamic_origin).to eq(:inferred_return_untyped)
   end
 
+  # Issue #522 — a call the dispatch tiers exhausted still names a PROJECT method: the discovered tier
+  # declined in favor of body inference (a def source exists) and inference declined on the parameter
+  # shape. The honest cause is the inference gap, not "unsupported syntax" — on mastodon every
+  # service-object `#call` carried the wrong label.
+  it "routes a chain behind an unresolved call with a discovered project def to inferred_return_untyped" do
+    # `call`'s own receiver is concrete (protected — not a site); the label shows on the DOWNSTREAM
+    # dispatch whose Dynamic receiver inherits the call node's provenance via ADR-82 WD6.
+    result = scan(<<~RUBY)
+      class Service
+        def call(*args)
+          args
+        end
+      end
+
+      Service.new.call(1).foo
+    RUBY
+    site = result.sites.find { |s| s.method_name == "foo" }
+    expect(site).not_to be_nil
+    expect(site.dynamic_origin).to eq(:inferred_return_untyped)
+  end
+
+  # The generic cause stays for a name no scanned file defines — the discriminating control for the
+  # relabel above.
+  it "keeps the generic cause behind an unresolved call with no discovered project def" do
+    result = scan(<<~RUBY)
+      class Service
+      end
+
+      Service.new.frobnicate(1).foo
+    RUBY
+    site = result.sites.find { |s| s.method_name == "foo" }
+    expect(site).not_to be_nil
+    expect(site.dynamic_origin).to eq(:unsupported_syntax)
+  end
+
   it "routes an unbound instance-variable's chain to inference (ADR-82 root-enrichment)" do
     # `@x` is not assigned in this scope — the engine does not track the field's type (an ADR-58 gap) —
     # so `@x.foo` and, via WD6, `@x.foo.bar` route to `inferred_return_untyped` instead of no cause.


### PR DESCRIPTION
Closes #522 (the narrow relabel; the broader `unresolved_name` cause split discussed there remains future work). Wave 0 of the 2026-09-01 corpus opacity sweep (`docs/notes/20260901-corpus-opacity-attribution.md`).

The sweep's construct census showed `unsupported_syntax` is a misnomer bucket on every target — mastodon: 27 genuinely unmodeled nodes out of 26,505 carrying the cause. One concrete label bug inside that mass: when `MethodDispatcher#try_discovered_method` declines because a re-typable def body exists (`method_dispatcher.rb:315`) and body inference then declines too (parameter shape, #524), the call exits through `unresolved_call_result` → `fallback_for` and records the generic syntax cause. Every service-object `#call` on mastodon reported as "unsupported syntax".

`unresolved_call_result` now asks the discovered-methods table whether the receiver's class has a project def for the method (same Nominal→instance / Singleton→singleton mapping as the dispatcher's tier) and records `INFERRED_RETURN_UNTYPED` — ADR-82's honest inference-gap cause — when it does.

Provenance-only, verified empirically: redmine `check` 792 → 792 diagnostics byte-identical, protection ratio unchanged (0.3503), 198 sites move `unsupported_syntax` → `inferred_return_untyped`. The movement compounds with #535's lens fix (most of the app-side "exhausted dispatch" mass was lens under-seeding, which #535 removes at the source). Specs: a must-fire case (discovered def + `*rest` body → relabeled, red on master) and a discriminating control (undefined name keeps the generic cause).

`make verify` and `git diff --check` green.