### PR TITLE
Audit NilClass#duplicable? into the pure-sweep ledger

### DIFF
--- a/spec/integration/plugins/activesupport_core_ext_effects_spec.rb
+++ b/spec/integration/plugins/activesupport_core_ext_effects_spec.rb
@@ -46,7 +46,7 @@ CORE_EXT_PURE_KEYS = %w[
   Integer#minutes Integer#month Integer#months Integer#multiple_of? Integer#ordinal
   Integer#ordinalize Integer#petabyte Integer#petabytes Integer#second Integer#seconds
   Integer#terabyte Integer#terabytes Integer#week Integer#weeks Integer#year Integer#years
-  NilClass#blank? NilClass#presence NilClass#present? NilClass#try NilClass#try!
+  NilClass#blank? NilClass#duplicable? NilClass#presence NilClass#present? NilClass#try NilClass#try!
   Object#acts_like? Object#blank? Object#in? Object#presence Object#present?
   String#at String#camelcase String#camelize String#classify String#dasherize String#deconstantize
   String#demodulize String#ends_with? String#exclude? String#first String#foreign_key String#from


### PR DESCRIPTION
Fixes the red master from #607's landing: the overlay fix annotated `NilClass#duplicable?` `%a{pure}` in the plugin twin (matching every sibling row) without registering it in the #388 audited `CORE_EXT_PURE_KEYS` set, so the sweep audit failed deterministically on the merge commit. The annotation is correct — `duplicable?` returns a constant with no side effects — so the ledger gains the row. Audit spec green locally; one-line diff.