### PR TITLE
Resolve alias_method aliases and literal-symbol send through the direct tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** `alias_method :new_name, :old_name` now resolves like the `alias` keyword — calls through the alias infer the original method's return — and `x.send(:selector)` with a literal symbol resolves as the direct call would, private methods included ([#549](https://github.com/rigortype/rigor/pull/549), [#533](https://github.com/rigortype/rigor/issues/533)).
+
 - **[cli]** `rigor coverage` and `rigor check --coverage` now measure the same engine `rigor check` runs: the precision ratio sees your project's cross-file methods, ancestry, and plugin-contributed types instead of under-reporting them as untyped, and precisely-folded `Data` / `Struct` values count as typed ([#535](https://github.com/rigortype/rigor/pull/535), [#513](https://github.com/rigortype/rigor/issues/513), [#523](https://github.com/rigortype/rigor/issues/523)).
 
 - **[engine]** A collection handed out by one method and filled through that reference — `(bucket_for(entry)[key] ||= {})[name] = row` — is no longer read as still empty, so `empty?` and `size` on it stop folding to a constant in every other method of the class ([#507](https://github.com/rigortype/rigor/pull/507), [#506](https://github.com/rigortype/rigor/issues/506)).

--- a/lib/rigor/inference/expression_typer.rb
+++ b/lib/rigor/inference/expression_typer.rb
@@ -1140,6 +1140,9 @@ module Rigor
         # asks nothing further of dispatch. Off (the default) this is one integer read.
         Effects::Collector.record_call(node, receiver, scope) if Effects::Collector.active?
 
+        literal_send = try_literal_send(node, receiver)
+        return literal_send if literal_send
+
         local_def_result = try_local_def_dispatch(node, receiver, arg_types)
         return local_def_result if local_def_result
 
@@ -1148,14 +1151,8 @@ module Rigor
         # the corresponding element bound to the block parameter and assemble the results into a
         # `Tuple[U_1..U_n]`. This sits ahead of `MethodDispatcher.dispatch` so the RBS tier does not re-widen
         # the answer back to `Array[union]`.
-        per_element = try_per_element_block_fold(node, receiver)
-        return per_element if per_element
-
-        inject_fold = try_block_inject_fold(node, receiver, arg_types)
-        return inject_fold if inject_fold
-
-        hash_transform = try_hash_shape_block_fold(node, receiver)
-        return hash_transform if hash_transform
+        block_fold = try_receiver_block_folds(node, receiver, arg_types)
+        return block_fold if block_fold
 
         result = MethodDispatcher.dispatch(
           receiver_type: receiver,
@@ -1326,16 +1323,58 @@ module Rigor
         end
       end
 
-      def try_user_method_inference(receiver, call_node, arg_types)
+      # The three receiver-shaped block folds, in their historical order (extracted whole from
+      # `call_dispatch_type_for` for method-length budget).
+      def try_receiver_block_folds(node, receiver, arg_types)
+        per_element = try_per_element_block_fold(node, receiver)
+        return per_element if per_element
+
+        inject_fold = try_block_inject_fold(node, receiver, arg_types)
+        return inject_fold if inject_fold
+
+        try_hash_shape_block_fold(node, receiver)
+      end
+
+      # Issue #533 — `x.send(:selector, args)` with a LITERAL symbol is statically `x.selector(args)`:
+      # the private-boundary idiom (protobuf's `send(:get_file_descriptor)` at 84 sites) resolves through
+      # the same dispatch + project-inference tiers as the direct call would. `send` legitimately crosses
+      # visibility, so no public-only gate applies (`public_send` is treated identically — typing the
+      # success path of a call that would raise on a private method is ADR-5 optimism). Declines: a
+      # non-literal selector, a splat / forwarded tail (positional correspondence unknown), or a block at
+      # the call site (block forwarding is out of this slice).
+      LITERAL_SEND_SELECTORS = %i[send __send__ public_send].freeze
+      private_constant :LITERAL_SEND_SELECTORS
+
+      def try_literal_send(node, receiver)
+        return nil unless LITERAL_SEND_SELECTORS.include?(node.name)
+        return nil unless node.block.nil?
+
+        args = node.arguments&.arguments
+        return nil unless args && args.first.is_a?(Prism::SymbolNode)
+
+        rest = args[1..]
+        return nil if rest.any? { |a| a.is_a?(Prism::SplatNode) || a.is_a?(Prism::ForwardingArgumentsNode) }
+
+        inner_name = args.first.unescaped.to_sym
+        inner_args = rest.map { |a| type_of(a) }
+        MethodDispatcher.dispatch(
+          receiver_type: receiver, method_name: inner_name, arg_types: inner_args,
+          block_type: nil, environment: scope.environment, call_node: node, scope: scope
+        ) ||
+          try_user_method_inference(receiver, node, inner_args, method_name: inner_name) ||
+          try_project_singleton_inference(receiver, node, inner_args, method_name: inner_name)
+      end
+
+      def try_user_method_inference(receiver, call_node, arg_types, method_name: call_node.name)
         return nil unless receiver.is_a?(Type::Nominal)
 
-        def_node, owner = resolve_user_def_with_owner(receiver.class_name, call_node.name)
+        def_node, owner = resolve_user_def_with_owner(receiver.class_name, method_name)
         return nil if def_node.nil?
 
         result = infer_user_method_return(def_node, receiver, arg_types)
         return result if result.nil?
 
-        degrade_if_overridable(result, owner, call_node.name, :instance)
+        degrade_if_overridable(result, owner, method_name, :instance)
       rescue StandardError
         nil
       end
@@ -1350,16 +1389,16 @@ module Rigor
       # Resolution is OWN-class only: the singleton-ancestry chain (`extend`ed modules, inherited
       # class-method dispatch) is not walked at this slice. A miss degrades to today's `Dynamic[top]`, never
       # a false resolution (ADR-57 follow-up § module-singleton).
-      def try_singleton_method_inference(receiver, call_node, arg_types)
+      def try_singleton_method_inference(receiver, call_node, arg_types, method_name: call_node.name)
         return nil unless receiver.is_a?(Type::Singleton)
 
-        def_node = scope.singleton_def_for(receiver.class_name, call_node.name)
+        def_node = scope.singleton_def_for(receiver.class_name, method_name)
         return nil if def_node.nil?
 
         result = infer_user_method_return(def_node, receiver, arg_types)
         return result if result.nil?
 
-        degrade_if_overridable(result, receiver.class_name, call_node.name, :singleton)
+        degrade_if_overridable(result, receiver.class_name, method_name, :singleton)
       rescue StandardError
         nil
       end
@@ -1368,9 +1407,9 @@ module Rigor
       # body the project itself wrote. Which of the two tiers applies is decided by the receiver carrier —
       # `Singleton[Foo]` when the constant names a class or module, `Nominal[…]` when it holds an ordinary
       # object (#320) — so the two are mutually exclusive and consulting both is one resolution attempt.
-      def try_project_singleton_inference(receiver, call_node, arg_types)
-        try_singleton_method_inference(receiver, call_node, arg_types) ||
-          try_singleton_object_constant_inference(receiver, call_node, arg_types)
+      def try_project_singleton_inference(receiver, call_node, arg_types, method_name: call_node.name)
+        try_singleton_method_inference(receiver, call_node, arg_types, method_name: method_name) ||
+          try_singleton_object_constant_inference(receiver, call_node, arg_types, method_name: method_name)
       end
 
       # #320 — resolves a call whose receiver is a constant holding an ordinary object with a `class << Const`
@@ -1378,10 +1417,10 @@ module Rigor
       # that object, so the receiver carrier is passed through unchanged. Own-constant only, and only for a
       # name the project actually recorded — a miss degrades to today's `Dynamic[top]`, never a false
       # resolution. `Singleton` receivers never reach here: {#try_singleton_method_inference} owns them.
-      def try_singleton_object_constant_inference(receiver, call_node, arg_types)
+      def try_singleton_object_constant_inference(receiver, call_node, arg_types, method_name: call_node.name)
         return nil unless receiver.is_a?(Type::Nominal)
 
-        def_node = SingletonObjectConstant.def_node_for(call_node, receiver, call_node.name, scope)
+        def_node = SingletonObjectConstant.def_node_for(call_node, receiver, method_name, scope)
         return nil if def_node.nil?
 
         infer_user_method_return(def_node, receiver, arg_types)

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -1532,7 +1532,21 @@ module Rigor
       def record_call_node_methods(node, qualified_prefix, in_singleton_class, methods_acc, source_path)
         record_define_method(node, qualified_prefix, in_singleton_class, methods_acc) if node.name == :define_method
         record_attr_methods(node, qualified_prefix, in_singleton_class, methods_acc) if ATTR_MACROS.include?(node.name)
+        record_alias_method_call(node, qualified_prefix, in_singleton_class, methods_acc)
         AnonymousMetaClass.name_for(node, source_path)
+      end
+
+      # The `alias_method :new, :old` CallNode twin of {#record_alias_method} (#533): the NEW name joins
+      # the discovered-methods table so calls to it stop reading undefined, and
+      # {#apply_alias_def_nodes}'s map walk gives it the ORIGINAL def node for return inference.
+      def record_alias_method_call(call_node, qualified_prefix, in_singleton_class, accumulator)
+        return if qualified_prefix.empty?
+
+        names = alias_method_call_names(call_node)
+        return if names.nil?
+
+        kind = in_singleton_class ? :singleton : :instance
+        record_method_kind(accumulator, qualified_prefix.join("::"), names.first, kind)
       end
 
       # #319 — walks a `Class.new do ... end` / `Module.new do ... end` / `Struct.new(*sym) do ... end` /
@@ -2223,10 +2237,34 @@ module Rigor
         when Prism::AliasMethodNode
           record_alias_map_entry(node, qualified_prefix, accumulator)
           return accumulator
+        when Prism::CallNode
+          # `alias_method :new, :old` — the CallNode twin of the `alias` keyword (#533; liquid's i18n
+          # `t` alias was the corpus case). Recorded, then the walk continues: unlike AliasMethodNode a
+          # call's children can carry further class bodies (`Class.new do … end`).
+          names = alias_method_call_names(node)
+          if names && !qualified_prefix.empty?
+            (accumulator[qualified_prefix.join("::")] ||= {})[names.first] =
+              names.last
+          end
         end
 
         node.rigor_each_child { |child| collect_class_alias_map(child, qualified_prefix, accumulator) }
         accumulator
+      end
+
+      # `[new_name, old_name]` for an implicit-self `alias_method` call with two literal symbol /
+      # string arguments, or nil. A variable-named alias is runtime data and stays unrecorded.
+      def alias_method_call_names(call_node)
+        return nil unless call_node.name == :alias_method && call_node.receiver.nil?
+
+        args = call_node.arguments&.arguments
+        return nil unless args && args.size == 2
+
+        new_name = literal_method_name(args[0])
+        old_name = literal_method_name(args[1])
+        return nil if new_name.nil? || old_name.nil?
+
+        [new_name, old_name]
       end
 
       def record_alias_map_entry(alias_node, qualified_prefix, accumulator)

--- a/spec/rigor/inference/expression_typer_spec.rb
+++ b/spec/rigor/inference/expression_typer_spec.rb
@@ -1543,4 +1543,38 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       expect(type.class_name).to eq("Array")
     end
   end
+
+  # Issue #533 — `x.send(:selector)` with a literal symbol is statically `x.selector` and resolves
+  # through the same tiers; `alias_method :new, :old` mirrors the `alias` keyword into the discovered
+  # tables with the original def node for return inference.
+  describe "literal send and alias_method resolution" do
+    def program_type(source, statement_index)
+      root = Prism.parse(source).value
+      index = Rigor::Inference::ScopeIndexer.index(root, default_scope: scope)
+      node = root.statements.body[statement_index]
+      index[node].type_of(node)
+    end
+
+    let(:box_source) do
+      "class Box\n  def open\n    \"contents\"\n  end\n\n  private\n\n  def secret\n    42\n  end\nend\n"
+    end
+
+    it "resolves send with a literal selector through the direct-call tiers, private included" do
+      expect(program_type("#{box_source}Box.new.send(:open)\n", 1).describe).to eq('"contents"')
+      expect(program_type("#{box_source}Box.new.send(:secret)\n", 1).describe).to eq("42")
+      expect(scope.type_of(parse_expression('"abc".send(:upcase)')).describe).to eq('"ABC"')
+    end
+
+    it "declines a variable selector and an unknown method (fail-soft controls)" do
+      variable = program_type("#{box_source}name = :open\nBox.new.send(name)\n", 2)
+      expect(variable.describe(:short)).to eq("Dynamic[top]")
+      expect(program_type("#{box_source}Box.new.send(:missing_method)\n", 1).describe(:short)).to eq("Dynamic[top]")
+    end
+
+    it "resolves a call through `alias_method :new, :old` with the original def's return" do
+      source = "class I18n\n  def translate(key)\n    key.to_s\n  end\n  " \
+               "alias_method :t, :translate\nend\nI18n.new.t(:hello)\n"
+      expect(program_type(source, 1).describe).to eq('"hello"')
+    end
+  end
 end


### PR DESCRIPTION
Part of #533 (items 2 and 3 — `alias_method` sends and `send(:literal_symbol)`; the other six minor gaps stay open there).

**`alias_method :new, :old`** now mirrors the `alias` keyword's two recordings: the new name joins the per-class discovered-methods table, and the alias map hands it the ORIGINAL def node so call-site return inference works through the alias — `I18n.new.t(:hello)` infers `"hello"` where it read Dynamic (liquid's i18n `t`, 33 sites). Implicit-self calls with two literal symbol/string arguments only.

**`x.send(:selector, args)` with a literal symbol** resolves through the same dispatch + project-inference tiers as the direct call, private methods included (`send` legitimately crosses visibility; `public_send` is treated identically — ADR-5 optimism on the success path). Declines: non-literal selector, splat/forwarded tail, block-bearing send. `Box.new.send(:secret)` infers the private method's `42`; protobuf's private-boundary idiom (84 sites) was the corpus case. The inference tiers take a `method_name:` override so the send node keeps the provenance.

Corpus diff over the 11 gate targets: **0 added / 0 removed**. `make verify` green; specs pin both resolutions plus the fail-soft controls (variable selector → Dynamic, unknown method → Dynamic).