### PR TITLE
Key the run-result cache on the project's lockfile contents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,9 +278,14 @@ jobs:
       #
       # The restore-keys are scoped to the current Gemfile.lock hash so
       # that a lockfile change (e.g. adding a gem) never restores a cache
-      # built under the old lockfile.  A stale-lockfile restore would make
-      # the gem-without-rbs count diverge between warm and cold, failing
-      # the warm==cold diff gate even when the analysis is correct.
+      # built under the old lockfile.  This was once load-bearing: it was
+      # compensating for a run-result cache key that did not encode the
+      # lockfile it depended on, so a stale-lockfile restore made the
+      # gem-without-rbs count diverge between warm and cold and failed the
+      # warm==cold diff gate on a correct analysis (#564).  The engine now
+      # keys on the lockfile's contents itself, so the scoping is kept as
+      # cache hygiene — it stops the store filling with entries whose keys
+      # can no longer hit — rather than for correctness.
       - name: Restore Rigor analysis cache
         id: restore-cache
         if: matrix.cache == 'warm'

--- a/changelog.d/fixed/run-cache-lockfile-identity.md
+++ b/changelog.d/fixed/run-cache-lockfile-identity.md
@@ -1,0 +1,1 @@
+- **[cache]** A warm `rigor check` now re-analyzes after a `bundle add` / `bundle remove` instead of replaying the diagnostics from before the lockfile changed. ([#565](https://github.com/rigortype/rigor/pull/565))

--- a/docs/internal-spec/cache.md
+++ b/docs/internal-spec/cache.md
@@ -351,6 +351,56 @@ but the reason the user sees would otherwise be `NO_SNAPSHOT`, which
 tells them to run `rigor check --incremental`, a fix for a different
 problem.
 
+### Project dependency identity in a computed-value key
+
+A cache whose value is a function of what the analyzer computes MUST also
+key on the project's **dependency lockfiles**, for the same reason it keys
+on the engine's source. The locked gem set decides which bundle-shipped
+`sig/` directories load, which `rbs_collection` directories load, which
+[ADR-72](../adr/72-gemfile-lock-gated-rbs-overlays.md) gem overlays apply,
+what the ADR-82 WD9 missing-gem constant index owns, and whether
+`rbs.coverage.missing-gem` fires — yet a lockfile edit touches no analyzed
+source and no `.rbs` file, so nothing else in a run's identity moves with
+it. Keyed without it, a warm run replays the pre-`bundle add` diagnostics:
+a `call.undefined-method` survives the edit that licenses the overlay
+retracting it, and — primed the other way — stays silent after the edit
+that revokes it ([#564](https://github.com/rigortype/rigor/issues/564)).
+
+`Analysis::RunCacheKey.descriptor` carries two config slots for it,
+`bundler.lockfile` and `rbs_collection.lockfile`, each holding a SHA-256
+of the file the corresponding resolver
+(`Environment::LockfileResolver.resolve_lockfile_path` /
+`Environment::RbsCollectionDiscovery.resolve_lockfile_path`) resolves
+under the run's configuration:
+
+- **Content, never the path.** A cache KEY may not carry machine-local
+  data (see `FileEntry`), and a content-only slot is what lets a moved
+  checkout — a CI workspace, a rename — still hit on an identical
+  lockfile.
+- **Absent is a value.** No lockfile resolving carries its own sentinel
+  rather than dropping the slot: "absent" and "present but empty" must not
+  key the same.
+- **A key slot, not a dependency entry.** A recorded dependency descriptor
+  can only say "a file I recorded changed"; it cannot express a lockfile
+  that did not exist when the entry was written and does now, which is the
+  first-`bundle install` case.
+
+Both slots are built inside `descriptor`, from the configuration alone, so
+the miss path (`Analysis::Runner`) and the ADR-87 WD4 boot-slim hit path
+(`Analysis::RunCacheProbe`) obtain them by construction and cannot drift
+out of key agreement — the invariant that module exists to hold. Both
+resolvers are leaf files, so the probe reaches them without loading
+`rigor/environment` or the RBS machinery.
+
+`IncrementalSnapshot.fingerprint` has always hashed the same two
+lockfiles (§ Two-level gating above); this states the rule the other
+computed-value caches are held to as well.
+
+One residual is deliberate rather than closed: a gem installed or removed
+**under the bundle root without a lockfile change** is half-covered. The
+discovered `sig/*.rbs` files are recorded dependencies, so a removal
+invalidates, while an appearance does not.
+
 ### Read fault tolerance
 
 A read encountering any of the following silently returns a

--- a/lib/rigor/analysis/run_cache_key.rb
+++ b/lib/rigor/analysis/run_cache_key.rb
@@ -14,8 +14,13 @@ end
 require_relative "../version"
 require_relative "../cache/descriptor"
 require_relative "../cache/engine_source"
+require_relative "../cache/file_digest"
 require_relative "../cache/rbs_descriptor"
 require_relative "../environment/default_libraries"
+# Both resolvers are leaf files (no requires beyond `yaml`), so the boot-slimming probe reaches the two
+# lockfile paths without loading `rigor/environment` or the RBS machinery.
+require_relative "../environment/lockfile_resolver"
+require_relative "../environment/rbs_collection_discovery"
 
 module Rigor
   module Analysis
@@ -80,7 +85,7 @@ module Rigor
       def descriptor(configuration:, files:, explain:, rbs_config_entries:)
         Cache::Descriptor.new(
           gems: [Cache::RbsDescriptor.rbs_gem_entry],
-          configs: rbs_config_entries + engine_source_entries + [
+          configs: rbs_config_entries + engine_source_entries + lockfile_entries(configuration) + [
             config_entry("configuration", Marshal.dump(configuration.to_h)),
             config_entry("engine",
                          "#{Rigor::VERSION}:#{Cache::Descriptor::SCHEMA_VERSION}:#{explain}"),
@@ -104,6 +109,41 @@ module Rigor
         return [] if identity.nil?
 
         [config_entry("engine-source", identity)]
+      end
+
+      # Issue #564 — the two dependency lockfiles, BY CONTENT. Both are inputs to the run's diagnostics and
+      # neither was represented in the key: the locked gem set decides which bundle-shipped `sig/` dirs and
+      # which `rbs_collection` dirs load, which ADR-72 gem overlays apply, what the ADR-82 WD9 missing-gem
+      # constant index owns, and whether `rbs.coverage.missing-gem` fires at all. Editing a lockfile touches
+      # no analyzed source and no `.rbs` file, so the `paths` slot, the `configuration` slot (which carries
+      # the lockfile PATH, never its bytes) and the recorded dependency descriptor were all unchanged by a
+      # `bundle add` — and a warm run replayed the pre-edit diagnostics in BOTH directions: an
+      # `undefined-method` on `3.minutes` surviving the `bundle add activesupport` that licenses the overlay,
+      # and the same call staying silent after the `bundle remove` that revokes it.
+      #
+      # A KEY slot rather than a dependency entry, because a dependency descriptor can only say "a file I
+      # recorded changed": it cannot express a lockfile that did not exist when the entry was written and
+      # does now, which is the `bundle init` / first-`bundle install` case.
+      #
+      # Content-only — the resolved PATH is deliberately not in the payload, so a checkout that moves (a CI
+      # runner's workspace, a renamed directory) still hits with an identical lockfile.
+      def lockfile_entries(configuration)
+        bundler = Environment::LockfileResolver.resolve_lockfile_path(
+          lockfile_path: configuration.bundler_lockfile, auto_detect: configuration.bundler_auto_detect
+        )
+        collection = Environment::RbsCollectionDiscovery.resolve_lockfile_path(
+          lockfile_path: configuration.rbs_collection_lockfile,
+          auto_detect: configuration.rbs_collection_auto_detect
+        )
+        [lockfile_entry("bundler.lockfile", bundler), lockfile_entry("rbs_collection.lockfile", collection)]
+      end
+
+      # `nil` — no lockfile resolves — is itself part of the identity, so it carries its own sentinel rather
+      # than dropping the slot: "absent" and "present but empty" must not key the same.
+      ABSENT_LOCKFILE = "\0absent"
+
+      def lockfile_entry(key, path)
+        config_entry(key, path.nil? ? ABSENT_LOCKFILE : Cache::FileDigest.hexdigest(path.to_s))
       end
 
       def config_entry(key, payload)

--- a/spec/rigor/analysis/runner_spec.rb
+++ b/spec/rigor/analysis/runner_spec.rb
@@ -366,6 +366,11 @@ RSpec.describe Rigor::Analysis::Runner do
       expect(budget_diags.first.severity).to eq(:warning)
     end
 
+    # Both coverage examples run on the process-wide shared store rather than `cache_store: nil`. They are alike in
+    # every other run-cache key slot — empty path set, identical configuration — so they are exactly the pair that
+    # used to collide, and the run-cache key's `bundler.lockfile` content slot (issue #564) is what separates them.
+    # Keeping them on the shared store means a regression of that slot fails HERE too, not only in
+    # `spec/rigor/cache/run_cache_lockfile_identity_spec.rb`.
     it "surfaces `rbs.coverage.missing-gem` :info exactly once when locked gems have no RBS (O4 slice 3)" do # rubocop:disable RSpec/ExampleLength
       # Build a tmpdir with Gemfile.lock listing two gems whose RBS is not covered by ANY of the four resolution paths
       # (DEFAULT_LIBRARIES / vendored / bundle / collection).
@@ -393,7 +398,9 @@ RSpec.describe Rigor::Analysis::Runner do
             "paths" => [],
             "bundler" => { "lockfile" => "Gemfile.lock", "auto_detect" => true }
           )
-          result = described_class.new(configuration: configuration, cache_store: nil).run
+          result = described_class.new(
+            configuration: configuration, cache_store: RunnerHelpers.shared_cache_store
+          ).run
           coverage_diags = result.diagnostics.select { |d| d.rule == "rbs.coverage.missing-gem" }
 
           expect(coverage_diags.length).to eq(1)
@@ -429,7 +436,9 @@ RSpec.describe Rigor::Analysis::Runner do
             "paths" => [],
             "bundler" => { "lockfile" => "Gemfile.lock", "auto_detect" => true }
           )
-          result = described_class.new(configuration: configuration, cache_store: nil).run
+          result = described_class.new(
+            configuration: configuration, cache_store: RunnerHelpers.shared_cache_store
+          ).run
           coverage_diags = result.diagnostics.select { |d| d.rule == "rbs.coverage.missing-gem" }
 
           expect(coverage_diags).to be_empty

--- a/spec/rigor/cache/run_cache_engine_source_spec.rb
+++ b/spec/rigor/cache/run_cache_engine_source_spec.rb
@@ -125,7 +125,12 @@ RSpec.describe "run-result cache invalidation on an engine-source edit" do
     Rigor::Cache::EngineSource.reset_process_identity! # the released gem is a SECOND process (#289)
     released = Rigor::Analysis::RunCacheKey.descriptor(**args)
 
-    expect(released.configs.map(&:key)).to contain_exactly("configuration", "engine", "paths")
+    # The pin is the whole composition, not just the absence: a released gem keeps every other slot and loses
+    # only `engine-source`. `bundler.lockfile` / `rbs_collection.lockfile` are issue #564's lockfile-identity
+    # slots, present in both builds.
+    expect(released.configs.map(&:key)).to contain_exactly(
+      "bundler.lockfile", "configuration", "engine", "paths", "rbs_collection.lockfile"
+    )
     expect(checkout.configs.map(&:key)).to include("engine-source")
     expect(released.to_canonical_hash).not_to eq(checkout.to_canonical_hash)
   end

--- a/spec/rigor/cache/run_cache_lockfile_identity_spec.rb
+++ b/spec/rigor/cache/run_cache_lockfile_identity_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fileutils"
+require "tmpdir"
+
+require "rigor/analysis/runner"
+require "rigor/cache/store"
+require "rigor/configuration"
+
+# Issue #564, acceptance — the defect was not "a slot is missing from the key string", it was that a warm
+# `rigor check` REPLAYS the pre-edit diagnostics after a `bundle add` / `bundle remove`. The locked gem set
+# decides which bundle-shipped `sig/` dirs and `rbs_collection` dirs load, which ADR-72 gem overlays apply,
+# and whether `rbs.coverage.missing-gem` fires — yet editing a lockfile touches no analyzed source and no
+# `.rbs` file, so nothing the run-result cache read used to change.
+#
+# Every example therefore drives the real {Analysis::Runner} against a real on-disk {Cache::Store} and
+# asserts on the DIAGNOSTICS, in both directions: a lockfile edit that licenses the ActiveSupport overlay
+# must retract the `call.undefined-method` on `3.minutes`, and the edit that revokes it must restore it.
+# A cache keyed without the lockfile serves a false positive one way and a false negative the other.
+RSpec.describe "run-result cache invalidation on a lockfile edit" do
+  def lockfile_body(gems)
+    specs = gems.map { |name, version| "    #{name} (#{version})\n" }.join
+    deps = gems.each_key.map { |name| "  #{name}\n" }.join
+    "GEM\n  remote: https://rubygems.org/\n  specs:\n#{specs}\nPLATFORMS\n  ruby\n\n" \
+      "DEPENDENCIES\n#{deps}\nBUNDLED WITH\n   2.5.3\n"
+  end
+
+  # A FRESH Store every time, so a hit has to come off disk rather than out of the Store's in-process memo —
+  # which is what the next `rigor check` process would face.
+  def analyse(dir, cache_root, paths:)
+    Dir.chdir(dir) do
+      Rigor::Analysis::Runner.new(
+        configuration: Rigor::Configuration.new(
+          "paths" => paths, "bundler" => { "lockfile" => "Gemfile.lock", "auto_detect" => true }
+        ),
+        cache_store: Rigor::Cache::Store.new(root: cache_root), collect_stats: false
+      ).run.diagnostics
+    end
+  end
+
+  def rules(diagnostics, rule)
+    diagnostics.select { |d| d.rule == rule }
+  end
+
+  # `3.minutes` resolves only through the ADR-72 `activesupport` overlay, which is licensed by the lockfile
+  # alone — so the call site is a direct read of which lockfile the run actually observed.
+  def overlay_arm(before_gems, after_gems)
+    Dir.mktmpdir("rigor-lockfile-key-cache-") do |cache_root|
+      Dir.mktmpdir("rigor-lockfile-key-project-") do |dir|
+        File.write(File.join(dir, "code.rb"), "x = 3.minutes\n")
+        File.write(File.join(dir, "Gemfile.lock"), lockfile_body(before_gems))
+        before = analyse(dir, cache_root, paths: ["code.rb"])
+        File.write(File.join(dir, "Gemfile.lock"), lockfile_body(after_gems))
+        [before, analyse(dir, cache_root, paths: ["code.rb"])]
+      end
+    end
+  end
+
+  it "retracts the overlay-covered diagnostic when the gem is ADDED to the lockfile" do
+    before, after = overlay_arm({ "rare_gem_a" => "1.0" }, { "activesupport" => "8.0.1" })
+
+    expect(rules(before, "call.undefined-method").map(&:message)).to include(a_string_including("minutes"))
+    expect(rules(after, "call.undefined-method")).to be_empty
+  end
+
+  it "restores the diagnostic when the gem is REMOVED from the lockfile" do
+    before, after = overlay_arm({ "activesupport" => "8.0.1" }, { "rare_gem_a" => "1.0" })
+
+    expect(rules(before, "call.undefined-method")).to be_empty
+    expect(rules(after, "call.undefined-method").map(&:message)).to include(a_string_including("minutes"))
+  end
+
+  # The shape that surfaced the bug: two projects sharing one cache, alike in everything the key read
+  # (empty path set, identical configuration) and differing only in their lockfile.
+  it "does not serve one project's gem-coverage answer to a sibling with a different lockfile" do
+    Dir.mktmpdir("rigor-lockfile-key-shared-") do |cache_root|
+      uncovered, covered = [{ "rare_gem_a" => "1.0", "rare_gem_b" => "2.5" }, { "json" => "2.7.0" }].map do |gems|
+        Dir.mktmpdir("rigor-lockfile-key-sibling-") do |dir|
+          File.write(File.join(dir, "Gemfile.lock"), lockfile_body(gems))
+          rules(analyse(dir, cache_root, paths: []), "rbs.coverage.missing-gem")
+        end
+      end
+
+      expect(uncovered.length).to eq(1)
+      expect(uncovered.first.message).to include("rare_gem_a")
+      # `json` is a DEFAULT_LIBRARIES entry, so this project has full coverage and must stay silent.
+      expect(covered).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Closes #564.

The ADR-45 run-result cache key (`Analysis::RunCacheKey.descriptor`) carried the `rbs` version, the RBS library list, the engine identity, a digest of the resolved configuration and the analyzed-path SET — and nothing that identified the project's `Gemfile.lock`. The recorded dependency descriptor did not carry it either: it records analyzed sources, `pre_eval:` files, the RBS signature tree and plugin-read files.

The locked gem set is a real input to a run's diagnostics: it decides which bundle-shipped `sig/` directories load, which `rbs_collection` directories load, which ADR-72 gem overlays apply, what the ADR-82 WD9 missing-gem constant index owns, and whether `rbs.coverage.missing-gem` fires. Editing a lockfile touches no analyzed source and no `.rbs` file, so every slot the cache consulted was unchanged by a `bundle add` — and the warm run replayed the pre-edit answer.

Measured at the CLI, on a project whose one file is `x = 3.minutes`, before this change:

```
$ rigor check --no-baseline lib          # cold, lockfile lists rare_gem_a
.rigor.yml:1:1: info: 1 gem(s) in Gemfile.lock have no RBS available: rare_gem_a. … [rbs.coverage.missing-gem]
lib/code.rb:1:7: error: undefined method `minutes' for 3 [call.undefined-method]

# `bundle add activesupport`
$ rigor check --no-baseline lib          # warm
.rigor.yml:1:1: info: 1 gem(s) in Gemfile.lock have no RBS available: rare_gem_a. … [rbs.coverage.missing-gem]
lib/code.rb:1:7: error: undefined method `minutes' for 3 [call.undefined-method]
```

A false positive surviving the very edit that licenses the ADR-72 overlay to retract it, and a notice naming a gem the lockfile no longer lists. Primed the other way round — `activesupport` locked, then removed — the warm run stays silently clean on `3.minutes`: the false-negative direction.

## The change

Both lockfiles now ride the key **by content**, resolved inside `RunCacheKey.descriptor`, so the miss path (`Analysis::Runner`) and the ADR-87 WD4 boot-slim hit path (`Analysis::RunCacheProbe`) get the slots by construction and cannot drift out of key agreement:

- `bundler.lockfile` — digest of whatever `Environment::LockfileResolver.resolve_lockfile_path` resolves, or a sentinel when none does.
- `rbs_collection.lockfile` — the same, via `Environment::RbsCollectionDiscovery.resolve_lockfile_path`.

A KEY slot rather than a dependency entry, because a dependency descriptor can only say "a file I recorded changed" — it cannot express a lockfile that did not exist when the entry was written and does now (the first-`bundle install` case). Content-only, with the resolved path deliberately excluded, so a checkout that moves (a CI workspace, a rename) still hits on an identical lockfile. Both resolvers are leaf files, so the probe reaches them without loading `rigor/environment` or the RBS machinery.

`.github/workflows/ci.yml` already scopes the Rigor-cache `restore-keys` to the `Gemfile.lock` hash, predicting in a comment that a stale-lockfile restore would make the gem-without-rbs count diverge between warm and cold. That workaround was compensating in CI configuration for a key that did not encode what it depended on; it is left in place, and is now belt-and-braces rather than load-bearing.

## Gate

`spec/rigor/cache/run_cache_lockfile_identity_spec.rb` drives the real `Runner` against a real on-disk `Cache::Store`, with a fresh `Store` per run so a hit has to come off disk: the ADD direction, the REMOVE direction, and the two-sibling-projects shape that surfaced this. All three fail without the slots.

`runner_spec.rb`'s matched gem-coverage pair moves back onto the shared store. They are alike in every other key slot — empty path set, identical configuration — so they are exactly the pair that used to collide, and a regression of the slot fails there too.

`run_cache_engine_source_spec.rb` pins the released-gem key composition (issue #285); its list grows by the two slots, and the intent it pins — a released gem loses only `engine-source` — is unchanged.

`make verify` green.

## Known residual, recorded on the issue

A gem installed or removed under the bundle root WITHOUT a lockfile change is still only half-covered: the discovered `sig/*.rbs` files are recorded dependencies, so a removal invalidates, but an appearance does not.