### PR TITLE
Resolve RBS alias and intersection types in the translator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** RBS type aliases and intersections now translate instead of collapsing to untyped — prism's `type node = Node & _Node` reads as `Prism::Node`, and aliased returns, parameters, and block parameters resolve through the alias table ([#556](https://github.com/rigortype/rigor/pull/556), [#529](https://github.com/rigortype/rigor/issues/529)).
 - **[cli]** `rigor coverage` and `rigor check --coverage` now measure the same engine `rigor check` runs: the precision ratio sees your project's cross-file methods, ancestry, and plugin-contributed types instead of under-reporting them as untyped, and precisely-folded `Data` / `Struct` values count as typed ([#535](https://github.com/rigortype/rigor/pull/535), [#513](https://github.com/rigortype/rigor/issues/513), [#523](https://github.com/rigortype/rigor/issues/523)).
 
 - **[engine]** A collection handed out by one method and filled through that reference — `(bucket_for(entry)[key] ||= {})[name] = row` — is no longer read as still empty, so `empty?` and `size` on it stop folding to a constant in every other method of the class ([#507](https://github.com/rigortype/rigor/pull/507), [#506](https://github.com/rigortype/rigor/issues/506)).

--- a/lib/rigor/environment/rbs_loader.rb
+++ b/lib/rigor/environment/rbs_loader.rb
@@ -1091,7 +1091,14 @@ module Rigor
         name = name.absolute! unless name.absolute?
         return nil unless env.type_alias_decls.key?(name)
 
-        builder.expand_alias2(name, rbs_alias.args)
+        # Memoized per (name, args): the env is immutable for the loader's lifetime, so the expansion is a
+        # pure function of the pair, and #529's translator wiring re-expands the same handful of aliases
+        # (`Prism::node`, `int`, `string`, …) at every call site — the memo recoups most of that wall cost.
+        memo = (@state[:type_alias_expansions] ||= {})
+        key = [name, rbs_alias.args]
+        return memo[key] if memo.key?(key)
+
+        memo[key] = builder.expand_alias2(name, rbs_alias.args)
       rescue ::RBS::BaseError, StandardError
         nil
       end

--- a/lib/rigor/inference/method_dispatcher/rbs_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/rbs_dispatch.rb
@@ -374,7 +374,8 @@ module Rigor
               method_type.type.return_type,
               self_type: self_type,
               instance_type: instance_type,
-              type_vars: full_type_vars
+              type_vars: full_type_vars,
+              alias_expander: environment.rbs_loader
             )
           end
 
@@ -658,7 +659,8 @@ module Rigor
               block,
               self_type: self_type,
               instance_type: instance_type,
-              type_vars: type_vars
+              type_vars: type_vars,
+              alias_expander: environment.rbs_loader
             )
           end
 
@@ -666,7 +668,7 @@ module Rigor
           # list; some signatures use `RBS::Types::UntypedFunction` (a `(?)` block) which exposes no
           # parameter types -- we treat it as "no information" and return an empty array so the binder
           # defaults every slot.
-          def translate_block_positional_params(block, self_type:, instance_type:, type_vars:)
+          def translate_block_positional_params(block, self_type:, instance_type:, type_vars:, alias_expander: nil)
             fun = block.type
             return [] unless fun.respond_to?(:required_positionals)
 
@@ -676,7 +678,8 @@ module Rigor
                 param.type,
                 self_type: self_type,
                 instance_type: instance_type,
-                type_vars: type_vars
+                type_vars: type_vars,
+                alias_expander: alias_expander
               )
             end
           end

--- a/lib/rigor/inference/method_parameter_binder.rb
+++ b/lib/rigor/inference/method_parameter_binder.rb
@@ -332,8 +332,7 @@ module Rigor
         when :rest_positional
           Type::Combinator.nominal_of("Array", type_args: [translated])
         when :rest_keyword
-          symbol_nominal = Type::Combinator.nominal_of("Symbol")
-          Type::Combinator.nominal_of("Hash", type_args: [symbol_nominal, translated])
+          Type::Combinator.nominal_of("Hash", type_args: [Type::Combinator.nominal_of("Symbol"), translated])
         else
           translated
         end
