### PR TITLE
Cut the spec suite's RBS environment rebuilds

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
       rubocop (~> 1.86, >= 1.86.2)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    test-prof (1.6.3)
+      logger
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -116,6 +118,7 @@ DEPENDENCIES
   rubocop (>= 1.70, < 2.0)
   rubocop-rake (>= 0.6, < 1.0)
   rubocop-rspec (>= 3.0, < 4.0)
+  test-prof (>= 1.6, < 2.0)
 
 CHECKSUMS
   activesupport (8.1.3.1) sha256=85458765f25ea48b9019c46b6bb3fa5683197bf4280d9f06710a6e8d7a831376
@@ -156,6 +159,7 @@ CHECKSUMS
   rubocop-rspec (3.10.2) sha256=0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  test-prof (1.6.3) sha256=027aea17612b2776069820e4209f6b446ece7ad6dc693f4aed0b742bcb3817a1
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42

--- a/rigortype.gemspec
+++ b/rigortype.gemspec
@@ -100,6 +100,14 @@ Gem::Specification.new do |spec|
   # users of `rigortype` paying the cost (ADR-0 zero-runtime-dep).
   spec.add_development_dependency "rbs-inline", ">= 0.5", "< 1.0"
   spec.add_development_dependency "rspec", ">= 3.13", "< 4.0"
+  # Suite-performance instrumentation. The suite's runtime is concentrated in a
+  # few hundred examples that each drive a real analysis, so "which files are
+  # slow" (binpacker's timing file already answers that) is not enough — the
+  # question is how much of an example goes to `let`/`before` setup versus the
+  # thing under test. `RD_PROF` answers it per file, and `EVENT_PROF` attributes
+  # suite time to instrumented engine entry points. Profilers stay inert unless
+  # their env var is set, so this costs the default run only its require.
+  spec.add_development_dependency "test-prof", ">= 1.6", "< 2.0"
   spec.add_development_dependency "rubocop", ">= 1.70", "< 2.0"
   spec.add_development_dependency "rubocop-rake", ">= 0.6", "< 1.0"
   spec.add_development_dependency "rubocop-rspec", ">= 3.0", "< 4.0"

