### PR TITLE
Land changelog fragments and the sequential-merge norm (ADR-105)

### DIFF
--- a/.claude/skills/rigor-release-prep/SKILL.md
+++ b/.claude/skills/rigor-release-prep/SKILL.md
@@ -70,6 +70,14 @@ to `make verify`, so nothing downstream will catch a skipped rewrite. It is the
 one step silently lost when the mechanical steps around it get done; do not let
 "the entries are already there" stand in for reviewing and consolidating them.
 
+**Consolidate `changelog.d/` fragments before anything else.** Since ADR-105,
+entries land as `changelog.d/<section>/<slug>.md` fragments, not as direct
+`[Unreleased]` edits — so the seal starts by moving every fragment's line(s)
+under the matching `###` section of `[Unreleased]` (creating sections in Keep
+a Changelog order as needed) and deleting the fragment files (`git rm`). After
+this, `changelog.d/` contains only its `README.md`, and the enumeration below
+runs over the consolidated `[Unreleased]` exactly as it always has.
+
 `CHANGELOG.md` follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
 **This skill is the canonical statement of the entry rules** — `AGENTS.md`
 carries only the landing-time one-liner, because the full set matters to a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,11 @@ per-class blocklist entry, or a genuine plugin-contract misuse — **never disab
   `docs/CURRENT_WORK.md`. Anything touching a non-`.md` file is code: branch + PR.
 - Push with an explicit refspec — `git push origin HEAD:refs/heads/<branch>`. This clone's
   `push.default` can otherwise land a bare `push -u` on `master`.
+- **Land audited+green PRs as you go; do not queue them.** In an autonomous session, merge each PR
+  (`gh pr merge N --merge`) as soon as the diff is audited and `make verify` + CI are green; fork
+  the next branch from post-merge `master`. If the merge is denied, say so immediately. Batching or
+  stacking is reserved for changes the user must adjudicate as a set — deferral manufactures stacks
+  and sibling conflicts ([ADR-105](docs/adr/105-pr-landing-flow.md)).
 
 ## Release Cadence
 
@@ -92,17 +97,15 @@ flow is the `rigor-release-prep` skill.
   - **The link is the half that gets more expensive to add later.** You know your own PR number now;
     recovering it at the cut costs a cycle-wide enumeration plus a per-entry match against it. v0.3.6
     reached its release with 21 entries and zero links, and reconstructing the 18 dominated the prep.
-- **Parallel agents each write their own entry; `CHANGELOG.md` merges by union.** `.gitattributes`
-  marks the file `merge=union`, so two branches appending to `## [Unreleased]` no longer conflict on
-  insertion order. That resolution was always "keep both" — git now applies it instead of stopping to
-  ask. Do **not** tell agents to skip their entry: the link is cheapest at landing (above), and a
-  deferred entry is one somebody has to reconstruct.
-  - The one artefact union can produce is a **duplicated `###` heading**, when two branches each open a
-    section `[Unreleased]` did not have. It merges silently, so it is gated instead:
-    `spec/docs/changelog_conformance_spec.rb` fails on a section declared twice in a release, and
-    merging the two headings is the whole fix. Prefer adding under a heading that already exists.
-  - Reviewing the wording is still yours, but it belongs **at the cut**, where release prep consolidates
-    across the whole cycle anyway — not serialised through one session while branches wait.
+- **Entries land as fragment files, never as direct `[Unreleased]` edits.** Write
+  `changelog.d/<section>/<branch-slug>.md` — one bullet line in the entry grammar above, `<section>`
+  one of `added changed deprecated removed fixed security`. Release prep consolidates fragments into
+  `CHANGELOG.md` at the cut; only release prep writes `[Unreleased]`. Gate:
+  `spec/docs/changelog_fragments_spec.rb`. Why ([ADR-105](docs/adr/105-pr-landing-flow.md)): GitHub
+  ignores `.gitattributes merge=union` for PR mergeability, so same-anchor entries serialized a
+  19-PR queue into ~17 update+CI cycles; per-PR file additions cannot conflict. Do **not** skip the
+  entry: the link is cheapest at landing (above). Reviewing the wording belongs **at the cut**,
+  where release prep consolidates across the whole cycle anyway.
 
 ## Implementation Guidelines
 

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,17 @@
+# Changelog fragments
+
+`[Unreleased]` entries land here as one file per PR, instead of editing `CHANGELOG.md` directly.
+GitHub ignores `.gitattributes merge=union` for PR mergeability, so same-anchor `CHANGELOG.md`
+edits serialize otherwise-independent PRs — the full story is
+[ADR-105](../docs/adr/105-pr-landing-flow.md).
+
+- **Path**: `changelog.d/<section>/<branch-slug>.md`, where `<section>` is one of `added`,
+  `changed`, `deprecated`, `removed`, `fixed`, `security` (Keep a Changelog 1.1.0, downcased).
+  Create the section directory if it does not exist yet.
+- **Content**: one bullet line in the standard entry grammar —
+  `- **[subsystem]** One user-facing sentence. ([#N](https://github.com/rigortype/rigor/pull/N))`
+  — optionally followed by `  - ` child items. Write it right after `gh pr create`, when the PR
+  number exists. Full entry rules: the `rigor-release-prep` skill.
+- Release prep consolidates every fragment into `CHANGELOG.md` at the cut and deletes it; only
+  release prep writes `[Unreleased]`.
+- **Gate**: `spec/docs/changelog_fragments_spec.rb`.

