### PR TITLE
See through RBS aliases on the check side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[check]** The declared side of `def.return-type-mismatch` and the ADR-35 override rules now sees through RBS type aliases, so a redefinition contradicting an alias-declared signature is reported instead of silently accepted ([#557](https://github.com/rigortype/rigor/pull/557), [#529](https://github.com/rigortype/rigor/issues/529)).
 - **[engine]** RBS type aliases and intersections now translate instead of collapsing to untyped — prism's `type node = Node & _Node` reads as `Prism::Node`, and aliased returns, parameters, and block parameters resolve through the alias table ([#556](https://github.com/rigortype/rigor/pull/556), [#529](https://github.com/rigortype/rigor/issues/529)).
 - **[cli]** `rigor coverage` and `rigor check --coverage` now measure the same engine `rigor check` runs: the precision ratio sees your project's cross-file methods, ancestry, and plugin-contributed types instead of under-reporting them as untyped, and precisely-folded `Data` / `Struct` values count as typed ([#535](https://github.com/rigortype/rigor/pull/535), [#513](https://github.com/rigortype/rigor/issues/513), [#523](https://github.com/rigortype/rigor/issues/523)).
 

--- a/lib/rigor/analysis/check_rules.rb
+++ b/lib/rigor/analysis/check_rules.rb
@@ -2516,8 +2516,8 @@ module Rigor
             function.trailing_positionals.empty?
         end
 
-        def translate_param_type(rbs_type, _environment)
-          Inference::RbsTypeTranslator.translate(rbs_type)
+        def translate_param_type(rbs_type, environment)
+          Inference::RbsTypeTranslator.translate(rbs_type, alias_expander: environment&.rbs_loader)
         rescue StandardError
           Type::Combinator.untyped
         end
@@ -2669,11 +2669,12 @@ module Rigor
         # a `-> T` return is translated at its instantiated type (`-> Integer`) rather than degrading
         # to `Dynamic[Top]`. The default empty map is the pre-WD9 behaviour, under which any type
         # variable degrades to `Dynamic[Top]` and the rule stays silent.
-        def declared_return_union(method_def, _environment, type_vars: {})
+        def declared_return_union(method_def, environment, type_vars: {})
           translated = method_def.method_types.filter_map do |mt|
             Inference::RbsTypeTranslator.translate(
               mt.type.return_type,
-              self_type: nil, instance_type: nil, type_vars: type_vars
+              self_type: nil, instance_type: nil, type_vars: type_vars,
+              alias_expander: environment&.rbs_loader
             )
           rescue StandardError
             nil
@@ -2971,7 +2972,10 @@ module Rigor
           return {} if param_names.empty? || param_names.size != args.size
 
           translated = args.map do |arg|
-            Inference::RbsTypeTranslator.translate(arg, self_type: nil, instance_type: nil, type_vars: {})
+            Inference::RbsTypeTranslator.translate(
+              arg, self_type: nil, instance_type: nil, type_vars: {},
+                   alias_expander: scope.environment&.rbs_loader
+            )
           rescue StandardError
             nil
           end
@@ -3028,8 +3032,9 @@ module Rigor
 
           scope, override_method, parent_class, parent_method = resolved
           parent_type_vars = ancestor_instantiation_type_vars(scope, parent_class)
-          override_params = positional_param_types(override_method)
-          parent_params = positional_param_types(parent_method, type_vars: parent_type_vars)
+          override_params = positional_param_types(override_method, environment: scope.environment)
+          parent_params = positional_param_types(parent_method, type_vars: parent_type_vars,
+                                                                environment: scope.environment)
           return nil if override_params.nil? || parent_params.nil?
 
           index = first_narrowed_param_index(override_params, parent_params)
@@ -3049,7 +3054,7 @@ module Rigor
         # map (parent class's type params → the subclass's instantiation) so a parent `(T)` parameter
         # is compared at its instantiated type. Empty (the default, and the override side) keeps the
         # pre-WD9 degrade-to-`Dynamic[Top]` behaviour.
-        def positional_param_types(method_def, type_vars: {})
+        def positional_param_types(method_def, type_vars: {}, environment: nil)
           method_types = method_def.method_types
           return nil unless method_types.size == 1
 
@@ -3058,7 +3063,8 @@ module Rigor
 
           (func.required_positionals + func.optional_positionals).map do |param|
             Inference::RbsTypeTranslator.translate(
-              param.type, self_type: nil, instance_type: nil, type_vars: type_vars
+              param.type, self_type: nil, instance_type: nil, type_vars: type_vars,
+                          alias_expander: environment&.rbs_loader
             )
           rescue StandardError
             nil

--- a/spec/rigor/analysis/check_rules/override_and_return_type_spec.rb
+++ b/spec/rigor/analysis/check_rules/override_and_return_type_spec.rb
@@ -180,6 +180,44 @@ RSpec.describe "return-type and Liskov override rules", type: :runner do
       end
     end
 
+    describe "declared_return_union (alias-declared returns, issue #529)" do
+      # An alias-declared return used to translate to untyped, so the rule was structurally silent on
+      # it. With the check side handing the loader to the translator, the declared side compares at the
+      # expanded type — the must-fire / must-still-succeed pair below discriminates the wiring.
+      let(:alias_sig) do
+        { "alias_demo.rbs" => <<~RBS }
+          type demo_id = ::Integer
+
+          class AliasDemo
+            def id: () -> demo_id
+          end
+        RBS
+      end
+
+      it "fires when the body contradicts the expanded alias" do
+        result = analyze(<<~RUBY, sig: alias_sig)
+          class AliasDemo
+            def id
+              "not-an-integer"
+            end
+          end
+        RUBY
+        expect(return_diags(result).first&.message)
+          .to eq("return-type mismatch on `id': declared Integer, inferred \"not-an-integer\"")
+      end
+
+      it "stays silent when the body satisfies the expanded alias" do
+        result = analyze(<<~RUBY, sig: alias_sig)
+          class AliasDemo
+            def id
+              42
+            end
+          end
+        RUBY
+        expect(return_diags(result)).to be_empty
+      end
+    end
+
     describe "compare_return / dynamic_top? (fires only on a proven :no)" do
       it "stays silent when the body types as Dynamic[top]" do
         result = analyze(<<~RUBY, sig: demo_sig)


### PR DESCRIPTION
Stacked on #556 (the branch point); merge that first, then retarget this to master (`gh pr edit <n> --base master`) — the stacked-PR discipline from the handoff applies.

Completes the check-side half of #529: the four check-rules translation sites (`declared_return_union`, `translate_param_type`, `positional_param_types`, `ancestor_instantiation_type_vars`) now hand the loader to the translator as #556 did on the inference side, so the declared half of `def.return-type-mismatch` and the ADR-35 override rules compare against the expanded alias instead of untyped. The `rbs_type_admits_nil?` / `rbs_type_accepts_arg?` walks needed nothing — they have expanded aliases themselves since ADR-64.

**Gates.** `make verify` + `git diff --check` green; self-check warning set byte-identical to master. The new must-fire spec ("fires when the body contradicts the expanded alias") is **red without the lib change** (verified by stashing it), and its silent twin pins the accepting arm — the paired-control discipline. Corpus (11 targets, same key): **byte-identical to the #556 arm** — alias-declared redefinitions do not occur in these codebases, so the spec pair is the discriminating evidence, and the zero says the stricter comparison starts no FP wave.
