### PR TITLE
Decline a receiver whose include the environment does not know

### DIFF
--- a/changelog.d/fixed/issue-746-unknown-mixin-includer.md
+++ b/changelog.d/fixed/issue-746-unknown-mixin-includer.md
@@ -1,0 +1,1 @@
+- **[check]** A class that includes a module no loaded RBS declares no longer draws `call.undefined-method`: its ancestors are not fully known, so its method surface cannot be enumerated — a class whose includes are all known keeps reporting typos as before. ([#746](https://github.com/rigortype/rigor/issues/746), [#747](https://github.com/rigortype/rigor/pull/747))

--- a/lib/rigor/analysis/check_rules.rb
+++ b/lib/rigor/analysis/check_rules.rb
@@ -783,6 +783,7 @@ module Rigor
         def last_resort_surface_answers?(receiver_type, class_name, call_node, scope, kind)
           return true if module_mixin_receiver?(receiver_type, scope)
           return true if mixin_self_class_receiver?(call_node, scope)
+          return true if unknown_mixin_includer?(class_name, scope)
 
           ancestry_declares_method?(scope, class_name, call_node.name, kind)
         end
@@ -979,6 +980,35 @@ module Rigor
         # its own evidence to gather.
         def unenumerable_receiver?(class_name, scope)
           METACLASS_ARMS.include?(class_name) || unbounded_receiver_surface?(class_name, scope)
+        end
+
+        # Issue #746 — a class that includes a module the environment does not know. `SudoMode::Form`
+        # includes `ActiveModel::Validations`, which no RBS in redmine's environment declares, and `valid?`
+        # comes from it: the ancestors are not fully known, so the method table is not enumerable and a
+        # verdict read off the part we can see is unsound. Same reasoning `unbounded_receiver_surface?`
+        # already applies to an ADR-26 open receiver and to Rigor's own synthesized stubs.
+        #
+        # Asked LATE, with {#ancestry_declares_method?} and for the same reason: `Scope#includes_of` records
+        # an ADR-46 file-level ancestry edge, so running it on the hot path made `Widget.new` — a call RBS
+        # answers, that never reaches a verdict — depend on `Widget`'s declaring file.
+        # `dependency_recorder_spec` caught it here exactly as it caught #723's walk.
+        #
+        # The receiver's OWN includes only. A project ancestor's unknown include makes the surface just as
+        # unknown; walking the chain is a deliberate deferral rather than an oversight.
+        def unknown_mixin_includer?(class_name, scope)
+          includes = scope.includes_of(class_name)
+          return false if includes.empty?
+
+          includes.any? { |raw| !known_mixin?(raw, class_name, scope) }
+        end
+
+        def known_mixin?(raw_name, class_name, scope)
+          scope.ancestor_name_candidates(class_name, raw_name).any? do |candidate|
+            next true if scope.discovered_classes.key?(candidate)
+
+            Rigor::Reflection.rbs_class_known?(candidate, scope: scope) &&
+              !synthesized_stub_receiver?(candidate, scope)
+          end
         end
 
         # Returns a qualified class name for the in-scope check.

--- a/spec/integration/unknown_mixin_includer_spec.rb
+++ b/spec/integration/unknown_mixin_includer_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Issue #746 — a class that includes a module the RBS environment does not know has a method surface Rigor
+# cannot enumerate, so `call.undefined-method` must not fire on it.
+#
+# `SudoMode::Form` includes `ActiveModel::Validations`, which no RBS in redmine's environment declares, and
+# `valid?` comes from it. The rule enumerated the part of the class it could see and reported the rest. That
+# is the same unsoundness `unbounded_receiver_surface?` already refuses for an ADR-26 open receiver and for
+# Rigor's own synthesized stubs: a class whose ancestors are not fully known is not a class whose methods
+# can be enumerated.
+#
+# Same precondition as #736 / #739 / #744: while the class has no RBS the rule cannot speak about it at all,
+# so the shape appears the moment a `sig/` — hand-written or generated — declares it.
+
+require "spec_helper"
+require "fileutils"
+require "tmpdir"
+
+require "rigor/analysis/runner"
+require "rigor/configuration"
+
+RSpec.describe "a class including an unknown module (#746)" do
+  def write_project(source)
+    FileUtils.mkdir_p("lib")
+    FileUtils.mkdir_p("sig")
+    File.write(File.join("sig", "form.rbs"), <<~RBS)
+      module Known
+      end
+      class Form
+      end
+      class Plain
+      end
+    RBS
+    File.write(File.join("lib", "form.rb"), source)
+  end
+
+  def undefined_messages
+    configuration = Rigor::Configuration.new(
+      Rigor::Configuration::DEFAULTS.merge(
+        "paths" => %w[lib], "signature_paths" => %w[sig], "workers" => 0
+      )
+    )
+    result = guarded_run(
+      Rigor::Analysis::Runner.new(configuration: configuration, cache_store: nil), %w[lib]
+    )
+    result.diagnostics.select { |d| d.qualified_rule == "call.undefined-method" }.map(&:message)
+  end
+
+  around do |example|
+    Dir.mktmpdir("rigor-unknown-mixin-") { |dir| Dir.chdir(dir) { example.run } }
+  end
+
+  it "does not fire on a class whose include the environment does not know" do
+    write_project(<<~RUBY)
+      class Form
+        include SomeGem::Validations
+
+        def check = self.valid?
+      end
+    RUBY
+    expect(undefined_messages).to be_empty
+  end
+
+  it "still fires when every include is known" do
+    # Mandatory must-still-fire: the stand-down is about ancestors Rigor cannot see, not about classes that
+    # happen to include something. `Known` is declared in the same `sig/`, so the surface IS enumerable.
+    write_project(<<~RUBY)
+      module Known
+        def helper = 1
+      end
+
+      class Plain
+        include Known
+
+        def go = self.no_such_method
+      end
+    RUBY
+    expect(undefined_messages).to eq(["undefined method `no_such_method' for Plain"])
+  end
+
+  it "still fires for a class with no includes at all" do
+    write_project(<<~RUBY)
+      class Plain
+        def go = self.no_such_method
+      end
+    RUBY
+    expect(undefined_messages).to eq(["undefined method `no_such_method' for Plain"])
+  end
+end


### PR DESCRIPTION
Closes #746.

```ruby
module SudoMode
  class Form
    include ActiveModel::Validations   # no RBS for it in the environment
  end
end
```

```
lib/redmine/sudo_mode.rb:138: error: undefined method `valid?' for Redmine::SudoMode::Form
```

`valid?` comes from the mixin. Probed against redmine's own environment (its committed `.rigor.dist.yml`, the bundled Rails plugin set): `ActiveModel::Validations: known=false synthesized=false`. The rule enumerated the part of the class it could see and reported the rest.

A class whose ancestors are not fully known is not a class whose methods can be enumerated — the same unsoundness `unbounded_receiver_surface?` already refuses for an ADR-26 open receiver and for Rigor's own synthesized stubs. Any project including a gem module without RBS has this shape, and it appears the moment a `sig/` declares the class.

## Placement

Asked **late**, with #723's ancestry walk and for the same reason: `Scope#includes_of` records an ADR-46 file-level ancestry edge, so on the hot path it made `Widget.new` — a call RBS answers, that never reaches a verdict — depend on `Widget`'s declaring file. `dependency_recorder_spec` failed on the first cut, exactly as it did for #723. That is twice this spec has been the only thing between a probe and a project-wide invalidation regression, and it is worth knowing before adding a third.

## Measured on redmine

- **no-`sig/` baseline: unchanged at 26** `call.undefined-method`. The suppression costs nothing there — the number the issue asked for before landing, and the one that would have said "too broad" if it had moved.
- generated `sig/`: **6 → 5** over that baseline.

Of the five left: three are `class_eval`-string metaprogramming (`Redmine::Plugin#def_field`), one is `include Singleton`'s class-side `instance` (#527, a known gap), and one is a **true positive** (`Views::Builders::Structure < BasicObject` calls `self.class.name`).

## Evidence

Three examples, two of them must-still-fire:

- the unknown include reports nothing;
- a class whose includes are **all known** still fires for a genuine typo — the stand-down is about ancestors Rigor cannot see, not about classes that happen to include something;
- a class with no includes at all is unchanged.

The receiver's own includes only; a project ancestor's unknown include is the same unsoundness and is called out in the code as a deferral rather than left implicit.

`make verify` green.
