### PR TITLE
Type the attribute compound-write family (x.attr ||= v, &&=, +=)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** `x.attr ||= v`, `x.attr &&= v`, and `x.attr += v` now carry their real value semantics instead of falling to untyped as unsupported syntax — the last genuinely unmodeled expressions the corpus survey found ([#552](https://github.com/rigortype/rigor/pull/552), [#532](https://github.com/rigortype/rigor/issues/532)).
+
 - **[cli]** `rigor coverage` and `rigor check --coverage` now measure the same engine `rigor check` runs: the precision ratio sees your project's cross-file methods, ancestry, and plugin-contributed types instead of under-reporting them as untyped, and precisely-folded `Data` / `Struct` values count as typed ([#535](https://github.com/rigortype/rigor/pull/535), [#513](https://github.com/rigortype/rigor/issues/513), [#523](https://github.com/rigortype/rigor/issues/523)).
 
 - **[engine]** A collection handed out by one method and filled through that reference — `(bucket_for(entry)[key] ||= {})[name] = row` — is no longer read as still empty, so `empty?` and `size` on it stop folding to a constant in every other method of the class ([#507](https://github.com/rigortype/rigor/pull/507), [#506](https://github.com/rigortype/rigor/issues/506)).

--- a/lib/rigor/inference/expression_typer.rb
+++ b/lib/rigor/inference/expression_typer.rb
@@ -83,6 +83,9 @@ module Rigor
         Prism::ProgramNode => :type_of_program,
         # Calls
         Prism::CallNode => :call_type_for,
+        Prism::CallOrWriteNode => :call_or_write_type_for,
+        Prism::CallAndWriteNode => :call_and_write_type_for,
+        Prism::CallOperatorWriteNode => :call_operator_write_type_for,
         Prism::ArgumentsNode => :type_of_non_value,
         # Constants
         Prism::ConstantReadNode => :type_of_constant_read,
@@ -1121,6 +1124,48 @@ module Rigor
         # propagates correctly through downstream call chains without surfacing misleading false-positive
         # diagnostics.
         dynamic_top
+      end
+
+      # Issue #532 — the attribute compound-write family (`x.attr ||= v`, `&&=`, `+=`), the last
+      # genuinely unmodeled value-position constructs the 2026-09-01 corpus census found (they fell to the
+      # `unsupported_syntax` fallback). Value semantics mirror the local / ivar / index siblings:
+      # `||=` is `truthy(read) | rhs`, `&&=` is `falsey(read) | rhs`, and an operator write is the
+      # operator dispatched on the read result. A `&.`-form compound write unions the skipped-call nil in
+      # (#518's rule). Scope effects stay as before (none) — the struct member writeback and shape
+      # widening for these forms are follow-up work recorded on #532.
+      def call_or_write_type_for(node)
+        current = attribute_compound_read_type(node)
+        value = Type::Combinator.union(Narrowing.narrow_truthy(current), type_of(node.value))
+        with_compound_write_safe_nav(node, value)
+      end
+
+      def call_and_write_type_for(node)
+        current = attribute_compound_read_type(node)
+        value = Type::Combinator.union(Narrowing.narrow_falsey(current), type_of(node.value))
+        with_compound_write_safe_nav(node, value)
+      end
+
+      def call_operator_write_type_for(node)
+        current = attribute_compound_read_type(node)
+        result = MethodDispatcher.dispatch(
+          receiver_type: current, method_name: node.binary_operator, arg_types: [type_of(node.value)],
+          environment: scope.environment, call_node: node, scope: scope
+        ) || dynamic_top
+        with_compound_write_safe_nav(node, result)
+      end
+
+      def attribute_compound_read_type(node)
+        receiver = type_of(node.receiver)
+        MethodDispatcher.dispatch(
+          receiver_type: receiver, method_name: node.read_name, arg_types: [],
+          environment: scope.environment, call_node: node, scope: scope
+        ) || dynamic_top
+      end
+
+      def with_compound_write_safe_nav(node, value)
+        return value unless node.call_operator_loc&.slice == "&."
+
+        Type::Combinator.union(value, Type::Combinator.constant_of(nil))
       end
 
       # Slice 2 routes call expressions through `MethodDispatcher`. The receiver and every argument are typed

--- a/spec/rigor/inference/expression_typer_spec.rb
+++ b/spec/rigor/inference/expression_typer_spec.rb
@@ -1543,4 +1543,33 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       expect(type.class_name).to eq("Array")
     end
   end
+
+  # Issue #532 — the attribute compound-write family (`x.attr ||= v` / `&&=` / `+=`), the last
+  # genuinely unmodeled value-position constructs the corpus census found. Value semantics mirror the
+  # local / ivar / index siblings; scope effects are unchanged (follow-up on the issue).
+  describe "attribute compound writes" do
+    def statement_type(source, statement_index)
+      root = Prism.parse(source).value
+      index = Rigor::Inference::ScopeIndexer.index(root, default_scope: scope)
+      node = root.statements.body[statement_index]
+      index[node].type_of(node)
+    end
+
+    let(:struct_source) { "Point = Struct.new(:x)\npt = Point.new(1)\n" }
+
+    it "types `x.attr ||= v` as the union of the truthy read and the RHS" do
+      type = statement_type("#{struct_source}pt.x ||= 9\n", 2)
+      expect(type.describe(:short)).to include("9")
+    end
+
+    it "unions the skipped-call nil into a `&.`-form compound write" do
+      type = statement_type("#{struct_source}pt&.x ||= 9\n", 2)
+      expect(type.describe(:short)).to include("nil")
+    end
+
+    it "keeps an operator write on an unresolved read fail-soft (control)" do
+      type = statement_type("def f(o)\n  o.count += 1\nend\n", 0)
+      expect(type).not_to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Closes #532 (the value-typing half; mutation-widening parity with PR #504's index forms stays on the issue as follow-up).

`CallOrWriteNode` / `CallAndWriteNode` / `CallOperatorWriteNode` had no typer handler and fell to the `unsupported_syntax` fallback — the 2026-09-01 corpus census showed they are the ONLY genuinely unmodeled value-position constructs real code uses (mastodon 27 nodes, redmine 37, the DSAR corpus 45 `self.size += 1` sites, rigor-lib 8).

Value semantics mirror the local/ivar/index siblings: `||=` is `truthy(read) | rhs`, `&&=` is `falsey(read) | rhs`, an operator write dispatches the operator on the read result. The read runs through the normal dispatch tiers (an unresolved read keeps the honest Dynamic — fail-soft control spec), and a `&.`-form compound write unions the skipped-call nil in, consistent with #518.

Corpus diff over the 11 gate targets: **0 added / 0 removed**. `make verify` green; specs pin the `||=` union, the `&.` nil, and the fail-soft control.