### PR TITLE
Carry the struct fold-safety set through scope joins

### DIFF
--- a/changelog.d/fixed/loop-preserves-untouched-carriers.md
+++ b/changelog.d/fixed/loop-preserves-untouched-carriers.md
@@ -1,0 +1,1 @@
+- **[engine]** A `Struct` member read now still folds to its known value after an `if` or `while` earlier in the method, instead of going untyped for the rest of the body whenever the code branched at all. ([#589](https://github.com/rigortype/rigor/issues/589))

--- a/changelog.d/fixed/loop-preserves-untouched-carriers.md
+++ b/changelog.d/fixed/loop-preserves-untouched-carriers.md
@@ -1,1 +1,1 @@
-- **[engine]** A `Struct` member read now still folds to its known value after an `if` or `while` earlier in the method, instead of going untyped for the rest of the body whenever the code branched at all. ([#589](https://github.com/rigortype/rigor/issues/589))
+- **[engine]** A `Struct` member read now still folds to its known value after an `if` or `while` earlier in the method, instead of going untyped for the rest of the body whenever the code branched at all. ([#589](https://github.com/rigortype/rigor/issues/589), [#596](https://github.com/rigortype/rigor/pull/596))

--- a/docs/adr/56-block-captured-local-mutation.md
+++ b/docs/adr/56-block-captured-local-mutation.md
@@ -370,6 +370,19 @@ that scan's answer rather than contradicting it. All three still
 decline, and folding now also holds across this ADR's loop fixpoint
 rather than for a single pass.
 
+Restoring the grant did expose a real gap in that scan, fixed in the
+same change. The scan's counting identity is about the LOCAL and says
+nothing about a member read's RESULT: `s.x << v` mutates the container
+`s.x` returns while `s.x` is a textbook pure read, so the local stayed
+fold-safe while its member's value changed underneath. A local whose
+member-read result is itself a receiver is now disqualified outright,
+with no allow-list of its own — `s.x.to_s` loses precision for
+nothing, but an allow-list is what produced the bug, and being too
+broad only costs a `Dynamic[top]`. That also removes a pre-existing
+false positive on the straight-line form, which fired before this
+branch existed. The scan header's claim that a missed case is "never
+unsound" was false and is corrected there. Remaining residual: #597.
+
 **The payoff was measured and it is NOT mail's ragel cluster**, which
 the issue named as the target. Both of that file's structs are
 excluded for reasons this fix does not touch:

--- a/docs/adr/56-block-captured-local-mutation.md
+++ b/docs/adr/56-block-captured-local-mutation.md
@@ -346,6 +346,43 @@ also remains open; the evidence from the attempt, including why a
 scope-side provenance mark cannot carry the signature protection across
 a method return, is recorded on the issue.
 
+### WD2.7 — A merge revoked struct fold-safety (2026-09-02, issue #589)
+
+Reported as "a `while` loop erases a struct local's carrier even when
+the body never touches it", and expected to be a loop-seam widening
+problem in this ADR's territory. It was neither.
+
+The carrier survives the merge intact — `s` still reads
+`S(raw: "r")` there. What was lost is the GRANT that lets a member
+read consult it: `Scope#join` omitted `struct_fold_safe_locals` from
+its constructor call, so it fell back to the empty default. Every
+merge in a method body silently revoked struct member folding for
+everything after it, and an `if` did it exactly as a `while` did —
+this was never loop-specific. The grant is now intersected across the
+merge (both arms normally carry the identical set, since it is a
+static scan over the method root; intersecting is the FP-safe
+direction, because the grant licenses a fold).
+
+Nothing about fold SAFETY moved. The static scan already disqualifies
+a local whose setter sits inside a loop or block (`deferred_setter`),
+one the body rebinds, and one that escapes; the join was discarding
+that scan's answer rather than contradicting it. All three still
+decline, and folding now also holds across this ADR's loop fixpoint
+rather than for a single pass.
+
+**The payoff was measured and it is NOT mail's ragel cluster**, which
+the issue named as the target. Both of that file's structs are
+excluded for reasons this fix does not touch:
+`address` takes 131 member setters INSIDE the ragel `while`, so
+`deferred_setter` disqualifies it — and that gate is load-bearing
+(#525's sibling verified that removing it serves a stale `nil`);
+`address_list` is returned twice as a bare read, so the escape rule
+disqualifies it. Zero of the ~250 sites unlock. What DOES unlock is
+every struct local a merge previously revoked: a member read after an
+untouching `if` or `while`, and an ADR-48 slice-4 setter write-back
+surviving one. Reaching mail needs a different lever — modelling an
+in-loop setter's per-iteration effect — not this one.
+
 ### WD3 — One mechanism, shared
 
 Slices A and B implement **one** fixpoint helper (body-evaluator +

--- a/lib/rigor/inference/struct_fold_safety.rb
+++ b/lib/rigor/inference/struct_fold_safety.rb
@@ -15,8 +15,16 @@ module Rigor
     # The analysis is a conservative ALLOW-LIST, not a deny-list: a local is fold-safe only when *every* read of it is
     # the receiver of a known-pure read call. Anything the scan does not recognise as a pure read — a setter, an `[]=` /
     # operator-write, an argument / alias / container store / return (escape), or an unknown method call (which could
-    # mutate `self` internally) — disqualifies the local. A missed case therefore makes the scan over-conservative (no
-    # fold), **never unsound** (folding a mutated value) — the false-positive-safe direction.
+    # mutate `self` internally) — disqualifies the local.
+    #
+    # A missed case is USUALLY only over-conservative (no fold), but the direction is not guaranteed, and an earlier
+    # version of this header claimed it was. The counting identity below is about the LOCAL; it says nothing about what
+    # happens to a member read's RESULT. `s.x << v` mutates the container `s.x` returns while `s.x` itself is a
+    # textbook pure read, so the identity held and the local stayed fold-safe while its member's VALUE changed
+    # underneath — `s = Point.new([5]); s.x << "a"; s.x.last` folded to `5` and drew `undefined method 'upcase' for 5`
+    # on correct code. That is why {#count_uses} disqualifies a local whose member-read result is itself a receiver
+    # (see there). Any future extension must ask the same question: does this shape reach the member's value through
+    # something other than the local?
     #
     # Soundness rests on a counting identity: a local `n` is fold-safe iff *every* `LocalVariableReadNode(n)` is the
     # receiver of a pure-read call. Equivalently `total_reads(n) == pure_receiver_reads(n)`. Any other occurrence — `n`
@@ -59,10 +67,12 @@ module Rigor
         collect_struct_locals(root, layout_lookup, members, writes)
         return EMPTY if members.empty?
 
-        total = Hash.new(0)
-        safe_uses = Hash.new(0)
-        deferred_setter = {}
-        count_uses(root, members, total, safe_uses, deferred_setter, false)
+        tally = Tally.new(total: Hash.new(0), safe_uses: Hash.new(0), deferred_setter: {}, chained: {})
+        count_uses(root, members, tally, false)
+        total = tally.total
+        safe_uses = tally.safe_uses
+        deferred_setter = tally.deferred_setter
+        chained = tally.chained
 
         # A local is fold-safe iff every read of it is a safe use — a pure read OR (ADR-48 slice 4) a
         # straight-line member setter (`n.x = v`) that the setter write-back re-types the binding for.
@@ -71,7 +81,7 @@ module Rigor
         # stale binding for the fold to read).
         safe = members.each_key.select do |name|
           writes[name] == 1 && total[name].positive? &&
-            total[name] == safe_uses[name] && !deferred_setter[name]
+            total[name] == safe_uses[name] && !deferred_setter[name] && !chained[name]
         end
         safe.empty? ? EMPTY : safe.to_set
       end
@@ -95,28 +105,61 @@ module Rigor
       # Pass 2 — count, per recorded struct local, total reads vs. SAFE-use reads (the receiver of a pure-read call,
       # or of a straight-line member setter). `deferred` is true inside a loop / block / lambda; a member setter seen
       # there marks the local's `deferred_setter` so it is excluded (its write-back cannot be modelled statically).
-      def count_uses(node, members, total, safe_uses, deferred_setter, deferred)
+      # The four per-local accumulators pass 2 fills, bundled so the walk stays one recursive call rather than a
+      # seven-argument one.
+      Tally = Struct.new(:total, :safe_uses, :deferred_setter, :chained, keyword_init: true)
+
+      def count_uses(node, members, tally, deferred)
         return if node.nil?
 
-        total[node.name] += 1 if node.is_a?(Prism::LocalVariableReadNode) && members.key?(node.name)
-
-        if node.is_a?(Prism::CallNode)
-          receiver = node.receiver
-          if receiver.is_a?(Prism::LocalVariableReadNode) && members.key?(receiver.name)
-            member_set = members[receiver.name]
-            if pure_read_call?(node, member_set)
-              safe_uses[receiver.name] += 1
-            elsif member_setter_call?(node, member_set)
-              safe_uses[receiver.name] += 1
-              deferred_setter[receiver.name] = true if deferred
-            end
-          end
-        end
+        tally.total[node.name] += 1 if node.is_a?(Prism::LocalVariableReadNode) && members.key?(node.name)
+        chained_local_of(node, members)&.then { |name| tally.chained[name] = true }
+        count_receiver_use(node, members, tally, deferred)
 
         child_deferred = deferred || deferred_boundary?(node)
         each_local_scope_child(node) do |child|
-          count_uses(child, members, total, safe_uses, deferred_setter, child_deferred)
+          count_uses(child, members, tally, child_deferred)
         end
+      end
+
+      # The `<local>.<call>` arm: a pure read or a member setter counts as a SAFE use of the local, and a setter
+      # seen inside a loop / block / lambda additionally marks `deferred_setter`.
+      def count_receiver_use(node, members, tally, deferred)
+        return unless node.is_a?(Prism::CallNode)
+
+        receiver = node.receiver
+        return unless receiver.is_a?(Prism::LocalVariableReadNode) && members.key?(receiver.name)
+
+        member_set = members[receiver.name]
+        if pure_read_call?(node, member_set)
+          tally.safe_uses[receiver.name] += 1
+        elsif member_setter_call?(node, member_set)
+          tally.safe_uses[receiver.name] += 1
+          tally.deferred_setter[receiver.name] = true if deferred
+        end
+      end
+
+      # The tracked local behind `<local>.<member>` when THAT read is itself the receiver of a further call —
+      # `s.x << v`, `s.x.push(v)`, `row.cells.size`. The counting identity above cannot see these: `s.x` is a
+      # pure read of `s` by every measure it applies, and the mutation lands on the object `s.x` RETURNS. The
+      # local stays fold-safe, the fold serves the materialisation value, and a correct program is told its
+      # accumulated container still holds only what it was built with.
+      #
+      # Any call on the result disqualifies, with no allow-list of its own. `s.x.to_s` is provably harmless and
+      # loses precision here for nothing — but an allow-list is what produced this bug in the first place, and
+      # the failure mode of being too broad is a `Dynamic[top]` where a constant would do. Reads that do NOT
+      # chain (`dump_type(p.x)`, `assert_type("1", stored.foo)`, a bare `s.x`) are arguments or values, not
+      # receivers, and keep folding.
+      def chained_local_of(node, members)
+        return nil unless node.is_a?(Prism::CallNode)
+
+        inner = node.receiver
+        return nil unless inner.is_a?(Prism::CallNode)
+
+        local = inner.receiver
+        return nil unless local.is_a?(Prism::LocalVariableReadNode) && members.key?(local.name)
+
+        local.name
       end
 
       # A call is a pure read of the receiver when its name is a fixed Struct read or one of the receiver's member

--- a/lib/rigor/scope.rb
+++ b/lib/rigor/scope.rb
@@ -900,12 +900,16 @@ module Rigor
 
     # Issue #589 — intersect the struct fold-safe grants. Zero-alloc on the common path, where both arms
     # carry the same frozen set the body scan stamped.
+    # A `nil` on EITHER side yields no grants. The field is keyword-defaulted to `EMPTY_FOLD_SAFE` and
+    # threaded by `rebuild`, so `nil` should be unreachable — but the two sides are deliberately symmetric
+    # rather than one arm trusting the other, because the asymmetric form kept every grant when the OTHER
+    # side was nil, which is the one direction that can fold a stale value.
     def join_struct_fold_safe(other)
       mine = @struct_fold_safe_locals
       theirs = other.struct_fold_safe_locals
-      return mine if mine.equal?(theirs) || theirs.nil?
-      return EMPTY_FOLD_SAFE if mine.nil? || mine.empty? || theirs.empty?
-      return mine if mine == theirs
+      return EMPTY_FOLD_SAFE if mine.nil? || theirs.nil?
+      return mine if mine.equal?(theirs) || mine == theirs
+      return EMPTY_FOLD_SAFE if mine.empty? || theirs.empty?
 
       intersected = mine & theirs
       intersected.empty? ? EMPTY_FOLD_SAFE : intersected.freeze

--- a/lib/rigor/scope.rb
+++ b/lib/rigor/scope.rb
@@ -875,6 +875,19 @@ module Rigor
         # flow-live and `possible-nil-receiver` fires as before.
         declaration_sourced: join_declaration_sourced(other),
         source_path: source_path,
+        # Issue #589 — the fold-safe set MUST survive a merge. It was simply absent from this constructor
+        # call, so it fell back to the empty default and every `if` / `while` in a method silently revoked
+        # struct member folding for the whole body after it: `s = S.new("r"); while c; i += 1; end; s.raw`
+        # answered `Dynamic[top]` while the straight-line sibling folded to `"r"`. The carrier was never
+        # the casualty — `s` still reads `S(raw: "r")` at the merge — only the grant that lets a read
+        # consult it, which is why the shape looked like carrier erasure from the outside.
+        #
+        # The set is a property of the method BODY (a static scan over its root, stamped once by
+        # `ScopeIndexer` / `StatementEvaluator` and threaded by `rebuild`), so both arms of a merge
+        # normally carry the identical set and the intersection below is that set. Intersecting rather
+        # than unioning is the FP-safe direction anyway: the grant licenses a FOLD, so retaining one an
+        # arm did not have could fold a stale constant, while dropping one only costs precision.
+        struct_fold_safe_locals: join_struct_fold_safe(other),
         dynamic_origins: @dynamic_origins,
         local_origins: join_origins(@local_origins, other.local_origins),
         ivar_origins: join_origins(@ivar_origins, other.ivar_origins),
@@ -883,6 +896,19 @@ module Rigor
         optimistic_locals: join_origins(@optimistic_locals, other.optimistic_locals),
         optimistic_ivars: join_origins(@optimistic_ivars, other.optimistic_ivars)
       )
+    end
+
+    # Issue #589 — intersect the struct fold-safe grants. Zero-alloc on the common path, where both arms
+    # carry the same frozen set the body scan stamped.
+    def join_struct_fold_safe(other)
+      mine = @struct_fold_safe_locals
+      theirs = other.struct_fold_safe_locals
+      return mine if mine.equal?(theirs) || theirs.nil?
+      return EMPTY_FOLD_SAFE if mine.nil? || mine.empty? || theirs.empty?
+      return mine if mine == theirs
+
+      intersected = mine & theirs
+      intersected.empty? ? EMPTY_FOLD_SAFE : intersected.freeze
     end
 
     # ADR-82 WD1 — merge two branches' propagated origins (self wins on a name conflict; advisory metadata, so

--- a/spec/rigor/inference/method_dispatcher/struct_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/struct_folding_spec.rb
@@ -96,6 +96,97 @@ RSpec.describe "Struct.new value folding", type: :runner do
       RUBY
     end
 
+    # Issue #589 — a merge must not revoke the grant. `Scope#join` omitted the fold-safe set from its
+    # constructor, so it fell back to the empty default and EVERY `if` / `while` in a method silently
+    # stopped struct folding for the rest of the body. The carrier survived the merge intact; only the
+    # grant that lets a read consult it was lost, which is why the shape read as carrier erasure.
+    it "folds after a loop whose body never touches the struct" do
+      expect(dumped_types(<<~RUBY)).to eq(["1"])
+        Point = Struct.new(:x, :y)
+        def reader(n)
+          p = Point.new(1, 2)
+          i = 0
+          while i < n
+            i += 1
+          end
+          dump_type(p.x)
+        end
+      RUBY
+    end
+
+    # The same seam, reached through an `if` — this was never loop-specific.
+    it "folds after a conditional whose branches never touch the struct" do
+      expect(dumped_types(<<~RUBY)).to eq(["1"])
+        Point = Struct.new(:x, :y)
+        def reader(cond)
+          p = Point.new(1, 2)
+          if cond
+            puts "side effect"
+          end
+          dump_type(p.x)
+        end
+      RUBY
+    end
+
+    # …and it holds across the ADR-56 loop fixpoint rather than for one pass: a read INSIDE a later loop
+    # sees the grant too.
+    it "folds inside a later loop body after an untouching loop" do
+      expect(dumped_types(<<~RUBY)).to eq(["1"])
+        Point = Struct.new(:x, :y)
+        def reader(cond, n)
+          p = Point.new(1, 2)
+          i = 0
+          while i < n
+            i += 1
+          end
+          while cond
+            dump_type(p.x)
+          end
+        end
+      RUBY
+    end
+
+    # The must-still-decline half, and the reason the grant is computed by a static body scan rather than
+    # inferred at the merge. A setter inside a loop or block cannot be modelled by a single static pass, so
+    # the local is disqualified up front; without that gate the read serves the stale materialisation value
+    # (verified unsound on #525's sibling — it answered `nil` for a member the block had written).
+    it "does NOT fold a member whose setter sits inside a block" do
+      expect(dumped_types(<<~RUBY)).to eq(["Dynamic[top]"])
+        Point = Struct.new(:x, :y)
+        def reader
+          p = Point.new(1, 2)
+          [1].each { p.x = 9 }
+          dump_type(p.x)
+        end
+      RUBY
+    end
+
+    it "does NOT fold a member whose setter sits inside a loop" do
+      expect(dumped_types(<<~RUBY)).to eq(["Dynamic[top]"])
+        Point = Struct.new(:x, :y)
+        def reader(cond)
+          p = Point.new(1, 2)
+          while cond
+            p.x = 9
+          end
+          dump_type(p.x)
+        end
+      RUBY
+    end
+
+    it "does NOT fold a local the loop body rebinds" do
+      expect(dumped_types(<<~RUBY)).to eq(["Dynamic[top]"])
+        Point = Struct.new(:x, :y)
+        def reader(cond)
+          p = Point.new(1, 2)
+          while cond
+            p = Point.new(3, 4)
+          end
+          dump_type(p.x)
+        end
+      RUBY
+    end
+
     it "does NOT fold a bound local that escapes through an alias" do
       expect(dumped_types(<<~RUBY)).to eq(["Dynamic[top]"])
         Point = Struct.new(:x, :y)

--- a/spec/rigor/inference/method_dispatcher/struct_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/struct_folding_spec.rb
@@ -187,6 +187,82 @@ RSpec.describe "Struct.new value folding", type: :runner do
       RUBY
     end
 
+    # Issue #589 / review of #596 — the scan's counting identity is about the LOCAL, and says nothing about
+    # a member read's RESULT. `s.x << v` mutates the container `s.x` returns while `s.x` is a pure read by
+    # every measure the scan applies, so the local stayed fold-safe while its member's value changed
+    # underneath: `s.x.last` folded to 5 and `.upcase` drew undefined-method on correct code.
+    it "does NOT fold a member whose result is mutated through a chained call in a loop" do
+      expect(dumped_types(<<~RUBY)).to eq(["Dynamic[top]"])
+        Point = Struct.new(:x)
+        def reader(c)
+          s = Point.new([5])
+          while c
+            s.x << "a"
+          end
+          dump_type(s.x.last)
+        end
+      RUBY
+    end
+
+    # The post-`if` form, read through a size the fold would answer 1 for while the runtime holds 2.
+    it "does NOT fold a member whose result is mutated through a chained call in a branch" do
+      expect(dumped_types(<<~RUBY)).to eq(["Dynamic[top]"])
+        Row = Struct.new(:cells)
+        def reader(c)
+          row = Row.new([1])
+          if c
+            row.cells.push(2)
+          end
+          dump_type(row.cells.size)
+        end
+      RUBY
+    end
+
+    # The STRAIGHT-LINE sibling, which fired before any of this branch's work: the merge fix extended the
+    # exposure but did not create it, and tightening the scan removes the older false positive too.
+    it "does NOT fold a member whose result is mutated through a chained call on the straight line" do
+      expect(dumped_types(<<~RUBY)).to eq(["Dynamic[top]"])
+        Point = Struct.new(:x)
+        def reader
+          s = Point.new([5])
+          s.x << "a"
+          dump_type(s.x.last)
+        end
+      RUBY
+    end
+
+    # must-still-fold: the disqualifier is about CHAINING, not about branching or about member reads in
+    # general. An untouched member read after a branch keeps its value.
+    it "still folds an untouched member read after a branch" do
+      expect(dumped_types(<<~RUBY)).to eq(["[5]"])
+        Point = Struct.new(:x)
+        def reader(c)
+          s = Point.new([5])
+          if c
+            puts "side"
+          end
+          dump_type(s.x)
+        end
+      RUBY
+    end
+
+    # …and a member read that is an ARGUMENT rather than a receiver is not a chain, so it folds. This is
+    # the shape every `dump_type(p.x)` / `assert_type(..., stored.foo)` in this suite relies on, and it is
+    # what keeps the broad no-allow-list disqualifier from swallowing the feature.
+    it "still folds a member read used as an argument rather than a receiver" do
+      expect(dumped_types(<<~RUBY)).to eq(["1"])
+        Point = Struct.new(:x, :y)
+        def reader(c)
+          p = Point.new(1, 2)
+          if c
+            puts "side"
+          end
+          sink(p.y)
+          dump_type(p.x)
+        end
+      RUBY
+    end
+
     it "does NOT fold a bound local that escapes through an alias" do
       expect(dumped_types(<<~RUBY)).to eq(["Dynamic[top]"])
         Point = Struct.new(:x, :y)

--- a/spec/rigor/scope_spec.rb
+++ b/spec/rigor/scope_spec.rb
@@ -368,4 +368,30 @@ RSpec.describe Rigor::Scope do
       expect(a).not_to eq(c)
     end
   end
+
+  # Issue #589 — the fold-safe set is a property of the method BODY, stamped once by a static scan and
+  # threaded by `rebuild`. `join` omitted it entirely, so every `if` / `while` merge reset it to empty and
+  # revoked struct member folding for the rest of the body.
+  describe "#join struct fold-safety" do
+    it "keeps a grant both arms carry" do
+      left = described_class.empty.with_struct_fold_safe(Set[:p])
+      right = described_class.empty.with_struct_fold_safe(Set[:p])
+      expect(left.join(right).struct_fold_safe?(:p)).to be(true)
+    end
+
+    # Intersection, not union: the grant licenses a FOLD, so retaining one an arm did not have could fold
+    # a stale constant. Dropping one only costs precision.
+    it "drops a grant only one arm carries" do
+      left = described_class.empty.with_struct_fold_safe(Set[:p])
+      expect(left.join(described_class.empty).struct_fold_safe?(:p)).to be(false)
+    end
+
+    it "keeps only the names both arms agree on" do
+      left = described_class.empty.with_struct_fold_safe(Set[:p, :q])
+      right = described_class.empty.with_struct_fold_safe(Set[:q, :r])
+      joined = left.join(right)
+      expect([joined.struct_fold_safe?(:p), joined.struct_fold_safe?(:q), joined.struct_fold_safe?(:r)])
+        .to eq([false, true, false])
+    end
+  end
 end


### PR DESCRIPTION
Implements the mechanism behind #589 — which the investigation corrected: the carrier was never erased. `Scope#join` omitted `struct_fold_safe_locals` from its constructor call, falling back to the empty default, so EVERY merge in a method body — an `if` exactly as much as the issue's `while` — silently revoked the fold grant for everything after it. The fix intersects the set across the merge (both arms normally carry the identical statically-scanned set; intersection is the FP-safe direction since the grant licenses a fold). Nothing about fold SAFETY moved: the static scan (deferred setters, rebinds, escapes) is unchanged — the join was discarding its answer, not contradicting it.

This is also the missing half of #591's flat corpus effect: the grant machinery was revoked by the first branch in most methods; with the set carried through joins, fold-safe struct locals survive ordinary control flow (verified: reads fold after an untouching `while`, after an `if`, and inside a LATER loop across the ADR-56 fixpoint; a slice-4 member write-back now survives a merge).

**The measured negative result, recorded on the issue: mail's ragel cluster does NOT unlock**, for reasons this fix correctly leaves alone — its 131 in-loop `address.<member> =` setters hit the load-bearing `deferred_setter` gate (removing it serves a stale nil, proven), and `address_list` escapes via bare returns. That residual is filed separately as the per-iteration setter-effect question.

Non-vacuity: removing the one join line turns exactly the three must-fold examples red, leaves the three must-decline green (deferred-setter-in-loop, rebinding loop, escapes). Controls live as heredocs (the fixture auto-formatter strips 'useless' if guards — every shape here needs one). Corpus spot-set (haml, kramdown converters, mail parsers) byte-identical; the full-11 arms run at landing with specific attention to new flow folds / return-mismatches on struct-heavy targets (the fix can only GRANT folds the static scan approves — any bug it exposes is a pre-existing scan bug previously masked by branching).

Closes #589.