--- a/spec/support/rbs_env_memo.rb
+++ b/spec/support/rbs_env_memo.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "digest"
+require "rigor/environment/rbs_loader"
+
+# Process-level reuse of identical `RBS::Environment` builds, for the spec suite only.
+#
+# Measured over a full `make test-binpacker` run, `RbsLoader.build_env_for` was called 1809 times for
+# 674.9 s — about 53 % of the suite's 1281 s of worker time. Only 240 distinct environments exist across
+# the whole suite, and 1487 of those builds (561.9 s) re-built an environment the *same worker process* had
+# already built. Three environment contents alone accounted for 1085 builds.
+#
+# The repeats are not a spec-hygiene failure that could be fixed file by file — they are spread over more
+# than fifty spec files and arise two ways at once. An example that passes `cache_store: nil` has no cache
+# to consult, and an example whose sig files land in a fresh `Dir.mktmpdir` gets a different
+# `Cache::RbsDescriptor` from an identical neighbour, because that descriptor keys on `(path, sha)`. Both
+# produce byte-identical environments from byte-identical inputs.
+#
+# So the reuse is keyed on the INPUT CONTENT — library list, signature-file bytes, virtual RBS bytes —
+# rather than on paths, which is what lets it collapse the repeats the cache descriptor cannot see.
+#
+# == Why sharing the instance is safe
+#
+# `build_env_for` is a pure function of the inputs digested here, and nothing outside `RbsLoader` mutates
+# the environment it returns: every `add_source` / decl insertion in `lib/` is inside the build itself.
+# Sharing one instance across examples is also not new — `Cache::Store`'s in-process memo already hands the
+# same `RBS::Environment` to every example whose descriptor matches, which is most of the suite.
+#
+# == Where it is NOT safe, and how to opt out
+#
+# What memoisation does change is the *act* of building: a repeat no longer re-parses, so it no longer
+# re-emits the build-time warnings (quarantined signature files, virtual-RBS collisions) that a handful of
+# specs assert on. Any example that exercises building rather than the built result must tag itself
+# `:fresh_rbs_env` and gets an unmemoised build.
+#
+# `RIGOR_SPEC_NO_ENV_MEMO=1` disables the memo suite-wide. That is the control arm: the suite must be green
+# both ways, and a difference between them is this file's bug, not a flake.
+module RbsEnvMemo
+  # An environment holds a few tens of MB, so the cache is a small LRU rather than unbounded. It costs
+  # almost nothing to keep it small: simulated against the census above, a cap of 1 already avoids 515.6 s
+  # of the 561.9 s available and a cap of 3 avoids 544.1 s, because each worker process is dominated by one
+  # or two environments. The median worker sees exactly one distinct environment; the busiest sees 51.
+  CAPACITY = 3
+
+  class << self
+    def enabled?
+      return false if ENV["RIGOR_SPEC_NO_ENV_MEMO"]
+
+      !RSpec.current_example&.metadata&.fetch(:fresh_rbs_env, false)
+    end
+
+    # @return [::RBS::Environment, nil] the cached environment for `key`, promoting it to most-recent.
+    def fetch(key)
+      value = cache.delete(key)
+      cache[key] = value unless value.nil?
+      value
+    end
+
+    def store(key, value)
+      cache.delete(key)
+      cache[key] = value
+      cache.shift while cache.size > CAPACITY
+      value
+    end
+
+    def digest(libraries, signature_paths, virtual_rbs)
+      parts = ["lib\0#{Array(libraries).map(&:to_s).sort.join(',')}"]
+
+      Array(signature_paths).map(&:to_s).sort.each do |root|
+        signature_files(root).each { |path| parts << "sig\0#{path}\0#{file_digest(path)}" }
+      end
+
+      Array(virtual_rbs).map { |name, content| "virt\0#{name}\0#{content}" }.sort.each { |p| parts << p }
+
+      Digest::SHA256.hexdigest(parts.join("\n"))
+    end
+
+    private
+
+    # Ruby hashes keep insertion order, so `shift` drops the least recently used entry.
+    def cache
+      @cache ||= {}
+    end
+
+    # The path is part of the digest alongside its content: two sig roots holding the same bytes under
+    # different names are different inputs to `add_project_signatures`, which reports diagnostics against
+    # the file name it read.
+    def signature_files(root)
+      return [root] if File.file?(root)
+
+      Dir.glob(File.join(root, "**", "*.rbs"))
+    end
+
+    # Re-hashing every signature file on each build would give back part of what the memo saves, so a file's
+    # digest is cached against its identity. `size` and `mtime` are what a spec rewriting a fixture in place
+    # changes; both move together with the content in every shape the suite produces.
+    def file_digest(path)
+      stat = File.stat(path)
+      identity = [path, stat.size, stat.mtime.to_r]
+      file_digests[identity] ||= Digest::SHA256.file(path).hexdigest
+    rescue SystemCallError
+      "unreadable"
+    end
+
+    def file_digests
+      @file_digests ||= {}
+    end
+  end
+
+  # Prepended onto the loader's singleton so it wraps `build_env_for` for every caller, including
+  # `Cache::RbsEnvironment.compute` on a cache miss.
+  module Interception
+    def build_env_for(libraries:, signature_paths:, virtual_rbs: [])
+      return super unless RbsEnvMemo.enabled?
+
+      key = RbsEnvMemo.digest(libraries, signature_paths, virtual_rbs)
+      cached = RbsEnvMemo.fetch(key)
+      return cached if cached
+
+      RbsEnvMemo.store(key, super)
+    end
+  end
+end
+
+Rigor::Environment::RbsLoader.singleton_class.prepend(RbsEnvMemo::Interception)
+
+RSpec.configure do |config|
+  # Two files take building itself as their subject rather than consuming a built environment, so they are
+  # exempted wholesale instead of example by example.
+  #
+  # `rbs_loader_spec.rb` asserts on what a build emits — the notice naming a quarantined signature file, the
+  # virtual-RBS collision report — which a memo hit would not re-emit. `rbs_environment_spec.rb` asserts on
+  # how MANY times the cache producer computed (`have_received(:build_env_for).once`), and the memo sits in
+  # front of the partial double, so a hit would never reach it.
+  #
+  # Both pass today either way, because each example feeds the loader signature content no other example
+  # uses and so never hits the memo. That is luck, not a contract: the assertions are about the act of
+  # building, and this tag is what keeps them measuring it.
+  config.define_derived_metadata(
+    file_path: Regexp.union(
+      %r{/spec/rigor/environment/rbs_loader_spec\.rb\z},
+      %r{/spec/rigor/cache/rbs_environment_spec\.rb\z}
+    )
+  ) do |meta|
+    meta[:fresh_rbs_env] = true
+  end
+end

