### PR TITLE
Record the raises facet on 36 builtin catalogue rows

### DIFF
--- a/data/builtins/ruby_core/date.yml
+++ b/data/builtins/ruby_core/date.yml
@@ -1038,7 +1038,8 @@ classes:
         arity: -1
         defined_at: references/ruby/ext/date/date_core.c:9694
         c_body_at: references/ruby/ext/date/date_core.c:3790
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(?Integer start) -> Date"
@@ -1618,7 +1619,8 @@ classes:
         arity: -1
         defined_at: references/ruby/ext/date/date_core.c:9988
         c_body_at: references/ruby/ext/date/date_core.c:8137
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(?Integer start) -> DateTime"

--- a/data/builtins/ruby_core/enumerable.yml
+++ b/data/builtins/ruby_core/enumerable.yml
@@ -492,6 +492,7 @@ classes:
         c_body_at: references/ruby/enum.c:4236
         c_effects:
         - block
+        - raises
         purity: block_dependent
       slice_after:
         source: c

--- a/data/builtins/ruby_core/exception.yml
+++ b/data/builtins/ruby_core/exception.yml
@@ -608,7 +608,8 @@ classes:
         arity: -1
         defined_at: references/ruby/error.c:3728
         c_body_at: references/ruby/error.c:287
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
     singleton_methods:
       "[]":

--- a/data/builtins/ruby_core/file.yml
+++ b/data/builtins/ruby_core/file.yml
@@ -53,7 +53,8 @@ classes:
         arity: 0
         defined_at: references/ruby/file.c:7599
         c_body_at: references/ruby/file.c:1565
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "() -> (File::Stat | nil)"
@@ -64,7 +65,8 @@ classes:
         arity: 0
         defined_at: references/ruby/file.c:7601
         c_body_at: references/ruby/file.c:2469
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "() -> Time"
@@ -75,7 +77,8 @@ classes:
         arity: 0
         defined_at: references/ruby/file.c:7602
         c_body_at: references/ruby/file.c:2517
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "() -> Time"
@@ -86,7 +89,8 @@ classes:
         arity: 0
         defined_at: references/ruby/file.c:7603
         c_body_at: references/ruby/file.c:2572
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "() -> Time"
@@ -118,7 +122,8 @@ classes:
         arity: 1
         defined_at: references/ruby/file.c:7607
         c_body_at: references/ruby/file.c:2773
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(int mode) -> (0 | nil)"
@@ -129,7 +134,8 @@ classes:
         arity: 2
         defined_at: references/ruby/file.c:7608
         c_body_at: references/ruby/file.c:2952
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(int? owner, int? group) -> (0 | nil)"
@@ -150,7 +156,8 @@ classes:
         arity: 1
         defined_at: references/ruby/file.c:7611
         c_body_at: references/ruby/file.c:5524
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(int locking_constant) -> (0 | false)"
@@ -162,7 +169,8 @@ classes:
         arity: 1
         defined_at: references/ruby/file.c:7545
         c_body_at: references/ruby/file.c:1460
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(path file_name) -> File::Stat"
@@ -173,7 +181,8 @@ classes:
         arity: 1
         defined_at: references/ruby/file.c:7546
         c_body_at: references/ruby/file.c:1534
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(path file_name) -> File::Stat"
@@ -184,7 +193,8 @@ classes:
         arity: 1
         defined_at: references/ruby/file.c:7547
         c_body_at: references/ruby/file.c:2419
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(path file_name) -> String"
@@ -195,7 +205,8 @@ classes:
         arity: 1
         defined_at: references/ruby/file.c:7549
         c_body_at: references/ruby/file.c:2445
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(path | IO file_name) -> Time"
@@ -206,7 +217,8 @@ classes:
         arity: 1
         defined_at: references/ruby/file.c:7550
         c_body_at: references/ruby/file.c:2494
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(path | IO file_name) -> Time"
@@ -217,7 +229,8 @@ classes:
         arity: 1
         defined_at: references/ruby/file.c:7551
         c_body_at: references/ruby/file.c:2546
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(path | IO file_name) -> Time"
@@ -361,7 +374,8 @@ classes:
         arity: -1
         defined_at: references/ruby/file.c:7568
         c_body_at: references/ruby/file.c:3496
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(?int umask) -> Integer"

--- a/data/builtins/ruby_core/hash.yml
+++ b/data/builtins/ruby_core/hash.yml
@@ -177,6 +177,7 @@ classes:
         c_effects:
         - block
         - dispatch
+        - raises
         purity: block_dependent
         rbs:
         - "(_Key key) -> V"

--- a/data/builtins/ruby_core/io.yml
+++ b/data/builtins/ruby_core/io.yml
@@ -230,7 +230,8 @@ classes:
         arity: 1
         defined_at: references/ruby/io.c:15757
         c_body_at: references/ruby/io.c:6094
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(_ToS object) -> Integer"
@@ -253,7 +254,8 @@ classes:
         arity: -1
         defined_at: references/ruby/io.c:15760
         c_body_at: references/ruby/io.c:6241
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(int maxlen, int offset, ?string? out_string) -> String"
@@ -264,7 +266,8 @@ classes:
         arity: 2
         defined_at: references/ruby/io.c:15761
         c_body_at: references/ruby/io.c:6329
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(_ToS object, int offset) -> Integer"
@@ -393,7 +396,8 @@ classes:
         arity: -1
         defined_at: references/ruby/io.c:15780
         c_body_at: references/ruby/io.c:3642
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(int maxlen, ?string? outbuf) -> String"
@@ -462,7 +466,8 @@ classes:
         arity: 0
         defined_at: references/ruby/io.c:15786
         c_body_at: references/ruby/io.c:5068
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "() -> String"
@@ -473,7 +478,8 @@ classes:
         arity: 0
         defined_at: references/ruby/io.c:15787
         c_body_at: references/ruby/io.c:5142
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "() -> Integer"
@@ -529,7 +535,8 @@ classes:
         arity: 0
         defined_at: references/ruby/io.c:15792
         c_body_at: references/ruby/io.c:2460
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "() -> Integer"
@@ -551,7 +558,8 @@ classes:
         arity: 0
         defined_at: references/ruby/io.c:15808
         c_body_at: references/ruby/io.c:2624
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "() -> Integer"
@@ -562,7 +570,8 @@ classes:
         arity: 0
         defined_at: references/ruby/io.c:15809
         c_body_at: references/ruby/io.c:2460
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
       pos=:
         source: c