@@ -344,7 +343,8 @@ module Rigor
         RbsTypeTranslator.translate(
           rbs_type,
           self_type: self_type,
-          instance_type: instance_type
+          instance_type: instance_type,
+          alias_expander: @environment&.rbs_loader
         )
       rescue StandardError
         Type::Combinator.untyped

--- a/lib/rigor/inference/rbs_type_translator.rb
+++ b/lib/rigor/inference/rbs_type_translator.rb
@@ -25,8 +25,19 @@ module Rigor
     # Element and value types are translated recursively under the caller's `self_type` /
     # `instance_type` / `type_vars` context.
     #
-    # Interface and intersection types still degrade to `Dynamic[Top]`; they are bound to acceptance
-    # and dispatch rules not yet implemented.
+    # Alias and intersection types (#529):
+    # - `RBS::Types::Alias` resolves through the caller-supplied `alias_expander:` (an object answering
+    #   `expand_type_alias`, in practice the environment's `RbsLoader`) and the expansion is translated
+    #   in the same context. Without an expander — or past the expansion budget that bounds recursive
+    #   aliases like `type json = ... | Array[json]` — the alias degrades to `Dynamic[Top]` as before.
+    # - `RBS::Types::Intersection` translates to its first member that carries static evidence. Every
+    #   value of `A & B` IS an `A`, so any single member is a sound superset read; taking the first
+    #   informative one turns prism's `type node = Node & _Node` into `Nominal[Prism::Node]` instead of
+    #   `untyped`. `Type::Intersection` stays out of this path: it is the same-base refinement composite
+    #   carrier, and the dispatch tiers do not accept it as a receiver.
+    #
+    # Interface types still degrade to `Dynamic[Top]`; they are bound to acceptance and dispatch rules
+    # not yet implemented.
     #
     # The optional `self_type:` and `instance_type:` arguments are the Rigor counterparts of RBS's
     # `self` and `instance` tokens:
@@ -64,8 +75,8 @@ module Rigor
         RBS::Types::Record => :translate_record,
         RBS::Types::Proc => :translate_proc_nominal,
         RBS::Types::ClassSingleton => :translate_class_singleton,
-        RBS::Types::Alias => :translate_untyped,
-        RBS::Types::Intersection => :translate_untyped,
+        RBS::Types::Alias => :translate_alias,
+        RBS::Types::Intersection => :translate_intersection,
         RBS::Types::Variable => :translate_variable,
         RBS::Types::Interface => :translate_untyped
       }.freeze
@@ -73,6 +84,21 @@ module Rigor
 
       EMPTY_TYPE_VARS = {}.freeze
       private_constant :EMPTY_TYPE_VARS
+
+      # The immutable translation context threaded through every handler. `alias_depth` counts alias
+      # expansions performed on the current walk, so a recursive alias terminates instead of looping.
+      Context = Struct.new(:self_type, :instance_type, :type_vars, :alias_expander, :alias_depth) do
+        def deeper
+          self.class.new(self_type, instance_type, type_vars, alias_expander, alias_depth + 1)
+        end
+      end
+      private_constant :Context
+
+      # Eight expansions cover any observed nesting (gem sigs rarely go past aliases-of-aliases) while
+      # bounding the `type json = ... | Array[json]` family: the ninth nested expansion degrades to
+      # `Dynamic[Top]`, which is exactly what every alias read before #529.
+      ALIAS_EXPANSION_LIMIT = 8
+      private_constant :ALIAS_EXPANSION_LIMIT
 
       class << self
         # @param rbs_type [RBS::Types::Bases::Base, RBS::Types::ClassInstance, ...]
@@ -82,36 +108,43 @@ module Rigor
         # @param type_vars [Hash{Symbol => Rigor::Type}] substitution map for `Bases::Variable`. Keys
         #   are the RBS variable names (e.g., `:Elem`); values are Rigor types that replace the
         #   variable. Variables that are not bound in the map degrade to Dynamic[Top].
+        # @param alias_expander [#expand_type_alias, nil] resolves `RBS::Types::Alias` one level out —
+        #   in practice the environment's `RbsLoader`. When nil, aliases degrade to Dynamic[Top].
         # @return [Rigor::Type]
