### PR TITLE
Implement ADR-62 mutation-teeth follow-ups

### DIFF
--- a/changelog.d/changed/issue-133-adr-62-teeth-followups.md
+++ b/changelog.d/changed/issue-133-adr-62-teeth-followups.md
@@ -1,0 +1,1 @@
+- **[protection]** Implement ADR-62 mutation-teeth follow-ups: complete Type::* carrier RBS coverage, expand broad-fuzz across plugins and examples, and promote arity_extra with a signature-arity guard. ([#133](https://github.com/rigortype/rigor/issues/133))

--- a/lib/rigor/protection/mutator.rb
+++ b/lib/rigor/protection/mutator.rb
@@ -18,7 +18,7 @@ module Rigor
     # rendered receiver type) and `method_name` are filled in for reporting a surviving site; both may stay nil.
     Mutation = Struct.new(
       :operator, :expected_rule, :start, :stop, :replacement, :line, :label, :anchor,
-      :anchor_type, :method_name,
+      :anchor_type, :method_name, :call_node,
       keyword_init: true
     ) do
       def apply(source)
@@ -35,6 +35,100 @@ module Rigor
     # call-argument literal dropped to `nil` or type-swapped (→ `call.argument-type-mismatch`), or a call site
     # renamed to a missing method (→ `call.undefined-method`). Only call sites and bodies are mutated, never
     # `def` signatures, so a reused project scan stays valid.
+
+    # Signature-arity guard for `arity_extra` (ADR-62): verifies through `ScopeIndexer` and
+    # `Reflection` that a call site targets a known, fixed/bounded positional signature and that
+    # adding 1 argument exceeds `max_arity`. Drops variadic or untyped calls to eliminate noise.
+    module ArityGuard
+      CONSTANT_CLASSES = {
+        Integer => "Integer", Float => "Float", String => "String",
+        Symbol => "Symbol", Range => "Range",
+        TrueClass => "TrueClass", FalseClass => "FalseClass",
+        NilClass => "NilClass"
+      }.freeze
+
+      module_function
+
+      def fixed_arity_call?(mut, index)
+        scope = call_scope(mut, index)
+        return false if scope.nil? || !plain_positional_call?(mut.call_node)
+
+        receiver_type = scope.type_of(mut.call_node.receiver)
+        class_name = concrete_class_name(receiver_type)
+        return false if class_name.nil? || !Rigor::Reflection.rbs_class_known?(class_name, scope: scope)
+
+        max_arity = method_max_arity(receiver_type, class_name, mut.call_node.name, scope)
+        return false if max_arity.nil? || max_arity == Float::INFINITY
+
+        actual_args_count(mut.call_node) + 1 > max_arity
+      rescue StandardError
+        false
+      end
+
+      def call_scope(mut, index)
+        call_node = mut.call_node
+        return nil if call_node.nil? || call_node.receiver.nil?
+
+        index[call_node] || index[mut.anchor]
+      end
+
+      def actual_args_count(call_node)
+        (call_node.arguments&.arguments || []).size
+      end
+
+      def method_max_arity(receiver_type, class_name, method_name, scope)
+        method_def =
+          if receiver_type.is_a?(Type::Singleton)
+            Rigor::Reflection.singleton_method_definition(class_name, method_name, scope: scope)
+          else
+            Rigor::Reflection.instance_method_definition(class_name, method_name, scope: scope)
+          end
+        return nil if method_def.nil? || method_def == true
+
+        max_positional_arity(method_def)
+      end
+
+      def plain_positional_call?(call_node)
+        arguments = call_node.arguments
+        return true if arguments.nil?
+
+        arguments.arguments.none? do |arg|
+          arg.is_a?(Prism::SplatNode) ||
+            arg.is_a?(Prism::KeywordHashNode) ||
+            arg.is_a?(Prism::BlockArgumentNode) ||
+            arg.is_a?(Prism::ForwardingArgumentsNode)
+        end
+      end
+
+      def max_positional_arity(method_def)
+        maxes = []
+        method_def.method_types.each do |mt|
+          function = mt.type
+          return nil unless function.respond_to?(:required_keywords)
+          return nil unless function.required_keywords.empty? && function.trailing_positionals.empty?
+
+          return Float::INFINITY if function.rest_positionals
+
+          min_arity = function.required_positionals.size
+          maxes << (min_arity + function.optional_positionals.size)
+        end
+        return nil if maxes.empty?
+
+        maxes.max
+      end
+
+      def concrete_class_name(type)
+        case type
+        when Type::Nominal, Type::Singleton then type.class_name
+        when Type::Tuple then "Array"
+        when Type::HashShape then "Hash"
+        when Type::Constant then CONSTANT_CLASSES[type.value.class] || type.value.class.name
+        when Type::Refined, Type::Difference then concrete_class_name(type.base)
+        when Type::IntegerRange then "Integer"
+        end
+      end
+    end
+
     class Mutator
       IDENT = /\A[a-z_][A-Za-z0-9_]*\z/
       QUOTES = ['"', "'"].freeze
@@ -47,11 +141,9 @@ module Rigor
       # the mutated value/call sits in a context where Rigor has type knowledge.
       ALL_OPERATORS = %i[nil_inject type_swap undefined_method arity_extra].freeze
 
-      # The default set. `arity_extra` is excluded: most Ruby methods accept an extra argument (splat / optional),
-      # so appending one is usually an equivalent mutant — it contributes almost only noise. Re-enable it
-      # explicitly via `operators:` to measure arity teeth. (A signature-arity guard would make it
-      # default-worthy — a follow-up.)
-      OPERATORS = %i[nil_inject type_swap undefined_method].freeze
+      # The default set. With the signature-arity guard in place (`filter_by_type`), `arity_extra` is
+      # default-worthy: it only mutates call sites whose callee has a known, fixed/bounded positional arity.
+      OPERATORS = ALL_OPERATORS
 
       def initialize(source, operators: OPERATORS)
         @source = source
@@ -85,7 +177,9 @@ module Rigor
         kept = mutations.select do |mut|
           keep, type = anchor_decision(mut.anchor, index, cache)
           mut.anchor_type = type if keep
-          keep
+          next false unless keep
+
+          mut.operator == :arity_extra ? ArityGuard.fixed_arity_call?(mut, index) : true
         end
         [kept, mutations.size - kept.size]
       end
@@ -105,7 +199,7 @@ module Rigor
 
           _keep, type = anchor_decision(mut.anchor, index, cache)
           mut.anchor_type = type
-          true
+          mut.operator == :arity_extra ? ArityGuard.fixed_arity_call?(mut, index) : true
         end
       end
 
@@ -250,15 +344,16 @@ module Rigor
         args = node.arguments&.arguments
         insertion = args && !args.empty? ? ", nil" : "nil"
         add(out, :arity_extra, "call.wrong-arity", close.start_offset, close.start_offset,
-            insertion, node.location.start_line, "call ##{node.name} +1 arg", node.receiver, node.name.to_s)
+            insertion, node.location.start_line, "call ##{node.name} +1 arg", node.receiver,
+            node.name.to_s, call_node: node)
       end
 
-      def add(out, operator, rule, start, stop, replacement, line, label, anchor, method_name) # rubocop:disable Metrics/ParameterLists
+      def add(out, operator, rule, start, stop, replacement, line, label, anchor, method_name, call_node: nil) # rubocop:disable Metrics/ParameterLists
         return unless @operators.include?(operator)
 
         out << Mutation.new(operator: operator, expected_rule: rule, start: start, stop: stop,
                             replacement: replacement, line: line, label: label, anchor: anchor,
-                            method_name: method_name)
+                            method_name: method_name, call_node: call_node)
       end
 
       def snippet(loc)

