### PR TITLE
Type Parameters#expect and #slice as strong-params chain links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Changed
 
+- **[plugins]** rigor-actionpack now types `params.expect(...)` and `params.slice(...)` as strong-parameter chains, so Rails 8's `expect` idiom keeps the same typed, protected receiver `require`/`permit` chains have ([#548](https://github.com/rigortype/rigor/pull/548), [#534](https://github.com/rigortype/rigor/issues/534)).
+
 - **[cli]** `rigor type-of` accepts several positions in one invocation and makes the column optional — `rigor type-of file.rb:42` lists up to 40 expressions on line 42 — so walking a chain of expressions costs one process instead of one each (five positions on a Rails application: 10.3 s → 2.1 s) ([#515](https://github.com/rigortype/rigor/pull/515)).
 
 - **[engine]** `Foo.instance` on a class that includes the stdlib `Singleton` mixin now types as `Foo` instead of untyped, so the methods you call on that instance are typed too ([#514](https://github.com/rigortype/rigor/pull/514)).

--- a/plugins/rigor-actionpack/lib/rigor/plugin/actionpack.rb
+++ b/plugins/rigor-actionpack/lib/rigor/plugin/actionpack.rb
@@ -203,7 +203,17 @@ module Rigor
       # method on a Parameters value stays engine-lenient (no `undefined-method`), and this types the
       # container only, never a caller's argument (ADR-5). The GitLab strong-params survey (108 leaked
       # `.permit` sites) is the demand.
-      STRONG_PARAMS_CHAIN_METHODS = %i[require permit permit!].freeze
+      # Issue #534 — `expect` (Rails 8's require+permit) and `slice` joined 2026-09-01, from the corpus
+      # sweep's pair counts (63 and 38 sites on mastodon). Both share `require`'s safety shape: they
+      # never return nil (`expect` raises like `require`; `slice` always returns a Parameters), so the
+      # non-nil lenient nominal cannot fold a flow rule wrong.
+      #
+      # `Parameters#[]` — the LARGEST pair on both apps (redmine 581, mastodon ~475) — is deliberately
+      # NOT here: `params[:missing]` returns nil at runtime, and typing it as the non-nil nominal folded
+      # `url.nil?` / `if params[:r]` conditions constant on five working controllers (measured before
+      # withdrawal). Typing it `Parameters | nil` instead trades those folds for a possible-nil-receiver
+      # storm on idiomatic unguarded reads. `[]` needs a rules-level decision first — see #534.
+      STRONG_PARAMS_CHAIN_METHODS = %i[require permit permit! expect slice].freeze
 
       dynamic_return receivers: [REQUEST_CONTEXT_READER_TYPES[:params]], methods: STRONG_PARAMS_CHAIN_METHODS do |call_node, _scope|
         next nil unless call_node.is_a?(Prism::CallNode)

--- a/spec/integration/plugins/actionpack_plugin_spec.rb
+++ b/spec/integration/plugins/actionpack_plugin_spec.rb
@@ -214,6 +214,44 @@ RSpec.describe "plugins/rigor-actionpack" do
       end
     end
 
+    it "keeps `expect` / `slice` chained off `params` typed as Parameters (#534)" do
+      # Both share `require`'s safety shape: they never return nil, so the non-nil lenient nominal
+      # cannot fold a flow rule wrong. `[]` is deliberately absent — see the control below.
+      source = <<~RUBY
+        class C
+          def create
+            Rigor.dump_type(params.expect(user: [:name]))
+            Rigor.dump_type(params.slice(:q, :page))
+            Rigor.dump_type(params.expect(user: [:name]).slice(:name))
+          end
+        end
+      RUBY
+      with_demo(source) do |result|
+        dumps = result.diagnostics.select { |d| d.rule == "dump.type" }.map(&:message)
+        expect(dumps.size).to eq(3)
+        expect(dumps).to all(include("ActionController::Parameters"))
+      end
+    end
+
+    it "leaves `params[:key]` untyped — it returns nil at runtime, and a non-nil nominal folds flow rules (#534)" do
+      # Measured before withdrawal: typing `[]` as the non-nil Parameters folded `url.nil?` /
+      # `if params[:r]` conditions constant on five working redmine/mastodon controllers.
+      source = <<~RUBY
+        class C
+          def create
+            url = params[:back_url]
+            if url.nil?
+              Rigor.dump_type(url)
+            end
+          end
+        end
+      RUBY
+      with_demo(source) do |result|
+        folds = result.diagnostics.select { |d| d.rule == "flow.always-truthy-condition" }
+        expect(folds).to be_empty
+      end
+    end
+
     it "does not re-type `require` / `permit` on a non-Parameters receiver" do
       # The receiver gate is `ActionController::Parameters` — a bare `require 'x'` (Kernel) or a `permit`
       # on some other object must not become Parameters.


### PR DESCRIPTION
Part of #534 (the `Parameters` chain half; the issue's other Rails surfaces — `Rails.*` readers, Duration, `perform_async`, concern scopes, AMS `object` — remain open there).

**Added:** `expect` (Rails 8's require+permit) and `slice` join `STRONG_PARAMS_CHAIN_METHODS`. Both share `require`'s safety shape — neither can return nil (`expect` raises, `slice` always returns a Parameters) — so the lenient non-nil nominal cannot fold a flow rule wrong. Measured on mastodon against a master arm: **protection 35.62% → 35.92% (+93 protected sites)**; `check` diagnostics 0 added / 0 removed on both apps.

**Deliberately withdrawn:** `Parameters#[]` — the single largest pair on both apps (redmine 581, mastodon ~475 sites). The first draft typed it and the corpus gate caught five wrong constant folds on working controllers (`url = params[:back_url]; if url.nil?` reads always-falsey once `[]` claims non-nil): `params[:missing]` returns nil at runtime, so `[]` does not share `require`'s safety argument. Typing it `Parameters | nil` instead would trade those folds for a `possible-nil-receiver` storm on idiomatic unguarded reads (`nil_bearing_union_witnesses?` treats the lenient nominal as a nameable arm and RBS-unknown methods as present). `[]` therefore needs a rules-level decision first; the analysis is in the table's comment and a control spec pins the untyped answer.

`make verify` green; plugin specs cover the two new links, a chained `expect(...).slice(...)`, and the `[]`-stays-untyped control.