### PR TITLE
Type attribute and index assignments as their RHS value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** An attribute or index assignment (`x.attr = v`, `h[k] = v`) now carries the assigned value's type, as Ruby defines, instead of the writer method's declared return — so `h[k] = true` no longer reads as untyped on an untyped hash ([#538](https://github.com/rigortype/rigor/pull/538), [#520](https://github.com/rigortype/rigor/issues/520)).
+
 - **[engine]** A collection handed out by one method and filled through that reference — `(bucket_for(entry)[key] ||= {})[name] = row` — is no longer read as still empty, so `empty?` and `size` on it stop folding to a constant in every other method of the class ([#507](https://github.com/rigortype/rigor/pull/507), [#506](https://github.com/rigortype/rigor/issues/506)).
 
 - **[engine]** A collection filled through `h[k] ||= v`, `h[k] &&= v` or `h[k] += v` is no longer read as still carrying the literal shape it was initialized with, so `empty?` and `size` on it stop folding to a constant and a guard like `return nil if x.nil? || @rows.empty?` stops drawing a false "condition is always truthy" ([#504](https://github.com/rigortype/rigor/pull/504), [#501](https://github.com/rigortype/rigor/issues/501)).

--- a/lib/rigor/inference/expression_typer.rb
+++ b/lib/rigor/inference/expression_typer.rb
@@ -1123,11 +1123,28 @@ module Rigor
         dynamic_top
       end
 
+      # Issue #520 — Ruby defines the value of an attribute / index assignment (`x.attr = v`, `h[k] = v`)
+      # as the RHS object itself, whatever the writer method returns. The dispatch pipeline still runs
+      # first for everything it observes on the side (effect collection, provenance, recorders, and the
+      # rules' own view of the writer), but its RESULT is discarded in favor of the last argument's type —
+      # `Hash#[]=`'s declared V made `h[k] = true` read Dynamic on an untyped hash, ~300 sites across the
+      # 2026-09-01 corpus sweep. Safe-navigation writes stay on the dispatch result: `x&.attr = v` is
+      # `v | nil`, which is #518's (safe-navigation) territory, not plain value semantics.
+      def call_type_for(node)
+        result = call_dispatch_type_for(node)
+        return result unless node.attribute_write? && !node.safe_navigation?
+
+        rhs = node.arguments&.arguments&.last
+        return result if rhs.nil? || rhs.is_a?(Prism::SplatNode)
+
+        type_of(rhs)
+      end
+
       # Slice 2 routes call expressions through `MethodDispatcher`. The receiver and every argument are typed
       # first, then the dispatcher is asked for a result type. A nil result triggers the fail-soft fallback
       # for the CallNode itself (the inner type_of calls already record their own fallbacks for unrecognised
       # receivers/args, so the tracer captures both the immediate dispatch miss and the deeper cause).
-      def call_type_for(node)
+      def call_dispatch_type_for(node)
         narrowed = indexed_narrowing_for(node)
         return narrowed if narrowed
 

--- a/spec/rigor/inference/expression_typer_spec.rb
+++ b/spec/rigor/inference/expression_typer_spec.rb
@@ -1543,4 +1543,33 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       expect(type.class_name).to eq("Array")
     end
   end
+
+  # Issue #520 — Ruby defines the value of an attribute / index assignment as the RHS object itself,
+  # whatever the writer method returns. `Hash#[]=`'s declared V made `h[k] = true` read Dynamic on an
+  # untyped hash.
+  describe "attribute / index assignment value semantics" do
+    def writer_call_type(source, method_name)
+      root = Prism.parse(source).value
+      index = Rigor::Inference::ScopeIndexer.index(root, default_scope: scope)
+      write = nil
+      Rigor::Source::NodeWalker.each(root) { |n| write = n if n.is_a?(Prism::CallNode) && n.name == method_name }
+      index[write].type_of(write)
+    end
+
+    it "types `h[k] = v` as the RHS, not the writer's declared return" do
+      # Inside the def, `h` is an untyped parameter; the write's value is still the RHS constant.
+      type = writer_call_type("def f(h)\n  h[:k] = true\nend\n", :[]=)
+      expect(type.describe).to eq("true")
+    end
+
+    it "types `x.attr = v` as the RHS" do
+      type = writer_call_type("def f(x)\n  x.size = 42\nend\n", :size=)
+      expect(type.describe).to eq("42")
+    end
+
+    it "leaves index READS on the dispatch result (control)" do
+      type = scope.type_of(parse_expression("[1, 2][0]"))
+      expect(type.describe).to eq("1")
+    end
+  end
 end


### PR DESCRIPTION
Closes #520. Wave 1 of the 2026-09-01 corpus opacity sweep (`docs/notes/20260901-corpus-opacity-attribution.md`).

**The gap.** Ruby defines the value of `x.attr = v` / `h[k] = v` as the RHS object itself, regardless of the writer's return. The typer answered the writer's dispatch result: `h[k] = true` read Dynamic on an untyped hash via `Hash#[]=`'s declared `V`. ~300 direct sites across the sweep (rigor-lib ~230, textbringer ~64, repeated on every corpus target), verified same-file.

**The fix.** `call_type_for` runs the dispatch pipeline unchanged for everything it observes on the side (effect collection, provenance, recorders, the rules' own view of the writer), then replaces the RESULT with the last argument's type for plain attribute writes. Safe-navigation writes (`x&.attr = v`, value `v | nil`) stay on the dispatch result — that is #518's territory — and splatted argument lists decline.

**Corpus FP diff (11 targets), every delta adjudicated:**
- redmine **+1** `flow.always-truthy-condition` at `lib/redmine/diff_table.rb:153` — a genuine latent bug: `elsif line[0, 1] = "\\"` assigns where `==` was meant, and the now-precise assignment value proves the condition truthy.
- textbringer **+18** `def.return-type-mismatch` warnings — all real drift between its handwritten `sig/` and its code (e.g. `delete_region` declared `-> Array[untyped]` while its tail returns `save_point`'s own declared `Integer`; `new_regexp`'s declared `String` param contradicts its `is_a?(Regexp)` arm). This is the contradiction surface the rule exists for; a project baseline absorbs them in normal use, and prior art (the 2026-06-01 textbringer survey) already established that pushing precision past a project's own RBS surfaces its RBS gaps.
- Zero added/removed on the other nine targets (kramdown, liquid, haml, concurrent-ruby, mail, net-ssh, numo-narray, herb, mastodon).

`make verify` / `git diff --check` green; specs pin the `[]=`/`attr=` RHS value with an index-READ control.