### PR TITLE
Split the Tests job across three shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,21 @@ jobs:
           fi
 
   # ── 1. RSpec suite (via binpacker) ──────────────────────────────
+  # The suite is the workflow's critical path, and a runner's core count is
+  # the ceiling on what workers alone can do with it — every other job here
+  # finishes inside 2m30s. So the run is also split across MACHINES: each
+  # shard analyses its own slice with its own workers, and the job's wall
+  # time becomes the slowest shard rather than the whole suite.
+  #
+  # Three shards, because a spec FILE is binpacker's scheduling unit and
+  # cannot be split: a shard can never finish faster than the heaviest file
+  # it holds. Measured at 423 files, the three heaviest are 87s / 51s / 40s
+  # and land in three different shards, so the floor is ~87s while an even
+  # split of the total is ~63s per runner. A fourth shard would buy nothing
+  # but another job's setup. Past that floor the next lever is not more
+  # shards but a cheaper `runner_spec.rb`.
   test:
-    name: Tests (Ruby ${{ matrix.ruby }})
+    name: Tests (Ruby ${{ matrix.ruby }}, shard ${{ matrix.shard }}/3)
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
@@ -95,6 +108,7 @@ jobs:
       matrix:
         ruby:
           - "4.0"
+        shard: [1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -114,23 +128,94 @@ jobs:
       # written at the end of each successful run and picked up by the
       # next. Key is unique per run-id so the post-step always saves
       # fresh timing data; restore-keys prefix-matches the most recent.
+      #
+      # The key carries the shard index because parallel jobs cannot all
+      # save the same key — the first wins and the rest warn. The RESTORE
+      # keys deliberately do NOT: every shard prefix-matches the same
+      # `binpacker-timings-<os>-ruby<v>-` namespace, so all three restore
+      # the same file and therefore cut the same partition. That is not a
+      # nicety — shards agree on which tests are theirs only while they
+      # agree on the timings, and the shard-coverage job below is what
+      # catches it when they do not.
+      #
+      # A shard's saved file stays complete rather than shrinking to its
+      # own slice: binpacker APPENDS samples and compacts to the three most
+      # recent per test, so a shard's write leaves its siblings' entries
+      # untouched.
       - name: Restore binpacker timing file
         uses: actions/cache@v6
         with:
           path: tmp/binpacker.timings
-          key: binpacker-timings-${{ runner.os }}-ruby${{ matrix.ruby }}-${{ github.run_id }}
+          key: binpacker-timings-${{ runner.os }}-ruby${{ matrix.ruby }}-${{ github.run_id }}-${{ matrix.shard }}
           restore-keys: binpacker-timings-${{ runner.os }}-ruby${{ matrix.ruby }}-
 
       - name: Run tests
-        run: make test-binpacker
+        run: >-
+          make test-binpacker
+          BINPACKER_FLAGS="--shard ${{ matrix.shard }}/3 --report tmp/binpacker-report-${{ matrix.shard }}.json"
+
+      # Consumed by the shard-coverage job, which is the only place a
+      # partition that dropped tests can be detected.
+      - name: Upload shard run report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: binpacker-report-${{ matrix.shard }}
+          path: tmp/binpacker-report-${{ matrix.shard }}.json
+          retention-days: 1
 
       # The pool-runner spec is excluded from the default suite (see
       # spec/spec_helper.rb) and runs as its own rspec process. Without
       # this step the gated file has no CI coverage at all — a
       # deterministic failure in it once rotted unnoticed for three
       # weeks (fork-backend default 86ed9129 → fixed 7ebeac08).
+      #
+      # Pinned to one shard: it is a single file outside the sharded set,
+      # so running it in every shard would triple its cost for no coverage.
       - name: Run pool-runner spec
+        if: matrix.shard == 1
         run: make test-ractor-pool
+
+  # ── 1b. Shard coverage ──────────────────────────────────────────
+  # Sharding's one silent failure: shards never coordinate, so each trusts
+  # the others to have cut the identical partition from the identical
+  # timing data. A shard that restored a different timing file partitions
+  # differently, some tests land in NO shard, and every job still reports
+  # success — a shard cannot tell "not mine" from "does not exist".
+  #
+  # `binpacker shards-check` is the fan-in that can: it reads each shard's
+  # run report and fails unless they describe one coherent split of one
+  # suite — same shard count, same whole-suite discovered count, every
+  # index present exactly once, and the slices summing to the whole.
+  #
+  # Runs whenever the matrix was not outright cancelled, so a mismatch
+  # still surfaces when one shard failed.
+  shard-coverage:
+    name: Shard coverage (every test ran)
+    needs: [changes, test]
+    runs-on: ubuntu-latest
+    if: always() && needs.changes.outputs.code == 'true' && needs.test.result != 'cancelled'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0"
+          bundler-cache: true
+
+      - name: Download shard run reports
+        uses: actions/download-artifact@v8
+        with:
+          pattern: binpacker-report-*
+          merge-multiple: true
+          path: reports
+
+      - name: Assert the shards covered the whole suite
+        run: bundle exec binpacker shards-check reports/binpacker-report-*.json
 
   # ── 2. RBS compatibility (3.x + 4.x) ────────────────────────────
   rbs-compat:
@@ -485,7 +570,7 @@ jobs:
   # gated without touching protection rules.
   required:
     name: CI required
-    needs: [changes, test, rbs-compat, lint, self-check, self-check-diff, self-check-bleeding-edge]
+    needs: [changes, test, shard-coverage, rbs-compat, lint, self-check, self-check-diff, self-check-bleeding-edge]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -493,6 +578,7 @@ jobs:
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
           TEST_RESULT: ${{ needs.test.result }}
+          SHARD_COVERAGE_RESULT: ${{ needs.shard-coverage.result }}
           RBS_COMPAT_RESULT: ${{ needs.rbs-compat.result }}
           LINT_RESULT: ${{ needs.lint.result }}
           SELF_CHECK_RESULT: ${{ needs.self-check.result }}
@@ -508,7 +594,7 @@ jobs:
           fi
           # A gated job that was skipped (Markdown-only PR) is acceptable;
           # only an outright failure or cancellation blocks the merge.
-          for job_result in "$TEST_RESULT" "$RBS_COMPAT_RESULT" "$LINT_RESULT" "$SELF_CHECK_RESULT" "$SELF_CHECK_DIFF_RESULT" "$SELF_CHECK_BLEEDING_EDGE_RESULT"; do
+          for job_result in "$TEST_RESULT" "$SHARD_COVERAGE_RESULT" "$RBS_COMPAT_RESULT" "$LINT_RESULT" "$SELF_CHECK_RESULT" "$SELF_CHECK_DIFF_RESULT" "$SELF_CHECK_BLEEDING_EDGE_RESULT"; do
             if [[ "$job_result" != "success" && "$job_result" != "skipped" ]]; then
               echo "A required job did not succeed (result: $job_result)"
               failed=1

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,14 @@ source "https://rubygems.org"
 ruby ">= 4.0.0", "< 4.1"
 
 gemspec
+
+# Source override only — the version constraint stays on the gemspec's development dependency.
+#
+# The sharded `Tests` matrix in .github/workflows/ci.yml needs `binpacker run --shard K/N` and
+# `binpacker shards-check`, which are on binpacker's master but not in any released gem: 0.4.0 predates
+# them. Pinned to an explicit revision rather than a branch so a push to binpacker cannot silently change
+# what Rigor's CI runs.
+#
+# Replace this whole entry with nothing — the gemspec dependency then resolves from rubygems again — as
+# soon as a binpacker release carries sharding.
+gem "binpacker", git: "https://github.com/rigortype/binpacker", ref: "6019ce9acc2882faa7496a24f54a25dbb8549f38"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/rigortype/binpacker
+  revision: 6019ce9acc2882faa7496a24f54a25dbb8549f38
+  ref: 6019ce9acc2882faa7496a24f54a25dbb8549f38
+  specs:
+    binpacker (0.4.0)
+
 PATH
   remote: .
   specs:
@@ -25,7 +32,6 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    binpacker (0.4.0)
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     diff-lcs (1.6.2)
@@ -109,7 +115,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (>= 7.0, < 9.0)
-  binpacker (>= 0.1.0, < 1.0)
+  binpacker (>= 0.1.0, >= 0, < 1.0)!
   rack (>= 2.0, < 4.0)
   rake (>= 13.0, < 15.0)
   rbs-inline (>= 0.5, < 1.0)
@@ -125,7 +131,7 @@ CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
-  binpacker (0.4.0) sha256=ce2b290b1a33b961aea44303f7e955e0ac27f281aa1bb1420d44d97039dce627
+  binpacker (0.4.0)
   bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a

--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,15 @@ test-ractor-pool:
 # rebalancing between workers) to absorb shared-runner noise.
 # Worker count comes from `workers: auto` in binpacker.yml (CPU
 # count); override it via the config profile.
+#
+# BINPACKER_FLAGS threads per-invocation arguments through without
+# turning this target into a second CLI. CI's sharded matrix uses it for
+# `--shard K/N --report …`; a local run leaves it empty and gets the
+# whole suite.
+BINPACKER_FLAGS ?=
+
 test-binpacker:
-	bundle exec binpacker run
+	bundle exec binpacker run $(BINPACKER_FLAGS)
 
 lint:
 	bundle exec rubocop lib/ spec/ plugins/ examples/ apps/


### PR DESCRIPTION
Follows [#563](https://github.com/rigortype/rigor/pull/563). That halved the `Tests` job by removing duplicated work; this one splits what remains across machines. `Tests` is still the workflow's critical path — every other job finishes inside 2m30s — and a runner's core count is the ceiling on what workers alone can do with it.

Needs [rigortype/binpacker#16](https://github.com/rigortype/binpacker/pull/16), merged.

## The split

Three shards, each analysing its own slice with its own workers. binpacker cuts the slice with the **same weight-balanced partitioner it uses for workers**, over the same cached timings, so shards carry equal predicted time rather than equal file counts. Measured over Rigor's 423 spec files:

| shard | files | predicted weight | predicted makespan |
| --- | --- | --- | --- |
| 1/3 | 141 | 252.3s | 87.0s |
| 2/3 | 141 | 252.3s | 51.0s |
| 3/3 | 141 | 252.3s | 40.2s |

Weight is split exactly evenly. Running all three end-to-end through `make test-binpacker` reproduced the full suite: 3010 + 4094 + 3099 = **10203 examples**, the whole suite, with no file in two shards.

**Three, not more.** A spec file is binpacker's scheduling unit and cannot be split, so a shard can never finish faster than the heaviest file it holds. The three heaviest are 87s / 51s / 40s and LPT places them in three different shards, so the floor is ~87s against an even split of ~63s per runner. A fourth shard would buy another job's setup and nothing else. Past that floor the next lever is a cheaper `runner_spec.rb`, not more shards.

## The silent failure this has to defend against, and the new job that does

Shards never coordinate. Each cuts the N-way partition itself and trusts its siblings to have cut the identical one — which holds only while they all load the same timing data. A shard that restored a **different** timing file partitions differently, some tests land in no shard at all, and every job still reports success. No shard can notice on its own: it cannot tell "not mine" from "does not exist".

So each shard writes a run report carrying its index, the whole-suite discovered count (taken before slicing), and its own selected count; the new **`shard-coverage`** job runs `binpacker shards-check` over all three and fails unless they describe one coherent split of one suite. It is in the required fan-in, and it runs whenever the matrix was not outright cancelled, so a mismatch surfaces even when a shard failed.

Verified with a negative control — one report's slice reduced by 7:

```
shard coverage check failed
  shards cover 415 of 422 tests — 7 ran no shard. The shards partitioned
  different timing data; make every shard load the same timing file.
```

exit 1.

## Timing cache

The **save** key gains the shard index, because parallel jobs cannot all save one key — the first wins and the rest warn. The **restore** keys deliberately do not: all three prefix-match the same `binpacker-timings-<os>-ruby<v>-` namespace, so they restore the same file and therefore cut the same partition. That is the invariant `shard-coverage` guards.

A shard's saved file stays whole rather than shrinking to its own slice: binpacker appends samples and compacts to the three most recent per test, so a shard's write leaves its siblings' entries untouched.

`make test-ractor-pool` is pinned to shard 1 — it is a single file outside the sharded set, so running it in all three would triple its cost for no coverage.

## The binpacker pin

`--shard` and `shards-check` are on binpacker's master; no release carries them yet (0.4.0 predates both). The Gemfile entry is a **source override only** — pinned to an explicit revision so a push to binpacker cannot silently change what CI runs — and the version constraint stays on the gemspec's development dependency. **It should come out as soon as a binpacker release ships sharding**, at which point the gemspec dependency resolves from rubygems again.

`make verify` green in a clean worktree at this branch (10203 examples, no offenses); `git diff --check` clean. No changelog fragment: `.github/`, `Makefile` and a development-dependency source are all dev-only, so nothing here reaches a user of the gem.