### PR TITLE
Pin the deferred-YJIT opt-out for the spec suite

### DIFF
--- a/changelog.d/fixed/spec-jit-deadline-thread-leak.md
+++ b/changelog.d/fixed/spec-jit-deadline-thread-leak.md
@@ -1,0 +1,1 @@
+- **[dev]** The spec suite pins `RIGOR_DISABLE_YJIT=1`, so an in-process CLI invocation no longer leaks a live deferred-YJIT deadline thread into later examples — the leak made `spec/rigor/runtime/jit_spec.rb` flake depending on how spec files were packed across parallel workers. ([#567](https://github.com/rigortype/rigor/pull/567))

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -41,22 +41,34 @@ RSpec.describe Rigor::CLI do
   # its whole 21 s interpreted while the same analysis under `check` (which armed the deadline) took
   # 14.8 s; pinning the arm at the dispatch seam is what keeps the next command from repeating that.
   describe "deferred YJIT" do
-    before do
-      require "rigor/runtime/jit"
-      allow(Rigor::Runtime::Jit).to receive(:enable_after)
+    before { require "rigor/runtime/jit" }
+
+    describe "the arm at the dispatch seam" do
+      before { allow(Rigor::Runtime::Jit).to receive(:enable_after) }
+
+      it "arms the deadline for a dispatched command" do
+        run_cli("effects", "--help")
+
+        expect(Rigor::Runtime::Jit).to have_received(:enable_after)
+          .with(Rigor::Runtime::Jit.deadline_seconds)
+      end
+
+      it "leaves the trivial built-ins unarmed" do
+        run_cli("version")
+
+        expect(Rigor::Runtime::Jit).not_to have_received(:enable_after)
+      end
     end
 
-    it "arms the deadline for a dispatched command" do
-      run_cli("effects", "--help")
-
-      expect(Rigor::Runtime::Jit).to have_received(:enable_after)
-        .with(Rigor::Runtime::Jit.deadline_seconds)
-    end
-
-    it "leaves the trivial built-ins unarmed" do
-      run_cli("version")
-
-      expect(Rigor::Runtime::Jit).not_to have_received(:enable_after)
+    # The other half of the arm, and the half that is a SUITE invariant rather than a product one: because dispatch
+    # arms unconditionally, an unpinned suite leaves one real sleeper thread behind per in-process CLI invocation, and
+    # a sleeper waking inside `jit_spec`'s process-wide `RubyVM::YJIT` stub inflated its single-call assertion to three
+    # on CI. `spec_helper` pins `RIGOR_DISABLE_YJIT=1` so the arm allocates nothing; this example is what fails if that
+    # pin is dropped, instead of the flake coming back somewhere unrelated. `jit_spec` clears the switch per example,
+    # so the real thread behaviour is still covered there.
+    it "spawns no real deadline thread, because the suite pins the opt-out" do
+      expect(Rigor::Runtime::Jit).to be_disabled
+      expect(Rigor::Runtime::Jit.enable_after(0.01)).to be_nil
     end
   end
 

--- a/spec/rigor/runtime/jit_spec.rb
+++ b/spec/rigor/runtime/jit_spec.rb
@@ -5,7 +5,12 @@ require "rigor/runtime/jit"
 
 RSpec.describe Rigor::Runtime::Jit do
   # Snapshot + restore the two env switches this module reads so an example
-  # that sets them never leaks state into the rest of the suite.
+  # that sets them never leaks state into the rest of the suite. This is also
+  # the one file that lifts `spec_helper`'s suite-wide `RIGOR_DISABLE_YJIT=1`
+  # pin — it has to, since the examples below exercise the enable paths that
+  # pin exists to suppress — so the window in which a stray sleeper thread
+  # could land on `stub_yjit_off` is exactly these examples. Nothing else may
+  # arm a real deadline; `cli_spec` pins that.
   # The recorded monotonic deadline is module state that outlives an example (and that any earlier spec
   # arming a real deadline would have set), so it is snapshotted and cleared here too.
   around do |example|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,6 +62,24 @@ Warning[:experimental] = false if Warning.respond_to?(:[]=)
 # per-example by setting the platform env var + `RIGOR_CI_DETECT=1` and restoring both after.
 ENV["RIGOR_CI_DETECT"] = "0"
 
+# Deferred YJIT off for the whole suite, for the same determinism reason and one stronger one: `CLI#dispatch` arms
+# `Runtime::Jit.enable_after` for EVERY dispatched command, and that arm spawns a real background thread that sleeps
+# the deadline (5 s) and then calls `RubyVM::YJIT.enable`. Every in-process `Rigor::CLI.start` / `CLI#run` a spec makes
+# therefore left one sleeper behind that OUTLIVED the example — they accumulate monotonically for the rest of the
+# worker process (measured before this pin: `spec/rigor/cli/trace_command_spec.rb` alone ends with one live sleeper per
+# example). A sleeper waking inside a later example's `RubyVM::YJIT` stub lands on that stub, which is exactly how
+# `spec/rigor/runtime/jit_spec.rb`'s single-call `have_received(:enable)` assertion observed three calls on CI: its
+# `around` hook clears this switch and its `stub_yjit_off` replaces both YJIT methods process-wide, so a leaked
+# sleeper skips its own opt-out check and is counted. Whether it flakes depends on which files share a binpacker
+# worker, which is why it passed at 12 workers locally and failed at 4 on CI.
+#
+# Pinning the product's own opt-out is what makes the leak unreachable rather than merely unlikely: `enable_after`
+# returns nil and spawns NO thread when it is set, so no CLI spec — including one written tomorrow — can arm a real
+# deadline. It reaches subprocess `rigor` runs by inheritance too, which only makes those more deterministic (YJIT
+# changes wall-time, never diagnostics or allocations). `jit_spec` is the one file that exercises the real thing, and
+# it already snapshots and clears both switches per example, so it keeps testing the unpinned behaviour.
+ENV["RIGOR_DISABLE_YJIT"] = "1"
+
 require "rigor"
 # Required explicitly: `rigor` boot-slims, so the cache key modules are not on its require graph, and the
 # per-example memo reset below must not depend on which spec file happened to pull this one in first.


### PR DESCRIPTION
`spec/rigor/runtime/jit_spec.rb`'s "spawns a thread that enables YJIT after the delay" flaked on the Ruby 4.0 job of #565 — it asserts `have_received(:enable)` exactly once and observed three calls, on a diff that touches only the run-result cache key and cannot reach the JIT code. This fixes the leak behind it rather than the assertion.

## Mechanism

`CLI#dispatch` arms `Runtime::Jit.enable_after` for **every** dispatched command, and that arm spawns a real background thread that sleeps the 5 s deadline and then calls `RubyVM::YJIT.enable`. Every in-process `Rigor::CLI.start` / `CLI#run` a spec makes therefore left one sleeper behind that outlived the example. Measured before this change, `spec/rigor/cli/trace_command_spec.rb` alone ends its run with one live sleeper per example, accumulating monotonically:

```
LEAKED-THREADS 7 after: Rigor::CLI::TraceCommand prints usage without a FILE argument
   #<Thread:0x… lib/rigor/runtime/jit.rb:112 sleep> ["…jit.rb:113:in 'Kernel#sleep'", …]
```

`jit_spec` is where the bill came due: its `around` hook deletes `RIGOR_DISABLE_YJIT` and its `stub_yjit_off` replaces both `RubyVM::YJIT` methods, all process-global. A leaked sleeper waking inside that window skips its own opt-out check and lands on the stub, so the example counts calls it never made. The stub lives for one ~10 ms example, which is why the race is rare — and why it depends on which spec files share a binpacker worker process: green at 12 workers locally, red at 4 on CI.

## Fix

Pin the product's own opt-out, `RIGOR_DISABLE_YJIT=1`, for the whole suite, beside the existing `RIGOR_CI_DETECT` pin in `spec_helper`. `enable_after` returns `nil` and spawns **no** thread when it is set, so the leak becomes unreachable rather than merely unlikely — a CLI spec written tomorrow cannot reintroduce it, and no shared helper has to be routed through. The pin reaches subprocess `rigor` runs by inheritance too, which only makes those more deterministic: YJIT changes wall-time, never diagnostics or allocations.

`jit_spec` already snapshots and clears both switches per example, so it keeps exercising the unpinned behaviour; it is now the one file that lifts the pin, and its comment says so. `cli_spec` gains the example that fails if the pin is ever dropped, so the next regression is named at the seam instead of resurfacing as a flake somewhere unrelated.

Loosening the assertion to `at_least(:once)` was rejected: it hides the count while leaving real sleeper threads roaming the suite.

## Verification

Deterministic reproduction — a staggered fleet of real deadlines armed through the dispatcher ahead of `jit_spec`, so wakes span its examples instead of racing a 10 ms window:

| suite | result |
| --- | --- |
| pin lifted (pre-fix) | `1) …enable_after spawns a thread that enables YJIT after the delay` — `expected: 1 time … received: 9 times` |
| pin active (this PR) | 3/3 green |

The thread-leak probe over the six CLI-driving spec files reports zero sleepers after the change (the only threads left are `jit_spec`'s own, already `join`ed or `kill`ed).

`make verify` green, exit 0; `git diff --check` clean.