### PR TITLE
Isolate plugin integration tests to prevent Test Pollution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,10 @@ jobs:
         if: matrix.shard == 1
         run: make test-ractor-pool
 
+      - name: Run plugin integration tests
+        if: matrix.shard == 1
+        run: make test-integration-plugins
+
   # ── 1b. Shard coverage ──────────────────────────────────────────
   # Sharding's one silent failure: shards never coordinate, so each trusts
   # the others to have cut the identical partition from the identical

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,12 @@ test:
 test-ractor-pool:
 	RIGOR_INCLUDE_RACTOR_POOL=1 bundle exec rspec spec/rigor/analysis/runner_pool_spec.rb
 
+# Plugin integration tests are excluded from the default suite because they modify global state (Test Pollution).
+# Specifically, rigor-ffi re-opens Rigor::Plugin::Base to define DSL macros.
+# Running them in a separate RSpec process avoids flaky failures in public_api_drift_spec.rb.
+test-integration-plugins:
+	RIGOR_INCLUDE_INTEGRATION_PLUGINS=1 bundle exec rspec spec/integration/plugins/
+
 # Spec suite via `binpacker`, distributing files across worker
 # processes using LPT scheduling driven by measured per-file
 # runtimes (tmp/binpacker.timings). On a cold start (no timings
@@ -234,12 +240,12 @@ effect-budget:
 # sequential variant below). Use `verify-sequential` when chasing
 # parallel-only flakes — the worker isolation hides certain
 # ordering bugs that surface only in a single-process run.
-verify: test-binpacker test-ractor-pool lint check check-plugins
+verify: test-binpacker test-ractor-pool test-integration-plugins lint check check-plugins
 
 # Sequential variant. Identical phases as `verify` but `test`
 # runs single-process. Slower but bit-for-bit reproducible
 # without inter-worker scheduling effects.
-verify-sequential: test test-ractor-pool lint check check-plugins
+verify-sequential: test test-ractor-pool test-integration-plugins lint check check-plugins
 
 # Backward-compatible alias for the previous `verify-parallel`
 # target name. Identical to `verify` now that parallel is the

--- a/binpacker.yml
+++ b/binpacker.yml
@@ -6,7 +6,7 @@ profiles:
     test_pattern: spec/**/*_spec.rb
     test_exclude:
       - spec/rigor/analysis/runner_pool_spec.rb
-      - spec/integration/plugins/**/*_spec.rb
+      - spec/integration/plugins/*_spec.rb
     scheduler:
       algorithm: lpt
 

--- a/binpacker.yml
+++ b/binpacker.yml
@@ -6,6 +6,7 @@ profiles:
     test_pattern: spec/**/*_spec.rb
     test_exclude:
       - spec/rigor/analysis/runner_pool_spec.rb
+      - spec/integration/plugins/**/*_spec.rb
     scheduler:
       algorithm: lpt
 

--- a/spec/integration/plugins/shoulda_matchers_plugin_spec.rb
+++ b/spec/integration/plugins/shoulda_matchers_plugin_spec.rb
@@ -22,7 +22,9 @@ require "fileutils"
 require "tmpdir"
 
 SHOULDA_PLUGIN_LIB = File.expand_path("../../../plugins/rigor-shoulda-matchers/lib", __dir__)
-ACTIVERECORD_PLUGIN_LIB = File.expand_path("../../../plugins/rigor-activerecord/lib", __dir__)
+unless defined?(ACTIVERECORD_PLUGIN_LIB)
+  ACTIVERECORD_PLUGIN_LIB = File.expand_path("../../../plugins/rigor-activerecord/lib", __dir__)
+end
 $LOAD_PATH.unshift(SHOULDA_PLUGIN_LIB) unless $LOAD_PATH.include?(SHOULDA_PLUGIN_LIB)
 $LOAD_PATH.unshift(ACTIVERECORD_PLUGIN_LIB) unless $LOAD_PATH.include?(ACTIVERECORD_PLUGIN_LIB)
 require "rigor-shoulda-matchers"

