### PR TITLE
Take binpacker from rubygems again, at 0.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,14 +5,3 @@ source "https://rubygems.org"
 ruby ">= 4.0.0", "< 4.1"
 
 gemspec
-
-# Source override only — the version constraint stays on the gemspec's development dependency.
-#
-# The sharded `Tests` matrix in .github/workflows/ci.yml needs `binpacker run --shard K/N` and
-# `binpacker shards-check`, which are on binpacker's master but not in any released gem: 0.4.0 predates
-# them. Pinned to an explicit revision rather than a branch so a push to binpacker cannot silently change
-# what Rigor's CI runs.
-#
-# Replace this whole entry with nothing — the gemspec dependency then resolves from rubygems again — as
-# soon as a binpacker release carries sharding.
-gem "binpacker", git: "https://github.com/rigortype/binpacker", ref: "6019ce9acc2882faa7496a24f54a25dbb8549f38"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/rigortype/binpacker
-  revision: 6019ce9acc2882faa7496a24f54a25dbb8549f38
-  ref: 6019ce9acc2882faa7496a24f54a25dbb8549f38
-  specs:
-    binpacker (0.4.0)
-
 PATH
   remote: .
   specs:
@@ -32,6 +25,7 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
+    binpacker (0.5.0)
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     diff-lcs (1.6.2)
@@ -115,7 +109,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (>= 7.0, < 9.0)
-  binpacker (>= 0.1.0, >= 0, < 1.0)!
+  binpacker (>= 0.5.0, < 1.0)
   rack (>= 2.0, < 4.0)
   rake (>= 13.0, < 15.0)
   rbs-inline (>= 0.5, < 1.0)
@@ -131,7 +125,7 @@ CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
-  binpacker (0.4.0)
+  binpacker (0.5.0) sha256=c6dde570909cdab7102dcc76abb95345b87b48233378c5f09b4fbe0f1ade76e4
   bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a

--- a/rigortype.gemspec
+++ b/rigortype.gemspec
@@ -90,7 +90,11 @@ Gem::Specification.new do |spec|
   # exercises the real catalogue; the production dep belongs on the
   # plugin gem (rspec-rails apps already pull rack via actionpack).
   spec.add_development_dependency "rack", ">= 2.0", "< 4.0"
-  spec.add_development_dependency "binpacker", ">= 0.1.0", "< 1.0"
+  # 0.5.0 is the floor, not a preference: CI's `Tests` matrix runs `binpacker run --shard K/N` and gates
+  # the merge on `binpacker shards-check`, both of which arrived in 0.5.0. An older binpacker would fail
+  # the run on an unknown flag rather than quietly running the whole suite three times, but it would fail
+  # it far from the cause.
+  spec.add_development_dependency "binpacker", ">= 0.5.0", "< 1.0"
   spec.add_development_dependency "rake", ">= 13.0", "< 15.0"
   # ADR-32 — the `rigor-rbs-inline` plugin under `plugins/`
   # depends on the upstream `rbs-inline` gem at runtime. The


### PR DESCRIPTION
Closes out the temporary git pin from [#566](https://github.com/rigortype/rigor/pull/566). [binpacker 0.5.0](https://rubygems.org/gems/binpacker/versions/0.5.0) released `--shard K/N` and `shards-check`, so the source override has done its job and comes out — the gemspec development dependency resolves from rubygems again.

Its floor moves `>= 0.1.0` → `>= 0.5.0`, which is now a real constraint rather than a formality: CI runs `binpacker run --shard K/N` and gates the merge on `binpacker shards-check`. An older binpacker would fail the run on an unknown flag rather than quietly running the whole suite three times, but it would fail it a long way from the cause, so the gemspec says what CI actually needs.

## Verified against the released gem, not just the lockfile

A gemspec `files` glob can omit a new file and still publish, so the check is that sharding works from the installed gem rather than that the lockfile says 0.5.0:

| shard | examples |
| --- | --- |
| 1/3 | 3103 |
| 2/3 | 3692 |
| 3/3 | 3412 |

`binpacker shards-check` → `3 shards cover all 423 tests`, and the slices sum to 10207 — the whole suite, which `make verify` independently reports for the unsharded run.

`make verify` green (10207 examples, no offenses); `git diff --check` clean. No changelog fragment: a development dependency is dev-only, so nothing here reaches a user of the gem.