### PR TITLE
Choose the content-join arm by pre-state evidence alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Older release notes are archived under [`docs/`](docs/) when the leading version
 
 ### Fixed
 
+- **[engine]** An index write on a receiver the engine cannot shape no longer synthesizes a Hash type — mail's `compose_codepoints`, which mutates its Array parameter through integer and range index writes, returns untyped instead of a phantom `Hash[Integer | Range, ...]` that fired on the caller's `.pack` ([#559](https://github.com/rigortype/rigor/pull/559), [#553](https://github.com/rigortype/rigor/issues/553)).
 - **[cli]** `rigor coverage` and `rigor check --coverage` now measure the same engine `rigor check` runs: the precision ratio sees your project's cross-file methods, ancestry, and plugin-contributed types instead of under-reporting them as untyped, and precisely-folded `Data` / `Struct` values count as typed ([#535](https://github.com/rigortype/rigor/pull/535), [#513](https://github.com/rigortype/rigor/issues/513), [#523](https://github.com/rigortype/rigor/issues/523)).
 
 - **[engine]** A collection handed out by one method and filled through that reference — `(bucket_for(entry)[key] ||= {})[name] = row` — is no longer read as still empty, so `empty?` and `size` on it stop folding to a constant in every other method of the class ([#507](https://github.com/rigortype/rigor/pull/507), [#506](https://github.com/rigortype/rigor/issues/506)).

--- a/lib/rigor/inference/statement_evaluator.rb
+++ b/lib/rigor/inference/statement_evaluator.rb
@@ -2336,7 +2336,11 @@ module Rigor
       end
 
       # Joins content evidence for a memo / param given its pre-state and a list of mutator calls, dispatching Array vs
-      # Hash by the mutator set.
+      # Hash by the PRE-STATE's own evidence. The mutator set never picks the arm on its own: `[]=` is legal on Array,
+      # Hash, and countless index-writable classes, so an index-write against a receiver the engine cannot shape must
+      # not synthesize a hash carrier — mail's `compose_codepoints` mutated its untyped Array param through
+      # integer/range index writes and returned `Hash[Integer | Range, …]` to its caller (issue #553). Dynamic in,
+      # Dynamic out: a shapeless pre-state falls through to `join_array_param`, which declines it.
       def join_content_for_param(calls, pre_state, block_entry)
         return nil if pre_state.nil?
 
@@ -2344,7 +2348,7 @@ module Rigor
           # String carries no element parameter; mutating `<<`/`concat` makes the constant value unsound (`s = "a"; s <<
           # x` → runtime `"a…"`), so widen to the nominal base. Sound — only widens.
           Type::Combinator.nominal_of("String")
-        elsif hashish?(pre_state) || (hash_mutations?(calls) && !arrayish?(pre_state))
+        elsif hashish?(pre_state)
           join_hash_param(calls, pre_state, block_entry)
         else
           join_array_param(calls, pre_state, block_entry)
@@ -2412,12 +2416,6 @@ module Rigor
       # accumulator, whose `<<` carries no element parameter and whose binding already types as `String`.
       def join_content_for_local(name, calls, post_scope, block_entry)
         join_content_for_param(calls, post_scope.local(name), block_entry)
-      end
-
-      def hash_mutations?(calls)
-        calls.any? do |c|
-          index_write?(c) || (c.is_a?(Prism::CallNode) && MutationWidening::HASH_CONTENT_ADDERS.include?(c.name))
-        end
       end
 
       def index_write?(node)

--- a/spec/rigor/inference/statement_evaluator_spec.rb
+++ b/spec/rigor/inference/statement_evaluator_spec.rb
@@ -2182,6 +2182,31 @@ RSpec.describe Rigor::Inference::StatementEvaluator do
       RUBY
       expect(post.local(:s)).to eq(Rigor::Type::Combinator.nominal_of("String"))
     end
+
+    # Issue #553 — the join arm is chosen by the pre-state's OWN evidence, never by the mutator set: `[]=` is legal
+    # on Array, Hash, and countless index-writable classes, so an index-write on a shapeless binding must not
+    # synthesize a hash carrier (mail's `compose_codepoints` mutated its untyped Array param through integer/range
+    # index writes and handed `Hash[Integer | Range, …]` to its caller's `.pack`).
+    it "does not synthesize a Hash from index writes on a shapeless captured binding" do
+      _, post = evaluate(<<~RUBY)
+        x = unknown_value
+        [1].each { x[0..2] = 9 }
+        x
+      RUBY
+      expect(post.local(:x)).to eq(Rigor::Type::Combinator.untyped)
+    end
+
+    it "still joins index-write evidence when the pre-state carries hash shape" do
+      _, post = evaluate(<<~RUBY)
+        h = {}
+        [1].each { h[:k] = 1 }
+        h
+      RUBY
+      joined = post.local(:h)
+      expect(joined).to be_a(Rigor::Type::Nominal)
+      expect(joined.class_name).to eq("Hash")
+      expect(joined.type_args.first).to eq(Rigor::Type::Combinator.constant_of(:k))
+    end
   end
 
   describe "rescue variable binding" do


### PR DESCRIPTION
Fixes #553.

`join_content_for_param` picked its Hash arm whenever the mutator list contained a hash-capable call on a receiver not proven Array — but `[]=` is legal on Array, Hash, and countless index-writable classes, so an index write against a **shapeless** binding synthesized a hash carrier from nothing. mail's `Unicode.compose_codepoints` mutates its untyped Array parameter through integer/range index writes inside a while loop; the loop write-back handed `Hash[Integer | Range[Integer?], Dynamic[top]?]` to the return, and the caller's `.pack('U*')` fired `call.undefined-method` on working code once #554's extend fold made the call resolvable — the one adjudicated FP in #554's corpus tally.

The arm now follows the pre-state's own evidence: stringish → `String`, hashish → hash join, everything else falls through to the array join, which already declines a non-arrayish pre-state. Dynamic in, Dynamic out. `hash_mutations?` had no other caller and is deleted.

**Gates.** `make verify` + `git diff --check` green. The spec pair pins both sides: the shapeless index write stays untyped (**red on master**: it read `Hash[0..2, 9]`), and a `{}`-seeded captured local still joins its stored pairs. `rigor type-of` on the mail checkout's `unicode.rb:239` reads `Dynamic[top]` where it read the synthesized Hash. Corpus standalone vs pre-session base: **+0/−0 on all 11 targets** — expected, since the mail FP only manifests with #554's extend fold in the tree; the discriminating run is the all-in local integration, where mail's tally drops from +1 to 0 (reported in the handoff).