--- a/spec/support/spec_profiling.rb
+++ b/spec/support/spec_profiling.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Suite-performance instrumentation (test-prof), loaded only when asked for.
+#
+# binpacker's timing file already answers "which files are slow". What it cannot
+# answer is where an example's time goes once it starts: 98 % of the suite's
+# measured example time sits in the ~2 100 examples that take 0.1 s or more, and
+# each of those drives a real analysis behind some amount of `let` / `before`
+# setup. Splitting the two is what says whether a file is slow because the work
+# is genuinely expensive or because the setup is being redone per example.
+#
+# Every profiler is opt-in through test-prof's own env vars, so the default
+# `make test` path does not even require the gem:
+#
+#   RD_PROF=1                — per-file split of `before`-hook vs `let` time
+#   EVENT_PROF=rigor.analyze — attribute suite time to the engine entry points
+#   TAG_PROF=type            — group time by example metadata
+module SpecProfiling
+  # test-prof's own set of `TestProf.activate` keys. A var outside it would
+  # silently profile nothing, so the list is enumerated rather than prefixed.
+  ENV_VARS = %w[
+    EVENT_PROF FDOC FPROF LOG RD_PROF RSTAMP TAG_PROF TAG_PROF_EVENT
+    TEST_MEM_PROF TEST_RUBY_PROF TEST_STACK_PROF TEST_VERNIER TPS_PROF
+  ].freeze
+
+  # Engine entry points worth attributing suite time to.
+  #
+  # `rigor.analyze` is one logical `rigor check`. `rigor.rbs_env` is the RBS
+  # environment build underneath it — the cost `RunnerHelpers`' shared cache
+  # store exists to amortise, so it doubles as the check on whether that sharing
+  # still works: a run where the two totals are close is a suite paying for
+  # environment builds rather than for analysis.
+  #
+  # Registered as blocks because `EventProf` patches only the events named in
+  # `EVENT_PROF`, and requiring these eagerly would defeat the boot-slim that
+  # `require "rigor"` performs.
+  def self.register_events
+    TestProf::EventProf::CustomEvents.register("rigor.analyze") do
+      require "rigor/analysis/runner"
+      TestProf::EventProf.monitor(Rigor::Analysis::Runner, "rigor.analyze", :run)
+    end
+
+    TestProf::EventProf::CustomEvents.register("rigor.rbs_env") do
+      require "rigor/environment/rbs_loader"
+      TestProf::EventProf.monitor(
+        Rigor::Environment::RbsLoader.singleton_class, "rigor.rbs_env", :build_env_for
+      )
+    end
+  end
+
+  # `require "test-prof"` activates the events named in `EVENT_PROF` as it
+  # loads, which is before anything here could have registered them. Activating
+  # again afterwards is what makes the registrations above reachable;
+  # `try_activate` consumes each registration, so the repeat is idempotent and
+  # an already-activated or unknown name is a no-op.
+  def self.activate_registered_events
+    %w[EVENT_PROF TAG_PROF_EVENT].each do |var|
+      events = ENV.fetch(var, nil)
+      TestProf::EventProf::CustomEvents.activate_all(events) if events
+    end
+  end
+end
+
+if SpecProfiling::ENV_VARS.any? { |var| ENV[var] }
+  require "test-prof"
+
+  SpecProfiling.register_events
+  SpecProfiling.activate_registered_events
+end


### PR DESCRIPTION
Adds `test-prof` as a development dependency, wires the suite's profilers behind its env vars, and uses what they measured to remove the suite's single largest cost.

## What the profilers said