-        def translate(rbs_type, self_type: nil, instance_type: nil, type_vars: EMPTY_TYPE_VARS)
-          handler = TRANSLATORS[rbs_type.class]
-          return send(handler, rbs_type, self_type, instance_type, type_vars) if handler
-
-          Type::Combinator.untyped
+        def translate(rbs_type, self_type: nil, instance_type: nil, type_vars: EMPTY_TYPE_VARS,
+                      alias_expander: nil)
+          translate_in(rbs_type, Context.new(self_type, instance_type, type_vars, alias_expander, 0))
         end
 
         private
 
-        def translate_top(_rbs_type, _self_type, _instance_type, _type_vars)
-          Type::Combinator.top
-        end
+        def translate_in(rbs_type, context)
+          handler = TRANSLATORS[rbs_type.class]
+          return send(handler, rbs_type, context) if handler
 
-        def translate_bot(_rbs_type, _self_type, _instance_type, _type_vars)
-          Type::Combinator.bot
-        end
-
-        def translate_untyped(_rbs_type, _self_type, _instance_type, _type_vars)
           Type::Combinator.untyped
         end
 
-        def translate_nil(_rbs_type, _self_type, _instance_type, _type_vars)
+        def translate_top(_rbs_type, _context)
+          Type::Combinator.top
+        end
+
+        def translate_bot(_rbs_type, _context)
+          Type::Combinator.bot
+        end
+
+        def translate_untyped(_rbs_type, _context)
+          Type::Combinator.untyped
+        end
+
+        def translate_nil(_rbs_type, _context)
           Type::Combinator.constant_of(nil)
         end
 
         # `bool` in RBS denotes `true | false`. We fold it to that union eagerly so downstream
         # comparisons (e.g., `result == Constant[true]`) remain structural. Memoized at the module
         # level because the union is value-equal across calls.
-        def translate_bool(_rbs_type, _self_type, _instance_type, _type_vars)
+        def translate_bool(_rbs_type, _context)
           BOOL_UNION
         end
 
@@ -121,60 +154,54 @@ module Rigor
         ).freeze
         private_constant :BOOL_UNION
 
-        def translate_self(_rbs_type, self_type, _instance_type, _type_vars)
-          self_type || Type::Combinator.untyped
+        def translate_self(_rbs_type, context)
+          context.self_type || Type::Combinator.untyped
         end
 
-        def translate_instance(_rbs_type, _self_type, instance_type, _type_vars)
-          instance_type || Type::Combinator.untyped
+        def translate_instance(_rbs_type, context)
+          context.instance_type || Type::Combinator.untyped
         end
 
-        def translate_optional(rbs_type, self_type, instance_type, type_vars)
-          inner = translate(rbs_type.type, self_type: self_type, instance_type: instance_type, type_vars: type_vars)
+        def translate_optional(rbs_type, context)
+          inner = translate_in(rbs_type.type, context)
           Type::Combinator.union(inner, Type::Combinator.constant_of(nil))
         end
 
-        def translate_union(rbs_type, self_type, instance_type, type_vars)
-          members = rbs_type.types.map do |t|
-            translate(t, self_type: self_type, instance_type: instance_type, type_vars: type_vars)
-          end
+        def translate_union(rbs_type, context)
+          members = rbs_type.types.map { |t| translate_in(t, context) }
           Type::Combinator.union(*members)
         end
 
-        def translate_literal(rbs_type, _self_type, _instance_type, _type_vars)
+        def translate_literal(rbs_type, _context)
           Type::Combinator.constant_of(rbs_type.literal)
         end
 
         # Translates the type arguments recursively so `Array[Integer]` round-trips into
         # `Nominal["Array", [Nominal["Integer"]]]`. Variables inside the args participate in
         # substitution through the same `type_vars:` map.
-        def translate_class_instance(rbs_type, self_type, instance_type, type_vars)
+        def translate_class_instance(rbs_type, context)
           name = rbs_type.name.relative!.to_s