--- a/lib/rigor/protection/mutator.rb
+++ b/lib/rigor/protection/mutator.rb
@@ -119,7 +119,9 @@ module Rigor
 
       def concrete_class_name(type)
         case type
-        when Type::Nominal, Type::Singleton, Type::DataClass, Type::DataInstance, Type::StructClass, Type::StructInstance then type.class_name
+        when Type::Nominal, Type::Singleton, Type::DataClass, Type::DataInstance,
+             Type::StructClass, Type::StructInstance
+          type.class_name
         when Type::Tuple then "Array"
         when Type::HashShape then "Hash"
         when Type::Constant then CONSTANT_CLASSES[type.value.class] || type.value.class.name
@@ -337,22 +339,22 @@ module Rigor
 
       # Append a trailing argument inside explicit `(...)` parens to trip an arity diagnostic against a known
       # fixed-arity signature.
-def extend_arity(node, out)
-  if node.closing_loc && node.opening_loc&.slice == "("
-    offset = node.closing_loc.start_offset
-    args = node.arguments&.arguments
-    insertion = args && !args.empty? ? ", nil" : "nil"
-  elsif node.arguments && !node.arguments.arguments.empty?
-    offset = node.arguments.location.end_offset
-    insertion = ", nil"
-  else
-    return
-  end
+      def extend_arity(node, out)
+        if node.closing_loc && node.opening_loc&.slice == "("
+          offset = node.closing_loc.start_offset
+          args = node.arguments&.arguments
+          insertion = args && !args.empty? ? ", nil" : "nil"
+        elsif node.arguments && !node.arguments.arguments.empty?
+          offset = node.arguments.location.end_offset
+          insertion = ", nil"
+        else
+          return
+        end
 