--- a/docs/adr/105-pr-landing-flow.md
+++ b/docs/adr/105-pr-landing-flow.md
@@ -1,0 +1,94 @@
+# ADR-105 — PR landing flow: sequential merges and changelog fragments
+
+Status: **Accepted, 2026-09-01.** Both halves land with this ADR: the sequential-landing norm is in
+`AGENTS.md` § "Commit and PR Etiquette", and the `changelog.d/` fragment mechanism ships here (the
+directory, the gate `spec/docs/changelog_fragments_spec.rb`, and the consolidation step in the
+`rigor-release-prep` skill). The `merge=union` attribute from
+[PR #500](https://github.com/rigortype/rigor/pull/500) is retained as prep-time insurance; the
+expectation it encoded is corrected below.
+
+## Context
+
+[PR #500](https://github.com/rigortype/rigor/pull/500) marked `CHANGELOG.md merge=union` so that
+parallel branches appending `## [Unreleased]` entries stop conflicting, and verified exactly that —
+against **local git**. The operative layer was github.com: GitHub's PR-mergeability and merge
+computation ignore `.gitattributes` merge drivers, union included. Landing the 2026-09-01
+opacity-sweep campaign made the cost concrete: a 19-PR queue, each PR carrying one entry at the same
+`### Fixed` anchor, where three PRs read CONFLICTING against a single previously-merged entry before
+any queue merge happened, and every merge re-dirtied all remaining PRs. The queue drained as ~17
+serial local-merge → push → full-CI → merge cycles of ~8–12 minutes each. Two independent causes
+compounded:
+
+- **A shared hot region.** Every PR appends at one anchor of one file, so any two PRs overlap
+  textually — and GitHub serializes them regardless of the local merge driver.
+- **A deferred queue.** The PRs accumulated all session instead of landing as each went green, a
+  deviation from the standing merge-as-you-go authorization (2026-08-01). Deferral is what
+  manufactured the stacks (#543, #557, #558 were stacked only because their bases had not landed)
+  and the sibling conflicts: a branch forked from post-merge `master` cannot conflict with its
+  predecessors.
+
+## Decision
+
+Two rules, one per cause.
+
+**1. Sequential landing (the serial case).** A session producing serially-audited changes lands
+each PR as soon as its gates pass (`make verify`, the corpus gate where applicable, CI green) —
+attempt the merge, and surface a denial immediately rather than queueing. The next branch forks
+from post-merge `master`; the merge's CI overlaps with developing the next item. *Criterion:
+batching and stacking are reserved for changes the user must adjudicate as a set; deferral
+manufactures stacks and sibling conflicts.*
+
+**2. Changelog fragments (the parallel case).** An `[Unreleased]` entry lands as a new file
+`changelog.d/<section>/<slug>.md` — one bullet line in the existing entry grammar (subsystem label,
+full PR link), with the section encoded by the subdirectory (the six Keep a Changelog types,
+downcased). Release prep consolidates fragments into `[Unreleased]` and deletes them at the cut;
+`CHANGELOG.md` itself is written only by release prep. *Criterion: a file every PR must append to
+is a serialization point on GitHub regardless of local merge drivers — convert per-PR appends into
+per-PR file additions, which cannot conflict.*
+
+## Working decisions
+
+- **WD1 — section as subdirectory.** `changelog.d/fixed/…`, `changelog.d/added/…`, …: the section
+  is lintable from the path, no content parsing.
+- **WD2 — slug from the branch name.** Unique before the PR exists (the PR number is not). The PR
+  link still goes in the entry text right after `gh pr create`, exactly as before — and the
+  fragment gate now checks the link mechanically, which the direct-edit flow only ever trusted.
+- **WD3 — `merge=union` stays.** Harmless, and still correct for the one writer left (release prep
+  racing a straggler master-direct commit).
+- **WD4 — the gate lives in `spec/docs/`** (both `make docs-check` and the suite run it), with the
+  validator pinned by inline examples so the grammar holds even while the directory is empty.
+- **WD5 — the honest trade.** Fragments keep sibling PRs MERGEABLE, so they merge with CI that ran
+  against an older `master`. The repo already does not require up-to-date branches, so this widens
+  an accepted window rather than opening a new one; the standing integrated-`master` verify after a
+  batch is the net.
+
+## Rejected alternatives
+
+| Alternative | Why not |
+| --- | --- |
+| `merge=union` alone (PR #500) | Falsified at the operative layer: GitHub ignores merge drivers for PR mergeability. |
+| Auto-drain bot (rebase + push each DIRTY PR) | Keeps the Θ(N) serialized CI cost, and keep-both code conflicts need human judgment — a mechanical resolver corrupted `expression_typer.rb` during this very campaign. |
+| Reconstruct entries at the cut | Re-litigates #500: wording and PR link are cheapest at landing; v0.3.6's reconstruction dominated its prep. |
+| GitHub merge queue | A CONFLICTING PR cannot enter the queue; the root cause is untouched. |
+| Commit-trailer changelog (GitLab style) | Returns link derivation to cut-time enumeration — the exact cost #500 removed. |
+
+## Consequences
+
+- Parallel PRs stay MERGEABLE through a drain; the serialized update+CI cycles disappear for the
+  conflict class that hit every PR pair. Genuine code overlaps still conflict and still deserve
+  hand resolution.
+- The PR link is mechanically gated at landing instead of trusted.
+- `[Unreleased]` reads empty mid-cycle; the pending view is `ls changelog.d/*/`.
+- One more file per PR; release prep gains one mechanical consolidation step.
+- Meta-lesson, binding future workflow changes: **verify at the layer that enforces the
+  behaviour** — a two-throwaway-PR probe on github.com would have falsified #500's premise in
+  minutes, where local-merge verification could not.
+
+## Relationship to other ADRs
+
+- Partially supersedes the expectation set by PR #500: the attribute survives, but the "parallel
+  entries no longer conflict" claim is corrected to local-only.
+- [ADR-98](98-development-flow-document-roles.md) — the changelog's document role is unchanged;
+  only the landing mechanism moves.
+- [ADR-50](50-release-engineering-and-stability-strategy.md) — release flow; the consolidation
+  step is specified in the `rigor-release-prep` skill.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -118,6 +118,7 @@ This directory contains the Architecture Decision Records (ADRs) for Rigor. Each
 | ADR-102 | [The unused-code reachability report is a report, not a diagnostic](102-unused-code-reachability-report.md) | Proposed (decisions for the `rigor unused` slices; all eight working decisions settled) |
 | ADR-103 | [Effect labels: an opt-in, snapshot-first effect system](103-effect-labels.md) | Proposed (design note landed 2026-08-16; nothing implemented; four items open at Proposed) |
 | ADR-104 | [Boot-slim probe for the effects surfaces](104-effects-boot-slim-probe.md) | Accepted (implemented for the report and the snapshot verbs, with #482's entry split) |
+| ADR-105 | [PR landing flow: sequential merges and changelog fragments](105-pr-landing-flow.md) | Accepted (changelog.d/ mechanism + gate landed with the ADR; norm in AGENTS.md) |
 
 ## Adding a New ADR
 

--- a/spec/docs/changelog_fragments_spec.rb
+++ b/spec/docs/changelog_fragments_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# Gate the `changelog.d/` fragment files (ADR-105). An `[Unreleased]` entry lands as
+# `changelog.d/<section>/<slug>.md` instead of a direct `CHANGELOG.md` edit — GitHub ignores
+# `.gitattributes merge=union` for PR mergeability, so same-anchor edits serialize otherwise
+# independent PRs. The fragment IS the entry, so this gate holds the entry grammar at landing,
+# including the PR/issue link the direct-edit flow only ever trusted.
+#
+# The validator is pinned by inline examples below so the grammar holds even while the directory
+# is empty (the steady state right after a release cut).
+require "spec_helper"
+
+FRAGMENTS_DIR = File.expand_path("../../changelog.d", __dir__)
+
+RSpec.describe "changelog.d fragment conformance (ADR-105)" do
+  # Keep a Changelog 1.1.0's section types, downcased — the allowed subdirectory names.
+  sections = %w[added changed deprecated removed fixed security].freeze
+  entry_line = /\A- \*\*\[[^\]]+\]\*\* \S.*\z/
+  child_line = /\A {2}- \S.*\z/
+  repo_link = %r{\[#\d+\]\(https://github\.com/rigortype/rigor/(?:pull|issues)/\d+\)}
+  slug = /\A[a-z0-9][a-z0-9._-]*\.md\z/
+
+  # Offense strings for one fragment, or [] when it conforms. `relative` is the path under
+  # changelog.d/ (e.g. "fixed/my-branch.md").
+  define_method(:fragment_offenses) do |relative, content|
+    offenses = []
+    segments = relative.split("/")
+    unless segments.size == 2 && sections.include?(segments.first)
+      offenses << "#{relative}: expected <section>/<slug>.md with section in #{sections.join(', ')}"
+    end
+    offenses << "#{relative}: slug must be lowercase [a-z0-9._-] ending in .md" unless segments.last.match?(slug)
+
+    lines = content.lines(chomp: true)
+    if lines.empty? || !lines.first.match?(entry_line)
+      offenses << "#{relative}: first line must be a `- **[subsystem]** …` bullet on ONE line"
+    end
+    lines.drop(1).each do |line|
+      unless line.match?(child_line)
+        offenses << "#{relative}: `#{line}` — only `  - ` child items may follow (no wrapping)"
+      end
+    end
+    offenses << "#{relative}: entry must carry a full markdown PR/issue link" unless content.match?(repo_link)
+    offenses
+  end
+
+  describe "the validator (inline examples, so the grammar holds while the directory is empty)" do
+    let(:good) { "- **[engine]** One sentence. ([#42](https://github.com/rigortype/rigor/pull/42))\n" }
+
+    it "accepts a conforming single-line entry" do
+      expect(fragment_offenses("fixed/my-branch.md", good)).to be_empty
+    end
+
+    it "accepts child items under the entry line" do
+      content = "#{good}  - Detail traced to ([#43](https://github.com/rigortype/rigor/pull/43)).\n"
+      expect(fragment_offenses("added/my-branch.md", content)).to be_empty
+    end
+
+    it "rejects a column-wrapped entry (the continuation is neither bullet nor child)" do
+      wrapped = "- **[engine]** A sentence that\nwraps. ([#42](https://github.com/rigortype/rigor/pull/42))\n"
+      expect(fragment_offenses("fixed/my-branch.md", wrapped)).not_to be_empty
+    end
+
+    it "rejects a missing or bare link" do
+      expect(fragment_offenses("fixed/my-branch.md", "- **[engine]** One sentence. (#42)\n")).not_to be_empty
+    end
+
+    it "rejects an unknown section directory and a top-level file" do
+      expect(fragment_offenses("performance/my-branch.md", good)).not_to be_empty
+      expect(fragment_offenses("my-branch.md", good)).not_to be_empty
+    end
+
+    it "rejects an uppercase slug" do
+      expect(fragment_offenses("fixed/My-Branch.md", good)).not_to be_empty
+    end
+  end
+
+  describe "the live directory" do
+    it "keeps its README (the directory stays tracked and self-describing)" do
+      expect(File).to exist(File.join(FRAGMENTS_DIR, "README.md"))
+    end
+
+    it "contains only conforming fragments" do
+      offenses = Dir.glob("#{FRAGMENTS_DIR}/**/*").filter_map do |path|
+        next unless File.file?(path)
+
+        relative = path.delete_prefix("#{FRAGMENTS_DIR}/")
+        next if relative == "README.md"
+
+        list = fragment_offenses(relative, File.read(path))
+        list.join("\n  ") unless list.empty?
+      end
+      expect(offenses).to be_empty, <<~MSG
+        Non-conforming changelog fragments (see changelog.d/README.md / ADR-105):
+          #{offenses.join("\n  ")}
+      MSG
+    end
+  end
+end


### PR DESCRIPTION
Remedial package for the 2026-09-01 merge drain, recorded as [ADR-105](https://github.com/rigortype/rigor/blob/pr-landing-flow/docs/adr/105-pr-landing-flow.md).

**What failed.** #500's `merge=union` was verified against local git, but GitHub's PR mergeability ignores `.gitattributes` merge drivers — observed ~15+ times during the drain: PR pairs whose only shared file was `CHANGELOG.md` read CONFLICTING on GitHub while the same merges union-resolved silently locally. With every PR appending at the same `### Fixed` anchor, each merge re-dirtied all remaining PRs and the 19-PR queue drained as ~17 serial local-merge → push → full-CI → merge cycles. The queue itself was the second cause: deferral (against the standing merge-as-you-go authorization) is what manufactured the stacks and the sibling conflicts.

**The two rules.** (1) Sequential landing: an autonomous session merges each audited+green PR as soon as its gates pass; batching is reserved for changes the user must adjudicate as a set (AGENTS.md § Commit and PR Etiquette). (2) Changelog fragments: entries land as `changelog.d/<section>/<slug>.md` — one bullet line, existing grammar, PR link required and now mechanically gated — consolidated into `[Unreleased]` by release prep at the cut (AGENTS.md § Release Cadence, `rigor-release-prep` skill). Rejected alternatives (drain bot, cut-time reconstruction, merge queue, commit trailers) are in the ADR.

**Gates.** `make verify` + `make docs-check` + `git diff --check` green; the new `spec/docs/changelog_fragments_spec.rb` pins the fragment grammar with inline examples so it holds while the directory is empty. No changelog fragment for this PR, per #500's own precedent (landing mechanics are invisible to gem users).