-          translated_args = rbs_type.args.map do |arg|
-            translate(arg, self_type: self_type, instance_type: instance_type, type_vars: type_vars)
-          end
+          translated_args = rbs_type.args.map { |arg| translate_in(arg, context) }
           Type::Combinator.nominal_of(name, type_args: translated_args)
         end
 
         # Preserves tuple precision through the boundary. Each positional element type is translated
         # recursively under the caller's substitution context, and the resulting list is wrapped in a
         # `Rigor::Type::Tuple`.
-        def translate_tuple(rbs_type, self_type, instance_type, type_vars)
-          elements = rbs_type.types.map do |t|
-            translate(t, self_type: self_type, instance_type: instance_type, type_vars: type_vars)
-          end
+        def translate_tuple(rbs_type, context)
+          elements = rbs_type.types.map { |t| translate_in(t, context) }
           Type::Combinator.tuple_of(*elements)
         end
 
         # Preserves hash-record precision through the boundary. RBS records use Symbol keys; the
         # translator keeps them as Symbol keys on the resulting exact closed HashShape so erasure can
         # round-trip back to `{ a: T, ?b: U }` syntax.
-        def translate_record(rbs_type, self_type, instance_type, type_vars)
+        def translate_record(rbs_type, context)
           pairs = rbs_type.fields.each_with_object({}) do |(key, value), acc|
-            acc[key] = translate(value, self_type: self_type, instance_type: instance_type, type_vars: type_vars)
+            acc[key] = translate_in(value, context)
           end
           optional_pairs = rbs_type.optional_fields.each_with_object({}) do |(key, value), acc|
-            acc[key] = translate(value, self_type: self_type, instance_type: instance_type, type_vars: type_vars)
+            acc[key] = translate_in(value, context)
           end
           Type::Combinator.hash_shape_of(
             pairs.merge(optional_pairs),
@@ -184,22 +211,45 @@ module Rigor
           )
         end
 
-        def translate_proc_nominal(_rbs_type, _self_type, _instance_type, _type_vars)
+        def translate_proc_nominal(_rbs_type, _context)
           Type::Combinator.nominal_of(Proc)
         end
 
         # `singleton(Foo)` is the type of the constant `Foo` itself (the class object). With the
         # dedicated Singleton type, we map directly to `Singleton[Foo]`.
-        def translate_class_singleton(rbs_type, _self_type, _instance_type, _type_vars)
+        def translate_class_singleton(rbs_type, _context)
           name = rbs_type.name.relative!.to_s
           Type::Combinator.singleton_of(name)
+        end
+
+        # #529 — sees through a type alias instead of reading `untyped`. `expand_type_alias` resolves
+        # one level (with the alias's own type params substituted, so generic aliases work); nested
+        # aliases in the expansion recurse back through here with the depth budget decremented. Every
+        # decline arm returns exactly what the alias translated to before this handler existed.
+        def translate_alias(rbs_type, context)
+          expander = context.alias_expander
+          return Type::Combinator.untyped if expander.nil? || context.alias_depth >= ALIAS_EXPANSION_LIMIT
+
+          expanded = expander.expand_type_alias(rbs_type)
+          return Type::Combinator.untyped if expanded.nil?
+
+          translate_in(expanded, context.deeper)
+        end
+
+        # #529 — `A & B` reads as its first member that carries static evidence. Every value of the
+        # intersection IS a value of each member, so any single member is a sound superset read; the
+        # skip list drops members that add nothing (an interface's `Dynamic[Top]`, `top` itself) so
+        # `Node & _Node` lands on `Nominal[Prism::Node]`. No informative member — the pre-#529 read.
+        def translate_intersection(rbs_type, context)
+          members = rbs_type.types.map { |t| translate_in(t, context) }
+          members.find { |m| !m.is_a?(Type::Dynamic) && !m.is_a?(Type::Top) } || Type::Combinator.untyped
         end
 
         # Looks up the variable's RBS name in the substitution map; bound variables are replaced
         # inline, free variables degrade to Dynamic[Top]. We use `fetch` with a default rather than
         # `[]` so a deliberate `nil` binding (a caller mistake) is never silently consumed.
