### PR TITLE
Update RBS and RuboCop dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
     rack (3.2.7)
     rainbow (3.1.1)
     rake (13.4.2)
-    rbs (4.1.3)
+    rbs (4.2.0)
       logger
       prism (>= 1.6.0)
       tsort
@@ -69,8 +69,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    rubocop (1.88.1)
-      json (~> 2.3)
+    rubocop (1.90.0)
+      json (>= 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
       parallel (>= 1.10)
@@ -144,7 +144,7 @@ CHECKSUMS
   rack (3.2.7) sha256=93e13e1c24f93556671d85d2d79fa228c3485815c50d7e2f265b5330c6528fb7
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  rbs (4.1.3) sha256=0c4474a9751cdc14364bfad0b3e53678323bbdc2c31683b0445932867dbab8c4
+  rbs (4.2.0) sha256=51f7b886dcc05bc09e10b901daa6a81829f6adc03101d6ca9ea4aac6103e0674
   rbs-inline (0.14.0) sha256=eaf47b46690d63acddab1f6804c9cc205a4bc78e637cfc421a0b1239874ef51c
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   rigortype (0.3.6)
@@ -153,7 +153,7 @@ CHECKSUMS
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
   rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
-  rubocop (1.88.1) sha256=726af773d6bc169ed3ff852f3ca020b7c58d39c34e7a8d879a8e0147cc994f26
+  rubocop (1.90.0) sha256=9eb4c065b5c5154e4ef554c547972f3905a9eb6b53e657e580b6796b54bf8242
   rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
   rubocop-rake (0.7.1) sha256=3797f2b6810c3e9df7376c26d5f44f3475eda59eb1adc38e6f62ecf027cbae4d
   rubocop-rspec (3.10.2) sha256=0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2

--- a/changelog.d/changed/rbs-rubocop-updates.md
+++ b/changelog.d/changed/rbs-rubocop-updates.md
@@ -1,0 +1,1 @@
+- **[development]** The development bundle now uses RBS 4.2.0 and RuboCop 1.90.0, keeping dependency checks and linting current for contributors. ([#651](https://github.com/rigortype/rigor/pull/651))

--- a/lib/rigor/analysis/check_rules.rb
+++ b/lib/rigor/analysis/check_rules.rb
@@ -51,7 +51,7 @@ module Rigor
     #   resolves these to their runtime class for dispatch.
     # - receivers whose class name is NOT registered in the
     #   loader (RBS-blind environments, unknown stdlib).
-    # rubocop:disable Metrics/ModuleLength
+    # rubocop:disable-next Metrics/ModuleLength
     module CheckRules
       # ADR-87 WD4 — the canonical rule-id table lives in the light `check_rules/rule_ids.rb` (required at the
       # top of this file) so {Analysis::RuleCatalog} can read it without loading the engine.
@@ -655,7 +655,7 @@ module Rigor
         resolved.nil? || resolved.empty? ? [token] : resolved
       end
 
-      # rubocop:disable Metrics/ClassLength
+      # rubocop:disable-next Metrics/ClassLength
       class << self
         private
 
@@ -1169,7 +1169,7 @@ module Rigor
         # by `undefined_method_diagnostic`; it returns nil
         # when the call's receiver / RBS coverage / call shape
         # disqualifies the rule.
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
+        # rubocop:disable-next Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
         def wrong_arity_diagnostic(path, call_node, scope_index)
           return nil if call_node.receiver.nil?
           return nil unless plain_positional_call?(call_node)
@@ -1212,7 +1212,6 @@ module Rigor
 
           build_arity_diagnostic(path, call_node, class_name, min, max, actual)
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
 
         # True for the outer `.new` of a chained `Struct.new(...).new`:
         # `class_name`/`kind` already pin the receiver to
@@ -3161,8 +3160,6 @@ module Rigor
           )
         end
       end
-      # rubocop:enable Metrics/ClassLength
     end
-    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/lib/rigor/analysis/plugin_fact_fingerprint.rb
+++ b/lib/rigor/analysis/plugin_fact_fingerprint.rb
@@ -151,7 +151,7 @@ module Rigor
       # value actually moves (a new action, a changed sig), which is what a cached diagnostic can depend on;
       # a value-preserving edit keeps the recheck incremental. Returns true when the plugin declared at least
       # one producer (a surface); a producer whose value cannot be digested marks the plugin opaque.
-      # rubocop:disable Naming/PredicateMethod -- reports has-surface AND appends parts (a side-effecting builder)
+      # rubocop:disable-next Naming/PredicateMethod -- reports has-surface AND appends parts (a side-effecting builder)
       def collect_producer_parts(plugin, id, parts, opaque)
         producer_ids = plugin.class.producers.keys
         return false if producer_ids.empty?
@@ -163,7 +163,6 @@ module Rigor
         end
         true
       end
-      # rubocop:enable Naming/PredicateMethod
 
       # Channel (c): the optional {Plugin::Base#incremental_state_fingerprint} hook. Returns true when the
       # plugin defines it (it has a surface).

--- a/lib/rigor/effects/plugin_facts.rb
+++ b/lib/rigor/effects/plugin_facts.rb
@@ -326,7 +326,7 @@ module Rigor
         payload = [
           @labels_by_owner.sort.map { |owner, labels| [owner, labels.sort] },
           @class_rows.keys.sort_by { |singleton| singleton ? 1 : 0 }
-                          .map { |singleton| [singleton, sorted(@class_rows[singleton])] },
+                     .map { |singleton| [singleton, sorted(@class_rows[singleton])] },
           sorted(@path_rows), sorted(@self_rows), sorted(@result_rows),
           @edges.map { |edge| [edge.target.to_s, edge.receiver, edge.selector.to_s, edge.plugin_id] }.sort,
           @entry_points.map(&:to_h).sort_by { |preset| preset["name"] },

--- a/lib/rigor/environment.rb
+++ b/lib/rigor/environment.rb
@@ -190,7 +190,7 @@ module Rigor
       #   {Environment::RbsLoader} so constant lookups (and, in later v0.0.9 slices, other reflection
       #   artefacts) consult the cache. Pass `nil` (the default) to skip caching for this environment.
       # @return [Rigor::Environment]
-      # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
+      # rubocop:disable-next Metrics/MethodLength, Metrics/ParameterLists
       def for_project(root: Dir.pwd, libraries: [], signature_paths: nil, cache_store: nil,
                       plugin_registry: nil, dependency_source_index: nil,
                       rbs_extended_reporter: nil, boundary_cross_reporter: nil,
@@ -297,7 +297,6 @@ module Rigor
           missing_rbs_bundle_path: bundle_root
         )
       end
-      # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
 
       private
 

--- a/lib/rigor/environment/rbs_loader.rb
+++ b/lib/rigor/environment/rbs_loader.rb
@@ -23,7 +23,7 @@ module Rigor
     # API stays purely functional.
     #
     # See docs/internal-spec/inference-engine.md for the binding contract.
-    # rubocop:disable Metrics/ClassLength
+    # rubocop:disable-next Metrics/ClassLength
     class RbsLoader
       # Buffer name stamped on the `module` declarations synthesized by {.synthesize_missing_namespaces}.
       # Re-read off the built env by {#synthesized_namespaces} so the analysis layer can surface an `:info`
@@ -173,7 +173,7 @@ module Rigor
             raise unless env.respond_to?(:unload)
 
             culprits = e.decls.filter_map { |decl| decl.location&.buffer&.name }
-                              .uniq.select { |name| virtual_names.include?(name) }
+                        .uniq.select { |name| virtual_names.include?(name) }
             raise if culprits.empty?
 
             env = env.unload(culprits)
@@ -1695,6 +1695,5 @@ module Rigor
         false
       end
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/rigor/inference/acceptance.rb
+++ b/lib/rigor/inference/acceptance.rb
@@ -23,7 +23,7 @@ module Rigor
     # `Nominal[Hash, [K, V]]` the shape is projected to its underlying nominal so the existing
     # generic-acceptance pipeline continues to apply; the converse direction (a Tuple receiver accepting a
     # generic Array) stays conservative because the analyzer cannot verify arity from a raw nominal alone.
-    # rubocop:disable Metrics/ModuleLength
+    # rubocop:disable-next Metrics/ModuleLength
     module Acceptance
       module_function
 
@@ -71,7 +71,7 @@ module Rigor
       }.freeze
       private_constant :TYPE_HANDLERS
 
-      # rubocop:disable Metrics/ClassLength
+      # rubocop:disable-next Metrics/ClassLength
       class << self
         private
 
@@ -797,8 +797,6 @@ module Rigor
           nil
         end
       end
-      # rubocop:enable Metrics/ClassLength
     end
-    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/lib/rigor/inference/expression_typer.rb
+++ b/lib/rigor/inference/expression_typer.rb
@@ -57,7 +57,7 @@ module Rigor
     # docs/internal-spec/inference-engine.md. The optional tracer is a Rigor::Inference::FallbackTracer (or
     # any object answering #record_fallback) that receives a Fallback event for each fallback; the tracer
     # MUST NOT change the return value of type_of.
-    # rubocop:disable Metrics/ClassLength
+    # rubocop:disable-next Metrics/ClassLength
     class ExpressionTyper
       # Hash-based dispatch keeps `type_of` linear and lets future slices add node kinds without growing a
       # single case statement past RuboCop's cyclomatic budget. Anonymous Prism subclasses are not expected.
@@ -3782,6 +3782,5 @@ module Rigor
         nil
       end
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/rigor/inference/method_dispatcher/block_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/block_folding.rb
@@ -136,7 +136,7 @@ module Rigor
         end
 
         # @return [:always_true, :always_false, :bool, nil]
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def predicate_decision(method_name, truthiness, emptiness)
           case method_name
           when :all?
@@ -159,7 +159,6 @@ module Rigor
             :bool
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def bool_union
           Type::Combinator.union(

--- a/lib/rigor/inference/method_dispatcher/overload_selector.rb
+++ b/lib/rigor/inference/method_dispatcher/overload_selector.rb
@@ -183,7 +183,7 @@ module Rigor
             matches
           end
 
-          # rubocop:disable Metrics/ParameterLists
+          # rubocop:disable-next Metrics/ParameterLists
           def find_matching_overload(overloads, arg_types:, self_type:, instance_type:, type_vars:, block_required:,
                                      param_overrides:, strict:, alias_expander: nil)
             return [] if strict && arg_types.any? { |t| untyped_arg?(t) }
@@ -205,7 +205,6 @@ module Rigor
 
             overloads.select(&predicate)
           end
-          # rubocop:enable Metrics/ParameterLists
 
           # Whether the overload's block clause is compatible with the call site's block shape: a
           # block-bearing call engages only block-declaring overloads; a block-less call skips overloads

--- a/lib/rigor/inference/method_dispatcher/rbs_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/rbs_dispatch.rb
@@ -51,7 +51,7 @@ module Rigor
       #   a rest positional (`*T`), or a keyword parameter is still unbound and degrades to `Dynamic[Top]`.
       #
       # See docs/adr/4-type-inference-engine.md for the broader plan.
-      # rubocop:disable Metrics/ModuleLength
+      # rubocop:disable-next Metrics/ModuleLength
       module RbsDispatch
         module_function
 
@@ -144,7 +144,7 @@ module Rigor
           )
         end
 
-        # rubocop:disable Metrics/ClassLength
+        # rubocop:disable-next Metrics/ClassLength
         class << self
           private
 
@@ -415,7 +415,7 @@ module Rigor
           # `Dynamic[T]` carrier keeps the candidate set visible without that license (ADR-5).
           # A candidate whose return does not translate leaves the join incomplete — decline (fail-soft
           # to Dynamic downstream) rather than answer a join missing an arm the runtime can take.
-          # rubocop:disable Metrics/ParameterLists
+          # rubocop:disable-next Metrics/ParameterLists
           def join_candidate_returns(candidates, self_type:, instance_type:, type_vars:, args:, block_type:,
                                      scope:, call_node:, call_site:, alias_expander: nil)
             returns = candidates.map do |method_type|
@@ -436,7 +436,6 @@ module Rigor
 
             Type::Combinator.dynamic(Type::Combinator.union(*distinct))
           end
-          # rubocop:enable Metrics/ParameterLists
 
           def compose_type_vars(method_type, type_vars, args, block_type, scope, call_node, call_site)
             vars = compose_block_type_vars(method_type, type_vars, block_type)
@@ -721,9 +720,7 @@ module Rigor
             end
           end
         end
-        # rubocop:enable Metrics/ClassLength
       end
-      # rubocop:enable Metrics/ModuleLength
     end
   end
 end

--- a/lib/rigor/inference/method_dispatcher/shape_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/shape_dispatch.rb
@@ -48,7 +48,7 @@ module Rigor
       #
       # See docs/internal-spec/inference-engine.md (Slice 5 phase 2) and docs/adr/4-type-inference-engine.md
       # for the slice rationale.
-      # rubocop:disable Metrics/ClassLength, Metrics/ModuleLength
+      # rubocop:disable-next Metrics/ClassLength, Metrics/ModuleLength
       module ShapeDispatch
         module_function
 
@@ -1920,7 +1920,6 @@ module Rigor
           end
         end
       end
-      # rubocop:enable Metrics/ClassLength, Metrics/ModuleLength
     end
   end
 end

--- a/lib/rigor/inference/narrowing.rb
+++ b/lib/rigor/inference/narrowing.rb
@@ -37,7 +37,7 @@ module Rigor
     #
     # See docs/internal-spec/inference-engine.md (Narrowing) and
     # docs/type-specification/control-flow-analysis.md for the binding contract.
-    # rubocop:disable Metrics/ModuleLength
+    # rubocop:disable-next Metrics/ModuleLength
     module Narrowing
       TRUSTED_EQUALITY_LITERAL_CLASSES = [String, Symbol, Integer, TrueClass, FalseClass, NilClass].freeze
       SINGLETON_LITERAL_CLASSES = [TrueClass, FalseClass, NilClass].freeze
@@ -439,7 +439,7 @@ module Rigor
         end
       end
 
-      # rubocop:disable Metrics/ClassLength
+      # rubocop:disable-next Metrics/ClassLength
       class << self
         private
 
@@ -2897,8 +2897,6 @@ module Rigor
           [truthy_a.join(truthy_b), falsey_b]
         end
       end
-      # rubocop:enable Metrics/ClassLength
     end
-    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -38,7 +38,7 @@ module Rigor
     # Nodes that are not part of the program subtree (e.g. synthesised virtual nodes that the caller looks up after the
     # fact) yield the `default_scope`. The returned Hash is mutable in principle but callers MUST treat it as read-only;
     # the indexer itself never exposes a way to update it past construction.
-    # rubocop:disable Metrics/ModuleLength
+    # rubocop:disable-next Metrics/ModuleLength
     module ScopeIndexer
       module_function
 
@@ -2306,7 +2306,7 @@ module Rigor
         accumulator.transform_values(&:freeze).freeze
       end
 
-      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize
+      # rubocop:disable-next Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize
       def walk_method_visibilities(node, qualified_prefix, in_singleton_class, current_visibility, accumulator)
         return current_visibility unless node.is_a?(Prism::Node)
 
@@ -2355,7 +2355,6 @@ module Rigor
         end
         current_visibility
       end
-      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize
 
       def record_def_visibility(def_node, qualified_prefix, in_singleton_class, current_visibility, accumulator)
         return if def_node.receiver.is_a?(Prism::SelfNode) || in_singleton_class
@@ -3363,6 +3362,5 @@ module Rigor
         propagate(node.else_clause, table, truthy_scope) if node.else_clause
       end
     end
-    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/lib/rigor/inference/statement_evaluator.rb
+++ b/lib/rigor/inference/statement_evaluator.rb
@@ -56,7 +56,7 @@ module Rigor
     #
     # See docs/internal-spec/inference-engine.md for the public contract and docs/adr/4-type-inference-engine.md for the
     # slice rationale.
-    # rubocop:disable Metrics/ClassLength
+    # rubocop:disable-next Metrics/ClassLength
     class StatementEvaluator
       # Hash-based dispatch keeps `evaluate` linear and lets future slices add control-flow node kinds without growing a
       # single case statement past RuboCop's cyclomatic budget. Anonymous Prism subclasses are not expected.
@@ -3259,6 +3259,5 @@ module Rigor
         merged.to_a
       end
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/rigor/language_server/selection_range_provider.rb
+++ b/lib/rigor/language_server/selection_range_provider.rb
@@ -73,7 +73,7 @@ module Rigor
         loc = node.location
         {
           start: { line: loc.start_line - 1, character: loc.start_column },
-          end: { line: loc.end_line - 1,   character: loc.end_column }
+          end: { line: loc.end_line - 1, character: loc.end_column }
         }
       end
 

--- a/lib/rigor/plugin/base.rb
+++ b/lib/rigor/plugin/base.rb
@@ -435,11 +435,10 @@ module Rigor
         # Frozen snapshot of the declared narrowing-facts rules. Memoised for the same reason as
         # {dynamic_returns} — consulted per plugin per dispatch, over an array fixed at class-definition
         # time.
-        # rubocop:disable Naming/MemoizedInstanceVariableName -- see dynamic_returns
+        # rubocop:disable-next Naming/MemoizedInstanceVariableName -- see dynamic_returns
         def narrowing_facts_rules
           @narrowing_facts_rules_snapshot ||= (@narrowing_facts_rules || []).dup.freeze
         end
-        # rubocop:enable Naming/MemoizedInstanceVariableName
       end
 
       attr_reader :services, :config

--- a/lib/rigor/scope.rb
+++ b/lib/rigor/scope.rb
@@ -16,7 +16,7 @@ module Rigor
   # #type_of(node), the Rigor counterpart of PHPStan's $scope->getType($node).
   #
   # See docs/internal-spec/inference-engine.md for the binding contract.
-  # rubocop:disable Metrics/ClassLength,Metrics/ParameterLists
+  # rubocop:disable-next Metrics/ClassLength,Metrics/ParameterLists
   class Scope
     attr_reader :environment, :locals, :fact_store, :self_type,
                 :ivars, :cvars, :globals,
@@ -1113,5 +1113,4 @@ module Rigor
       filtered.size == @method_chain_narrowings.size ? @method_chain_narrowings : filtered.freeze
     end
   end
-  # rubocop:enable Metrics/ClassLength,Metrics/ParameterLists
 end

--- a/lib/rigor/triage/catalogue.rb
+++ b/lib/rigor/triage/catalogue.rb
@@ -327,7 +327,7 @@ module Rigor
           parser == :toplevel ? d.method_name : parse_undefined_method(d)&.fetch(:method)
         end
         names.tally.sort_by { |method, count| [-count, method] }
-                   .first(limit).map { |method, count| "#{method}×#{count}" }.join(" ")
+             .first(limit).map { |method, count| "#{method}×#{count}" }.join(" ")
       end
 
       def rule_of(diag)

--- a/lib/rigor/type/refined.rb
+++ b/lib/rigor/type/refined.rb
@@ -77,14 +77,13 @@ module Rigor
       # Recognises a Ruby value against this carrier's predicate. The trinary return is intentional:
       # `true` / `false` when the predicate registry decides, `nil` when the predicate is unknown to the
       # registry, so callers (today {Inference::Acceptance}) can fall through to gradual-mode `:maybe`.
-      # rubocop:disable Style/ReturnNilInPredicateMethodDefinition
+      # rubocop:disable-next Style/ReturnNilInPredicateMethodDefinition
       def matches?(value)
         recogniser = PREDICATES[predicate_id]
         return nil if recogniser.nil?
 
         !!recogniser.call(value)
       end
-      # rubocop:enable Style/ReturnNilInPredicateMethodDefinition
 
       # `predicate_id => recogniser` table. The recogniser is called with a Ruby value (typically the
       # inner `value` of a `Constant`) and returns truthy when the value satisfies the predicate. The

--- a/plugins/rigor-graphql/lib/rigor/plugin/graphql/type_scanner.rb
+++ b/plugins/rigor-graphql/lib/rigor/plugin/graphql/type_scanner.rb
@@ -254,7 +254,7 @@ module Rigor
         # Mirror of `extract_nullability` but reads the `required:` kwarg, defaulting to `false`
         # (graphql-ruby's argument default — the OPPOSITE polarity of `field`'s `null:` / nullability
         # default).
-        # rubocop:disable Naming/PredicateMethod  -- extractor returns the literal required value
+        # rubocop:disable-next Naming/PredicateMethod  -- extractor returns the literal required value
         def extract_required_flag(args)
           kwargs = args.last
           return false unless kwargs.is_a?(Prism::KeywordHashNode)
@@ -270,7 +270,6 @@ module Rigor
           else false
           end
         end
-        # rubocop:enable Naming/PredicateMethod
         private_class_method :extract_required_flag
 
         # `field :name, Type, null: false` shape. The first positional is a Symbol (field name); the
@@ -331,7 +330,7 @@ module Rigor
 
         # Defaults to `true` (matches graphql-ruby's `field` default nullability). Looks for an explicit
         # `null:` keyword and reads its boolean literal.
-        # rubocop:disable Naming/PredicateMethod  -- extractor returns the literal nullability value
+        # rubocop:disable-next Naming/PredicateMethod  -- extractor returns the literal nullability value
         def extract_nullability(args)
           kwargs = args.last
           return true unless kwargs.is_a?(Prism::KeywordHashNode)
@@ -347,7 +346,6 @@ module Rigor
           else true
           end
         end
-        # rubocop:enable Naming/PredicateMethod
         private_class_method :extract_nullability
 
         # Returns the constant chain as an Array of String segments (`["GraphQL", "Schema", "Object"]`).

--- a/spec/integration/plugins/rails_i18n_plugin_spec.rb
+++ b/spec/integration/plugins/rails_i18n_plugin_spec.rb
@@ -12,7 +12,7 @@ require "rigor-rails-i18n"
 
 # `%{name}` is the I18n interpolation placeholder syntax — RuboCop's `Style/FormatStringToken` would prefer
 # `%<name>s`, but here the YAML payload is data the plugin parses, not a Ruby format string.
-# rubocop:disable Style/FormatStringToken
+# rubocop:disable-next Style/FormatStringToken
 DEFAULT_LOCALES = {
   "config/locales/en.yml" => <<~YAML,
     en:
@@ -30,7 +30,6 @@ DEFAULT_LOCALES = {
         bye: "さようなら"
   YAML
 }.freeze
-# rubocop:enable Style/FormatStringToken
 
 RSpec.describe "plugins/rigor-rails-i18n" do
   before { Rigor::Plugin.unregister! }
@@ -96,7 +95,7 @@ RSpec.describe "plugins/rigor-rails-i18n" do
       result = run_plugin(
         source: "t('accounts.posts', count: 3)\n",
         files: {
-          # rubocop:disable Style/FormatStringToken -- I18n YAML uses %{count}, not annotated form
+          # rubocop:disable-next Style/FormatStringToken -- I18n YAML uses %{count}, not annotated form
           "config/locales/en.yml" => <<~YAML
             en:
               accounts:
@@ -104,7 +103,6 @@ RSpec.describe "plugins/rigor-rails-i18n" do
                   one: "%{count} post"
                   other: "%{count} posts"
           YAML
-          # rubocop:enable Style/FormatStringToken
         }
       )
       diags = plugin_diagnostics(result)
@@ -276,7 +274,7 @@ RSpec.describe "plugins/rigor-rails-i18n" do
     # producer and the shared cache doesn't know how to invalidate it across different tmpdir-based tests).
     let(:default_run_plugin_cache_store) { nil }
 
-    # rubocop:disable Style/FormatStringToken
+    # rubocop:disable-next Style/FormatStringToken
     let(:view_locales) do
       {
         "config/locales/en.yml" => <<~YAML
@@ -308,7 +306,6 @@ RSpec.describe "plugins/rigor-rails-i18n" do
         YAML
       }
     end
-    # rubocop:enable Style/FormatStringToken
 
     it "expands `t('.title')` in a view to `<scope>.<key>`" do
       result = run_plugin(

--- a/spec/rigor/analysis/runner/pool_coordinator_spec.rb
+++ b/spec/rigor/analysis/runner/pool_coordinator_spec.rb
@@ -736,7 +736,7 @@ RSpec.describe Rigor::Analysis::Runner::PoolCoordinator do
   end
 
   describe "#build_runner_environment" do
-    # rubocop:disable RSpec/ExampleLength
+    # rubocop:disable-next RSpec/ExampleLength
     it "threads the configuration, cache_store, injected readers, and source_files into " \
        "Environment.for_project" do
       configuration = Rigor::Configuration.new(
@@ -773,7 +773,6 @@ RSpec.describe Rigor::Analysis::Runner::PoolCoordinator do
         source_files: ["a.rb"]
       )
     end
-    # rubocop:enable RSpec/ExampleLength
 
     it "defaults source_files to an empty Array for callers with no file list yet " \
        "(e.g. a pre-pass-only build path)" do

--- a/spec/rigor/analysis/runner/project_pre_passes_spec.rb
+++ b/spec/rigor/analysis/runner/project_pre_passes_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Rigor::Analysis::Runner::ProjectPrePasses do
   end
 
   describe "#discover / #discover_from_bundles / #build_discovery" do
-    # rubocop:disable RSpec/ExampleLength
+    # rubocop:disable-next RSpec/ExampleLength
     it "builds every Discovery slot from the matching def_index key, without transposing any of the 12 slots" do
       index = {
         classes: :classes_marker,
@@ -168,7 +168,6 @@ RSpec.describe Rigor::Analysis::Runner::ProjectPrePasses do
       expect(discovery.data_member_layouts).to eq(:data_member_layouts_marker)
       expect(discovery.struct_member_layouts).to eq(:struct_member_layouts_marker)
     end
-    # rubocop:enable RSpec/ExampleLength
 
     it "#discover walks the real project once and returns a Discovery whose class table finds a cross-file class" do
       Dir.mktmpdir do |dir|

--- a/spec/rigor/inference/method_dispatcher/receiver_affinity_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/receiver_affinity_spec.rb
@@ -16,9 +16,8 @@ RSpec.describe Rigor::Inference::MethodDispatcher::ReceiverAffinity do
     allow(func).to receive_messages(required_positionals: [param], optional_positionals: [], trailing_positionals: [])
     allow(func).to receive(:respond_to?).with(:required_positionals).and_return(true)
     # RBS::Types::MethodType is not loaded in the spec context
-    # rubocop:disable RSpec/VerifiedDoubles
+    # rubocop:disable-next RSpec/VerifiedDoubles
     double("MethodType", type: func)
-    # rubocop:enable RSpec/VerifiedDoubles
   end
 
   describe ".reorder" do

--- a/spec/rigor/language_server/end_to_end_spec.rb
+++ b/spec/rigor/language_server/end_to_end_spec.rb
@@ -30,7 +30,7 @@ LSP_E2E_TIMEOUT_SECONDS = 30
 RSpec.describe "rigor lsp end-to-end session", type: :integration do
   let(:binary) { File.expand_path("../../../exe/rigor", __dir__) }
 
-  # rubocop:disable RSpec/ExampleLength
+  # rubocop:disable-next RSpec/ExampleLength
   it "round-trips a full initialize → didOpen → hover → completion → shutdown → exit session" do
     session_inputs = [
       request(1, "initialize", { capabilities: {} }),
@@ -80,7 +80,6 @@ RSpec.describe "rigor lsp end-to-end session", type: :integration do
     shutdown_response = request_responses.find { |f| f[:id] == 4 }
     expect(shutdown_response[:result]).to be_nil
   end
-  # rubocop:enable RSpec/ExampleLength
 
   private
 

--- a/spec/rigor/sig_gen/generator_spec.rb
+++ b/spec/rigor/sig_gen/generator_spec.rb
@@ -874,7 +874,7 @@ RSpec.describe Rigor::SigGen::Generator do
       config = Rigor::Configuration.new(Rigor::Configuration::DEFAULTS)
       candidates = described_class.new(configuration: config, paths: [path], observations: observations)
                                   .run.select { |c| %i[x y].include?(c.method_name) }
-                                      .to_h { |c| [c.method_name, c.rbs] }
+                                  .to_h { |c| [c.method_name, c.rbs] }
 
       expect(candidates[:x]).to eq("def x: () -> 0")
       expect(candidates[:y]).to eq(%(def y: () -> "origin"))


### PR DESCRIPTION
## Summary

- Update `rbs` from 4.1.3 to 4.2.0.
- Update `rubocop` from 1.88.1 to 1.90.0.
- Apply RuboCop 1.90 compatibility corrections for existing directive scopes and layout.

## Verification

- `make verify`

The remaining `diff-lcs` 2.0.0 update is blocked by the current RSpec dependency range.