### PR TITLE
Fold extend / extend self / module_function into singleton dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Changed
 
+- **[engine]** Methods a class gains through `extend SomeModule`, `extend self`, or `module_function` now resolve on the class itself — existence and inferred return types both — removing 39 undefined-method false positives across the survey corpus ([#554](https://github.com/rigortype/rigor/pull/554), [#526](https://github.com/rigortype/rigor/issues/526)).
+
 - **[cli]** `rigor type-of` accepts several positions in one invocation and makes the column optional — `rigor type-of file.rb:42` lists up to 40 expressions on line 42 — so walking a chain of expressions costs one process instead of one each (five positions on a Rails application: 10.3 s → 2.1 s) ([#515](https://github.com/rigortype/rigor/pull/515)).
 
 - **[engine]** `Foo.instance` on a class that includes the stdlib `Singleton` mixin now types as `Foo` instead of untyped, so the methods you call on that instance are typed too ([#514](https://github.com/rigortype/rigor/pull/514)).

--- a/lib/rigor/cache/descriptor.rb
+++ b/lib/rigor/cache/descriptor.rb
@@ -38,7 +38,11 @@ module Rigor
       # whose RBS dangles an interface or type-alias reference gets stubs where an older Rigor discarded the
       # whole batch and cached an env in which those signatures are inert. Same reasoning as v3: the
       # marshalled env is the cached value, so it MUST be rebuilt for the fix to take effect.
-      SCHEMA_VERSION = 6
+      # v7: #526 — the def-index seed bundles gain the `:extends` table (`extend M` / `extend self` /
+      # bare `module_function`), which `finalize_def_index` folds into the singleton-side method tables. A
+      # pre-7 bundle would silently contribute no extends for an unchanged file, so cached bundles must
+      # read as misses once and rebuild carrying the slot.
+      SCHEMA_VERSION = 7
 
       # Per-slot entry value objects. Constructors validate enums / required fields and freeze the resulting
       # struct so no caller can mutate after the entry is in a Descriptor.

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -180,8 +180,14 @@ module Rigor
         # authoritative).
         data_member_layouts, struct_member_layouts = merge_member_layouts(default_scope, root)
 
+        # #526 — this file's extends folded against the MERGED instance def-nodes (so `extend M` sees a
+        # sibling-file M through the cross-file seed). The project-wide fold in {#finalize_def_index}
+        # covers cross-file CONSUMERS; this covers the file that declares the extend.
+        methods_table = fold_per_file_extends(root, def_nodes, singleton_def_nodes, seeded_scope)
+
         seeded_scope.with_discovery(
           seeded_scope.discovery.with(
+            discovered_methods: methods_table,
             discovered_def_nodes: def_nodes,
             discovered_singleton_def_nodes: singleton_def_nodes,
             discovered_superclasses: superclasses,
@@ -191,6 +197,18 @@ module Rigor
             struct_member_layouts: struct_member_layouts
           )
         )
+      end
+
+      # The per-file half of the #526 fold: mutable copies of the merged tables take the extends, and the
+      # existence table (already seeded onto the scope) is rebuilt only when the fold touched it.
+      def fold_per_file_extends(root, def_nodes, singleton_def_nodes, seeded_scope)
+        extends = build_discovered_extends(root)
+        methods_table = seeded_scope.discovered_methods
+        return methods_table if extends.empty?
+
+        mutable_methods = methods_table.transform_values(&:dup)
+        fold_extends_into_singleton_tables(extends, def_nodes, singleton_def_nodes, mutable_methods)
+        mutable_methods
       end
 
       # ADR-48 — the per-file Data + Struct member-layout tables, each merged OVER the cross-file seed so a same-file
@@ -2049,6 +2067,78 @@ module Rigor
         end
       end
 
+      # Issue #526 — `extend M` / `extend self` / bare `module_function`, the singleton-side siblings of
+      # {#build_discovered_includes}. `extend self` and the bare `module_function` toggle both map the
+      # module's own instance defs onto its singleton (recorded as extending ITSELF); `module_function`
+      # with symbol arguments already resolves through the existing recording, and the toggle's
+      # order-sensitivity (only SUBSEQUENT defs become module functions) is deliberately over-approximated
+      # — the extra names only suppress `undefined-method` and enable inference on calls that raise at
+      # runtime, both the ADR-5-safe direction.
+      def build_discovered_extends(root)
+        accumulator = {}
+        walk_class_extends(root, [], nil, accumulator)
+        accumulator.transform_values { |mods| mods.uniq.freeze }.freeze
+      end
+
+      def walk_class_extends(node, qualified_prefix, current_class, accumulator)
+        return unless node.is_a?(Prism::Node)
+
+        case node
+        when Prism::ClassNode, Prism::ModuleNode
+          name = Source::ConstantPath.qualified_name(node.constant_path)
+          if name
+            full = (qualified_prefix + [name]).join("::")
+            walk_class_extends(node.body, qualified_prefix + [name], full, accumulator) if node.body
+            return
+          end
+        when Prism::CallNode
+          record_extend_call(node, current_class, accumulator)
+        end
+
+        node.rigor_each_child do |child|
+          walk_class_extends(child, qualified_prefix, current_class, accumulator)
+        end
+      end
+
+      def record_extend_call(node, current_class, accumulator)
+        return unless current_class && node.receiver.nil?
+
+        case node.name
+        when :extend then record_extend_targets(node, current_class, accumulator)
+        when :module_function
+          (accumulator[current_class] ||= []) << current_class if node.arguments.nil?
+        end
+      end
+
+      def record_extend_targets(node, current_class, accumulator)
+        node.arguments&.arguments&.each do |arg|
+          target = arg.is_a?(Prism::SelfNode) ? current_class : Source::ConstantPath.qualified_name(arg)
+          (accumulator[current_class] ||= []) << target if target
+        end
+      end
+
+      # The materialization half of #526: for every `C extends M`, M's INSTANCE defs become C's
+      # SINGLETON defs — existence (so `C.helper` stops firing undefined-method) and def nodes (so
+      # call-site return inference runs with `self = Singleton[C]`, which is what Ruby binds). A name C
+      # already defines on its own singleton wins (`||=`); an extend target with no discovered defs
+      # contributes nothing (RBS-module extends stay on the dispatch tiers).
+      def fold_extends_into_singleton_tables(extends, def_nodes, singleton_def_nodes, methods)
+        extends.each do |class_name, mods|
+          mods.each do |mod_name|
+            source_defs = def_nodes[mod_name]
+            next if source_defs.nil?
+
+            # An inner table inherited unchanged from a frozen seed must be thawed before the fold writes.
+            target = singleton_def_nodes[class_name]
+            target = singleton_def_nodes[class_name] = (target ? target.dup : {}) if target.nil? || target.frozen?
+            source_defs.each do |method_name, def_node|
+              target[method_name] ||= def_node
+              record_method_kind(methods, class_name, method_name, :singleton)
+            end
+          end
+        end
+      end
+
       VISIBILITY_MODIFIERS = %i[public private protected].freeze
 
       # v0.1.2 — per-class method-visibility table for the `def.method-visibility-mismatch` CheckRule.
@@ -2634,10 +2724,16 @@ module Rigor
       # superclasses later-wins; includes / class_sources accumulate; member layouts later-wins.
       def fold_ancestry_tables(acc, file_index)
         acc[:superclasses].merge!(file_index[:superclasses])
-        file_index[:includes].each { |cn, mods| acc[:includes][cn] = ((acc[:includes][cn] || []) + mods).uniq }
+        accumulate_module_lists(acc[:includes], file_index[:includes])
+        accumulate_module_lists(acc[:extends], file_index[:extends] || {})
         file_index[:class_sources].each { |cn, files| (acc[:class_sources][cn] ||= Set.new).merge(files) }
         acc[:data_member_layouts].merge!(file_index[:data_member_layouts])
         acc[:struct_member_layouts].merge!(file_index[:struct_member_layouts])
+      end
+
+      # Shared accumulate-and-dedupe fold for the class -> module-name-list tables (includes / extends).
+      def accumulate_module_lists(target, additions)
+        additions.each { |cn, mods| target[cn] = ((target[cn] || []) + mods).uniq }
       end
 
       # ADR-85 WD2 — converts a file's live single-file index + its class table into a Marshal-clean seed
@@ -2656,6 +2752,7 @@ module Rigor
           # value stored here equals the one a later recheck recomputes for an unchanged declaration.
           declaration_signature: declaration_signature(file_index),
           classes: file_classes,
+          extends: file_index[:extends],
           def_nodes: live_defs_to_bundle(file_index[:def_nodes]),
           singleton_def_nodes: live_defs_to_bundle(file_index[:singleton_def_nodes]),
           def_sources: file_index[:def_sources],
@@ -2683,6 +2780,8 @@ module Rigor
           singleton_def_sources: bundle[:singleton_def_sources] || {},
           superclasses: bundle[:superclasses],
           includes: bundle[:includes],
+          # #526 — pre-extends bundles lack the key; default `{}` keeps the fold total.
+          extends: bundle[:extends] || {},
           method_visibilities: bundle[:method_visibilities],
           methods: bundle[:methods],
           class_sources: bundle[:class_source_names].to_h { |name| [name, Set[path]] },
@@ -2712,12 +2811,13 @@ module Rigor
       # The empty per-run accumulator the def-index passes fold each file into.
       def new_def_index_accumulator
         { def_nodes: {}, singleton_def_nodes: {}, def_sources: {}, singleton_def_sources: {},
-          superclasses: {}, includes: {}, method_visibilities: {}, methods: {}, class_sources: {},
+          superclasses: {}, includes: {}, extends: {}, method_visibilities: {}, methods: {}, class_sources: {},
           data_member_layouts: {}, struct_member_layouts: {} }
       end
 
       # Post-processes and freezes a fully-folded def-index accumulator.
       def finalize_def_index(acc)
+        fold_extends_into_singleton_tables(acc[:extends], acc[:def_nodes], acc[:singleton_def_nodes], acc[:methods])
         # Cross-file method suppression is for the project's OWN accessors (attr_* / define_method / alias) — NOT for
         # plain `def`s. A cross-file `def` on a class is exactly the ADR-17 monkey-patch case the undefined-method rule
         # deliberately surfaces (fire + def-site annotation, nudging `pre_eval:`), so dropping the `def`-declared names
@@ -2767,9 +2867,8 @@ module Rigor
         superclasses = build_discovered_superclasses(root, path)
         includes = build_discovered_includes(root)
         acc[:superclasses].merge!(superclasses)
-        includes.each do |class_name, mods|
-          acc[:includes][class_name] = ((acc[:includes][class_name] || []) + mods).uniq
-        end
+        accumulate_module_lists(acc[:includes], includes)
+        accumulate_module_lists(acc[:extends], build_discovered_extends(root))
         record_class_sources(acc[:class_sources], path, root, superclasses, includes, file_def_nodes)
         merge_class_keyed_index_tables(acc, root, file_methods)
         merge_member_layout_tables(acc, root)

--- a/spec/rigor/inference/scope_indexer_spec.rb
+++ b/spec/rigor/inference/scope_indexer_spec.rb
@@ -2014,4 +2014,44 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
       end
     end
   end
+
+  # Issue #526 — `extend M` / `extend self` / bare `module_function` fold the module's instance defs
+  # onto the extender's singleton, so `C.helper` resolves (existence AND call-site return inference,
+  # with `self = Singleton[C]` exactly as Ruby binds).
+  describe "extend-family singleton fold" do
+    def last_statement_type(source)
+      program = parse(source)
+      idx = described_class.index(program, default_scope: default_scope)
+      node = program.statements.body.last
+      idx[node].type_of(node)
+    end
+
+    it "resolves a call through `extend M` with the module def's inferred return" do
+      source = "module Tools\n  def label\n    \"tool\"\n  end\nend\n" \
+               "module Registry\n  extend Tools\nend\n" \
+               "Registry.label\n"
+      expect(last_statement_type(source).describe).to eq('"tool"')
+    end
+
+    it "resolves `extend self` and the bare `module_function` toggle" do
+      extend_self = "module Host\n  extend self\n  def on_jruby?\n    false\n  end\nend\nHost.on_jruby?\n"
+      expect(last_statement_type(extend_self).describe).to eq("false")
+
+      module_function_toggle = "module Util\n  module_function\n\n  def message(text)\n    text\n  end\nend\n" \
+                               "Util.message(:hi)\n"
+      expect(last_statement_type(module_function_toggle).describe).to eq(":hi")
+    end
+
+    it "keeps a genuine `def self.` winning over the folded module def (control)" do
+      source = "module Tools\n  def label\n    \"tool\"\n  end\nend\n" \
+               "module Registry\n  extend Tools\n  def self.label\n    :own\n  end\nend\n" \
+               "Registry.label\n"
+      expect(last_statement_type(source).describe).to eq(":own")
+    end
+
+    it "contributes nothing for an extend target with no discovered defs (control)" do
+      source = "module Registry\n  extend SomeGemModule\nend\nRegistry.helper\n"
+      expect(last_statement_type(source).describe(:short)).to eq("Dynamic[top]")
+    end
+  end
 end


### PR DESCRIPTION
Closes #526 — the last big engine mechanism from the 2026-09-01 sweep's backlog (mail ~218 sites, concurrent-ruby ~120, faraday, textbringer; all same-file-verified).

**Design: materialize, not a new slot.** Instead of a `discovered_extends` DiscoveryIndex slot (seed tables, fork marshaling, lens plumbing), a census walk (the includes walk's sibling) records `extend M` / `extend self` / the bare `module_function` toggle, and a fold copies each target module's INSTANCE defs into the extender's SINGLETON def-node + method-existence tables. Existence suppresses `undefined-method`; def nodes enable call-site return inference with `self = Singleton[C]` — exactly what Ruby binds. A genuine `def self.` wins (first-write); an extend target with no discovered defs contributes nothing (RBS-module extends stay on the dispatch tiers). The fold runs in `finalize_def_index` for the project-wide tables — both the sequential walk and the ADR-85 bundle re-fold, whose bundles gain an `:extends` slot (**cache `SCHEMA_VERSION` 6 → 7** so pre-slot bundles rebuild) — and per file against the merged def tables. The `module_function` toggle's order-sensitivity is deliberately over-approximated (extra names only suppress undefined-method or infer calls that raise — the ADR-5-safe direction, noted in the walk's comment).

Probe: `AddressParser.chars(...)` (extend M) infers through the module def; `Host.on_jruby?` (extend self) → `false`; `Util.message(:hi)` (module_function) → `"hi"` — all Dynamic before.

**Corpus gate (11 targets): 1 added / 39 removed.** The 39 are `call.undefined-method` FPs on haml (26) and textbringer (13). The +1 is a pre-existing inference bug the fold unmasks — mail's `Unicode.compose_codepoints` (`extend self`) infers its index-written Array parameter's return as `Hash[Integer | Range, …]`, so the caller's `.pack` fires — filed as #553 with the analysis and repro pointer.

`make verify` / `git diff --check` green; specs pin all three forms, the `def self.`-wins control, and the unknown-target decline.