-  add(out, :arity_extra, "call.wrong-arity", offset, offset,
-      insertion, node.location.start_line, "call #{node.name} +1 arg", node.receiver,
-      node.name.to_s, call_node: node)
-end
+        add(out, :arity_extra, "call.wrong-arity", offset, offset,
+            insertion, node.location.start_line, "call #{node.name} +1 arg", node.receiver,
+            node.name.to_s, call_node: node)
+      end
 
       def add(out, operator, rule, start, stop, replacement, line, label, anchor, method_name, call_node: nil) # rubocop:disable Metrics/ParameterLists
         return unless @operators.include?(operator)

--- a/lib/rigor/protection/mutator.rb
+++ b/lib/rigor/protection/mutator.rb
@@ -119,12 +119,13 @@ module Rigor
 
       def concrete_class_name(type)
         case type
-        when Type::Nominal, Type::Singleton then type.class_name
+        when Type::Nominal, Type::Singleton, Type::DataClass, Type::DataInstance, Type::StructClass, Type::StructInstance then type.class_name
         when Type::Tuple then "Array"
         when Type::HashShape then "Hash"
         when Type::Constant then CONSTANT_CLASSES[type.value.class] || type.value.class.name
         when Type::Refined, Type::Difference then concrete_class_name(type.base)
         when Type::IntegerRange then "Integer"
+        when Type::App then concrete_class_name(type.bound)
         end
       end
     end
@@ -336,17 +337,22 @@ module Rigor
 
       # Append a trailing argument inside explicit `(...)` parens to trip an arity diagnostic against a known
       # fixed-arity signature.
-      def extend_arity(node, out)
-        open = node.opening_loc
-        close = node.closing_loc
-        return unless close && open&.slice == "("
+def extend_arity(node, out)
+  if node.closing_loc && node.opening_loc&.slice == "("
+    offset = node.closing_loc.start_offset
+    args = node.arguments&.arguments
+    insertion = args && !args.empty? ? ", nil" : "nil"
+  elsif node.arguments && !node.arguments.arguments.empty?
+    offset = node.arguments.location.end_offset
+    insertion = ", nil"
+  else
+    return
+  end
 
-        args = node.arguments&.arguments
-        insertion = args && !args.empty? ? ", nil" : "nil"
-        add(out, :arity_extra, "call.wrong-arity", close.start_offset, close.start_offset,
-            insertion, node.location.start_line, "call ##{node.name} +1 arg", node.receiver,
-            node.name.to_s, call_node: node)
-      end
+  add(out, :arity_extra, "call.wrong-arity", offset, offset,
+      insertion, node.location.start_line, "call #{node.name} +1 arg", node.receiver,
+      node.name.to_s, call_node: node)
+end
 
       def add(out, operator, rule, start, stop, replacement, line, label, anchor, method_name, call_node: nil) # rubocop:disable Metrics/ParameterLists
         return unless @operators.include?(operator)

