### PR TITLE
Synthesize Zeitwerk implicit namespaces from discovered compact class names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Changed
 
+- **[engine]** Rails-style implicit namespaces now resolve: `Api` in `class Api::V1::AccountsController` types as the namespace module even though Zeitwerk means no `module Api` ever appears in source — worth +1.16 points of type precision on Mastodon ([#551](https://github.com/rigortype/rigor/pull/551), [#528](https://github.com/rigortype/rigor/issues/528)).
+
 - **[cli]** `rigor type-of` accepts several positions in one invocation and makes the column optional — `rigor type-of file.rb:42` lists up to 40 expressions on line 42 — so walking a chain of expressions costs one process instead of one each (five positions on a Rails application: 10.3 s → 2.1 s) ([#515](https://github.com/rigortype/rigor/pull/515)).
 
 - **[engine]** `Foo.instance` on a class that includes the stdlib `Singleton` mixin now types as `Foo` instead of untyped, so the methods you call on that instance are typed too ([#514](https://github.com/rigortype/rigor/pull/514)).

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -2311,7 +2311,7 @@ module Rigor
           # Skip files that fail to parse or read; the per-file analyzer surfaces the parse error separately.
           next
         end
-        accumulator.freeze
+        synthesize_namespace_prefixes(accumulator).freeze
       end
 
       # ADR-24 slice 2 — cross-file companion to `discovered_classes_for_paths`. Walks every project file once and
@@ -2917,7 +2917,32 @@ module Rigor
         identity_table = {}.compare_by_identity
         discovered = {}
         record_declarations(root, [], identity_table, discovered)
-        [identity_table.freeze, discovered.freeze]
+        [identity_table.freeze, synthesize_namespace_prefixes(discovered).freeze]
+      end
+
+      # Issue #528 — every proper prefix of a discovered COMPACT class name is a namespace module that
+      # provably exists at runtime, even when no `module X` declaration is anywhere in the source
+      # (Zeitwerk derives it from the directory: mastodon writes `class Api::V1::AccountsController`
+      # and never `module Api`). Registering the prefixes lets a bare `Api` read — and the inner
+      # ConstantReadNodes of every resolving constant path — type as the namespace singleton instead of
+      # falling to the unresolved fallback (~500 sites on mastodon). An explicitly-declared name always
+      # wins: prefixes never overwrite an existing entry.
+      def synthesize_namespace_prefixes(discovered)
+        additions = {}
+        discovered.each_key do |full|
+          next unless full.include?("::")
+
+          segments = full.split("::")
+          (1...segments.size).each do |keep|
+            prefix = segments.first(keep).join("::")
+            next if discovered.key?(prefix) || additions.key?(prefix)
+
+            additions[prefix] = Type::Combinator.singleton_of(prefix)
+          end
+        end
+        return discovered if additions.empty?
+
+        discovered.merge(additions)
       end
 
       def record_declarations(node, qualified_prefix, identity_table, discovered)

--- a/spec/rigor/inference/scope_indexer_spec.rb
+++ b/spec/rigor/inference/scope_indexer_spec.rb
@@ -2014,4 +2014,42 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
       end
     end
   end
+
+  # Issue #528 — every proper prefix of a discovered compact class name is a namespace module that
+  # provably exists at runtime (Zeitwerk derives it from the directory; mastodon never writes
+  # `module Api`). The prefixes join the discovered-classes table so bare namespace reads — and the
+  # inner ConstantReadNodes of resolving constant paths — type as singletons.
+  describe "namespace-prefix synthesis" do
+    it "registers each proper prefix of a compact class declaration" do
+      _, idx = index_for("class Api::V1::AccountsController
+end
+Api
+")
+      scope = idx[parse("x").statements.body.first]
+      classes = scope.discovered_classes
+      expect(classes.keys).to include("Api", "Api::V1", "Api::V1::AccountsController")
+      expect(classes["Api"].describe(:short)).to eq("singleton(Api)")
+    end
+
+    it "never overwrites an explicitly declared namespace" do
+      source = "module Api
+  VERSION = 1
+end
+class Api::V1::AccountsController
+end
+"
+      _, idx = index_for(source)
+      scope = idx[parse("x").statements.body.first]
+      expect(scope.discovered_classes["Api"].describe(:short)).to eq("singleton(Api)")
+    end
+
+    it "leaves a genuinely unknown constant unresolved (control)" do
+      program, idx = index_for("class Api::V1::AccountsController
+end
+Unrelated
+")
+      read = program.statements.body.last
+      expect(idx[read].type_of(read).describe(:short)).to eq("Dynamic[top]")
+    end
+  end
 end


### PR DESCRIPTION
Closes #528. From the 2026-09-01 corpus sweep's mechanism backlog.

Rails apps never write `module Api` — Zeitwerk derives the namespace from the directory — so mastodon declares `class Api::V1::AccountsController` and every bare `Api` read (plus the inner `ConstantReadNode`s of every resolving constant path) fell to the unresolved fallback with an `unsupported_syntax` cause: ~500 terminal reads + 1,920 path-child artifacts on mastodon alone.

Every proper prefix of a discovered compact class name is a namespace module that provably exists at runtime. Both discovered-classes builders (the per-file declaration artifacts and the cross-file pre-pass) now register those prefixes as `Singleton[prefix]` entries. An explicitly declared name always wins (prefixes never overwrite), and a genuinely unknown constant still declines — both pinned by specs.

**Measured on mastodon against a master arm: precision 52.90% → 54.06% (+1.16pp).** Corpus diff over the 11 gate targets: 0 added / 0 removed. `make verify` / `git diff --check` green.