### PR TITLE
Close spec-analyzer guard and seed-bundle scope gaps

### DIFF
--- a/spec/docs/spec_analyzer_guard_spec.rb
+++ b/spec/docs/spec_analyzer_guard_spec.rb
@@ -23,9 +23,9 @@
 # `Rigor::Analysis::Runner.new(...).run` re-creates one member of it, and nothing about writing that line
 # feels wrong. So the rule is mechanical: an analyzer run in `spec/` has to end up in front of
 # {InternalAnalyzerErrorGuard}. `GuardedAnalysis#guarded_run` / `#guarded_run_source` /
-# `#guarded_session_analyze` / `#guarded_baseline` / `#guarded_recheck` / `#guarded_run_incremental` /
-# `#guarded_run_buffer_recheck` are the one-liners that satisfy it; a wrapper outside example scope calls
-# `InternalAnalyzerErrorGuard.check!` (or `.check_diagnostics!`) itself.
+# `#guarded_session_analyze` / `#guarded_baseline` / `#guarded_recheck` / `#guarded_reanalyze_subset` /
+# `#guarded_run_incremental` / `#guarded_run_buffer_recheck` are the one-liners that satisfy it; a
+# wrapper outside example scope calls `InternalAnalyzerErrorGuard.check!` (or `.check_diagnostics!`) itself.
 #
 # What is checked is the RUN, never the construction: `WorkerSession.new(...)` on its own is what
 # `ractor_readiness_spec.rb` legitimately does to ask whether the object is shareable, and failing that
@@ -79,11 +79,12 @@ module SpecAnalyzerGuardScan
   # `analyze` is `WorkerSession`'s PUBLIC per-file entry; `analyze_body` is the private half behind it,
   # listed so that making it public later cannot open a hole. A bare `analyze(...)` with no receiver is
   # `RunnerHelpers#analyze`, which is already guarded — a run site needs an analyzer receiver, so it is
-  # never matched here. `baseline` / `recheck` / `run_incremental` / `run_buffer_recheck` are
-  # `IncrementalSession`'s four run methods (#683) — none of their names collide with `Runner`'s or
-  # `WorkerSession`'s, so listing them here applies only to an `IncrementalSession` receiver in practice.
+  # never matched here. `baseline` / `recheck` / `run_incremental` / `run_buffer_recheck` /
+  # `reanalyze_subset` are `IncrementalSession`'s five run methods (#683, #695) — none of their names
+  # collide with `Runner`'s or `WorkerSession`'s, so listing them here applies only to an
+  # `IncrementalSession` receiver in practice.
   RUN_METHODS = %i[run run_source analyze analyze_body baseline recheck run_incremental
-                   run_buffer_recheck].freeze
+                   run_buffer_recheck reanalyze_subset].freeze
   GUARD_CONSTANT = "InternalAnalyzerErrorGuard"
   GUARD_METHODS = %i[check! check_diagnostics!].freeze
   # Where an example's own scope begins. A run site inside one of these must carry its own guard.
@@ -184,16 +185,38 @@ module SpecAnalyzerGuardScan
     end
 
     # `def build_runner(...) = <construction>` — a factory, so `build_runner(...).run` is a run site too.
+    # Issue #695 — transitive and conditional:
+    # 1. A factory whose body calls another factory (`def make(d) = session_for(d)`) is recognised.
+    # 2. A factory whose return expression is an `if` statement returns an analyzer if any branch does.
     def collect_factory_methods(root)
       described = describes_analyzer?(root)
-      names = []
-      walk(root, []) do |node, _|
-        next unless node.is_a?(Prism::DefNode)
+      factories = []
+      loop do
+        size_before = factories.size
+        walk(root, []) do |node, _|
+          next unless node.is_a?(Prism::DefNode)
+          next if factories.include?(node.name)
 
-        last = node.body.is_a?(Prism::StatementsNode) ? node.body.body.last : node.body
-        names << node.name if construction?(last, described: described)
+          last = node.body.is_a?(Prism::StatementsNode) ? node.body.body.last : node.body
+          factories << node.name if produces_analyzer?(last, described: described, factories: factories)
+        end
+        break if factories.size == size_before
       end
-      names.uniq
+      factories.uniq
+    end
+
+    def produces_analyzer?(node, described:, factories:)
+      return false if node.nil?
+      return true if construction?(node, described: described) || factory_call?(node, factories)
+
+      if node.is_a?(Prism::IfNode)
+        then_body = node.statements&.body&.last
+        else_body = node.subsequent.is_a?(Prism::StatementsNode) ? node.subsequent.body.last : node.subsequent
+        return produces_analyzer?(then_body, described: described, factories: factories) ||
+               produces_analyzer?(else_body, described: described, factories: factories)
+      end
+
+      false
     end
 
     def run_site?(node, analyzer_locals:, factories:, described:)