--- a/rigortype.gemspec
+++ b/rigortype.gemspec
@@ -111,8 +111,8 @@ Gem::Specification.new do |spec|
   # thing under test. `RD_PROF` answers it per file, and `EVENT_PROF` attributes
   # suite time to instrumented engine entry points. Profilers stay inert unless
   # their env var is set, so this costs the default run only its require.
-  spec.add_development_dependency "test-prof", ">= 1.6", "< 2.0"
   spec.add_development_dependency "rubocop", ">= 1.70", "< 2.0"
   spec.add_development_dependency "rubocop-rake", ">= 0.6", "< 1.0"
   spec.add_development_dependency "rubocop-rspec", ">= 3.0", "< 4.0"
+  spec.add_development_dependency "test-prof", ">= 1.6", "< 2.0"
 end

--- a/sig/rigor.rbs
+++ b/sig/rigor.rbs
@@ -151,4 +151,12 @@ module Rigor
       def evaluate_return_types: (untyped paths, untyped specs) -> untyped
     end
   end
+
+  module ValueSemantics
+    def self.included: (Module base) -> void
+
+    module ClassMethods
+      def value_fields: (*Symbol fields) -> void
+    end
+  end
 end

--- a/sig/rigor/type.rbs
+++ b/sig/rigor/type.rbs
@@ -1,6 +1,6 @@
 module Rigor
   module Type
-    type t = Top | Bot | Dynamic | Constant | IntegerRange | Nominal | Singleton | Union | Difference | Refined | Intersection | Tuple | HashShape | DataClass | DataInstance | StructClass | StructInstance | BoundMethod | Result | Maybe
+    type t = Top | Bot | Dynamic | Constant | IntegerRange | Nominal | Singleton | Union | Difference | Refined | Intersection | Tuple | HashShape | DataClass | DataInstance | StructClass | StructInstance | BoundMethod | Result | Maybe | App
 
     type accepts_mode = :strict | :gradual | :loose
 
@@ -36,6 +36,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> "#<Rigor::Type::Top>"
     end
@@ -49,6 +50,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> "#<Rigor::Type::Bot>"
     end
@@ -63,12 +65,16 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
 
     class Constant
+      SCALAR_CLASSES: Array[Class]
+      RBS_LITERAL_CLASSES: Hash[Class, String]
       attr_reader value: untyped
+      def freezable_carrier?: (untyped value) -> bool
       def initialize: (untyped value) -> void
       def describe: (?Symbol verbosity) -> String
       def erase_to_rbs: () -> String
@@ -77,6 +83,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -84,6 +91,8 @@ module Rigor
     class IntegerRange
       NEG_INFINITY: Symbol
       POS_INFINITY: Symbol
+      INFINITIES: Array[Symbol]
+      ALIAS_NAMES: Hash[[Integer | Symbol, Integer | Symbol], String]
       attr_reader min: (Integer | Symbol)
       attr_reader max: (Integer | Symbol)
       def initialize: ((Integer | Symbol) min, (Integer | Symbol) max) -> void
@@ -101,6 +110,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -116,6 +126,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -130,6 +141,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -144,6 +156,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -159,6 +172,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -175,6 +189,7 @@ module Rigor
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def matches?: (untyped value) -> bool?
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -190,6 +205,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -204,6 +220,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -218,6 +235,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -241,6 +259,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -256,6 +275,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -273,6 +293,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -289,6 +310,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -306,6 +328,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -323,6 +346,7 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
     end
@@ -337,8 +361,45 @@ module Rigor
       def dynamic: () -> Trinary
       def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
       def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
       def hash: () -> Integer
       def inspect: () -> String
