### PR TITLE
Resolve struct-factory block defs through the named member carriers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** Methods defined in a `Struct.new(...) do ... end` block now resolve on the struct's values — `Line.new(text).describe` infers the block def's return instead of reading untyped ([#555](https://github.com/rigortype/rigor/pull/555), [#525](https://github.com/rigortype/rigor/issues/525)).
+
 - **[cli]** `rigor coverage` and `rigor check --coverage` now measure the same engine `rigor check` runs: the precision ratio sees your project's cross-file methods, ancestry, and plugin-contributed types instead of under-reporting them as untyped, and precisely-folded `Data` / `Struct` values count as typed ([#535](https://github.com/rigortype/rigor/pull/535), [#513](https://github.com/rigortype/rigor/issues/513), [#523](https://github.com/rigortype/rigor/issues/523)).
 
 - **[engine]** A collection handed out by one method and filled through that reference — `(bucket_for(entry)[key] ||= {})[name] = row` — is no longer read as still empty, so `empty?` and `size` on it stop folding to a constant in every other method of the class ([#507](https://github.com/rigortype/rigor/pull/507), [#506](https://github.com/rigortype/rigor/issues/506)).

--- a/lib/rigor/inference/expression_typer.rb
+++ b/lib/rigor/inference/expression_typer.rb
@@ -1326,8 +1326,20 @@ module Rigor
         end
       end
 
+      # #525 — instance-side user-method inference accepts the named ADR-48 member carriers alongside
+      # plain nominals: a `Line = Struct.new(...) do ... end` value is a StructInstance whose block defs
+      # live under "Line", and the carrier itself is the right `self` for the body (member reads inside
+      # the def project through it).
+      def user_inference_receiver?(receiver)
+        case receiver
+        when Type::Nominal then true
+        when Type::StructInstance, Type::DataInstance then !receiver.class_name.nil?
+        else false
+        end
+      end
+
       def try_user_method_inference(receiver, call_node, arg_types)
-        return nil unless receiver.is_a?(Type::Nominal)
+        return nil unless user_inference_receiver?(receiver)
 
         def_node, owner = resolve_user_def_with_owner(receiver.class_name, call_node.name)
         return nil if def_node.nil?

--- a/lib/rigor/inference/method_dispatcher.rb
+++ b/lib/rigor/inference/method_dispatcher.rb
@@ -322,9 +322,13 @@ module Rigor
       # on. `Nominal[X]` looks up instance methods on X; `Singleton[X]` looks up singleton
       # methods on X. Other carriers return `[nil, nil]` so the tier declines.
       def discovered_method_lookup(receiver_type)
+        # #525 — the ADR-48 member carriers name their class too: a `Line = Struct.new(...) do ... end`
+        # value is a StructInstance whose block-def methods are discovered under "Line".
         case receiver_type
-        when Type::Nominal then [receiver_type.class_name, :instance]
-        when Type::Singleton then [receiver_type.class_name, :singleton]
+        when Type::Nominal, Type::StructInstance, Type::DataInstance
+          [receiver_type.class_name, :instance]
+        when Type::Singleton, Type::StructClass, Type::DataClass
+          [receiver_type.class_name, :singleton]
         else [nil, nil]
         end
       end

--- a/spec/rigor/inference/expression_typer_spec.rb
+++ b/spec/rigor/inference/expression_typer_spec.rb
@@ -1543,4 +1543,35 @@ RSpec.describe Rigor::Inference::ExpressionTyper do
       expect(type.class_name).to eq("Array")
     end
   end
+
+  # Issue #525 — a `Line = Struct.new(...) do ... end` value is a StructInstance carrier whose
+  # block-def methods are discovered under "Line"; the discovered and user-inference tiers accept the
+  # named member carriers as receivers, so those methods resolve with the carrier itself as `self`.
+  describe "struct-factory block-def resolution" do
+    def statement_type(source, statement_index)
+      root = Prism.parse(source).value
+      index = Rigor::Inference::ScopeIndexer.index(root, default_scope: scope)
+      node = root.statements.body[statement_index]
+      index[node].type_of(node)
+    end
+
+    let(:factory_source) do
+      "Line = Struct.new(:text, :indent) do\n  def describe\n    \"line\"\n  end\nend\n"
+    end
+
+    it "infers a block-def method's return on the struct-instance carrier" do
+      type = statement_type("#{factory_source}Line.new(\"a\", 2).describe\n", 1)
+      expect(type.describe).to eq('"line"')
+    end
+
+    it "keeps member reads projecting on the same carrier (control)" do
+      type = statement_type("#{factory_source}Line.new(\"a\", 2).text\n", 1)
+      expect(type.describe).to eq('"a"')
+    end
+
+    it "stays fail-soft for a method the factory never defines (control)" do
+      type = statement_type("#{factory_source}Line.new(\"a\", 2).missing\n", 1)
+      expect(type.describe(:short)).to eq("Dynamic[top]")
+    end
+  end
 end


### PR DESCRIPTION
Part of #525 (the block-def half; the do-block `self` scoping inside defs — faraday's `singleton(Faraday)` observation — and fold-safety conservatism for locals with intervening calls stay on the issue).

**What was already true**: `Line = Struct.new(:text) do … end` walks its block body under the constant's name (the discovered tables carry `Line#describe`), and `.new` answers the `StructInstance` carrier. **The gap**: `discovered_method_lookup` and `try_user_method_inference` accepted only `Nominal`/`Singleton` receivers, so every call to a block-def method on the carrier fell to Dynamic (haml/hamlit `ParseNode`+`Line` ~285 sites, faraday's Options layer, the algorithm corpora's `Struct.new` node classes).

Both tiers now accept the named ADR-48 member carriers (`StructInstance`/`DataInstance` → `:instance`, `StructClass`/`DataClass` → `:singleton`), inferring with the carrier itself as `self` — member reads inside the resolved bodies project through it. Probe: `Line.new("a", 2).describe` → `"line"` (was Dynamic); member reads (`.text` → `"a"`) and fail-soft misses pinned by control specs.

Corpus diff over the 11 gate targets: **0 added / 0 removed**. (First measurement re-ran after the deleted-`.rigor-ab.yml` tell — −787/−2306 with "silenced by baseline" — appeared again; the handoff's pitfall note earns its keep.) `make verify` / `git diff --check` green.