@@ -339,6 +362,42 @@ RSpec.describe "analyzer runs in spec/ reach the internal-error guard (#674)" do
       RUBY
     end
 
+    # Issue #695 — transitive factory: def make(d) = session_for(d)
+    it "flags a run through a transitive factory method" do
+      expect(offense_lines(<<~RUBY)).to eq([11])
+        def session_for(dir)
+          Rigor::Analysis::IncrementalSession.new(configuration: config(dir))
+        end
+
+        def make(dir)
+          session_for(dir)
+        end
+
+        it "x" do
+          session = make(dir)
+          session.baseline
+        end
+      RUBY
+    end
+
+    # Issue #695 — conditional factory: def make(d) = if cond then Runner.new else other_runner end
+    it "flags a run through a factory whose return expression is a conditional with an analyzer branch" do
+      expect(offense_lines(<<~RUBY)).to eq([11])
+        def make_runner(flag, dir)
+          if flag
+            Rigor::Analysis::Runner.new(configuration: config(dir))
+          else
+            Rigor::Analysis::Runner.new(configuration: other_config(dir))
+          end
+        end
+
+        it "x" do
+          runner = make_runner(true, dir)
+          runner.run
+        end
+      RUBY
+    end
+
     it "accepts a run wrapped in the guard at the site" do
       expect(offense_lines(<<~RUBY)).to be_empty
         it "x" do
@@ -428,6 +487,15 @@ RSpec.describe "analyzer runs in spec/ reach the internal-error guard (#674)" do
       RUBY
     end
 
+    it "flags an unguarded `IncrementalSession#reanalyze_subset` call (#695)" do
+      expect(offense_lines(<<~RUBY)).to eq([3])
+        it "x" do
+          session = Rigor::Analysis::IncrementalSession.new(configuration: config)
+          session.reanalyze_subset(%w[a.rb])
+        end
+      RUBY
+    end
+
     it "accepts an `IncrementalSession` run through the matching guarded_* helper" do
       expect(offense_lines(<<~RUBY)).to be_empty
         it "x" do
@@ -435,6 +503,7 @@ RSpec.describe "analyzer runs in spec/ reach the internal-error guard (#674)" do
           guarded_baseline(session)
           edit_files
           guarded_recheck(session)
+          guarded_reanalyze_subset(session, %w[a.rb])
           guarded_run_incremental(session, snapshot: s, fingerprint: fp)
           guarded_run_buffer_recheck(session, snapshot: s, fingerprint: fp)
         end
@@ -612,6 +681,7 @@ RSpec.describe "analyzer runs in spec/ reach the internal-error guard (#674)" do
             guarded_session_analyze(session, path)
             guarded_baseline(session)
             guarded_recheck(session)
+            guarded_reanalyze_subset(session, subset)
             guarded_run_incremental(session, snapshot: snapshot, fingerprint: fingerprint)
             guarded_run_buffer_recheck(session, snapshot: snapshot, fingerprint: fingerprint)
 

--- a/spec/integration/fixtures/array_new_dynamic_seed/demo.rb
+++ b/spec/integration/fixtures/array_new_dynamic_seed/demo.rb
@@ -128,8 +128,10 @@ class Grid
     a
   end
 
-  # The widening is RECURSIVE, not one level deep. Every nested position is a
-  # fresh object per constructed slot that the program goes on to mutate, so
+  # The widening is RECURSIVE, not one level deep. For the block form, every
+  # nested position is a fresh object per constructed slot that the program
+  # goes on to mutate. For the fill form, all slots alias a single object,
+  # so mutating a nested slot mutates every slot's view of it. In both cases,
   # stopping at the outermost container only moved the wrong-precise answer one
   # level in: `Array[Array[[1]]]` left the inner tuple fixed-arity, and
   # `a[0][0].last == 5` folded always-falsey on correct code.

--- a/spec/rigor/inference/scope_indexer_seed_bundle_spec.rb
+++ b/spec/rigor/inference/scope_indexer_seed_bundle_spec.rb
@@ -73,18 +73,22 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
     end
   end
 
-  # Issue #682 — `header_nestings` belongs in this list, not beside it: a warm fold that dropped it would
-  # compare equal on every other table while resolving a compact declaration's superclass in a namespace a
-  # cold run does not, which is the `--verify-incremental` divergence #707 was bumped for.
+  # Issue #724 — derive the plain tables from the accumulator rather than restating them by hand,
+  # so a new table is compared by default and only def-node / def-nesting tables need custom normalization.
+  def non_plain_tables
+    %i[def_nodes singleton_def_nodes def_nestings].freeze
+  end
+
   def plain_tables