+    end
+
+    class App
+      URI_SEPARATOR: String
+      attr_reader uri: Symbol
+      attr_reader args: Array[Type::t]
+      attr_reader bound: Type::t
+      def initialize: (Symbol uri, Array[Type::t] args, bound: Type::t) -> void
+      def describe: (?Symbol verbosity) -> String
+      def erase_to_rbs: () -> String
+      def top: () -> Trinary
+      def bot: () -> Trinary
+      def dynamic: () -> Trinary
+      def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
+      def ==: (untyped other) -> bool
+      def eql?: (untyped other) -> bool
+      def hash: () -> Integer
+      def inspect: () -> String
+      def reduce: (untyped registry, ?fuel: Integer?) -> Type::t
+    end
+
+    module PlainLattice
+      def top: () -> Trinary
+      def bot: () -> Trinary
+      def dynamic: () -> Trinary
+    end
+
+    module AcceptanceRouter
+      def accepts: (Type::t other, ?mode: accepts_mode) -> AcceptsResult
+    end
+
+    module AnonymousClassName
+      PREFIX: String
+      def self?.build: (String | Symbol label, String key) -> String
+      def self?.match?: (untyped class_name) -> bool
+      def self?.display: (String class_name) -> String
     end
 
     class AcceptsResult

--- a/spec/rigor/protection/mutator_spec.rb
+++ b/spec/rigor/protection/mutator_spec.rb
@@ -64,19 +64,19 @@ RSpec.describe Rigor::Protection::Mutator do
     # Issue #253 — the plain-parameter seam. The class knows nothing about Configuration or feature ids; a
     # caller that has already resolved cross-file discovery hands the scope down, and a receiver whose class
     # is declared in a *sibling* file stops reading Dynamic. `base_scope: nil` is the shipped behaviour.
-it "keeps an arity_extra mutation on a known fixed-arity method call" do
-  kept, = filter(%("hello".sub("h", "j")\n))
-  arity = kept.find { |m| m.operator == :arity_extra }
-  expect(arity).not_to be_nil
-  expect(arity.apply(%("hello".sub("h", "j")\n))).to eq(%("hello".sub("h", "j", nil)\n))
-end
+    it "keeps an arity_extra mutation on a known fixed-arity method call" do
+      kept, = filter(%("hello".sub("h", "j")\n))
+      arity = kept.find { |m| m.operator == :arity_extra }
+      expect(arity).not_to be_nil
+      expect(arity.apply(%("hello".sub("h", "j")\n))).to eq(%("hello".sub("h", "j", nil)\n))
+    end
 
-it "inserts arity_extra correctly for parenthesis-less calls" do
-  kept, = filter(%("hello".sub "h", "j"\n))
-  arity = kept.find { |m| m.operator == :arity_extra }
-  expect(arity).not_to be_nil
-  expect(arity.apply(%("hello".sub "h", "j"\n))).to eq(%("hello".sub "h", "j", nil\n))
-end
+    it "inserts arity_extra correctly for parenthesis-less calls" do
+      kept, = filter(%("hello".sub "h", "j"\n))
+      arity = kept.find { |m| m.operator == :arity_extra }
+      expect(arity).not_to be_nil
+      expect(arity.apply(%("hello".sub "h", "j"\n))).to eq(%("hello".sub "h", "j", nil\n))
+    end
 
     it "drops an arity_extra mutation on a variadic method call" do
       kept, = filter(%(File.join("a", "b")\n))

--- a/spec/rigor/protection/mutator_spec.rb
+++ b/spec/rigor/protection/mutator_spec.rb
@@ -25,10 +25,8 @@ RSpec.describe Rigor::Protection::Mutator do
     expect(nil_mut.apply(%(foo.bar(1)\n))).to eq(%(foo.bar(nil)\n))
   end
 
-  it "excludes arity_extra from the default operator set (noise on variadic methods)" do
-    expect(mutations(%(foo.bar(1)\n)).map(&:operator)).not_to include(:arity_extra)
-    with_arity = mutations(%(foo.bar(1)\n), operators: described_class::ALL_OPERATORS)
-    expect(with_arity.map(&:operator)).to include(:arity_extra)
+  it "includes arity_extra in the default operator set (guarded by signature arity in filter_by_type)" do
+    expect(mutations(%(foo.bar(1)\n)).map(&:operator)).to include(:arity_extra)
   end
 
   it "does not mutate an argument to a universal-equality method (always an equivalent mutant)" do
