### PR TITLE
Decline constant-value folds for block-bearing call sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** A block-taking call on a statically-folded `Set` constant (`NAMES.any? { … }`) no longer answers the blockless method's constant — the block decides the runtime answer, and the wrong fold could flag reachable conditions as always-truthy ([#546](https://github.com/rigortype/rigor/pull/546), [#539](https://github.com/rigortype/rigor/issues/539)).
+
 - **[cli]** `rigor coverage` and `rigor check --coverage` now measure the same engine `rigor check` runs: the precision ratio sees your project's cross-file methods, ancestry, and plugin-contributed types instead of under-reporting them as untyped, and precisely-folded `Data` / `Struct` values count as typed ([#535](https://github.com/rigortype/rigor/pull/535), [#513](https://github.com/rigortype/rigor/issues/513), [#523](https://github.com/rigortype/rigor/issues/523)).
 
 - **[engine]** A collection handed out by one method and filled through that reference — `(bucket_for(entry)[key] ||= {})[name] = row` — is no longer read as still empty, so `empty?` and `size` on it stop folding to a constant in every other method of the class ([#507](https://github.com/rigortype/rigor/pull/507), [#506](https://github.com/rigortype/rigor/issues/506)).

--- a/lib/rigor/inference/method_dispatcher/block_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/block_folding.rb
@@ -185,10 +185,13 @@ module Rigor
         end
 
         def constant_emptiness(value)
-          # Only `Range` constants reach these folds: `Type::Constant` rejects Array / Hash literals (they
-          # become `Tuple` / `HashShape` carriers), and the remaining scalar constants (Integer / Float /
-          # Symbol / String / …) are not Enumerable receivers for the filter or predicate methods folded here.
+          # `Range` constants and folded `Set` values (SetFolding wraps a real frozen ::Set) are the
+          # Enumerable receivers that reach these folds: `Type::Constant` rejects Array / Hash literals
+          # (they become `Tuple` / `HashShape` carriers), and the remaining scalar constants (Integer /
+          # Float / Symbol / String / …) are not Enumerable receivers for the filter or predicate methods
+          # folded here.
           return range_emptiness(value) if value.is_a?(Range)
+          return (value.empty? ? :empty : :non_empty) if value.is_a?(::Set)
 
           :unknown
         end

--- a/lib/rigor/inference/method_dispatcher/constant_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/constant_folding.rb
@@ -220,6 +220,16 @@ module Rigor
           method_name = context.method_name
           args = context.args
 
+          # Issue #539 — every fold in this tier executes the BLOCKLESS form of the method against the
+          # constant value. A call site that passes a block (literal or `&arg`) has different semantics —
+          # `SET.any? { |n| lookup(n) }` folded to the blockless `Set#any?`'s `true` on any non-empty set,
+          # a wrong type the flow rules then amplified (`flow.always-truthy-condition` on our own lib).
+          # The catalog's `block_dependent` classification covers the C body's own iterator, not the call
+          # site's block, so the guard belongs here. Internal per-element dispatches hand a non-CallNode
+          # (e.g. the `&:sym` BlockArgumentNode) as `call_node` — those carry no call-site block.
+          call_node = context.call_node
+          return nil if call_node.is_a?(Prism::CallNode) && call_node.block
+
           if REFLECTIVE_SEND_METHODS.include?(method_name)
             first_arg = args.first
             return nil unless first_arg.is_a?(Type::Constant) && first_arg.value.is_a?(Symbol)

--- a/spec/rigor/inference/method_dispatcher/constant_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/constant_folding_spec.rb
@@ -25,6 +25,36 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ConstantFolding do
     end
   end
 
+  # Issue #539 — every fold here executes the BLOCKLESS form against the constant value, so a call
+  # site that passes a block must decline: `SET.any? { |n| lookup(n) }` folded to the blockless
+  # `Set#any?`'s `true` on any non-empty set — a wrong type the runtime contradicts whenever the
+  # block answers falsey everywhere.
+  describe "block-bearing call sites never value-fold" do
+    def fold_with_block(source, value, method_name)
+      call = Prism.parse(source).value.statements.body.first
+      described_class.try_dispatch(cc(
+                                     receiver: Rigor::Type::Combinator.constant_of(value),
+                                     method_name: method_name,
+                                     args: [],
+                                     call_node: call
+                                   ))
+    end
+
+    it "declines any? with a literal block on a folded Set" do
+      expect(fold_with_block("s.any? { |n| lookup(n) }", Set["a", "b"], :any?)).to be_nil
+    end
+
+    it "declines with a `&proc` block argument too" do
+      expect(fold_with_block("s.any?(&pred)", Set["a", "b"], :any?)).to be_nil
+    end
+
+    it "still folds the blockless form (control)" do
+      type = fold(Set["a", "b"], :any?)
+      expect(type).to be_a(Rigor::Type::Constant)
+      expect(type.value).to be(true)
+    end
+  end
+
   describe "per-process-non-reproducible selectors never fold" do
     # `#hash` is SipHash-salted per process; folding `"abc".hash` would bake one process's random value into a Constant
     # (and the on-disk cache), wrong in every other process. The fold must decline so the RBS tier answers with the


### PR DESCRIPTION
Closes #539. Continuation of the 2026-09-01 sweep's fix wave.

**The bug.** `SetFolding` folds `Set[...]` literals into `Constant[::Set]` values, and every `ConstantFolding` rule executes the **blockless** form of a method against the folded value. A call site that passes a block therefore took the wrong semantics: `MIXIN_NAMES.any? { |name| scope...key?(...) }` folded to the blockless `Set#any?`'s `true` on any non-empty set — runtime truth depends entirely on the block. This fired a standing `flow.always-truthy-condition` warning on our own `lib` (`singleton_mixin_dispatch.rb:46`, present in every `make verify` log this cycle).

**The fix.** `ConstantFolding.try_dispatch` declines when the call site carries a syntactic block (literal `do/{}` or `&arg`). Internal per-element dispatches that hand a non-CallNode (the `&:sym` `BlockArgumentNode`) as `call_node` are unaffected — caught by the ADR-14 specs on the first draft. `BlockFolding#constant_emptiness` also learns folded `::Set` values so the truthiness-gated predicate folds keep their reach on Set constants.

**Verification.** `make verify` green **and the standing lib warning is gone**; corpus diff over the 11 gate targets: 0 added / 0 removed (the first run mis-measured the two Rails apps against their committed baselines after a cleanup deleted the stripped configs — the tell was −787/−2306 with "silenced by baseline" in stderr; re-run with regenerated `.rigor-ab.yml` configs). Specs pin the literal-block and `&arg` declines plus the blockless-fold control (`Set["a","b"].any?` still folds `true`).