@@ -570,7 +579,8 @@ classes:
         arity: 1
         defined_at: references/ruby/io.c:15810
         c_body_at: references/ruby/io.c:2584
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(Integer new_position) -> Integer"
@@ -981,7 +991,8 @@ classes:
         arity: -1
         defined_at: references/ruby/io.c:15712
         c_body_at: references/ruby/io.c:8007
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(string | cmd_array cmd, ?string | int mode, ?path: string?, ?external_encoding:
@@ -1118,6 +1129,7 @@ classes:
         c_body_at: references/ruby/io.c:11912
         c_effects:
         - block
+        - raises
         purity: block_dependent
         rbs:
         - "(?String | Encoding | nil ext_or_ext_int_enc, ?String | Encoding | nil
@@ -1330,7 +1342,8 @@ classes:
         arity: -1
         defined_at: references/ruby/io.c:15912
         c_body_at: references/ruby/io.c:10508
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
       getc:
         source: c
@@ -1354,7 +1367,8 @@ classes:
         arity: 0
         defined_at: references/ruby/io.c:15915
         c_body_at: references/ruby/io.c:14143
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
       readbyte:
         source: c
@@ -1362,7 +1376,8 @@ classes:
         arity: 0
         defined_at: references/ruby/io.c:15916
         c_body_at: references/ruby/io.c:14183
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
       tell:
         source: c

--- a/data/builtins/ruby_core/re.yml
+++ b/data/builtins/ruby_core/re.yml
@@ -390,7 +390,8 @@ classes:
         arity: 1
         defined_at: references/ruby/re.c:4884
         c_body_at: references/ruby/re.c:1085
-        c_effects: []
+        c_effects:
+        - raises
         purity: leaf
         rbs:
         - "(MatchData instance) -> self"

--- a/data/builtins/ruby_core/struct.yml
+++ b/data/builtins/ruby_core/struct.yml
@@ -333,6 +333,7 @@ classes:
         c_body_at: references/ruby/struct.c:1833
         c_effects:
         - mutate
+        - raises
         purity: mutates_self
       initialize_copy:
         source: c


### PR DESCRIPTION
Adopts an uncommitted `data/builtins/` edit that was sitting loose in the shared main clone, after verifying every row. Files #756 for the missing check that let the wrong data stand.

`c_effects:` is a positive claim, and an empty list is the strongest form of it — *"this method has no C-level effects"*, `raises` included. **36 rows across eight files claimed that while the function their own `c_body_at` points at raises**; 32 of them with a bare `c_effects: []`.

## Verified, not adopted on trust

35 rows by scanning the function the cited location names for raise primitives (`rb_raise`, `rb_sys_fail*`, `rb_error_arity`, `rb_check_*`, `Check_Type`, `NUM2*`, `rb_struct_modify`, `rb_eof_error`, …), and the 36th by hand:

| method | `c_body_at` | what raises |
| --- | --- | --- |
| `File#chmod` | `file.c:2773` | `NUM2MODET`, `rb_sys_fail_path` |
| `Struct#[]=`, `Data#initialize` | `struct.c:1833` | `rb_struct_modify` (FrozenError), `rb_error_arity` |
| `Enumerable#slice_when` | `enum.c:4236` | `rb_error_arity` |
| `MatchData#initialize_copy` | `re.c:1085` | `OBJ_INIT_COPY` → `rb_obj_init_copy`, `rb_memerror` |

The last one is why the scan is not the whole story: neither `OBJ_INIT_COPY` nor `rb_memerror` is in the primitive list, so it came back unverified and was read by hand rather than waved through.

## This changes no analyzer behaviour, and that is stated deliberately

**Nothing reads `c_effects`.** `Inference::Builtins::MethodCatalog` reads these files for their `purity:` facet only; the effect system's catalogue is `data/effects/core.yml`, which `Effects::Catalog` documents as *not* a re-reading of this file, and which carries **no `raises` label at all**. So there is no gate to write: the claim being corrected is about recorded data, and the verification is the C source above. `make verify` is green, which here means "nothing broke", not "the change works".

It matters anyway because the facet is already designed into filed work: **#390** gates `effect.discarded-pure-result` on the callee being *total on its domain* and names "the catalogue's `raises` facet" as the source. A row that under-claims `raises` is a row that would let that rule fire on `hash.fetch(:k)`-shaped code — the exact false positive it was built to avoid. Whoever wires that gate should also know that `data/effects/core.yml`, the catalogue the engine actually reads, has no `raises` today.

**No changelog fragment**: nothing user-visible changes, and an entry would describe a behaviour no user can observe.

## Process note

These edits were uncommitted in `/Users/megurine/repo/ruby/rigor`'s working tree, where they travelled across branch switches and came within one `git add -A` of riding an unrelated engine PR. They are on their own branch now. The audit script behind the table is ~30 lines and is described in #756, which proposes turning it into a real gate — including the two decisions it needs first (`references/ruby` is an optional submodule, so the check must skip rather than fail without it; and the primitive list is a heuristic whose false hits are spec failures on correct rows).
