### PR TITLE
Stop pinning one overload when an untyped argument cannot discriminate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** A call whose argument Rigor cannot type no longer picks one RBS overload by declaration order — `[true] * n` with an untyped `n` read as `String` and produced argument-type false positives on the array it actually returns; such calls now carry the candidate set gradually, removing 18 false positives across the survey corpus with none added ([#537](https://github.com/rigortype/rigor/pull/537), [#521](https://github.com/rigortype/rigor/issues/521)).
+
 - **[engine]** A collection handed out by one method and filled through that reference — `(bucket_for(entry)[key] ||= {})[name] = row` — is no longer read as still empty, so `empty?` and `size` on it stop folding to a constant in every other method of the class ([#507](https://github.com/rigortype/rigor/pull/507), [#506](https://github.com/rigortype/rigor/issues/506)).
 
 - **[engine]** A collection filled through `h[k] ||= v`, `h[k] &&= v` or `h[k] += v` is no longer read as still carrying the literal shape it was initialized with, so `empty?` and `size` on it stop folding to a constant and a guard like `return nil if x.nil? || @rows.empty?` stops drawing a false "condition is always truthy" ([#504](https://github.com/rigortype/rigor/pull/504), [#501](https://github.com/rigortype/rigor/issues/501)).

--- a/lib/rigor/inference/method_dispatcher/overload_selector.rb
+++ b/lib/rigor/inference/method_dispatcher/overload_selector.rb
@@ -80,10 +80,22 @@ module Rigor
         #   declaration.
         # @return [RBS::MethodType, nil] the chosen overload, or nil when the definition has no method
         #   types at all.
-        def select(method_definition, arg_types:, self_type:, instance_type:, type_vars: {}, block_required: false,
-                   environment: nil)
+        def select(method_definition, **) = select_candidates(method_definition, **).first
+
+        # Issue #521 — like {.select}, but when a `Dynamic[Top]` argument reaches the gradual pass it
+        # returns EVERY gradually-matching overload instead of pinning the first. An untyped argument
+        # accepts every param indiscriminately, so "first gradual match" is decided by overload-list
+        # position, not by types — `[true] * n` with an untyped `n` pinned `Array#*(string) -> String`
+        # and answered a wrong precise type the runtime can contradict. The caller unions the candidates'
+        # returns, which contains the truth whichever overload the runtime takes. Every other path (strict,
+        # alias-resolved, typed-gradual, arity fallback) still yields exactly one candidate, so `select`
+        # keeps its historical single answer.
+        #
+        # @return [Array<RBS::MethodType>] matching overloads; empty when the definition declares none.
+        def select_candidates(method_definition, arg_types:, self_type:, instance_type:, type_vars: {},
+                              block_required: false, environment: nil)
           overloads = method_definition.method_types
-          return nil if overloads.empty?
+          return [] if overloads.empty?
 
           # `rigor:v1:param: <name> <refinement>` annotations on this method override the RBS-declared
           # parameter type at the matching name. The map is consumed inside `accepts_param?` so overload
@@ -103,8 +115,8 @@ module Rigor
             )
           end
 
-          match = passes.call(block_required)
-          return match if match
+          matches = passes.call(block_required)
+          return matches unless matches.empty?
 
           # A block at the call site that no block-declaring overload matched: Ruby ignores a block handed
           # to a method that never yields it, so retry treating the block as ignorable rather than failing
@@ -112,8 +124,8 @@ module Rigor
           # `define_command(:x) do … end` against `def define_command: (Symbol) -> Symbol`) degraded to
           # `Dynamic[Top]` — and on a self-send suppressed the whole method's return type.
           if block_required
-            match = passes.call(false)
-            return match if match
+            matches = passes.call(false)
+            return matches unless matches.empty?
           end
 
           # No (usable) block at the call site: prefer an overload that does not REQUIRE a block over
@@ -121,7 +133,7 @@ module Rigor
           # overload first (`() { ... } -> Array[Elem]`) and the bare-call overload second
           # (`() -> Enumerator[...]`). Without this, a no-block `[1, 2].filter` would adopt the block
           # overload's `Array[Elem]` return when the call actually yields an `Enumerator`.
-          overloads.find { |mt| !overload_requires_block?(mt) } || overloads.first
+          [overloads.find { |mt| !overload_requires_block?(mt) } || overloads.first]
         end
 
         def overload_has_block?(method_type)
@@ -153,32 +165,54 @@ module Rigor
               arg_types: arg_types, self_type: self_type, instance_type: instance_type,
               type_vars: type_vars, block_required: block_required, param_overrides: param_overrides
             }
-            find_matching_overload(overloads, **shared, strict: true) ||
-              find_matching_overload_via_aliases(overloads, arg_types: arg_types, block_required: block_required) ||
-              find_matching_overload(overloads, **shared, strict: false)
+            strict = find_matching_overload(overloads, **shared, strict: true)
+            return strict unless strict.empty?
+
+            alias_hit = find_matching_overload_via_aliases(overloads, arg_types: arg_types,
+                                                                      block_required: block_required)
+            return [alias_hit] if alias_hit
+
+            # Pass 2, array-valued. With every argument carrying real type information the first gradual
+            # match keeps its historical single-winner contract. With a `Dynamic[Top]` argument in play the
+            # matches are indistinguishable by types — position alone would pick — so ALL of them come back
+            # and the dispatch layer unions their returns (#521).
+            matches = find_matching_overload(overloads, **shared, strict: false)
+            return matches.first(1) unless arg_types.any? { |t| untyped_arg?(t) }
+
+            matches
           end
 
           # rubocop:disable Metrics/ParameterLists
           def find_matching_overload(overloads, arg_types:, self_type:, instance_type:, type_vars:, block_required:,
                                      param_overrides:, strict:)
-            return nil if strict && arg_types.any? { |t| untyped_arg?(t) }
+            return [] if strict && arg_types.any? { |t| untyped_arg?(t) }
 
-            overloads.find do |method_type|
-              next false if block_required && !OverloadSelector.overload_has_block?(method_type)
-              next false if !block_required && OverloadSelector.overload_requires_block?(method_type)
+            predicate = lambda do |method_type|
+              next false unless engages_block_shape?(method_type, block_required)
               next false if strict && !strictly_typed_params?(method_type, arg_types.size)
 
               matches?(
-                method_type,
-                arg_types,
-                self_type: self_type,
-                instance_type: instance_type,
-                type_vars: type_vars,
-                param_overrides: param_overrides
+                method_type, arg_types,
+                self_type: self_type, instance_type: instance_type,
+                type_vars: type_vars, param_overrides: param_overrides
               )
             end
+            # Strict keeps its historical first-match short-circuit (a dispatch hot path); the gradual
+            # pass needs the full candidate list for the #521 union.
+            return [overloads.find(&predicate)].compact if strict
+
+            overloads.select(&predicate)
           end
           # rubocop:enable Metrics/ParameterLists
+
+          # Whether the overload's block clause is compatible with the call site's block shape: a
+          # block-bearing call engages only block-declaring overloads; a block-less call skips overloads
+          # that REQUIRE one.
+          def engages_block_shape?(method_type, block_required)
+            return OverloadSelector.overload_has_block?(method_type) if block_required
+
+            !OverloadSelector.overload_requires_block?(method_type)
+          end
 
           # Treats the literal `untyped` carrier (`Dynamic[Top]`) as too imprecise to drive a strict-pass
           # match. Other `Dynamic`-wrapped types with a concrete static facet carry enough information to
@@ -194,9 +228,13 @@ module Rigor
           # to `Dynamic[Top]` at the param level. Only fires when EVERY positional param has a known
           # alias-or-strict shape; otherwise gradual matching takes over.
           def find_matching_overload_via_aliases(overloads, arg_types:, block_required:)
+            # Issue #521 — an untyped argument "maybe"-accepts EVERY alias's strict arm, so it cannot
+            # discriminate between overloads here any more than in the strict pass; without this guard a
+            # Dynamic arg pinned `Array#*(string) -> String` purely by declaration order.
+            return nil if arg_types.any? { |t| untyped_arg?(t) }
+
             overloads.find do |method_type|
-              next false if block_required && !OverloadSelector.overload_has_block?(method_type)
-              next false if !block_required && OverloadSelector.overload_requires_block?(method_type)
+              next false unless engages_block_shape?(method_type, block_required)
 
               fun = method_type.type
               next false unless arity_compatible?(fun, arg_types.size)

--- a/lib/rigor/inference/method_dispatcher/rbs_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/rbs_dispatch.rb
@@ -355,7 +355,7 @@ module Rigor
             # fallback returns the caller's type, not Object.
             self_type = self_type_override || resolved_self_type
 
-            method_type = OverloadSelector.select(
+            candidates = OverloadSelector.select_candidates(
               method_definition,
               arg_types: args,
               self_type: self_type,
@@ -364,17 +364,14 @@ module Rigor
               block_required: !block_type.nil?,
               environment: environment
             )
-            return nil unless method_type
+            return nil if candidates.empty?
 
             call_site = [class_name, method_name, kind]
-            record_dispatch_provenance(method_definition, method_type, scope, call_node, call_site)
-            full_type_vars = compose_type_vars(method_type, type_vars, args, block_type, scope, call_node, call_site)
-
-            RbsTypeTranslator.translate(
-              method_type.type.return_type,
-              self_type: self_type,
-              instance_type: instance_type,
-              type_vars: full_type_vars
+            record_dispatch_provenance(method_definition, candidates.first, scope, call_node, call_site)
+            join_candidate_returns(
+              candidates,
+              self_type: self_type, instance_type: instance_type, type_vars: type_vars,
+              args: args, block_type: block_type, scope: scope, call_node: call_node, call_site: call_site
             )
           end
 
@@ -400,6 +397,38 @@ module Rigor
           # The two method-level type-parameter binding positions, layered in precedence order over the
           # receiver-derived `type_vars`: the block return type first, then the argument positions (which
           # never displace an existing key). See {#compose_arg_type_vars} for the argument envelope.
+          # Issue #521 — more than one candidate means a `Dynamic[Top]` argument made the overloads
+          # indistinguishable; pinning the first answered a wrong precise type the runtime can contradict
+          # (`[true] * n` read as String). The join is the candidates' return union wrapped in `Dynamic`,
+          # not the bare union: the untyped argument may satisfy constraints (kwarg shapes, value pins)
+          # that exclude arms statically-indistinguishable here, so a bare union licenses the negative
+          # rules to fire on arms the runtime never takes — measured immediately as three false positives
+          # on this repository's own `lib` (`Integer(v)` joining the `exception: bool` nil arm). The
+          # `Dynamic[T]` carrier keeps the candidate set visible without that license (ADR-5).
+          # A candidate whose return does not translate leaves the join incomplete — decline (fail-soft
+          # to Dynamic downstream) rather than answer a join missing an arm the runtime can take.
+          # rubocop:disable Metrics/ParameterLists
+          def join_candidate_returns(candidates, self_type:, instance_type:, type_vars:, args:, block_type:,
+                                     scope:, call_node:, call_site:)
+            returns = candidates.map do |method_type|
+              full_type_vars = compose_type_vars(method_type, type_vars, args, block_type, scope, call_node, call_site)
+              RbsTypeTranslator.translate(
+                method_type.type.return_type,
+                self_type: self_type,
+                instance_type: instance_type,
+                type_vars: full_type_vars
+              )
+            end
+            return returns.first if returns.size == 1
+            return nil if returns.any?(&:nil?)
+
+            distinct = returns.uniq
+            return distinct.first if distinct.size == 1
+
+            Type::Combinator.dynamic(Type::Combinator.union(*distinct))
+          end
+          # rubocop:enable Metrics/ParameterLists
+
           def compose_type_vars(method_type, type_vars, args, block_type, scope, call_node, call_site)
             vars = compose_block_type_vars(method_type, type_vars, block_type)
             compose_arg_type_vars(method_type, vars, args, scope: scope, call_node: call_node,

--- a/spec/rigor/inference/method_dispatcher/overload_selector_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/overload_selector_spec.rb
@@ -196,6 +196,49 @@ RSpec.describe Rigor::Inference::MethodDispatcher::OverloadSelector do
       end
     end
 
+    # Issue #521 — an untyped argument accepts every param indiscriminately, so neither the alias pass
+    # nor "first gradual match" may pin ONE overload: `[true] * n` with untyped `n` answered String (the
+    # `(string) -> String` arm, by declaration order), a wrong precise type the runtime contradicts.
+    describe "untyped discriminating argument (.select_candidates)" do
+      def select_candidates(class_name, method_name, arg_types)
+        definition = loader.instance_definition(class_name)
+        method = definition.methods[method_name]
+        instance_type = Rigor::Type::Combinator.nominal_of(class_name)
+        described_class.select_candidates(
+          method, arg_types: arg_types, self_type: instance_type, instance_type: instance_type
+        )
+      end
+
+      it "returns every gradual match for Array#* with an untyped argument" do
+        candidates = select_candidates("Array", :*, [Rigor::Type::Combinator.untyped])
+        param_names = candidates.map { |mt| mt.type.required_positionals.first.type.name.to_s }
+        expect(param_names).to contain_exactly("::string", "::int")
+      end
+
+      it "keeps a single candidate when the argument carries a real type" do
+        candidates = select_candidates("Array", :*, [Rigor::Type::Combinator.nominal_of("Integer")])
+        expect(candidates.size).to eq(1)
+        expect(candidates.first.type.required_positionals.first.type.name.to_s).to eq("::int")
+      end
+
+      it "answers a Dynamic-wrapped candidate union at the dispatch layer instead of pinning String" do
+        env = Rigor::Environment.for_project(libraries: [], signature_paths: [])
+        scope = Rigor::Scope.empty(environment: env)
+        root = Prism.parse("def f(n)\n  [true] * n\nend\n").value
+        index = Rigor::Inference::ScopeIndexer.index(root, default_scope: scope)
+        call = nil
+        Rigor::Source::NodeWalker.each(root) { |n| call = n if n.is_a?(Prism::CallNode) && n.name == :* }
+        type = index[call].type_of(call)
+        # The Dynamic wrapper (not a bare union) is load-bearing: an untyped argument may satisfy
+        # constraints that exclude arms, so the bare union let the negative rules fire on arms the
+        # runtime never takes (three false positives on this repository's own lib).
+        expect(type).to be_a(Rigor::Type::Dynamic)
+        rendered = type.describe(:short)
+        expect(rendered).to include("String")
+        expect(rendered).to include("[true]")
+      end
+    end
+
     describe "receiver-affinity pre-sort (BigDecimal-coerce regression)" do
       # When the `bigdecimal` stdlib RBS is loaded, its reopen of `Integer#+` adds `(BigDecimal) -> BigDecimal` at the
       # FRONT of the overload list. Without the pre-sort the selector picks that arm for unknown / Integer args and


### PR DESCRIPTION
Closes #521. Wave 1 of the 2026-09-01 corpus opacity sweep (`docs/notes/20260901-corpus-opacity-attribution.md`) — ranked first among the engine fixes because it is FP-relevant, and false positives outrank worst-case static reading.

**The bug.** With a `Dynamic[Top]` argument, overload selection pinned the FIRST overload by declaration order twice over: the alias pass's strict-arm probe answers "maybe" for an untyped arg against every alias, and the gradual pass's first-match contract is positional. `[true] * n` with untyped `n` pinned `Array#*(string) -> String` — a wrong precise type the runtime contradicts, with real downstream cost (numo-narray: 8 `String#[]=` argument-type-mismatch false positives in the shipped baseline).

**The fix.** The alias pass declines on untyped arguments (same rationale the strict pass documents); the gradual pass returns every match via the new `OverloadSelector.select_candidates` (singleton everywhere else, so `select`'s single-winner API is unchanged); `RbsDispatch#join_candidate_returns` joins the candidates' returns as **`Dynamic[union]`**. The Dynamic wrapper is deliberate: a bare union licenses the negative rules to fire on arms the runtime never takes — tried first, and it immediately cost three false positives on our own `lib` (`Integer(v)` joining the `exception: bool` nil arm). `Dynamic[T]` keeps the candidate set visible without that license (ADR-5).

**Verification.** `make verify` / `make coverage` / `git diff --check` green; selector specs cover the candidate list, the typed-argument single-winner control, and a dispatch-layer spec pinning the Dynamic wrapper as load-bearing. Corpus FP diff over 11 targets: **0 added / 18 removed**, every removal in the wrong-pin class (`String#[]=` ×8 numo-narray, undefined-method-for-String textbringer/redmine, `strftime`-for-Float concurrent-ruby).