-        def translate_variable(rbs_type, _self_type, _instance_type, type_vars)
-          type_vars.fetch(rbs_type.name) { Type::Combinator.untyped }
+        def translate_variable(rbs_type, context)
+          context.type_vars.fetch(rbs_type.name) { Type::Combinator.untyped }
         end
       end
     end

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -1603,6 +1603,7 @@ module Rigor
         return nil unless node.is_a?(Prism::ConstantWriteNode)
 
         rvalue = node.value
+        return nil unless rvalue.is_a?(Prism::CallNode)
         return nil unless data_define_call?(rvalue) ||
                           struct_new_call?(rvalue) ||
                           module_new_call?(rvalue) ||

--- a/sig/rigor/inference.rbs
+++ b/sig/rigor/inference.rbs
@@ -136,7 +136,7 @@ module Rigor
     end
 
     module RbsTypeTranslator
-      def self.translate: (untyped rbs_type, ?self_type: Type::t?, ?instance_type: Type::t?, ?type_vars: Hash[Symbol, Type::t]) -> Type::t
+      def self.translate: (untyped rbs_type, ?self_type: Type::t?, ?instance_type: Type::t?, ?type_vars: Hash[Symbol, Type::t], ?alias_expander: untyped) -> Type::t
     end
 
     class Fallback

--- a/sig/rigor/type.rbs
+++ b/sig/rigor/type.rbs
@@ -1,6 +1,6 @@
 module Rigor
   module Type
-    type t = Top | Bot | Dynamic | Constant | IntegerRange | Nominal | Singleton | Union | Difference | Tuple | HashShape | DataClass | DataInstance | StructClass | StructInstance
+    type t = Top | Bot | Dynamic | Constant | IntegerRange | Nominal | Singleton | Union | Difference | Refined | Intersection | Tuple | HashShape | DataClass | DataInstance | StructClass | StructInstance | BoundMethod
 
     type accepts_mode = :strict | :gradual | :loose
 

--- a/spec/rigor/inference/method_dispatcher/rbs_dispatch_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/rbs_dispatch_spec.rb
@@ -319,6 +319,54 @@ RSpec.describe Rigor::Inference::MethodDispatcher::RbsDispatch do
       end
     end
 
+    # Issue #529 — a signature whose return names a type alias (or an intersection through one) used to
+    # collapse to `untyped` at the translation boundary. The dispatch tier passes its loader as the
+    # translator's alias expander, so the aliased return resolves like the spelled-out type would.
+    describe "aliased return types (issue #529)" do
+      let(:aliased_rbs) do
+        <<~RBS
+          interface _RigorSpecMarker
+          end
+
+          class RigorSpecLeaf
+          end
+
+          type rigor_spec_leaf = RigorSpecLeaf & _RigorSpecMarker
+
+          class RigorSpecTree
+            def leaf: () -> rigor_spec_leaf
+            def leaf_or_nil: () -> rigor_spec_leaf?
+          end
+        RBS
+      end
+      let(:aliased_environment) do
+        Rigor::Environment.new(
+          rbs_loader: Rigor::Environment::RbsLoader.new(virtual_rbs: [["(spec: issue #529)", aliased_rbs]])
+        )
+      end
+      let(:tree) { Rigor::Type::Combinator.nominal_of("RigorSpecTree") }
+
+      def dispatch_on_tree(method_name)
+        described_class.try_dispatch(cc(
+                                       receiver: tree,
+                                       method_name: method_name,
+                                       args: [],
+                                       environment: aliased_environment
+                                     ))
+      end
+
+      it "resolves an alias-of-intersection return to the nominal member" do
+        type = dispatch_on_tree(:leaf)
+        expect(type).to be_a(Rigor::Type::Nominal)
+        expect(type.class_name).to eq("RigorSpecLeaf")
+      end
+
+      it "keeps the optional wrapper around a resolved alias" do
+        type = dispatch_on_tree(:leaf_or_nil)
+        expect(type.describe(:short)).to eq("RigorSpecLeaf?")
+      end
+    end
+
     it "returns nil when the environment has no RBS loader" do
       blank_env = Rigor::Environment.new
       expect(blank_env.rbs_loader).to be_nil