--- a/spec/rigor/public_api_drift_spec.rb
+++ b/spec/rigor/public_api_drift_spec.rb
@@ -630,11 +630,7 @@ RSpec.describe "Public API drift", :public_api_drift do
     collected = []
     cursor = klass
     while cursor
-      methods = cursor.public_instance_methods(false).reject do |name|
-        loc = cursor.instance_method(name).source_location
-        loc && loc[0].include?("/plugins/")
-      end
-      collected.concat(methods)
+      collected.concat(cursor.public_instance_methods(false))
       parent = cursor.superclass
       break unless parent && parent.name.nil? && parent != Object
 
@@ -644,11 +640,7 @@ RSpec.describe "Public API drift", :public_api_drift do
   end
 
   def singleton_signatures(klass)
-    methods = klass.singleton_methods(false).reject do |name|
-      loc = klass.method(name).source_location
-      loc && loc[0].include?("/plugins/")
-    end
-    methods.sort.map { |name| signature(klass.method(name)) }
+    klass.singleton_methods(false).sort.map { |name| signature(klass.method(name)) }
   end
 
   describe "Rigor::Scope" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,7 +103,10 @@ RSpec.configure do |config|
   # spawns no Ractors unless RIGOR_POOL_BACKEND=ractor is exported; the exclusion is kept so an exported backend
   # override can never destabilise the main suite. Set `RIGOR_INCLUDE_RACTOR_POOL=1` to opt the file back in to a
   # same-process run.
-  config.exclude_pattern = "spec/rigor/analysis/runner_pool_spec.rb" unless ENV["RIGOR_INCLUDE_RACTOR_POOL"]
+  exclusions = []
+  exclusions << "spec/rigor/analysis/runner_pool_spec.rb" unless ENV["RIGOR_INCLUDE_RACTOR_POOL"]
+  exclusions << "spec/integration/plugins/**/*_spec.rb" unless ENV["RIGOR_INCLUDE_INTEGRATION_PLUGINS"]
+  config.exclude_pattern = exclusions.join(",") unless exclusions.empty?
 
   # ADR-93 WD2 — `Configuration.load` default-wires the bundled `rigor-rbs-inline` plugin whenever the upstream
   # `rbs-inline` library is resolvable, which it is under this repo's bundle. Left live, that would inject the

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,7 +105,7 @@ RSpec.configure do |config|
   # same-process run.
   exclusions = []
   exclusions << "spec/rigor/analysis/runner_pool_spec.rb" unless ENV["RIGOR_INCLUDE_RACTOR_POOL"]
-  exclusions << "spec/integration/plugins/**/*_spec.rb" unless ENV["RIGOR_INCLUDE_INTEGRATION_PLUGINS"]
+  exclusions << "spec/integration/plugins/*_spec.rb" unless ENV["RIGOR_INCLUDE_INTEGRATION_PLUGINS"]
   config.exclude_pattern = exclusions.join(",") unless exclusions.empty?
 
   # ADR-93 WD2 — `Configuration.load` default-wires the bundled `rigor-rbs-inline` plugin whenever the upstream


### PR DESCRIPTION
Resolves #729.

This PR implements the fundamental fix for the test pollution problem caused by `spec/integration/plugins/ffi_plugins_spec.rb`. Since that spec requires `rigor-ffi` which modifies the global `Rigor::Plugin::Base` class, we isolate it completely into its own RSpec process, similarly to `test-ractor-pool`.

- Removed the `.reject { ... }` workaround from `spec/rigor/public_api_drift_spec.rb`.
- Excluded `spec/integration/plugins/` from the default RSpec run in `spec/spec_helper.rb`, `binpacker.yml`, and `Makefile`.
- Added a `test-integration-plugins` target in `Makefile`.
- Added an isolated step for this target in `.github/workflows/ci.yml`.