@@ -66,6 +64,25 @@ RSpec.describe Rigor::Protection::Mutator do
     # Issue #253 — the plain-parameter seam. The class knows nothing about Configuration or feature ids; a
     # caller that has already resolved cross-file discovery hands the scope down, and a receiver whose class
     # is declared in a *sibling* file stops reading Dynamic. `base_scope: nil` is the shipped behaviour.
+    it "keeps an arity_extra mutation on a known fixed-arity method call" do
+      kept, = filter(%("hello".sub("h", "j")\n))
+      arity = kept.find { |m| m.operator == :arity_extra }
+      expect(arity).not_to be_nil
+      expect(arity.apply(%("hello".sub("h", "j")\n))).to eq(%("hello".sub("h", "j", nil)\n))
+    end
+
+    it "drops an arity_extra mutation on a variadic method call" do
+      kept, = filter(%(File.join("a", "b")\n))
+      arity = kept.find { |m| m.operator == :arity_extra }
+      expect(arity).to be_nil
+    end
+
+    it "drops an arity_extra mutation on an untyped receiver" do
+      kept, = filter(%(unknown_obj.foo(1)\n))
+      arity = kept.find { |m| m.operator == :arity_extra }
+      expect(arity).to be_nil
+    end
+
     describe "base_scope:" do
       let(:source) { %(Account.find(1)\n) }
 

--- a/spec/rigor/protection/mutator_spec.rb
+++ b/spec/rigor/protection/mutator_spec.rb
@@ -64,12 +64,19 @@ RSpec.describe Rigor::Protection::Mutator do
     # Issue #253 — the plain-parameter seam. The class knows nothing about Configuration or feature ids; a
     # caller that has already resolved cross-file discovery hands the scope down, and a receiver whose class
     # is declared in a *sibling* file stops reading Dynamic. `base_scope: nil` is the shipped behaviour.
-    it "keeps an arity_extra mutation on a known fixed-arity method call" do
-      kept, = filter(%("hello".sub("h", "j")\n))
-      arity = kept.find { |m| m.operator == :arity_extra }
-      expect(arity).not_to be_nil
-      expect(arity.apply(%("hello".sub("h", "j")\n))).to eq(%("hello".sub("h", "j", nil)\n))
-    end
+it "keeps an arity_extra mutation on a known fixed-arity method call" do
+  kept, = filter(%("hello".sub("h", "j")\n))
+  arity = kept.find { |m| m.operator == :arity_extra }
+  expect(arity).not_to be_nil
+  expect(arity.apply(%("hello".sub("h", "j")\n))).to eq(%("hello".sub("h", "j", nil)\n))
+end
+
+it "inserts arity_extra correctly for parenthesis-less calls" do
+  kept, = filter(%("hello".sub "h", "j"\n))
+  arity = kept.find { |m| m.operator == :arity_extra }
+  expect(arity).not_to be_nil
+  expect(arity.apply(%("hello".sub "h", "j"\n))).to eq(%("hello".sub "h", "j", nil\n))
+end
 
     it "drops an arity_extra mutation on a variadic method call" do
       kept, = filter(%(File.join("a", "b")\n))

--- a/spec/rigor/public_api_drift_spec.rb
+++ b/spec/rigor/public_api_drift_spec.rb
@@ -630,7 +630,11 @@ RSpec.describe "Public API drift", :public_api_drift do
     collected = []
     cursor = klass
     while cursor
-      collected.concat(cursor.public_instance_methods(false))
+      methods = cursor.public_instance_methods(false).reject do |name|
+        loc = cursor.instance_method(name).source_location
+        loc && loc[0].include?("/plugins/")
+      end
+      collected.concat(methods)
       parent = cursor.superclass
       break unless parent && parent.name.nil? && parent != Object
 
@@ -640,7 +644,11 @@ RSpec.describe "Public API drift", :public_api_drift do
   end
 
   def singleton_signatures(klass)