--- a/spec/rigor/inference/method_parameter_binder_spec.rb
+++ b/spec/rigor/inference/method_parameter_binder_spec.rb
@@ -51,19 +51,23 @@ RSpec.describe Rigor::Inference::MethodParameterBinder do
       binder = described_class.new(environment: env, class_path: "Array", singleton: false)
       result = binder.bind(def_node("def first(n); n; end"))
 
-      # The single relevant overload's type is `int` (an RBS interface), which the translator currently degrades to
-      # `Dynamic[Top]`. The binder MUST NOT have left it at the default-untyped sentinel under a different identity — it
-      # should match the translator's canonical Dynamic[Top].
-      expect(result[:n]).to eq(Rigor::Type::Combinator.untyped)
+      # The single relevant overload's type is the `int` alias (`::Integer | ::_ToInt`). Since #529 the
+      # translator expands it: the Integer member survives as evidence and the interface member keeps the
+      # union gradual, so the binder's result proves the `(int)` overload — not the `()` one — was read.
+      type = result[:n]
+      expect(type).to be_a(Rigor::Type::Union)
+      expect(type.members).to include(Rigor::Type::Combinator.nominal_of("Integer"))
+      expect(type.members).to include(Rigor::Type::Combinator.untyped)
     end
 
     it "binds singleton (class-method) parameters when singleton: true" do
       binder = described_class.new(environment: env, class_path: "Integer", singleton: true)
       result = binder.bind(def_node("def sqrt(n); n; end"))
 
-      # `Integer.sqrt(::int)` again degrades to Dynamic[Top] but the singleton path MUST be the one consulted.
+      # `Integer.sqrt(::int)` — the expanded alias's Integer member proves the singleton path was the one
+      # consulted (the instance side has no `sqrt`).
       expect(result.keys).to eq([:n])
-      expect(result[:n]).to eq(Rigor::Type::Combinator.untyped)
+      expect(result[:n].members).to include(Rigor::Type::Combinator.nominal_of("Integer"))
     end
 
     it "routes def self.foo through the singleton path even when singleton: false" do

--- a/spec/rigor/inference/rbs_type_translator_spec.rb
+++ b/spec/rigor/inference/rbs_type_translator_spec.rb
@@ -190,5 +190,67 @@ RSpec.describe Rigor::Inference::RbsTypeTranslator do
         expect(type.class_name).to eq("Integer")
       end
     end
+
+    describe "alias and intersection types (issue #529)" do
+      let(:loader) do
+        Rigor::Environment::RbsLoader.new(virtual_rbs: [["(spec: issue #529)", <<~RBS]])
+          type str_like = ::String
+          type wrapped = ::Array[str_like]
+          type json = ::String | ::Array[json]
+
+          interface _Marker
+          end
+
+          class AliasedNode
+          end
+
+          type nodeish = AliasedNode & _Marker
+        RBS
+      end
+
+      it "resolves an alias through the expander" do
+        type = described_class.translate(parse_rbs("str_like"), alias_expander: loader)
+        expect(type).to be_a(Rigor::Type::Nominal)
+        expect(type.class_name).to eq("String")
+      end
+
+      it "resolves an alias nested inside a class-instance argument" do
+        type = described_class.translate(parse_rbs("wrapped"), alias_expander: loader)
+        expect(type.describe).to eq("Array[String]")
+      end
+
+      it "reads an intersection as its first informative member" do
+        type = described_class.translate(parse_rbs("::String & ::Integer"), alias_expander: loader)
+        expect(type).to be_a(Rigor::Type::Nominal)
+        expect(type.class_name).to eq("String")
+      end
+
+      it "skips interface members when picking the intersection's representative" do
+        type = described_class.translate(parse_rbs("nodeish"), alias_expander: loader)
+        expect(type).to be_a(Rigor::Type::Nominal)
+        expect(type.class_name).to eq("AliasedNode")
+      end
+
+      it "degrades an all-interface intersection to Dynamic[Top]" do
+        type = described_class.translate(parse_rbs("_Marker & _Marker"), alias_expander: loader)
+        expect(type).to equal(Rigor::Type::Combinator.untyped)
+      end
+
+      it "terminates on a recursive alias via the expansion budget" do
+        type = described_class.translate(parse_rbs("json"), alias_expander: loader)
+        expect(type).to be_a(Rigor::Type::Union)
+        expect(type.members.map { |m| m.describe(:short) }).to include("String")
+      end
+
+      it "degrades an alias to Dynamic[Top] without an expander" do
+        type = described_class.translate(parse_rbs("str_like"))
+        expect(type).to equal(Rigor::Type::Combinator.untyped)
+      end
+
+      it "degrades an unresolvable alias to Dynamic[Top]" do
+        type = described_class.translate(parse_rbs("no_such_alias"), alias_expander: loader)
+        expect(type).to equal(Rigor::Type::Combinator.untyped)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #529.

