### PR TITLE
Erase refinements to their base for RBS lookup; widen is_a? guards on unknown classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** Methods on refined strings (`RUBY_VERSION != "1.0"`, `RUBY_VERSION.split(".")`) now resolve through the underlying `String` instead of losing the whole call to untyped, and an `is_a?` guard against a class Rigor cannot see no longer keeps the old type on the guarded branch — the guard's own proof wins ([#550](https://github.com/rigortype/rigor/pull/550), [#533](https://github.com/rigortype/rigor/issues/533)).
+
 - **[cli]** `rigor coverage` and `rigor check --coverage` now measure the same engine `rigor check` runs: the precision ratio sees your project's cross-file methods, ancestry, and plugin-contributed types instead of under-reporting them as untyped, and precisely-folded `Data` / `Struct` values count as typed ([#535](https://github.com/rigortype/rigor/pull/535), [#513](https://github.com/rigortype/rigor/issues/513), [#523](https://github.com/rigortype/rigor/issues/523)).
 
 - **[engine]** A collection handed out by one method and filled through that reference — `(bucket_for(entry)[key] ||= {})[name] = row` — is no longer read as still empty, so `empty?` and `size` on it stop folding to a constant in every other method of the class ([#507](https://github.com/rigortype/rigor/pull/507), [#506](https://github.com/rigortype/rigor/issues/506)).

--- a/lib/rigor/inference/method_dispatcher/rbs_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/rbs_dispatch.rb
@@ -230,6 +230,13 @@ module Rigor
               # still resolve through Method's RBS contract. Routing here keeps reflective Method methods
               # working without forcing the carrier to collapse to a plain Nominal at construction.
               ["Method", :instance, []]
+            when Type::Refined, Type::Difference
+              # #533 — a refinement (`Refined`) or subtraction (`Difference` — `non-empty-string` is
+              # `String − ""`) is a precision layer over its base; RBS method lookup erases to the base
+              # carrier (`RUBY_VERSION != "1.0"` resolves through `String#!=` instead of declining the
+              # whole dispatch to Dynamic). The refinement-aware promotions (`String#upcase` →
+              # `uppercase-string`, …) run in their own catalog tier ABOVE this one, so they still win.
+              receiver_descriptor(receiver.base)
             when Type::Dynamic
               receiver_descriptor(receiver.static_facet)
             end

--- a/lib/rigor/inference/narrowing.rb
+++ b/lib/rigor/inference/narrowing.rb
@@ -2387,7 +2387,13 @@ module Rigor
           case class_ordering(nominal.class_name, class_name, context)
           when :superclass then Type::Combinator.nominal_of(class_name)
           when :disjoint then Type::Combinator.bot
-          else nominal # :subclass preserves the bound; :unknown stays conservative
+          when :subclass then nominal
+          else
+            # :unknown — the guard proved membership in a class the environment cannot order against the
+            # bound (an RBS-less gem class, typically). Keeping the old bound licenses `undefined-method`
+            # on the guard-proven branch (concurrent-ruby's `done.is_a?(Concurrent::Maybe)` kept `Array`
+            # and fired on `.value`); the honest join is Dynamic — the guard destroyed the old knowledge.
+            Type::Combinator.untyped
           end
         end
 

--- a/spec/rigor/inference/expression_typer_spec.rb
+++ b/spec/rigor/inference/expression_typer_spec.rb
@@ -1543,4 +1543,20 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       expect(type.class_name).to eq("Array")
     end
   end
+
+  # Issue #533 — a refinement (`Refined`) or subtraction (`Difference` — `non-empty-string` is
+  # `String − \"\"`) erases to its base for RBS method lookup, so a method the catalog tier does not
+  # promote still resolves instead of declining the whole dispatch to Dynamic.
+  describe "refined-receiver RBS lookup erasure" do
+    let(:project_scope) { Rigor::Scope.empty(environment: Rigor::Environment.for_project) }
+
+    it "resolves comparison and plain methods on the predefined-constant refinements" do
+      expect(project_scope.type_of(parse_expression('RUBY_VERSION != "1.0"')).describe(:short)).to eq("bool")
+      expect(project_scope.type_of(parse_expression('RUBY_VERSION.split(".")')).describe(:short)).to eq("Array[String]")
+    end
+
+    it "keeps the catalog tier's refinement promotions winning (control)" do
+      expect(project_scope.type_of(parse_expression("RUBY_VERSION.upcase")).describe(:short)).to eq("non-empty-string")
+    end
+  end
 end

--- a/spec/rigor/inference/narrowing_spec.rb
+++ b/spec/rigor/inference/narrowing_spec.rb
@@ -735,10 +735,14 @@ RSpec.describe Rigor::Inference::Narrowing do
       expect(described_class.narrow_class(integer_nominal, "Integer", exact: true)).to eq(integer_nominal)
     end
 
-    it "leaves the type unchanged when the asked class is unknown to the host Ruby" do
-      # `Foo::Bar` is not defined in the test environment, so the ordering check returns `:unknown` and we stay
-      # conservative.
-      expect(described_class.narrow_class(integer_nominal, "Foo::Bar")).to eq(integer_nominal)
+    it "widens to Dynamic when the asked class is unknown to the host Ruby (#533)" do
+      # `Foo::Bar` is not defined in the test environment, so the ordering check returns `:unknown`. The
+      # guard proved membership in a class the environment cannot order against the bound; KEEPING the
+      # bound licensed `undefined-method` on the guard-proven branch (concurrent-ruby's
+      # `done.is_a?(Concurrent::Maybe)` kept `Array` and fired on `.value`), so the honest join is
+      # Dynamic — the guard destroyed the old knowledge.
+      narrowed = described_class.narrow_class(integer_nominal, "Foo::Bar")
+      expect(narrowed).to be_a(Rigor::Type::Dynamic)
     end
 
     it "uses the analyzer environment for RBS-only hierarchy lookups" do


### PR DESCRIPTION
Part of #533 (item 4 — refined-receiver lookup), plus the narrowing companion its own corpus gate demanded.

**Refined/Difference lookup erasure.** `non-empty-string` is `Difference[String, ""]`; neither `Refined` nor `Difference` had a `receiver_descriptor` arm in `RbsDispatch`, so any method the refinement catalog does not promote declined the whole dispatch to Dynamic — `RUBY_VERSION != "1.0"` / `RUBY_PLATFORM == "java"` read `Dynamic[top]` (parser 13 sites, net-ssh 15). Lookup now erases to the base carrier; the catalog tier's refinement promotions (`upcase` → `uppercase-string`) run above this tier and still win (control spec).

**`is_a?` narrowing on an unorderable class.** The erasure made one new firing reachable and its root is a standalone narrowing bug: `narrow_nominal_to_class` KEPT the old bound on `:unknown` ordering (guard class = an RBS-less gem class). Keeping the bound contradicts the guard — concurrent-ruby's `break done.value if done.is_a?(Concurrent::Maybe)` kept `Array` through the guard and fired `undefined-method` on `.value`. The `:unknown` arm now answers Dynamic (the guard proved membership in a class the engine cannot name; the old knowledge is destroyed). `:subclass` still preserves the bound; `:superclass`/`:disjoint` unchanged; the old behavior's pinning spec is rewritten to pin the new contract with the rationale.

Corpus diff over the 11 gate targets: **0 added / 0 removed** (the interim single firing was neutralized by the narrowing half). `make verify` / `git diff --check` green.