### PR TITLE
Optional receivers: dispatch &. on the nil-stripped receiver, retry T|nil on the non-nil arm, widen mutated literal constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** Safe navigation is no longer typed as a plain call: `x&.m` keeps the nil the skipped call produces and answers the non-nil arm's type instead of collapsing to untyped, a plain call on a `T | nil` receiver answers `T`'s type when the method would raise on nil, and a mutable literal constant (`CACHE = {}`) the same file mutates stops folding reads through its stale empty shape ([#543](https://github.com/rigortype/rigor/pull/543), [#518](https://github.com/rigortype/rigor/issues/518), [#519](https://github.com/rigortype/rigor/issues/519), [#540](https://github.com/rigortype/rigor/issues/540)).
+
 - **[engine]** An attribute or index assignment (`x.attr = v`, `h[k] = v`) now carries the assigned value's type, as Ruby defines, instead of the writer method's declared return — so `h[k] = true` no longer reads as untyped on an untyped hash ([#538](https://github.com/rigortype/rigor/pull/538), [#520](https://github.com/rigortype/rigor/issues/520)).
 
 - **[engine]** A collection handed out by one method and filled through that reference — `(bucket_for(entry)[key] ||= {})[name] = row` — is no longer read as still empty, so `empty?` and `size` on it stop folding to a constant in every other method of the class ([#507](https://github.com/rigortype/rigor/pull/507), [#506](https://github.com/rigortype/rigor/issues/506)).

--- a/lib/rigor/inference/expression_typer.rb
+++ b/lib/rigor/inference/expression_typer.rb
@@ -1131,8 +1131,15 @@ module Rigor
       # 2026-09-01 corpus sweep. Safe-navigation writes stay on the dispatch result: `x&.attr = v` is
       # `v | nil`, which is #518's (safe-navigation) territory, not plain value semantics.
       def call_type_for(node)
-        result = call_dispatch_type_for(node)
-        return result unless node.attribute_write? && !node.safe_navigation?
+        return safe_navigation_call_type(node) if node.safe_navigation?
+
+        attribute_write_value(node, call_dispatch_type_for(node))
+      end
+
+      # The RHS-value override for plain attribute / index writes (#520); a non-write call keeps the
+      # dispatch result.
+      def attribute_write_value(node, result)
+        return result unless node.attribute_write?
 
         rhs = node.arguments&.arguments&.last
         return result if rhs.nil? || rhs.is_a?(Prism::SplatNode)
@@ -1140,15 +1147,49 @@ module Rigor
         type_of(rhs)
       end
 
+      # Issue #518 — `x&.m` is NOT a plain call: when `x` is nil the method never runs and the expression
+      # is nil. Typed as a plain call it inherited both defects of union dispatch — the nil arm's method
+      # was folded as if `&.` called it (`s&.to_s` on `String?` read `String`, missing the nil the runtime
+      # produces), and a method absent from NilClass declined the whole union to `Dynamic[top]` even when
+      # the non-nil arm is fully typed (herb's own sig declares `Token#value: String`; the `?` alone
+      # discarded it). The call is dispatched on the nil-stripped receiver and the nil the skip produces is
+      # unioned back in; a receiver that IS nil skips the call statically.
+      def safe_navigation_call_type(node)
+        # A literal `nil&.m` is the statically-skipped call and folds to nil. An INFERRED exactly-nil
+        # receiver deliberately does NOT fold: every corpus site with that shape traced to a wrong
+        # upstream nil (an `attr_writer`-backed ivar whose only static write is nil — #541 — or a mutated
+        # literal-shape constant — #540), and folding it turned those latent wrong types into
+        # `flow.always-truthy-condition` firings on working programs. Until those uplinks are honest,
+        # the inferred-nil receiver keeps the plain pipeline's Dynamic.
+        return Type::Combinator.constant_of(nil) if node.receiver.is_a?(Prism::NilNode)
+
+        receiver = type_of(node.receiver)
+        non_nil = Narrowing.narrow_non_nil(receiver)
+        # A Bot or Dynamic fragment cannot improve on the plain pipeline (Bot: the inferred-exactly-nil
+        # receivers trace to the #540 / #541 uplinks; Dynamic: the stripped dispatch re-answers Dynamic),
+        # so both keep the historical path and its flow bookkeeping.
+        return call_dispatch_type_for(node) if non_nil.is_a?(Type::Bot) || non_nil.is_a?(Type::Dynamic)
+
+        result = attribute_write_value(node, call_dispatch_type_for(node, receiver_override: non_nil))
+        # Structural equality: `narrow_non_nil` rebuilds a Union even when it removed nothing, and a
+        # receiver that cannot be nil must not have a phantom nil unioned into its result.
+        return result if non_nil == receiver
+
+        Type::Combinator.union(result, Type::Combinator.constant_of(nil))
+      end
+
       # Slice 2 routes call expressions through `MethodDispatcher`. The receiver and every argument are typed
       # first, then the dispatcher is asked for a result type. A nil result triggers the fail-soft fallback
       # for the CallNode itself (the inner type_of calls already record their own fallbacks for unrecognised
       # receivers/args, so the tracer captures both the immediate dispatch miss and the deeper cause).
-      def call_dispatch_type_for(node)
+      # `receiver_override` substitutes the receiver type for the whole pipeline (folds, dispatch, the
+      # inference tiers) without re-reading the receiver node — the safe-navigation path (#518) dispatches
+      # on the nil-stripped fragment, and the optional-receiver retry (#519) re-runs the pipeline on it.
+      def call_dispatch_type_for(node, receiver_override: nil)
         narrowed = indexed_narrowing_for(node)
         return narrowed if narrowed
 
-        receiver = call_receiver_type_for(node)
+        receiver = receiver_override || call_receiver_type_for(node)
         arg_types = call_arg_types(node)
         block_type = block_return_type_for(node, receiver, arg_types)
 
@@ -1185,6 +1226,12 @@ module Rigor
         )
         return result if result
 
+        dispatch_miss_result(node, receiver, arg_types)
+      end
+
+      # The post-dispatch tiers for a call `MethodDispatcher` could not answer, in their historical
+      # order; extracted from {#call_dispatch_type_for} whole.
+      def dispatch_miss_result(node, receiver, arg_types)
         # v0.0.2 #5 — inter-procedural inference for user-defined methods. When dispatch misses but the
         # receiver is a user class with a `def` body, re-type the body with the call's argument types bound
         # and return the body's last-expression type.
@@ -1204,7 +1251,44 @@ module Rigor
         # semantic outcome, not a fail-soft compromise, so it MUST NOT record a tracer event.
         return inherit_receiver_origin(node) if receiver.is_a?(Type::Dynamic)
 
+        # Issue #519 — a `T | nil` receiver whose dispatch exhausted every tier: the nil arm vetoed the
+        # union (dispatch_union declines when ANY member declines, and the later tiers refuse unions), so
+        # `StringScanner?#scan` lost a type its RBS fully declares. Retry the whole pipeline on the
+        # non-nil fragment and answer its result: the nil path raises, which is `possible-nil-receiver`'s
+        # job (that rule reads the RECEIVER and is untouched); the value describes the path that returns
+        # (ADR-5 optimism, same polarity as the accessor-read nil-drop ADR-58 records). Unions whose
+        # non-nil members still decline fall through unchanged.
+        optional_retry = try_non_nil_receiver_retry(node, receiver)
+        return optional_retry if optional_retry
+
         unresolved_call_result(node, receiver)
+      end
+
+      def try_non_nil_receiver_retry(node, receiver)
+        return nil unless receiver.is_a?(Type::Union)
+        # When NilClass DEFINES the method (`nil?`, `to_s`, `==`, `inspect`, …), the nil arm is a live
+        # returner, not the veto — the union declined on some other member, and answering the stripped
+        # receiver's result would drop the nil arm's contribution (`(Journal | nil).nil?` must never
+        # answer the non-nil arm's constant-folded `false`). Retry only when the nil path raises.
+        return nil if nil_class_defines?(node.name)
+
+        non_nil = Narrowing.narrow_non_nil(receiver)
+        # Structural equality, not identity: `narrow_non_nil` rebuilds a Union even when it removed
+        # nothing, and an identity check would send a nil-free union that exhausts dispatch through the
+        # retry forever. A Dynamic fragment is excluded too: its retry can only re-answer Dynamic, and
+        # running the pipeline twice for that non-answer perturbs the flow bookkeeping for nothing.
+        return nil if non_nil.is_a?(Type::Bot) || non_nil.is_a?(Type::Dynamic) || non_nil == receiver
+
+        call_dispatch_type_for(node, receiver_override: non_nil)
+      end
+
+      # Conservative when NilClass's definition is unavailable: without the proof that the nil path
+      # raises, the retry stays off.
+      def nil_class_defines?(method_name)
+        definition = Rigor::Reflection.instance_definition("NilClass", scope: scope)
+        return true if definition.nil?
+
+        !definition.methods[method_name.to_sym].nil?
       end
 
       # The engine choke-point where a call has exhausted every resolution tier (RBS dispatch + user-class

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -79,7 +79,14 @@ module Rigor
         # Slice 7 phase 6. Same pre-pass shape for cvars (per class) and globals (program-wide). Globals are also
         # materialised into the top-level scope's `globals` map so reads at the top level (and in CLI probes that do not
         # enter a method body) observe the precise type without consulting the accumulator on every lookup.
-        class_cvars = build_class_cvar_index(root, seeded_scope)
+        # Issue #540 — a literal-shape carrier assigned to a constant or class variable is only as good as
+        # the file's OWN mutations of it: `ISPELL_STATUS = {}` with a sibling method writing
+        # `ISPELL_STATUS[:key] = param` must not fold reads through the closed empty shape. One census walk
+        # collects the mutated names; the two accumulators below widen their entries to the Dynamic-wrapped
+        # form so reads stay honest without licensing the negative rules.
+        literal_mutations = collect_literal_receiver_mutations(root)
+
+        class_cvars = widen_mutated_cvars(build_class_cvar_index(root, seeded_scope), literal_mutations[:cvars])
         seeded_scope = seeded_scope.with_discovery(seeded_scope.discovery.with(class_cvars: class_cvars))
         program_globals = build_program_global_index(root, seeded_scope)
         seeded_scope = seeded_scope.with_discovery(seeded_scope.discovery.with(program_globals: program_globals))
@@ -93,7 +100,9 @@ module Rigor
         # `pre_eval:` constant seed `Runner#project_scope_seed_tables` applies). Same-file declarations are the
         # most specific authority, exactly as `merged_classes` above resolves the same collision. Without the
         # merge, the assignment below would silently drop the project seed on every file.
-        in_source_constants = build_in_source_constants(root, seeded_scope)
+        in_source_constants = widen_mutated_constants(
+          build_in_source_constants(root, seeded_scope), literal_mutations[:constants]
+        )
         merged_constants = merge_seeded_constants(default_scope.in_source_constants, in_source_constants)
         seeded_scope = seeded_scope.with_discovery(seeded_scope.discovery.with(in_source_constants: merged_constants))
 
@@ -1349,6 +1358,111 @@ module Rigor
         accumulator = {}
         walk_constant_writes(root, [], default_scope, accumulator)
         accumulator.freeze
+      end
+
+      # Issue #540 — the mutation census behind the two wideners. Walks the whole tree once, tracking the
+      # lexical class/module prefix, and records every node that MUTATES a constant-read or
+      # class-variable-read receiver: the `Index{Or,And,Operator}Write` family, and a CallNode whose name
+      # is a known in-place mutator (`MutationWidening`'s tables) or a plain attribute/index writer
+      # (`name=` / `[]=`). Non-mutating reads never register, so `VERSION`-style constants keep their fold.
+      #
+      # @return [Hash{Symbol => Object}] `:constants` — a Set of candidate qualified names (each mutation
+      #   contributes every lexical-resolution candidate, `A::B::C` outward to bare `C`, mirroring how the
+      #   reads resolve); `:cvars` — `{class_name => Set[Symbol]}`.
+      def collect_literal_receiver_mutations(root)
+        census = { constants: Set.new, cvars: Hash.new { |h, k| h[k] = Set.new } }
+        walk_literal_receiver_mutations(root, [], census)
+        census
+      end
+
+      def walk_literal_receiver_mutations(node, qualified_prefix, census)
+        return unless node.is_a?(Prism::Node)
+
+        case node
+        when Prism::ClassNode, Prism::ModuleNode
+          name = Source::ConstantPath.qualified_name(node.constant_path)
+          if name
+            walk_literal_receiver_mutations(node.body, qualified_prefix + [name], census) if node.body
+            return
+          end
+        else
+          record_literal_receiver_mutation(node, qualified_prefix, census)
+        end
+
+        node.rigor_each_child { |child| walk_literal_receiver_mutations(child, qualified_prefix, census) }
+      end
+
+      def record_literal_receiver_mutation(node, qualified_prefix, census)
+        receiver = mutating_receiver_of(node)
+        return if receiver.nil?
+
+        case receiver
+        when Prism::ConstantReadNode
+          constant_mutation_candidates(receiver.name.to_s, qualified_prefix, census[:constants])
+        when Prism::ConstantPathNode
+          full = Source::ConstantPath.qualified_name_or_nil(receiver)
+          census[:constants] << full if full
+        when Prism::ClassVariableReadNode
+          census[:cvars][qualified_prefix.join("::")] << receiver.name unless qualified_prefix.empty?
+        end
+      end
+
+      # The receiver a node mutates, or nil when the node is not a mutation.
+      def mutating_receiver_of(node)
+        case node
+        when Prism::IndexOrWriteNode, Prism::IndexAndWriteNode, Prism::IndexOperatorWriteNode
+          node.receiver
+        when Prism::CallNode
+          return nil if node.receiver.nil?
+          return node.receiver if node.attribute_write?
+          return node.receiver if MutationWidening::ARRAY_MUTATORS.include?(node.name) ||
+                                  MutationWidening::HASH_MUTATORS.include?(node.name)
+
+          nil
+        end
+      end
+
+      # Every lexical-resolution candidate for a bare constant name under `qualified_prefix`, outermost
+      # last — `[A, B]` + `C` yields `A::B::C`, `A::C`, `C` — so the widener matches whichever form the
+      # write accumulator recorded.
+      def constant_mutation_candidates(base_name, qualified_prefix, into)
+        (0..qualified_prefix.size).each do |keep|
+          prefix = qualified_prefix.first(qualified_prefix.size - keep)
+          into << (prefix.empty? ? base_name : "#{prefix.join('::')}::#{base_name}")
+        end
+      end
+
+      def widen_mutated_constants(accumulator, mutated_names)
+        return accumulator if mutated_names.empty?
+
+        widened = accumulator.dup
+        mutated_names.each do |name|
+          existing = widened[name]
+          next if existing.nil? || existing.is_a?(Type::Dynamic)
+
+          widened[name] = Type::Combinator.dynamic(existing)
+        end
+        widened.freeze
+      end
+
+      def widen_mutated_cvars(accumulator, mutated_by_class)
+        return accumulator if mutated_by_class.empty?
+
+        widened = accumulator.dup
+        mutated_by_class.each do |class_name, names|
+          table = widened[class_name]
+          next if table.nil?
+
+          updated = table.dup
+          names.each do |cvar|
+            existing = updated[cvar]
+            next if existing.nil? || existing.is_a?(Type::Dynamic)
+
+            updated[cvar] = Type::Combinator.dynamic(existing)
+          end
+          widened[class_name] = updated.freeze
+        end
+        widened.freeze
       end
 
       # Issue #352 — folds the project-wide `pre_eval:` constant seed under this file's own table. Returns the

--- a/lib/rigor/inference/struct_fold_safety.rb
+++ b/lib/rigor/inference/struct_fold_safety.rb
@@ -171,7 +171,9 @@ module Rigor
         return nil unless meta_constant?(call_node.receiver, :Struct)
 
         args = call_node.arguments&.arguments || []
-        positional = args.last.is_a?(Prism::KeywordHashNode) ? args[0..-2] : args
+        # `[0..-2]` cannot return nil for a start of 0, but `Array#[](Range) -> Array[T]?` says it can;
+        # the `|| []` keeps the read well-typed on that worst case.
+        positional = args.last.is_a?(Prism::KeywordHashNode) ? (args[0..-2] || []) : args
         positional = positional[1..] if positional.first.is_a?(Prism::StringNode)
         return nil if positional.nil? || positional.empty?
         return nil unless positional.all?(Prism::SymbolNode)

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/catalog_walker.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/catalog_walker.rb
@@ -180,8 +180,8 @@ module Rigor
           return nil unless node.is_a?(Prism::CallNode) && node.receiver.nil?
           return nil unless VISIBILITY_MACROS.include?(node.name)
 
-          args = node.arguments&.arguments
-          return nil unless args&.size == 1 && args.first.is_a?(Prism::DefNode)
+          args = node.arguments&.arguments || []
+          return nil unless args.size == 1 && args.first.is_a?(Prism::DefNode)
 
           args.first
         end

--- a/spec/rigor/inference/expression_typer_spec.rb
+++ b/spec/rigor/inference/expression_typer_spec.rb
@@ -1572,4 +1572,43 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       expect(type.describe).to eq("1")
     end
   end
+
+  # Issues #518 / #519 — optional receivers. `&.` is not a plain call (the nil arm's method never runs,
+  # and the skip produces nil), and a plain call on `T | nil` must not lose T's answer to the nil arm's
+  # veto of the union dispatch.
+  describe "optional receivers and safe navigation" do
+    let(:project_scope) { Rigor::Scope.empty(environment: Rigor::Environment.for_project) }
+
+    def type_description(source)
+      project_scope.type_of(parse_expression(source)).describe(:short)
+    end
+
+    it "types `x&.m` by dispatching on the nil-stripped receiver and unioning the skip's nil back (#518)" do
+      # NilClass has no `upcase`, so the plain-call union dispatch declined this to Dynamic[top].
+      expect(type_description('(rand < 0.5 ? "abc" : nil)&.upcase')).to eq('"ABC"?')
+    end
+
+    it "does not fold the nil arm's own method as if `&.` called it (#518)" do
+      # As a plain call, NilClass#to_s -> "" joined the union and the runtime's nil was missing:
+      # the expression read `"" | "abc"` while `nil&.to_s` is nil.
+      expect(type_description('(rand < 0.5 ? "abc" : nil)&.to_s')).to eq('"abc"?')
+    end
+
+    it "types a call on a receiver that IS nil as the statically-skipped nil" do
+      expect(type_description("nil&.upcase")).to eq("nil")
+    end
+
+    it "adds no phantom nil when the receiver cannot be nil" do
+      expect(type_description('"a"&.upcase')).to eq('"A"')
+    end
+
+    it "retries a plain call on the non-nil fragment when the nil arm vetoed the union dispatch (#519)" do
+      # The value describes the path that returns; the nil path raising is possible-nil-receiver's job.
+      expect(type_description('(rand < 0.5 ? "abc" : nil).upcase')).to eq('"ABC"')
+    end
+
+    it "keeps full-union dispatch for a method every member defines (control)" do
+      expect(type_description('(rand < 0.5 ? "abc" : nil).to_s')).to eq('"" | "abc"')
+    end
+  end
 end


### PR DESCRIPTION
Closes #518, closes #519, closes #540. Wave 1 of the 2026-09-01 corpus opacity sweep. **Stacked on #538** (same `call_type_for` region) — merge #538 first, then retarget/merge this.

Three changes, ordered as commits:

**1. Mutated literal-shape constants/class variables widen (#540).** `ISPELL_STATUS = {}` with sibling `[]= param` writes, `@@emails = []` grown through mutators — reads folded through outgrown shapes and fired flow constants on working code. A ScopeIndexer census walk (reusing `MutationWidening`'s mutator tables) Dynamic-wraps the affected accumulator entries. Removes 8 standing corpus firings on textbringer alone (6 `always-truthy-condition`, 1 argument-type-mismatch), several of which predate this session.

**2. Safe navigation (#518).** `x&.m` dispatched as a plain call — `s&.to_s` on `String?` read `"" | "abc"` (a wrong type: the runtime produces nil, and the `""` arm folds a method `&.` never calls), and `s&.upcase` collapsed to Dynamic because the nil arm vetoed union dispatch. Now: strip nil, run the full pipeline on the fragment (`receiver_override`), union the skip's nil back. Literal `nil&.m` folds to nil; an inferred exactly-nil receiver keeps the plain pipeline until the #540/#541 uplinks are honest.

**3. `T | nil` plain-call retry (#519).** When dispatch exhausts and NilClass does NOT define the method (the nil arm is the veto and the nil path raises), retry on the non-nil fragment — `(rand < 0.5 ? "abc" : nil).upcase` types `"ABC"`; `possible-nil-receiver` still owns the hazard (it reads the receiver, untouched). The NilClass gate matters: the unguarded version folded `(Journal | nil).nil?` through the non-nil arm and broke ivar-guard narrowing — caught by the integration fixture, pinned by a control spec.

**Corpus gate (11 targets, vs the #538 arm), every delta adjudicated:** +8 / −8, all on textbringer + mail: two **true positives** (textbringer LSP client crashes its failure path — `stderr_output = @stderr&.read rescue ""` lets nil reach `.strip` outside the rescue, lines 193/219), three `def.return-type-mismatch` warnings against textbringer's own handwritten sig (one a message refinement of a removed twin), two `possible-nil-receiver` from the pre-existing default-bearing-Hash modeling gap (filed #542), one mail `always-truthy-condition` that traces to the overload wrong-pin #537 fixes on its own branch (re-verify at integration). Net −4 false positives.

`make verify` / `git diff --check` green; specs: six safe-nav/retry cases including the wrong-type regression and full-union controls, plus the census's must-still-succeed fold controls via the untouched suite.