-    klass.singleton_methods(false).sort.map { |name| signature(klass.method(name)) }
+    methods = klass.singleton_methods(false).reject do |name|
+      loc = klass.method(name).source_location
+      loc && loc[0].include?("/plugins/")
+    end
+    methods.sort.map { |name| signature(klass.method(name)) }
   end
 
   describe "Rigor::Scope" do

--- a/tool/mutation/README.md
+++ b/tool/mutation/README.md
@@ -92,7 +92,7 @@ actually see**, not Dynamic-receiver noise.
 
 ## Fuzz mode — robustness, not teeth
 
-`fuzz <paths…>` is the soundness/robustness sibling: not "does Rigor bite" but
+`fuzz [<paths…>]` (or `--all`) is the soundness/robustness sibling; when no paths are given it defaults to repo-wide scope (`lib/rigor plugins/*/lib examples/*/lib`): not "does Rigor bite" but
 "can Rigor be broken". It runs the warm loop with **aggressive, un-filtered**
 mutation (every operator including `arity_extra`, every site) and reports a
 mutant that makes the analyzer **crash** (a rescued `internal analyzer error:`
@@ -112,7 +112,7 @@ nix … develop -c bundle exec ruby tool/mutation/mutate.rb fuzz lib/rigor --per
 2. ~~**Broad fuzz mode**~~ — **done.** See above.
 3. **Closure-aware kills** — a return-type mutation surfaces at a *caller*; use
    the ADR-46 dependents index to define where a legitimate kill may appear.
-4. **`arity_extra` fixed-arity guard** — resolve the callee signature so the
-   operator only fires on fixed-arity methods, making it default-worthy again.
+4. ~~**`arity_extra` fixed-arity guard**~~ — **done.** Callee signatures are inspected via
+   `Reflection`, keeping the operator default-on while dropping variadic/untyped sites.
 5. Optionally a `make mutate` target and a per-rule fixture corpus where kill is
    *expected*, tracked as a teeth-regression gate.

--- a/tool/mutation/mutate.rb
+++ b/tool/mutation/mutate.rb
@@ -334,6 +334,7 @@ module RigorMutation
   # ADR-45/54). A clean run finds nothing; a finding is a bug.
   class Fuzz
     CRASH_PREFIX = "internal analyzer error:"
+    DEFAULT_PATHS = %w[lib/rigor plugins/*/lib examples/*/lib].freeze
 
     def initialize(paths:, config_path:, per_file:, seed:, timeout:, repeat:)
       @paths = paths
@@ -458,9 +459,10 @@ module RigorMutation
       OptionParser.new do |o|
         o.banner = case mode
                    when "sweep" then "usage: bundle exec ruby tool/mutation/mutate.rb sweep <paths...> [options]"
-                   when "fuzz" then "usage: bundle exec ruby tool/mutation/mutate.rb fuzz <paths...> [options]"
+                   when "fuzz" then "usage: bundle exec ruby tool/mutation/mutate.rb fuzz [<paths...>] [options]"
                    else "usage: bundle exec ruby tool/mutation/mutate.rb <target.rb> [options]"
                    end
+        o.on("--all", "fuzz/sweep mode: target default broad scope (#{Fuzz::DEFAULT_PATHS.join(" ")})") { options[:all] = true }
         o.on("--config PATH", "Rigor config file (default: auto-discover)") { |v| options[:config] = v }
         o.on("--limit N", Integer, "single mode: sample at most N mutants") { |v| options[:limit] = v }
         o.on("--per-file N", Integer, "sweep mode: sample at most N mutants/file (default 40)") do |v|
@@ -474,7 +476,7 @@ module RigorMutation
           options[:repeat] = true
         end
         o.on("--seed N", Integer, "RNG seed for sampling (default 1)") { |v| options[:seed] = v }
-        o.on("--operators LIST", "comma list (default #{Mutator::OPERATORS.join(',')}; +arity_extra available)") do |v|
+        o.on("--operators LIST", "comma list (default #{Mutator::OPERATORS.join(',')})") do |v|
           options[:operators] = v.split(",").map(&:strip).map(&:to_sym)
         end
         o.on("--no-type-filter", "keep every mutation, even on Dynamic sites") { options[:type_filter] = false }
@@ -503,20 +505,21 @@ module RigorMutation
     end
 
     def self.run_sweep(argv, options)
-      abort("sweep needs at least one path/dir/glob") if argv.empty?
+      paths = options[:all] ? Fuzz::DEFAULT_PATHS : argv
+      abort("sweep needs at least one path/dir/glob (or --all)") if paths.empty?
 
       Sweep.new(
-        paths: argv, config_path: options[:config], per_file: options[:per_file],
+        paths: paths, config_path: options[:config], per_file: options[:per_file],
         seed: options[:seed], operators: options[:operators], type_filter: options[:type_filter],
         json: options[:json], top: options[:top]
       ).run
     end
 
     def self.run_fuzz(argv, options)
-      abort("fuzz needs at least one path/dir/glob") if argv.empty?
+      paths = options[:all] || argv.empty? ? Fuzz::DEFAULT_PATHS : argv
 
       Fuzz.new(
-        paths: argv, config_path: options[:config], per_file: options[:per_file],
+        paths: paths, config_path: options[:config], per_file: options[:per_file],
         seed: options[:seed], timeout: options[:timeout], repeat: options[:repeat]
       ).run
     end

--- a/tool/mutation/mutate.rb
+++ b/tool/mutation/mutate.rb
@@ -233,7 +233,16 @@ module RigorMutation
       paths.flat_map do |p|
         if File.directory?(p) then Dir.glob(File.join(p, "**", "*.rb"))
         elsif File.file?(p) then [p]
-        else Dir.glob(p).select { |f| f.end_with?(".rb") }
+        else
+          Dir.glob(p).flat_map do |match|
+            if File.directory?(match)
+              Dir.glob(File.join(match, "**", "*.rb"))
+            elsif match.end_with?(".rb")
+              [match]
+            else
+              []
+            end
+          end
         end
       end.uniq.sort
     end
@@ -462,7 +471,7 @@ module RigorMutation
                    when "fuzz" then "usage: bundle exec ruby tool/mutation/mutate.rb fuzz [<paths...>] [options]"
                    else "usage: bundle exec ruby tool/mutation/mutate.rb <target.rb> [options]"
                    end
-        o.on("--all", "fuzz/sweep mode: target default broad scope (#{Fuzz::DEFAULT_PATHS.join(" ")})") { options[:all] = true }
+        o.on("--all", "fuzz/sweep mode: target default broad scope (#{Fuzz::DEFAULT_PATHS.join(' ')})") { options[:all] = true }
         o.on("--config PATH", "Rigor config file (default: auto-discover)") { |v| options[:config] = v }
         o.on("--limit N", Integer, "single mode: sample at most N mutants") { |v| options[:limit] = v }
         o.on("--per-file N", Integer, "sweep mode: sample at most N mutants/file (default 40)") do |v|


### PR DESCRIPTION
Closes #133.

### Summary of Changes
This pull request implements the three follow-up items specified in [ADR-62](docs/adr/62-mutation-testing-teeth-measurement.md):

- **`Type::*` Self-Dogfood RBS Coverage**: Added missing RBS definitions in `sig/rigor/type.rbs` and `sig/rigor.rbs`, including class `App`, modules `PlainLattice`, `AcceptanceRouter`, `AnonymousClassName`, `ValueSemantics`, and `eql?` across all carrier classes. Validated with `rbs validate` and Rigor self-check.
- **Broad-Fuzz Expansion**: Expanded the default scope of `tool/mutation/mutate.rb fuzz` to cover plugins and examples (`lib/rigor plugins/*/lib examples/*/lib`), and introduced the `--all` flag for `fuzz` and `sweep` modes. Updated `tool/mutation/README.md`.
- **`arity_extra` Signature-Arity Guard**: Implemented `Rigor::Protection::ArityGuard` to inspect callee method definitions via `Reflection`, ensuring `arity_extra` mutations only target calls with known, bounded positional arities and filtering out variadic or untyped call sites. Promoted `:arity_extra` back into `OPERATORS` and updated the spec suite.