-    %i[def_sources superclasses header_nestings includes method_visibilities methods
-       class_sources data_member_layouts struct_member_layouts]
+    @plain_tables ||= (described_class.new_def_index_accumulator.keys - non_plain_tables).freeze
   end
 
   def expect_index_equivalent(actual, reference)
     expect(actual[:classes]).to eq(reference[:classes])
     a = actual[:def_index]
     r = reference[:def_index]
+    expect(plain_tables + non_plain_tables)
+      .to match_array(described_class.new_def_index_accumulator.keys)
     plain_tables.each { |key| expect(a[key]).to eq(r[key]), "#{key} diverged" }
     expect_def_tables_equivalent(a, r, :def_nodes)
     expect_def_tables_equivalent(a, r, :singleton_def_nodes)
@@ -255,6 +259,34 @@ RSpec.describe Rigor::Inference::ScopeIndexer do
       round_tripped = Marshal.load(Marshal.dump(cold[:bundles]))
       warm = described_class.discovered_project_index_incremental(paths, seed_bundles: round_tripped)
       expect_index_equivalent(warm, described_class.discovered_project_index_for_paths(paths))
+    end
+  end
+
+  # Issue #724 Gate — removing any one table from the fold (specifically the three previously omitted tables:
+  # singleton_def_sources, extends, constant_writes, plus def_sources) must fail equivalence.
+  describe "equivalence gate discrimination (#724)" do
+    it "fails equivalence when any plain table is stripped from the compared index" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "ext.rb"), <<~RUBY)
+          module Mod
+            def bar = 2
+            def self.foo = 1
+            extend Enumerable
+            CONST = 42
+          end
+        RUBY
+        paths = [File.join(dir, "ext.rb")]
+        reference = described_class.discovered_project_index_for_paths(paths)
+
+        %i[singleton_def_sources extends constant_writes def_sources].each do |table_key|
+          tampered = {
+            classes: reference[:classes],
+            def_index: reference[:def_index].merge(table_key => {})
+          }
+          expect { expect_index_equivalent(tampered, reference) }
+            .to raise_error(RSpec::Expectations::ExpectationNotMetError, /#{table_key} diverged/)
+        end
+      end
     end
   end
 end

--- a/spec/support/guarded_analysis.rb
+++ b/spec/support/guarded_analysis.rb
@@ -99,6 +99,19 @@ module GuardedAnalysis
     result
   end
 
+  # `IncrementalSession#reanalyze_subset` — the verification engine (`--verify-incremental`). Returns
+  # `Array<Diagnostic>` directly (the merged diagnostics), so the guard checks the returned array.
+  #
+  # @param session [Rigor::Analysis::IncrementalSession]
+  # @param subset [Enumerable<String>]
+  # @return [Array<Rigor::Analysis::Diagnostic>]
+  # @raise [InternalAnalyzerErrorGuard::AnalyzerCrashed]
+  def guarded_reanalyze_subset(session, subset)
+    InternalAnalyzerErrorGuard.check_diagnostics!(
+      session.reanalyze_subset(subset), context: guarded_analysis_context("guarded_reanalyze_subset")
+    )
+  end
+
   # `IncrementalSession#run_incremental` — the `--incremental` CLI engine — returns `[diagnostics,
   # warm]`. Guards the diagnostics half and hands back the same tuple.
   #


### PR DESCRIPTION
Closes #695, closes #724

### Summary
1. **#724 Item 1**: Derived `plain_tables` in `spec/rigor/inference/scope_indexer_seed_bundle_spec.rb` directly from `ScopeIndexer.new_def_index_accumulator.keys - non_plain_tables` rather than hardcoding the list. Verified that stripping any plain table (including the previously omitted `singleton_def_sources`, `extends`, `constant_writes`) fails the gate with `#{table_key} diverged`.
2. **#724 Item 2**: Updated the comment in `spec/integration/fixtures/array_new_dynamic_seed/demo.rb` to accurately state that for the fill form, slots alias a single object, whereas for the block form each slot gets a fresh object.
3. **#695 Item 1**: Added `IncrementalSession#reanalyze_subset` to `RUN_METHODS` in `spec/docs/spec_analyzer_guard_spec.rb` and introduced `guarded_reanalyze_subset` in `GuardedAnalysis`.
4. **#695 Item 2**: Made `collect_factory_methods` transitive and handle `if` expressions returning analyzer instances.