### PR TITLE
Bind user-method call args per parameter instead of bailing per signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** Calling your own method with optional, keyword, rest, or block parameters no longer loses its inferred return type — the call-site binder binds each parameter it can identify (defaults included, `options = {}` too) instead of giving up on the whole signature, which also surfaced a real crash path in a survey app the code's own TODO had flagged ([#547](https://github.com/rigortype/rigor/pull/547), [#524](https://github.com/rigortype/rigor/issues/524)).
+
+- **[engine]** `File.read(path)` and `IO.read(path)` without a length now type as `String` instead of `String?` — the no-length form never returns nil, so guards on whole-file reads stop flagging impossible nils ([#547](https://github.com/rigortype/rigor/pull/547)).
+
 - **[cli]** `rigor coverage` and `rigor check --coverage` now measure the same engine `rigor check` runs: the precision ratio sees your project's cross-file methods, ancestry, and plugin-contributed types instead of under-reporting them as untyped, and precisely-folded `Data` / `Struct` values count as typed ([#535](https://github.com/rigortype/rigor/pull/535), [#513](https://github.com/rigortype/rigor/issues/513), [#523](https://github.com/rigortype/rigor/issues/523)).
 
 - **[engine]** A collection handed out by one method and filled through that reference — `(bucket_for(entry)[key] ||= {})[name] = row` — is no longer read as still empty, so `empty?` and `size` on it stop folding to a constant in every other method of the class ([#507](https://github.com/rigortype/rigor/pull/507), [#506](https://github.com/rigortype/rigor/issues/506)).

--- a/lib/rigor/analysis/check_rules.rb
+++ b/lib/rigor/analysis/check_rules.rb
@@ -2651,7 +2651,7 @@ module Rigor
           return nil unless self_type.respond_to?(:class_name)
 
           method_def =
-            if def_node.receiver.nil?
+            if def_node.receiver.nil? && !singleton_context_def?(scope, self_type.class_name, def_node.name)
               Reflection.instance_method_definition(self_type.class_name, def_node.name, scope: scope)
             else
               Reflection.singleton_method_definition(self_type.class_name, def_node.name, scope: scope)
@@ -2662,6 +2662,16 @@ module Rigor
           return override if override
 
           declared_return_union(method_def, scope.environment)
+        end
+
+        # A receiverless `def` inside `class << self` is a singleton def; the def NODE alone cannot say
+        # so, but the discovery walk recorded it under the singleton kind (and not the instance kind).
+        # Without this, `class << self; def load` compared its body against `Kernel#load: -> bool` — the
+        # inherited INSTANCE method — instead of its own `def self.load` signature. A name defined on
+        # both facets stays on the instance lookup (the pre-existing conservative reading).
+        def singleton_context_def?(scope, class_name, method_name)
+          scope.discovered_method?(class_name, method_name, :singleton) &&
+            !scope.discovered_method?(class_name, method_name, :instance)
         end
 
         # `type_vars:` — ADR-35 WD9 tier 1. When the caller supplies a generic-instantiation

--- a/lib/rigor/builtins/static_return_refinements.rb
+++ b/lib/rigor/builtins/static_return_refinements.rb
@@ -66,13 +66,32 @@ module Rigor
       FILE_NON_EMPTY = ->(_arg_types) { NON_EMPTY_STRING }
       private_constant :FILE_NON_EMPTY
 
+      STRING_NOMINAL = Type::Combinator.nominal_of("String").freeze
+      private_constant :STRING_NOMINAL
+
+      # `IO.read(name)` / `File.read(name)` return nil ONLY when a `length` argument is given
+      # and the stream is at EOF; the no-length form always returns a String (it raises on
+      # error). Upstream RBS declares one row with an optional length — `-> String?` for every
+      # call shape — so the whole-file idiom `File.read(path, mode: 'rb')` read as nilable and
+      # fired `possible-nil-receiver` on working code (redmine's Import#read_file_head, three
+      # sites). The refinement drops the nil exactly when no positional length is present; a
+      # keyword-only trailing hash (`mode:`, `encoding:`) is not a length. Same family as the
+      # staged upstream signature fixes (#159).
+      IO_READ_NO_LENGTH = lambda do |arg_types|
+        positional = arg_types.grep_v(Type::HashShape)
+        positional.size <= 1 ? STRING_NOMINAL : nil
+      end
+      private_constant :IO_READ_NO_LENGTH
+
       # Frozen ((owner_class_name, method_name, kind) => handler) table. The kind tag is
       # `:both`, `:singleton`, or `:instance`. New entries SHOULD prefer `:both` unless the
       # singleton- and instance-side shapes genuinely differ.
       OVERRIDES = {
         ["Kernel", :__dir__, :both] => KERNEL_DIR,
         ["File", :expand_path, :singleton] => FILE_NON_EMPTY,
-        ["File", :dirname, :singleton] => FILE_NON_EMPTY
+        ["File", :dirname, :singleton] => FILE_NON_EMPTY,
+        ["IO", :read, :singleton] => IO_READ_NO_LENGTH,
+        ["File", :read, :singleton] => IO_READ_NO_LENGTH
       }.freeze
       private_constant :OVERRIDES
 

--- a/lib/rigor/inference/expression_typer.rb
+++ b/lib/rigor/inference/expression_typer.rb
@@ -9,6 +9,7 @@ require_relative "../source/constant_path"
 require_relative "../source/node_children"
 require_relative "../analysis/self_call_resolution_recorder"
 require_relative "block_parameter_binder"
+require_relative "method_parameter_binder"
 require_relative "body_fixpoint"
 require_relative "budget_trace"
 require_relative "dynamic_origin"
@@ -2382,20 +2383,23 @@ module Rigor
 
       # Builds the body scope for a user-defined instance method call: a fresh `Scope` with `self_type` set
       # to the receiver's nominal type, the project-wide accumulators inherited (so the body sees the same
-      # `discovered_classes` / `class_ivars` / etc. the caller does), and required positional parameters
-      # bound from the call's `arg_types` by index. Returns nil when the parameter shape is too complex for
-      # the first-iteration binder (rest args, keyword args, block params, etc.).
+      # `discovered_classes` / `class_ivars` / etc. the caller does), and the call's `arg_types` bound to
+      # the parameters. Returns nil when the binding is truly ambiguous (arity mismatch, trailing `post`
+      # params, `...` forwarding).
+      #
+      # Issue #524 — the binder is per-PARAMETER, not per-signature. The first iteration declined any def
+      # with an optional / rest / keyword / block parameter outright, so ONE `options = {}` default zeroed
+      # out an otherwise-inferable return at every call site (the widest engine lever the 2026-09-01 sweep
+      # measured, verified on ten targets). Now: requireds bind by index; supplied optionals by index and
+      # unsupplied ones from a LITERAL default (else `Dynamic`); `*rest` collects the leftover positionals
+      # as a Tuple; keywords bind by name from a trailing keyword-hash shape, falling back to their literal
+      # default — or `Dynamic` when the shape is open or absent; `**kwrest`, `&block`, and destructured
+      # positionals bind `Dynamic`. Binding `Dynamic` is monotone-safe (wider in → wider out), so the only
+      # declines left are the shapes where positional CORRESPONDENCE itself is unknowable.
       def build_user_method_body_scope(def_node, receiver, arg_types)
         params = def_node.parameters
-        required = params&.requireds || []
-        return nil unless params.nil? || user_method_param_shape_simple?(params)
-        return nil unless required.size == arg_types.size
-
-        # Bind required positionals by index. The body scope starts from an empty fact store and narrowing
-        # set, so `with_local`'s fact / narrowing invalidations would be no-ops here — build the locals
-        # table directly (matching `with_local`'s `name.to_sym` key).
-        locals = {}
-        required.each_with_index { |param, index| locals[param.name.to_sym] = arg_types[index] }
+        locals = bind_params_from_call_types(params, arg_types)
+        return nil if locals.nil?
 
         # Construct the body scope in a SINGLE allocation — the previous `Scope.empty.with_*.with_*…` chain
         # allocated a fresh frozen Scope per field, run per user-method-call inference (ADR-44). The
@@ -2411,6 +2415,102 @@ module Rigor
         )
       end
 
+      # The locals table for the body scope, or nil to decline. Keys match `with_local`'s `name.to_sym`.
+      # The body scope starts from an empty fact store and narrowing set, so `with_local`'s fact /
+      # narrowing invalidations would be no-ops here — the table is built directly.
+      def bind_params_from_call_types(params, arg_types)
+        return arg_types.empty? ? {} : nil if params.nil?
+        return nil unless bindable_param_shape?(params)
+
+        positional = arg_types.dup
+        kw_shape = positional.pop if takes_keywords?(params) && positional.last.is_a?(Type::HashShape)
+        locals = bind_positional_params(params, positional)
+        return nil if locals.nil?
+
+        bind_keyword_params(params, kw_shape, locals)
+        locals[params.keyword_rest.name.to_sym] = dynamic_top if params.keyword_rest&.name
+        locals[params.block.name.to_sym] = dynamic_top if params.block&.name
+        locals
+      end
+
+      # Trailing required positionals after a rest (`def f(a, *m, z)`) shift the correspondence; `...`
+      # arrives as the keyword_rest slot. Both stay declined — correspondence, not width, is the issue.
+      def bindable_param_shape?(params)
+        params.is_a?(Prism::ParametersNode) &&
+          params.posts.empty? &&
+          !params.keyword_rest.is_a?(Prism::ForwardingParameterNode)
+      end
+
+      def takes_keywords?(params)
+        params.keywords.any? || !params.keyword_rest.nil?
+      end
+
+      def bind_positional_params(params, positional)
+        requireds = params.requireds
+        optionals = params.optionals
+        return nil if positional.size < requireds.size
+        return nil if params.rest.nil? && positional.size > requireds.size + optionals.size
+
+        locals = {}
+        requireds.each_with_index { |param, index| bind_positional_param(locals, param, positional[index]) }
+        optionals.each_with_index do |param, index|
+          supplied = positional[requireds.size + index]
+          locals[param.name.to_sym] = supplied || literal_default_type(param.value)
+        end
+        bind_rest_param(params, positional, locals)
+        locals
+      end
+
+      def bind_rest_param(params, positional, locals)
+        rest_name = params.rest&.name
+        return if rest_name.nil?
+
+        leftover = positional[(params.requireds.size + params.optionals.size)..] || []
+        locals[rest_name.to_sym] = Type::Combinator.tuple_of(*leftover)
+      end
+
+      # A destructured positional (`def f((a, b))`) consumes one argument slot but binds its leaf names
+      # `Dynamic` — element correspondence through the destructure is a later slice.
+      def bind_positional_param(locals, param, arg_type)
+        if param.is_a?(Prism::MultiTargetNode)
+          Destructure.target_names(param).each { |name| locals[name.to_sym] = dynamic_top }
+        else
+          locals[param.name.to_sym] = arg_type
+        end
+      end
+
+      def bind_keyword_params(params, kw_shape, locals)
+        open_shape = kw_shape && kw_shape.extra_keys == :open
+        params.keywords.each do |param|
+          name = param.name.to_s.delete_suffix(":").to_sym
+          supplied = kw_shape&.pairs&.[](name)
+          locals[name] = supplied ||
+                         (open_shape ? dynamic_top : keyword_default_type(param))
+        end
+      end
+
+      def keyword_default_type(param)
+        param.respond_to?(:value) && param.value ? literal_default_type(param.value) : dynamic_top
+      end
+
+      # A default expression contributes its type only when it is lexically scope-free — a scalar literal
+      # or an EMPTY collection literal (`options = {}` is the dominant Rails idiom). Anything that could
+      # read the def's own lexical scope binds `Dynamic` instead of being mis-typed in the caller's scope.
+      LITERAL_DEFAULT_NODES = [
+        Prism::IntegerNode, Prism::FloatNode, Prism::StringNode, Prism::SymbolNode,
+        Prism::TrueNode, Prism::FalseNode, Prism::NilNode
+      ].freeze
+      private_constant :LITERAL_DEFAULT_NODES
+
+      def literal_default_type(value_node)
+        return dynamic_top if value_node.nil?
+        return type_of(value_node) if LITERAL_DEFAULT_NODES.any? { |klass| value_node.is_a?(klass) }
+        return type_of(value_node) if value_node.is_a?(Prism::ArrayNode) && value_node.elements.empty?
+        return type_of(value_node) if value_node.is_a?(Prism::HashNode) && value_node.elements.empty?
+
+        dynamic_top
+      end
+
       # ADR-48 Struct slice 3 — the fold-safe-local set for a method body (runs only on a return-memo miss,
       # so the per-call cost is bounded — measured perf-neutral). Struct member layouts of constant
       # receivers are resolved through the discovery side-table the body scope inherits.
@@ -2419,19 +2519,6 @@ module Rigor
           body,
           ->(name) { scope.struct_member_layout(name)&.[](:members) }
         )
-      end
-
-      # First iteration accepts only required positional parameters: `def foo(a, b, c)`. Optionals, rest,
-      # keyword params, and block params disqualify the method from inference (the caller observes
-      # `Dynamic[Top]` instead).
-      def user_method_param_shape_simple?(params)
-        return false unless params.is_a?(Prism::ParametersNode)
-
-        params.optionals.empty? &&
-          params.rest.nil? &&
-          params.keywords.empty? &&
-          params.keyword_rest.nil? &&
-          params.block.nil?
       end
 
       # Slice A-engine. Implicit-self calls (no `node.receiver`) adopt the surrounding scope's `self_type`

--- a/lib/rigor/inference/statement_evaluator.rb
+++ b/lib/rigor/inference/statement_evaluator.rb
@@ -1444,6 +1444,10 @@ module Rigor
         # whose body we cannot prove match-free). A call provably match-free on a known receiver — `$3.to_i`, `year <
         # 50` — does NOT clobber, so the multi-statement `m = /…/ =~ s; …; use($2)` stdlib idiom keeps its precision
         # while a genuinely interposed match still invalidates.
+        # The chain above is Scope-total by construction (every helper returns its input scope or a
+        # combinator result); the `||=` is a runtime no-op that pins the INFERRED type back to Scope for
+        # the negative rules when a helper's return widens to `Scope?` under call-site binding (#524).
+        post_scope ||= scope
         post_scope = post_scope.forget_match_globals if match_capable_call?(node)
         [call_type, post_scope]
       end
@@ -1482,12 +1486,14 @@ module Rigor
         seed = current_scope.class_ivars_for(class_name)
         return current_scope if seed.empty?
 
-        seed.reduce(current_scope) do |acc, (ivar_name, seed_type)|
+        widened = current_scope
+        seed.each do |ivar_name, seed_type|
           local_type = current_scope.ivar(ivar_name)
-          next acc if local_type.nil? || local_type == seed_type
+          next if local_type.nil? || local_type == seed_type
 
-          acc.with_ivar(ivar_name, Type::Combinator.union(local_type, seed_type))
+          widened = widened.with_ivar(ivar_name, Type::Combinator.union(local_type, seed_type))
         end
+        widened
       end
 
       def intervening_call_candidate?(call_node)

--- a/sig/rigor.rbs
+++ b/sig/rigor.rbs
@@ -141,6 +141,14 @@ module Rigor
       # #387 — the loaded plugins' compiled effect contributions, read by `rigor effects` so the snapshot's
       # vocabulary is the one the collection window scanned under. Same `untyped` reasoning again.
       def effect_plugin_facts: () -> untyped
+      # The incremental session's read surface (ADR-46 / ADR-67 / ADR-103) — `IncrementalSession`
+      # drives a live Runner through these between rechecks. Typed `untyped` like the cache / effects
+      # readers above until their namespaces are sig-covered.
+      def return_summaries: () -> untyped
+      def param_inferred_types: () -> untyped
+      def effect_collections_by_path: () -> untyped
+      def collect_param_inference_table: (untyped files) -> untyped
+      def evaluate_return_types: (untyped paths, untyped specs) -> untyped
     end
   end
 end

--- a/sig/rigor/analysis/baseline.rbs
+++ b/sig/rigor/analysis/baseline.rbs
@@ -9,7 +9,7 @@ module Rigor
       # Load a baseline file from disk.
       # Returns `nil` when `path` is nil (no baseline configured).
       # Raises {LoadError} on malformed or unsupported content.
-      def self.load: (::String? path) -> Baseline?
+      def self.load: (::String? path, ?project_root: ::String) -> Baseline?
 
       # Build a baseline from a current run's diagnostic stream.
       def self.from_diagnostics: (untyped diagnostics, ?match_mode: :rule | :message) -> Baseline

--- a/spec/rigor/analysis/runner_spec.rb
+++ b/spec/rigor/analysis/runner_spec.rb
@@ -4665,20 +4665,22 @@ RSpec.describe Rigor::Analysis::Runner do
       expect(result.diagnostics.select { |d| d.rule == "assert.type-mismatch" }).to be_empty
     end
 
-    it "returns Dynamic[Top] when the top-level def has a complex param shape" do
-      # `def helper(x, kind: :default)` has a kwarg — the first-iteration binder rejects it. The engine still prefers
-      # the local def over RBS dispatch and returns `Dynamic[Top]`, suppressing the spurious `Array#select`-style
-      # mis-routing that previously caused `select(...)` to type as `Array[Elem]`.
+    it "infers through a complex param shape while still preferring the local def over RBS dispatch" do
+      # `def select(class_name, method_name, kind: :instance)` has a kwarg. The first-iteration binder
+      # rejected the whole signature and answered `Dynamic[Top]`; the #524 per-parameter binder infers the
+      # return — and the property this spec has always guarded still holds: the LOCAL def wins over
+      # `Array#select` / `Kernel#select`, so `mt` is the def's own return, never `Array[Elem]`.
       result = analyze(<<~RUBY)
+        require "rigor/testing"
+        include Rigor::Testing
         def select(class_name, method_name, kind: :instance)
           class_name
         end
         mt = select("Array", :first)
-        mt.no_such_method_on_array
+        assert_type("\\"Array\\"", mt)
       RUBY
 
-      # `mt` is `Dynamic[Top]`; the undefined-method rule skips Dynamic receivers so no diagnostic surfaces.
-      expect(result.diagnostics.select { |d| d.rule == "call.undefined-method" }).to be_empty
+      expect(result.diagnostics.select { |d| d.rule == "assert.type-mismatch" }).to be_empty
     end
   end
 

--- a/spec/rigor/builtins/static_return_refinements_spec.rb
+++ b/spec/rigor/builtins/static_return_refinements_spec.rb
@@ -29,6 +29,37 @@ RSpec.describe Rigor::Builtins::StaticReturnRefinements do
       expect(type).to eq(expected_dir_type)
     end
 
+    # `IO.read` / `File.read` return nil only when a positional LENGTH is given (EOF); the
+    # no-length whole-file idiom always returns a String — the upstream RBS's single
+    # `-> String?` row fired possible-nil-receiver on working code (redmine's read_file_head).
+    it "drops the nil for IO.read / File.read without a positional length" do
+      path = Rigor::Type::Combinator.constant_of("x.txt")
+      %w[IO File].each do |owner|
+        type = described_class.lookup(
+          owner_class_name: owner, method_name: :read, kind: :singleton, arg_types: [path]
+        )
+        expect(type).to eq(Rigor::Type::Combinator.nominal_of("String"))
+      end
+    end
+
+    it "keeps a keyword-only trailing hash out of the length count (File.read(path, mode: 'rb'))" do
+      path = Rigor::Type::Combinator.constant_of("x.txt")
+      kwargs = Rigor::Type::Combinator.hash_shape_of(mode: Rigor::Type::Combinator.constant_of("rb"))
+      type = described_class.lookup(
+        owner_class_name: "File", method_name: :read, kind: :singleton, arg_types: [path, kwargs]
+      )
+      expect(type).to eq(Rigor::Type::Combinator.nominal_of("String"))
+    end
+
+    it "declines IO.read WITH a positional length — nil is really possible at EOF" do
+      path = Rigor::Type::Combinator.constant_of("x.txt")
+      length = Rigor::Type::Combinator.constant_of(100)
+      type = described_class.lookup(
+        owner_class_name: "IO", method_name: :read, kind: :singleton, arg_types: [path, length]
+      )
+      expect(type).to be_nil
+    end
+
     it "is nil for an unregistered method name" do
       type = described_class.lookup(
         owner_class_name: "Kernel",


### PR DESCRIPTION
Closes #524 — the widest engine lever the 2026-09-01 corpus sweep measured (`docs/notes/20260901-corpus-opacity-attribution.md`), verified on ten targets before implementation.

**The gap.** `user_method_param_shape_simple?` accepted only exact-arity required positionals, so ONE optional/rest/keyword/block parameter disqualified the whole method from call-site return inference: `render_404(options = {})`, `Buffer.from(*args)` (46 sites), `HamlError.message(key, *args)` (a certain String), parser's optional-trailing builder API — every call site read `Dynamic[top]`.

**The binder, per parameter.** Requireds by index · supplied optionals by index, unsupplied from a **literal** default (scalar or empty collection — `options = {}`) else Dynamic · `*rest` = Tuple of the leftovers · keywords by name from a trailing keyword-hash shape, else literal default, else Dynamic (open shapes always Dynamic) · `**kwrest`/`&block`/destructures = Dynamic. Declines only where positional correspondence is unknowable (`post` params, `...`, arity mismatch). Dynamic binding is monotone-safe; the return-memo key is unchanged. Probe: `Util.greet("Bob")` → literal-string, `Util.from(1,2,3)` → `3`, `Util.message(:hi, count: 2)` → `"hihi"` — all Dynamic before.

**Three latent defects unmasked on our own lib, fixed at their roots here:** `sig/rigor.rbs` lacked the five IncrementalSession-facing `Runner` readers; `def.return-type-mismatch` resolved a receiverless `class << self` def against the inherited INSTANCE method (`Baseline.load` vs `Kernel#load -> bool`) — the rule now consults the discovery walk's singleton kind, **removing a standing herb corpus FP of the same shape**; `IO.read`/`File.read` without a positional length now refine to `String` (the no-length form never returns nil — `StaticReturnRefinements`, arg-conditional, with must-decline control for the length form).

**Corpus gate (11 targets), every delta adjudicated: +14 / −1.**
- **8 true positives**: mastodon `app/lib/activitypub/activity/quote_request.rb` dereferences `status.quote` on a fetch that can return nil — the code's own comment says `# TODO: raise if status is nil`.
- 3 redmine worst-case-sound `String?` reads (`Import#read_file_head`'s length-read tail — RBS optional-return noise; the runtime guards make nil unreachable), 1 safe-nav-guard narrowing gap (mastodon `fetch_featured_collection_service.rb:37`, `status&.account_id == @account.id` implies non-nil only if `id` is), 1 borderline (concurrent-ruby `Delay` posts to a nil executor when constructed without `:executor`), 1 textbringer sig-drift warning.
- −1: herb's pre-existing `Configuration.load` bool FP (the `class << self` fix).

**Perf, measured interleaved (3 reps alternating arms):** redmine cold check 8.6s → 9.7s (**~+12%**); mastodon ~+5% single-run. The cost is body inference running on the newly-bindable def population. Headroom if it matters: widen value-pinned args in the memo key so `f(1)`/`f(2)` share a summary; a per-run inference cap already exists (ADR-84 memo, RECURSION fuel).

`make verify` / `make coverage` / `git diff --check` green.