`RD_PROF` first, on the slowest file (`spec/rigor/analysis/runner_spec.rb`): `before` / `let` account for **0.042 s of 68.8 s**. Setup was never the problem, so nothing in the `let_it_be` family applies here.

`EVENT_PROF` next, against two engine entry points registered as custom events. 98.9 % of that file runs inside `Analysis::Runner#run` — genuine analysis — and **28.5 % of it is `RbsLoader.build_env_for`**, over 92 calls. A single build costs ~208 ms, of which ~186 ms (89 %) is the core+stdlib portion that is identical in every one of them.

A census over a full `make test-binpacker` run sized it suite-wide:

| | |
| --- | --- |
| `build_env_for` calls | 1809 |
| total build time | 674.9 s (~53 % of the suite's worker time) |
| distinct environment contents suite-wide | 240 |
| builds that rebuilt what that worker already had | **1487, 561.9 s** |

Three environment contents accounted for 1085 of those builds, spread across more than fifty spec files.

## Why it cannot be fixed file by file

The repeats arise two ways at once. An example passing `cache_store: nil` has no cache to consult. An example whose sig files land in a fresh `Dir.mktmpdir` gets a different `Cache::RbsDescriptor` from an identical neighbour, because that descriptor keys on `(path, sha)`. Both produce byte-identical environments from byte-identical inputs — so `spec/support/rbs_env_memo.rb` keys on input *content*, which is what lets it collapse the repeats the descriptor cannot see.

Two approaches were measured and rejected before this one. Reusing a marshalled library environment is not cheaper than rebuilding it (`Marshal.load` 140 ms vs 180 ms rebuild, on a 9.8 MB blob). Routing `runner_spec.rb`'s 64 direct-construction examples through the shared `Cache::Store` moved every second saved on environment building into `Marshal.dump` and disk writes, for a net wall-clock change of zero — and it broke a test, which is where the separate finding below came from.

## Safety

`build_env_for` is a pure function of the digested inputs, and every mutation of the environment in `lib/` is inside the build itself. Sharing the instance is not new: `Cache::Store`'s in-process memo already hands the same `RBS::Environment` to every example whose descriptor matches, which is most of the suite.

What memoisation *does* change is the act of building — a hit no longer re-parses, so it no longer re-emits build-time warnings, and it no longer reaches a partial double counting builds. `spec/rigor/environment/rbs_loader_spec.rb` and `spec/rigor/cache/rbs_environment_spec.rb` take building itself as their subject and are exempted by derived metadata. `RIGOR_SPEC_NO_ENV_MEMO=1` disables the memo suite-wide, so the control arm is runnable and the suite is green both ways.

The LRU holds 3 environments. Simulated against the census, a cap of 1 already avoids 515.6 s of the 561.9 s available and a cap of 3 avoids 544.1 s, because each worker process is dominated by one or two environments — the median worker sees exactly one.

## Result

Alternating arms, full `make test-binpacker`:

| | memo off | memo on |
| --- | --- | --- |
| worker CPU time | ~1267 s | **~758 s (−40 %)** |
| local wall clock | ~133 s | **~93 s (−30 %)** |
| examples | 10203 passed | 10203 passed |

CI's `Tests` job is the critical path of the whole workflow (9 m 04 s of a ~10 m 30 s run, with every other job finishing inside 2 m 30 s), so this should take roughly 3–4 minutes off it.

`make verify` green; `git diff --check` clean.

## Not included

No changelog fragment: `spec/` is dev-only and `test-prof` is a development dependency, so nothing here reaches a user of the gem.

One finding is deliberately left open rather than fixed here. The paired examples `surfaces rbs.coverage.missing-gem …` and `suppresses rbs.coverage.missing-gem …` differ only in the `Gemfile.lock` each writes, and behind a shared `Cache::Store` the second was served the first's answer — the diagnostic fired against a lockfile whose only gem is covered. `.github/workflows/ci.yml` already scopes its Rigor-cache restore-keys to the Gemfile.lock hash with a comment anticipating exactly this divergence. Whether the gem-coverage cache key should carry lockfile identity is an engine question, and it is untouched by this PR — both examples still pass `cache_store: nil`, as they always did.