## What

`RbsTypeTranslator` mapped `RBS::Types::Alias` and `RBS::Types::Intersection` to the untyped carrier, so any signature naming a type alias collapsed at the translation boundary — prism's `type node = Node & _Node` made every AST-edge accessor (`CallNode#receiver`, `ConstantPathNode#parent`, …) read `Dynamic[top]?` in our own lib (~120 pair sites), and core aliases (`int`, `string`) plus gem domain aliases generalize the collapse to every target with real RBS.

- **Alias** now resolves through an optional `alias_expander:` — the environment's `RbsLoader`, whose `expand_type_alias` already existed for the overload-acceptance path. One level per step under an expansion budget of 8, so a recursive alias (`type json = … | Array[json]`) terminates by degrading exactly where every alias degraded before.
- **Intersection** reads as its first member carrying static evidence. Every value of `A & B` IS an `A`, so a single member is a sound superset approximation; skipping `Dynamic`/`Top` members lands `Node & _Node` on `Nominal[Prism::Node]`. `Type::Intersection` stays out of this path — it is the same-base refinement composite carrier, and dispatch tiers do not accept it as a receiver.
- The handler table threads an immutable `Context` struct instead of three positionals; the public `translate` signature only gains the optional `alias_expander:` keyword.
- Wired inference-side: `RbsDispatch` return translation, its block-positional-parameter translation, and `MethodParameterBinder#translate_with_self`. The overload selector keeps its own alias-acceptance pass (it also covers interfaces); check-side declared-return translation is a follow-up noted on the issue.

## Latent finds surfaced by the stricter translation (both fixed here)

- `sig/rigor/type.rbs`'s `Type::t` alias had **drifted**: missing `Refined`, `Intersection`, `BoundMethod` — invisible while aliases read untyped, an immediate self-check error once they resolved.
- `ScopeIndexer#meta_new_block_body` read `.block` on a `Prism::node`-typed rvalue whose `CallNode` narrowing lived inside its helper predicates; the guard is hoisted so the flow proves it (all four predicates already required `CallNode`, so this is semantics-preserving).

## Gates

- `make verify` + `git diff --check` green. Self-check warning set byte-identical to master.
- Two `MethodParameterBinder` specs updated: both bound against the `int` alias and their own comments documented the old degradation ("which the translator currently degrades to `Dynamic[Top]`"); they now pin the expanded union with its `Integer` evidence member.
- lib coverage **59.8% → 60.8%** on this branch alone (+1,680 precise expressions), concentrated on the `Prism::` accessor cluster.
- Corpus FP gate (11 targets, `check --no-cache --no-ci-detect --format=json`, key = `path|line|col|rule|message`): **+0 / −0 on every target** vs the pre-session master baseline — the precision gain crosses no diagnostic threshold anywhere. The zero is affirmative: the arm ran with the tree frozen on this branch, and a live dispatch probe on the same tree showed `CallNode#receiver` resolving to `Prism::Node?`. (A first collection was discarded: a `git stash` for an unrelated baseline ran mid-arm and reverted the code under measurement — the working tree is part of the instrument.)
- Perf, interleaved 3-rep (`/usr/bin/time`, master worktree vs branch): **flat on mail** (4.19s vs 4.19s median), **~+5.5% on rigor's own lib** (8.70s → 9.18s median) — the alias-heaviest target via the `Prism::` cluster. A per-`(name, args)` expansion memo on the loader (second commit) already recouped a third of the initial ~+8%; the remainder is the inherent cost of translating the larger expanded trees.
