### PR TITLE
Fold JSON.generate and JSON.pretty_generate to String

### DIFF
--- a/changelog.d/added/json-generate-fold.md
+++ b/changelog.d/added/json-generate-fold.md
@@ -1,1 +1,1 @@
-- **[engine]** `JSON.generate` and `JSON.pretty_generate` now type as `String` instead of widening to `untyped`, closing a named-receiver-opaque gap upstream RBS left on `pretty_generate`. ([PR #TBD](https://github.com/rigortype/rigor/pull/TBD))
+- **[engine]** `JSON.generate` and `JSON.pretty_generate` now type as `String` instead of widening to `untyped`, closing a named-receiver-opaque gap upstream RBS left on `pretty_generate`. ([#571](https://github.com/rigortype/rigor/pull/571))

--- a/changelog.d/added/json-generate-fold.md
+++ b/changelog.d/added/json-generate-fold.md
@@ -1,0 +1,1 @@
+- **[engine]** `JSON.generate` and `JSON.pretty_generate` now type as `String` instead of widening to `untyped`, closing a named-receiver-opaque gap upstream RBS left on `pretty_generate`. ([PR #TBD](https://github.com/rigortype/rigor/pull/TBD))

--- a/lib/rigor/inference/method_dispatcher.rb
+++ b/lib/rigor/inference/method_dispatcher.rb
@@ -749,7 +749,7 @@ module Rigor
       # receiver and their relative trial order was never observable. Compiling them into a
       # class-name table turns nine no-op trials per call into one Hash read, skipped entirely
       # when the receiver is not a `Singleton` (the overwhelmingly common case). The table sits
-      # where the nine sat in the old flat list: after ShapeDispatch, before KernelDispatch.
+      # where the original eight sat in the old flat list: after ShapeDispatch, before KernelDispatch.
       STDLIB_SINGLETON_FOLDERS = Ractor.make_shareable({
         "File" => FileFolding,
         "Shellwords" => ShellwordsFolding,

--- a/lib/rigor/inference/method_dispatcher.rb
+++ b/lib/rigor/inference/method_dispatcher.rb
@@ -29,6 +29,7 @@ require_relative "method_dispatcher/regexp_folding"
 require_relative "method_dispatcher/cgi_folding"
 require_relative "method_dispatcher/uri_folding"
 require_relative "method_dispatcher/set_folding"
+require_relative "method_dispatcher/json_folding"
 require_relative "method_dispatcher/kernel_dispatch"
 require_relative "method_dispatcher/universal_object_dispatch"
 require_relative "method_dispatcher/singleton_mixin_dispatch"
@@ -732,7 +733,7 @@ module Rigor
       #
       # The precise-tier folders, consulted in order via the uniform `_DispatchTier` interface
       # (`try_dispatch(CallContext) -> Type?`). Order is significant: ConstantFolding's
-      # exact-value folds win first, the eight stdlib singleton folders sit in the middle (each
+      # exact-value folds win first, the stdlib singleton folders sit in the middle (each
       # gates on a distinct `Singleton` receiver, so their relative order is immaterial), and
       # BlockFolding runs last because its rules only apply to block-taking calls — the cheaper
       # arity folds above it filter the common cases first. Adding a precise tier is a one-line
@@ -742,13 +743,13 @@ module Rigor
       ].freeze)
       private_constant :PRECISE_TIERS_HEAD
 
-      # ADR-53 re-review follow-up (gate-by-held-key applied to the built-in tiers): the eight
-      # stdlib singleton folders are mutually exclusive — each fires only on `Singleton[<its
+      # ADR-53 re-review follow-up (gate-by-held-key applied to the built-in tiers): the stdlib
+      # singleton folders are mutually exclusive — each fires only on `Singleton[<its
       # class>]`, the first check in every `try_dispatch` — so at most one can match a given
       # receiver and their relative trial order was never observable. Compiling them into a
-      # class-name table turns eight no-op trials per call into one Hash read, skipped entirely
+      # class-name table turns nine no-op trials per call into one Hash read, skipped entirely
       # when the receiver is not a `Singleton` (the overwhelmingly common case). The table sits
-      # where the eight sat in the old flat list: after ShapeDispatch, before KernelDispatch.
+      # where the nine sat in the old flat list: after ShapeDispatch, before KernelDispatch.
       STDLIB_SINGLETON_FOLDERS = Ractor.make_shareable({
         "File" => FileFolding,
         "Shellwords" => ShellwordsFolding,
@@ -757,7 +758,8 @@ module Rigor
         "Regexp" => RegexpFolding,
         "CGI" => CGIFolding,
         "URI" => URIFolding,
-        "Set" => SetFolding
+        "Set" => SetFolding,
+        "JSON" => JSONFolding
       }.freeze)
       private_constant :STDLIB_SINGLETON_FOLDERS
 

--- a/lib/rigor/inference/method_dispatcher/json_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/json_folding.rb
@@ -29,7 +29,7 @@ module Rigor
       # * `generate(obj)` / `generate(obj, opts)` — returns `Nominal[String]`.
       # * `pretty_generate(obj)` / `pretty_generate(obj, opts)` — returns `Nominal[String]`.
       #
-      # === Non-constant / unsupported cases
+      # === Unsupported cases
       #
       # Returns `nil` (deferring to the next dispatcher tier) when:
       # - the receiver is not `Singleton[JSON]`,

--- a/lib/rigor/inference/method_dispatcher/json_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/json_folding.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require_relative "../../type"
+require_relative "singleton_folding"
+
+module Rigor
+  module Inference
+    module MethodDispatcher
+      # Folds `JSON.generate` / `JSON.pretty_generate` to their precise return type.
+      #
+      # Both methods always return a `String` or raise (`JSON::GeneratorError`, `JSON::NestingError`, …) —
+      # never `nil`, never a non-`String` value. Upstream RBS (`stdlib/json/0/json.rbs`) already declares
+      # `generate` as `-> String`, but `pretty_generate` is declared `-> untyped`, so every
+      # `JSON.pretty_generate` call widens to `Dynamic[top]` and every downstream method call on the result
+      # loses precision with it. This tier closes that gap by construction rather than waiting on an
+      # upstream RBS fix, and folds `generate` alongside it for symmetry — a `Nominal[String]` answer here
+      # is monotone over both today's `untyped` (`pretty_generate`) and today's already-precise `String`
+      # (`generate`).
+      #
+      # Unlike `CGIFolding` / `ShellwordsFolding`, this tier does NOT evaluate the argument. `JSON.generate`
+      # is not a pure function whose *result* can be computed at analysis time in general — the object graph
+      # can be arbitrarily large, cyclic, or rely on a user-defined `#to_json` — so only the *return type* is
+      # folded here, never the *return value*. A future literal-argument constant fold (mirroring
+      # `ConstantFolding`'s treatment of other pure stdlib calls) can layer on top of this tier without
+      # changing it.
+      #
+      # === Supported methods
+      #
+      # * `generate(obj)` / `generate(obj, opts)` — returns `Nominal[String]`.
+      # * `pretty_generate(obj)` / `pretty_generate(obj, opts)` — returns `Nominal[String]`.
+      #
+      # === Non-constant / unsupported cases
+      #
+      # Returns `nil` (deferring to the next dispatcher tier) when:
+      # - the receiver is not `Singleton[JSON]`,
+      # - the method is not `generate` / `pretty_generate` (e.g. `JSON.parse`, `JSON.dump`),
+      # - the call has the wrong arity (not 1 or 2 positional arguments).
+      module JSONFolding
+        JSON_GENERATE_METHODS = Set[:generate, :pretty_generate].freeze
+        private_constant :JSON_GENERATE_METHODS
+
+        module_function
+
+        # @return [Rigor::Type, nil] folded result, or nil to defer.
+        def try_dispatch(context)
+          receiver = context.receiver
+          method_name = context.method_name
+          args = context.args
+          return nil unless SingletonFolding.receiver?(receiver, "JSON")
+          return nil unless JSON_GENERATE_METHODS.include?(method_name)
+          return nil unless args.size.between?(1, 2)
+
+          Type::Combinator.nominal_of("String")
+        end
+      end
+    end
+  end
+end

--- a/spec/rigor/inference/method_dispatcher/json_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/json_folding_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Rigor::Inference::MethodDispatcher::JSONFolding do
+  def json_singleton = Rigor::Type::Combinator.singleton_of("JSON")
+  def c(value) = Rigor::Type::Combinator.constant_of(value)
+  def string_t = Rigor::Type::Combinator.nominal_of("String")
+
+  def fold(method_name, *arg_types)
+    described_class.try_dispatch(cc(
+                                   receiver: json_singleton,
+                                   method_name: method_name,
+                                   args: arg_types
+                                 ))
+  end
+
+  # ── generate / pretty_generate ─────────────────────────────────────────
+
+  describe "generate / pretty_generate" do
+    it "types JSON.pretty_generate({}) as Nominal[String]" do
+      hash_arg = Rigor::Type::Combinator.hash_shape_of({})
+      expect(fold(:pretty_generate, hash_arg)).to eq(string_t)
+    end
+
+    it "types JSON.generate([]) as Nominal[String]" do
+      array_arg = Rigor::Type::Combinator.tuple_of
+      expect(fold(:generate, array_arg)).to eq(string_t)
+    end
+
+    it "folds regardless of the argument's shape (not a literal-value fold)" do
+      expect(fold(:generate, Rigor::Type::Combinator.untyped)).to eq(string_t)
+      expect(fold(:generate, c(42))).to eq(string_t)
+      expect(fold(:generate, Rigor::Type::Combinator.nominal_of("Object"))).to eq(string_t)
+    end
+
+    it "accepts the optional second (options) argument" do
+      hash_arg = Rigor::Type::Combinator.hash_shape_of({})
+      opts = Rigor::Type::Combinator.hash_shape_of({})
+      expect(fold(:pretty_generate, hash_arg, opts)).to eq(string_t)
+    end
+  end
+
+  # ── decline / edge cases ────────────────────────────────────────────────
+
+  describe "decline cases" do
+    it "declines for JSON.parse — an unrelated JSON method stays untyped" do
+      expect(fold(:parse, c("{}"))).to be_nil
+    end
+
+    it "declines for JSON.dump — another unsupported method" do
+      expect(fold(:dump, Rigor::Type::Combinator.hash_shape_of({}))).to be_nil
+    end
+
+    it "declines when the argument list is empty" do
+      expect(fold(:generate)).to be_nil
+    end
+
+    it "declines when given more than two arguments" do
+      hash_arg = Rigor::Type::Combinator.hash_shape_of({})
+      expect(fold(:generate, hash_arg, hash_arg, hash_arg)).to be_nil
+    end
+
+    it "declines for a non-Singleton receiver" do
+      result = described_class.try_dispatch(cc(
+                                              receiver: c("JSON"),
+                                              method_name: :generate,
+                                              args: [Rigor::Type::Combinator.hash_shape_of({})]
+                                            ))
+      expect(result).to be_nil
+    end
+
+    it "declines for a Nominal[JSON] instance receiver (not the singleton)" do
+      result = described_class.try_dispatch(cc(
+                                              receiver: Rigor::Type::Combinator.nominal_of("JSON"),
+                                              method_name: :generate,
+                                              args: [Rigor::Type::Combinator.hash_shape_of({})]
+                                            ))
+      expect(result).to be_nil
+    end
+
+    it "declines for a wrong singleton class" do
+      result = described_class.try_dispatch(cc(
+                                              receiver: Rigor::Type::Combinator.singleton_of("CGI"),
+                                              method_name: :generate,
+                                              args: [Rigor::Type::Combinator.hash_shape_of({})]
+                                            ))
+      expect(result).to be_nil
+    end
+
+    it "declines for a Dynamic receiver" do
+      result = described_class.try_dispatch(cc(
+                                              receiver: Rigor::Type::Combinator.untyped,
+                                              method_name: :generate,
+                                              args: [Rigor::Type::Combinator.hash_shape_of({})]
+                                            ))
+      expect(result).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Implements #570, from the 2026-09-01 post-campaign opacity re-run: `JSON.pretty_generate` is declared `-> untyped` in upstream RBS (`stdlib/json/0/json.rbs`), so all 25 rigor-lib + 3 herb call sites widened to `Dynamic[top]`. This adds a `JSONFolding` singleton tier (modeled on `CGIFolding`/`ShellwordsFolding`, registered in the `STDLIB_SINGLETON_FOLDERS` table) returning `Nominal[String]` for `generate`/`pretty_generate` with 1–2 args — monotone over today's answers. Return-TYPE fold only: the tier deliberately does not evaluate the argument (a literal-argument constant fold can layer on later without changing it).

Note for review: upstream RBS already declares `generate -> String`, so the `generate` half is redundant defense-in-depth today; `pretty_generate` is the actual gap. Both are folded for symmetry per the issue.

Specs: 12 examples mirroring `cgi_folding_spec.rb` — must-fire for both methods and the 2-arg form, paired declines for `JSON.parse`/`JSON.dump`, wrong arity, non-Singleton and instance receivers, wrong singleton class, and Dynamic receiver.

Gates: full `make verify` + 11-target corpus FP diff run serially at landing (expected byte-identical — the fold is monotone); results will be posted below before merge.

Closes #570.