### PR TITLE
Decline the indexed ||= narrowing record when the receiver has an untracked arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 - **[cli]** `rigor coverage` and `rigor check --coverage` now measure the same engine `rigor check` runs: the precision ratio sees your project's cross-file methods, ancestry, and plugin-contributed types instead of under-reporting them as untyped, and precisely-folded `Data` / `Struct` values count as typed ([#535](https://github.com/rigortype/rigor/pull/535), [#513](https://github.com/rigortype/rigor/issues/513), [#523](https://github.com/rigortype/rigor/issues/523)).
 
+- **[engine]** `h[k] ||= default` no longer pins later `h[k]` reads to the default when Rigor cannot fully see the hash — a caller-supplied value kept by the `||=` was folded away, firing "condition is always truthy" on reachable branches ([#545](https://github.com/rigortype/rigor/pull/545), [#544](https://github.com/rigortype/rigor/issues/544)).
+
 - **[engine]** A collection handed out by one method and filled through that reference — `(bucket_for(entry)[key] ||= {})[name] = row` — is no longer read as still empty, so `empty?` and `size` on it stop folding to a constant in every other method of the class ([#507](https://github.com/rigortype/rigor/pull/507), [#506](https://github.com/rigortype/rigor/issues/506)).
 
 - **[engine]** A collection filled through `h[k] ||= v`, `h[k] &&= v` or `h[k] += v` is no longer read as still carrying the literal shape it was initialized with, so `empty?` and `size` on it stop folding to a constant and a guard like `return nil if x.nil? || @rows.empty?` stops drawing a false "condition is always truthy" ([#504](https://github.com/rigortype/rigor/pull/504), [#501](https://github.com/rigortype/rigor/issues/501)).

--- a/lib/rigor/inference/indexed_narrowing.rb
+++ b/lib/rigor/inference/indexed_narrowing.rb
@@ -83,6 +83,20 @@ module Rigor
         [receiver.first, receiver.last, key]
       end
 
+      # Issue #544 — whether the RECEIVER's type is precise enough for a recorded slot value to be a
+      # fact. A `Dynamic` / `Top` constituent means the collection can hold a caller-supplied value at
+      # the slot that `||=` keeps, so recording the default alone would invent a fact (mail's
+      # `options[:count] ||= :all` folded a reachable `count: 1` path away). Unions walk their members;
+      # everything else — the tracked `HashShape` / `Tuple` carriers this feature was built for, and
+      # plain nominals whose RBS read already answers honestly — passes.
+      def fully_tracked_receiver_type?(type)
+        case type
+        when Type::Dynamic, Type::Top then false
+        when Type::Union then type.members.all? { |m| fully_tracked_receiver_type?(m) }
+        else true
+        end
+      end
+
       # Looks up a recorded narrowing for `receiver[key]` against `scope`, returning the narrowed
       # type or nil when no entry applies. Used by ExpressionTyper's `[]` dispatch to refine the
       # result of a stable indexed read.

--- a/lib/rigor/inference/statement_evaluator.rb
+++ b/lib/rigor/inference/statement_evaluator.rb
@@ -435,6 +435,9 @@ module Rigor
 
         key_node = first_index_argument(node)
         address = key_node && IndexedNarrowing.stable_address(node.receiver, key_node)
+        # Issue #544 — a receiver with an untracked (Dynamic / Top) constituent can hold a caller-supplied
+        # slot value the `||=` keeps, so the recorded default would invent a fact; decline the record.
+        address = nil if address && !IndexedNarrowing.fully_tracked_receiver_type?(scope.type_of(node.receiver))
         post = post_rhs
         # Widen BEFORE recording the narrowing: rebinding the receiver drops the per-slot narrowings keyed on it, so
         # the reverse order would trade this feature away for the widening. The two are complementary — the shape

--- a/spec/integration/fixtures/indexed_or_narrowing_dynamic_arm.rb
+++ b/spec/integration/fixtures/indexed_or_narrowing_dynamic_arm.rb
@@ -1,0 +1,19 @@
+require "rigor/testing"
+include Rigor::Testing
+
+# Issue #544 — the decline side of `receiver[key] ||= default` narrowing. `options` carries an
+# untracked (Dynamic) arm — a caller can pass `count: 1`, which the `||=` KEEPS — so recording the
+# default alone would invent a fact and fold the reachable `== 1` branch away
+# (`flow.always-truthy-condition` fired on mail's TestRetriever#find exactly this way).
+def half_tracked(given = nil)
+  options = given ? Hash[given] : {}
+  options[:count] ||= :all
+  options[:what] ||= :first
+  items = [1, 2, 3]
+  items.reverse! if options[:what] == :last
+  if options[:count] == 1
+    :one
+  else
+    :many
+  end
+end

--- a/spec/integration/type_construction_spec.rb
+++ b/spec/integration/type_construction_spec.rb
@@ -110,6 +110,17 @@ RSpec.describe "Rigor type construction (integration)" do
     end
   end
 
+  # Issue #544 — the decline side: a receiver whose type carries an untracked (Dynamic) arm can hold
+  # a caller-supplied slot value the `||=` keeps, so the recorded default alone would invent a fact
+  # and fold a reachable branch away (mail's TestRetriever#find).
+  describe "fixtures/indexed_or_narrowing_dynamic_arm.rb — Dynamic-armed receivers decline the record" do
+    let(:harness) { harness_for("indexed_or_narrowing_dynamic_arm") }
+
+    it "does not fold the post-`||=` comparison — the caller's slot value is still live" do
+      expect(harness.errors.map(&:message)).to be_empty
+    end
+  end
+
   describe "fixtures/universal_object_methods.rb — receiver-independent Object/Kernel selectors" do
     let(:harness) { harness_for("universal_object_methods") }
 

--- a/spec/rigor/inference/statement_evaluator_spec.rb
+++ b/spec/rigor/inference/statement_evaluator_spec.rb
@@ -1869,6 +1869,32 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
     end
   end
 
+  # Issue #544 — the recording gate: a receiver with an untracked (Dynamic) constituent can hold a
+  # caller-supplied slot value the `||=` keeps, so recording the default alone invents a fact (mail's
+  # `options[:count] ||= :all` folded a reachable `count: 1` path away once #537 stopped hiding the
+  # Dynamic arm behind a wrong overload pin).
+  describe "indexed `||=` narrowing recording gate" do
+    def indexed_key(name, key)
+      Rigor::Scope::IndexedKey.new(receiver_kind: :local, receiver_name: name, key: key)
+    end
+
+    it "declines the record when the receiver carries an untracked Dynamic arm" do
+      _, shaped = evaluate("h = {}")
+      dynamic_hash = Rigor::Type::Combinator.dynamic(Rigor::Type::Combinator.nominal_of("Hash"))
+      seeded = scope.with_local(:options, Rigor::Type::Combinator.union(dynamic_hash, shaped.local(:h)))
+
+      _, post = evaluate("options[:count] ||= :all", base_scope: seeded)
+
+      expect(post.indexed_narrowings).not_to have_key(indexed_key(:options, :count))
+    end
+
+    it "still records for a fully tracked receiver (control)" do
+      _, post = evaluate("params = {}\nparams[:f] ||= []")
+
+      expect(post.indexed_narrowings).to have_key(indexed_key(:params, :f))
+    end
+  end
+
   describe "compound writes rebind into post-scope (Slice 7 phase 3)" do
     def constant(value) = Rigor::Type::Combinator.constant_of(value)
 


### PR DESCRIPTION
Closes #544. Found by #543's integrated corpus gate; the family predates this session.

`StatementEvaluator#eval_index_or_write` recorded the per-slot `receiver[key] ||= default` narrowing regardless of the receiver's own precision. With mail's `options = options ? Hash[options] : {}` the receiver types `Dynamic[Hash | Hash[D, D]] | {}` — a caller-supplied `count: 1` lives in the Dynamic arm and the `||=` keeps it — so later `options[:count]` reads folded `:all` and `flow.always-truthy-condition` fired on a working program. The module's own header says a narrowing must never invent a fact.

The record now requires the receiver type to be **fully tracked** (`IndexedNarrowing.fully_tracked_receiver_type?`: no `Dynamic` / `Top` constituent, unions member-wise). The redmine `params[:f] ||= []` shape the feature was built for keeps its record — pinned by a control spec next to the decline spec.

**Corpus evidence (integrated tree with #535–#543):** `rigor check` on `mail/lib/mail/network/retriever_methods/test_retriever.rb` goes **6 → 3 firings** — the gate removes the new line-40 fold AND the two pre-existing sibling folds (lines 26, 33) that shipped in the baseline; the remaining three are the unrelated pre-existing `Array#[](int, int) -> Array?` worst-case reads. Full-corpus arms for the other ten targets are byte-identical.

Note for reviewers: the always-falsey fold does not reproduce inside the spec harness's environment (it needs mail's full class context), so the integration fixture and unit specs are contract pins; the discriminating evidence is the corpus run above.

`make verify` / `git diff --check` green.