### PR TITLE
Drop comments that restated a nearby contract

### DIFF
--- a/.rigor.dist.yml
+++ b/.rigor.dist.yml
@@ -2,6 +2,12 @@
 target_ruby: "4.0"
 paths:
   - lib
-plugins: []
+# Types for lib/ live in sig/. Listing the plugin here skips ADR-93 auto-wire
+# (magic-comment-free) so `# @rbs` comments in lib/ are not a second type source.
+plugins:
+  - gem: rigor-rbs-inline
+    id: rbs-inline
+    config:
+      require_magic_comment: true
 cache:
   path: .rigor/cache

--- a/changelog.d/fixed/comment-redundancy.md
+++ b/changelog.d/fixed/comment-redundancy.md
@@ -1,0 +1,1 @@
+- **[rigor-rbs-inline]** An `# @rbs` annotation next to a method already declared in `sig/` no longer duplicates the definition (the `.rbs` wins), and unannotated siblings in the same file no longer synthesize `untyped` skeletons. ([#779](https://github.com/rigortype/rigor/pull/779))

--- a/lib/rigor/analysis/baseline.rb
+++ b/lib/rigor/analysis/baseline.rb
@@ -236,9 +236,10 @@ module Rigor
       # Walk the current diagnostic stream and report bucket-level drift. Each baseline bucket becomes one
       # DriftRow regardless of whether the current run still matches it.
       #
-      # @param diagnostics [Array<Diagnostic>] current run's diagnostic stream (PRE-filter — pass the raw
-      #   `result.diagnostics` from `Runner#run`, not the post-baseline surface).
-      # @return [Array<DriftRow>] one entry per baseline bucket, in baseline-file order.
+      # @rbs diagnostics: Array[Diagnostic] --
+      #   Current run's diagnostic stream (PRE-filter — pass the raw `result.diagnostics` from `Runner#run`, not the
+      #   post-baseline surface).
+      # @rbs return: Array[DriftRow] -- One entry per baseline bucket, in baseline-file order.
       def audit(diagnostics)
         counts = Hash.new(0)
         diagnostics.each do |diag|

--- a/lib/rigor/analysis/check_rules.rb
+++ b/lib/rigor/analysis/check_rules.rb
@@ -2880,13 +2880,7 @@ module Rigor
         def build_undefined_method_diagnostic(path, call_node, receiver_type, definition_site = nil, class_name = nil)
           rendered_receiver = receiver_type.describe
           message = "undefined method `#{call_node.name}' for #{rendered_receiver}"
-          # ADR-17 — when the project itself defines this method on the
-          # receiver class somewhere in the file set, name the site and
-          # point at `pre_eval:`. Rigor does not apply project monkey-
-          # patches cross-file automatically, so the diagnostic still
-          # fires, but the enriched message makes it actionable (and
-          # `rigor triage` keys on the structured `project_definition_site`
-          # field to recommend `pre_eval:` with high confidence).
+          # See {#project_definition_site}.
           if definition_site
             def_owner = class_name || rendered_receiver
             message += "; the project defines `#{def_owner}##{call_node.name}' at " \

--- a/lib/rigor/analysis/check_rules.rb
+++ b/lib/rigor/analysis/check_rules.rb
@@ -83,8 +83,7 @@ module Rigor
       # have already produced `scope_index` through
       # `Rigor::Inference::ScopeIndexer.index(root, default_scope:)`.
       #
-      # @param path [String] used to populate
-      #   `Diagnostic#path`; the rule does not open files.
+      # @rbs path: String -- Used to populate `Diagnostic#path`; the rule does not open files.
       #
       # ADR-53 B4 — when `node_collectors` is supplied, the converged
       # {Plugin::NodeRuleWalk} traversal has already populated the built-in
@@ -487,9 +486,8 @@ module Rigor
         /\A#\s*rigor:(?<marker>disable-(?!file(?![\w-]))[\w-]+|enable(?:-[\w-]+)?)(?![\w-])(?<rest>.*)/
       private_constant :UNKNOWN_SUPPRESSION_MARKER
 
-      # @return [Array<(Hash{Integer => Set}, Set)>] pair of
-      #   `(line_suppressions, file_suppressions)`. Line
-      #   suppressions are keyed by source line number; file
+      # @rbs return: Array[(Hash{Integer => Set}, Set)] --
+      #   Pair of `(line_suppressions, file_suppressions)`. Line suppressions are keyed by source line number; file
       #   suppressions apply to every line.
       def parse_suppression_comments(comments)
         line_suppressions = Hash.new { |h, k| h[k] = Set.new }

--- a/lib/rigor/analysis/check_rules.rb
+++ b/lib/rigor/analysis/check_rules.rb
@@ -85,9 +85,6 @@ module Rigor
       #
       # @param path [String] used to populate
       #   `Diagnostic#path`; the rule does not open files.
-      # @param root [Prism::Node]
-      # @param scope_index [Hash{Prism::Node => Rigor::Scope}]
-      # @return [Array<Rigor::Analysis::Diagnostic>]
       #
       # ADR-53 B4 — when `node_collectors` is supplied, the converged
       # {Plugin::NodeRuleWalk} traversal has already populated the built-in

--- a/lib/rigor/analysis/check_rules/always_truthy_condition_collector.rb
+++ b/lib/rigor/analysis/check_rules/always_truthy_condition_collector.rb
@@ -53,8 +53,8 @@ module Rigor
         NODE_CLASSES = [Prism::IfNode, Prism::UnlessNode].freeze
         RULE_WALK_GATES = [:loop_or_block].freeze
 
-        # @return [Array<Result>] one entry per qualifying predicate. Empty when the tree carries no firing
-        #   predicates.
+        # @rbs return: Array[Result] --
+        #   One entry per qualifying predicate. Empty when the tree carries no firing predicates.
         def initialize(scope_index)
           @scope_index = scope_index
           @results = []

--- a/lib/rigor/analysis/check_rules/dead_version_guard_arms.rb
+++ b/lib/rigor/analysis/check_rules/dead_version_guard_arms.rb
@@ -41,7 +41,7 @@ module Rigor
           diagnostics.reject { |diagnostic| arms.any? { |arm| covers?(arm, diagnostic) } }
         end
 
-        # @return [Array<Prism::Location>] the source ranges of every dead version-guard arm
+        # @rbs return: Array[Prism::Location] -- The source ranges of every dead version-guard arm
         def scan(root)
           arms = []
           collect(root, arms)

--- a/lib/rigor/analysis/check_rules/dead_version_guard_arms.rb
+++ b/lib/rigor/analysis/check_rules/dead_version_guard_arms.rb
@@ -30,9 +30,6 @@ module Rigor
       module DeadVersionGuardArms
         module_function
 
-        # @param diagnostics [Array<Rigor::Analysis::Diagnostic>]
-        # @param root [Prism::Node]
-        # @return [Array<Rigor::Analysis::Diagnostic>]
         def filter(diagnostics, root)
           # The scan is a whole-file walk, so it is paid only when there is something to drop. A file with
           # no diagnostics — the overwhelming majority — never walks.
@@ -44,7 +41,6 @@ module Rigor
           diagnostics.reject { |diagnostic| arms.any? { |arm| covers?(arm, diagnostic) } }
         end
 
-        # @param root [Prism::Node]
         # @return [Array<Prism::Location>] the source ranges of every dead version-guard arm
         def scan(root)
           arms = []

--- a/lib/rigor/analysis/check_rules/main_pass_collector.rb
+++ b/lib/rigor/analysis/check_rules/main_pass_collector.rb
@@ -25,8 +25,8 @@ module Rigor
           Prism::CallNode, Prism::DefNode, Prism::IfNode, Prism::UnlessNode
         ].freeze
 
-        # @param node_diagnostics [#call] maps a `Prism::Node` to the array of diagnostics the main pass emits
-        #   for it.
+        # @rbs node_diagnostics: untyped --
+        #   Maps a `Prism::Node` to the array of diagnostics the main pass emits for it.
         def initialize(node_diagnostics)
           @node_diagnostics = node_diagnostics
           @diagnostics = []

--- a/lib/rigor/analysis/check_rules/published_constant_guard.rb
+++ b/lib/rigor/analysis/check_rules/published_constant_guard.rb
@@ -66,7 +66,7 @@ module Rigor
 
         module_function
 
-        # @return [Boolean] true when the rule MUST withhold its firing.
+        # @rbs return: bool -- True when the rule MUST withhold its firing.
         def rooted?(node, scope, depth = 0)
           return false if node.nil? || depth > MAX_DEPTH || scope.nil?
 

--- a/lib/rigor/analysis/check_rules/self_closedness_scanner.rb
+++ b/lib/rigor/analysis/check_rules/self_closedness_scanner.rb
@@ -29,7 +29,7 @@ module Rigor
           @root = root
         end
 
-        # @return [Set<String>] qualified names to exclude from the rule.
+        # @rbs return: Set[String] -- Qualified names to exclude from the rule.
         def open_class_names
           names = Set.new
           walk(@root, [], names)

--- a/lib/rigor/analysis/check_rules/shadowed_rescue_collector.rb
+++ b/lib/rigor/analysis/check_rules/shadowed_rescue_collector.rb
@@ -58,7 +58,7 @@ module Rigor
         # Legacy single-collector walk — the oracle the shadow harness (`RIGOR_SHADOW_RULE_WALK=1`) compares
         # the shared {RuleWalk} traversal against. Tracks the lexical class / module prefix itself, exactly
         # as {RuleWalk} threads `qualified_prefix`.
-        # @return [Array<Result>] one entry per provably-shadowed rescue clause.
+        # @rbs return: Array[Result] -- One entry per provably-shadowed rescue clause.
         def collect(root)
           walk(root, [])
           @results.freeze

--- a/lib/rigor/analysis/check_rules/unreachable_clause_collector.rb
+++ b/lib/rigor/analysis/check_rules/unreachable_clause_collector.rb
@@ -42,11 +42,10 @@ module Rigor
         DEFENSIVE_EXIT_CALLS = %i[raise fail throw abort exit].freeze
 
         # @!attribute kind
-        #   @return [Symbol] `:disjoint` (this clause's type is disjoint
-        #     from the still-possible subject), `:prior_exhaustion` (an
-        #     earlier clause already covered the subject), or
-        #     `:exhausted_else` (every subject value is covered, so the
-        #     `else` never runs).
+        # @rbs return: Symbol --
+        #   `:disjoint` (this clause's type is disjoint from the still-possible subject), `:prior_exhaustion` (an
+        #   earlier clause already covered the subject), or `:exhausted_else` (every subject value is covered, so the
+        #   `else` never runs).
         Result = Data.define(:clause, :body, :subject_name, :condition_source, :kind, :keyword)
 
         # ADR-53 Track B — the node classes the shared {RuleWalk} dispatches to this collector, and the
@@ -63,7 +62,7 @@ module Rigor
 
         # Legacy single-collector walk — kept as the oracle the ADR-53 Track B equivalence harness compares
         # {RuleWalk} against; deleted when Track B completes.
-        # @return [Array<Result>] one entry per provably-dead `when` clause.
+        # @rbs return: Array[Result] -- One entry per provably-dead `when` clause.
         def collect(root)
           walk(root, in_loop_or_block: false)
           @results.freeze

--- a/lib/rigor/analysis/check_rules/void_value_use_collector.rb
+++ b/lib/rigor/analysis/check_rules/void_value_use_collector.rb
@@ -52,7 +52,6 @@ module Rigor
         # Legacy single-collector walk — kept as the oracle the ADR-53 Track B equivalence harness compares
         # {RuleWalk} against. Walks the whole subtree once, checking each consumer node's value slots.
         # Returns one {Result} per value-context use of a recovered-`void` call.
-        # @return [Array<Result>]
         def collect(root)
           walk(root)
           @results.freeze

--- a/lib/rigor/analysis/crash_signature.rb
+++ b/lib/rigor/analysis/crash_signature.rb
@@ -77,7 +77,7 @@ module Rigor
 
       module_function
 
-      # @return [Symbol, nil] `:check_rule`, `:plugin`, `:rbs_build`, or nil for an ordinary diagnostic.
+      # @rbs return: Symbol? -- `:check_rule`, `:plugin`, `:rbs_build`, or nil for an ordinary diagnostic.
       def reason(diagnostic)
         return :check_rule if diagnostic.message.to_s.start_with?(CHECK_RULE_MESSAGE_PREFIX)
         return :plugin if plugin_isolation_row?(diagnostic)

--- a/lib/rigor/analysis/crash_signature.rb
+++ b/lib/rigor/analysis/crash_signature.rb
@@ -77,7 +77,6 @@ module Rigor
 
       module_function
 
-      # @param diagnostic [Rigor::Analysis::Diagnostic]
       # @return [Symbol, nil] `:check_rule`, `:plugin`, `:rbs_build`, or nil for an ordinary diagnostic.
       def reason(diagnostic)
         return :check_rule if diagnostic.message.to_s.start_with?(CHECK_RULE_MESSAGE_PREFIX)
@@ -90,17 +89,12 @@ module Rigor
       # True when `diagnostic` is the rescue row that REPLACED a file's analysis — the only shape after which
       # the run's diagnostics say nothing about the code. NOT a general "something went wrong" predicate; see
       # the class doc for why `:plugin` and `:rbs_build` are excluded.
-      #
-      # @param diagnostic [Rigor::Analysis::Diagnostic]
       def discards_file_analysis?(diagnostic)
         reason(diagnostic) == DISCARDS_FILE_ANALYSIS_REASON
       end
 
       # A one-line "<reason> at <path>:<line>: <message>" for a failure message, so whoever reads the raise
       # sees which shape fired and where without re-deriving it.
-      #
-      # @param diagnostic [Rigor::Analysis::Diagnostic]
-      # @return [String]
       def describe(diagnostic)
         "#{reason(diagnostic) || :unknown} at #{diagnostic.path}:#{diagnostic.line}: #{diagnostic.message}"
       end

--- a/lib/rigor/analysis/dependency_source_inference/boundary_cross_reporter.rb
+++ b/lib/rigor/analysis/dependency_source_inference/boundary_cross_reporter.rb
@@ -25,9 +25,10 @@ module Rigor
           @mutex = Mutex.new
         end
 
-        # @return [Array<Entry>] frozen snapshot of the recorded boundary-cross events. Each entry is a Data
-        #   with `class_name` (String), `method_name` (Symbol), `gem_name` (String), and `rbs_display` (String
-        #   — the authoritative-side type's human-facing form, embedded into the diagnostic message).
+        # @rbs return: Array[Entry] --
+        #   Frozen snapshot of the recorded boundary-cross events. Each entry is a Data with `class_name` (String),
+        #   `method_name` (Symbol), `gem_name` (String), and `rbs_display` (String — the authoritative-side type's
+        #   human-facing form, embedded into the diagnostic message).
         def entries
           @mutex.synchronize { @entries.dup.freeze }
         end

--- a/lib/rigor/analysis/dependency_source_inference/builder.rb
+++ b/lib/rigor/analysis/dependency_source_inference/builder.rb
@@ -17,8 +17,6 @@ module Rigor
       module Builder
         module_function
 
-        # @param dependencies [Rigor::Configuration::Dependencies]
-        # @return [Index]
         def build(dependencies)
           return Index::EMPTY if dependencies.empty?
 

--- a/lib/rigor/analysis/dependency_source_inference/gem_resolver.rb
+++ b/lib/rigor/analysis/dependency_source_inference/gem_resolver.rb
@@ -30,8 +30,6 @@ module Rigor
 
         module_function
 
-        # @param entry [Rigor::Configuration::Dependencies::Entry]
-        # @return [Resolved, Unresolvable]
         def resolve(entry)
           spec = locate_gem_spec(entry.gem)
           return Unresolvable.new(gem_name: entry.gem, reason: :not_in_bundle) if spec.nil?

--- a/lib/rigor/analysis/dependency_source_inference/index.rb
+++ b/lib/rigor/analysis/dependency_source_inference/index.rb
@@ -13,23 +13,23 @@ module Rigor
         attr_reader :resolved_gems, :unresolvable, :method_catalog, :budget_exceeded,
                     :class_to_gem, :budget_overrun_strategy, :gem_modes
 
-        # @param method_catalog [Hash{[String, Symbol] => Symbol}] the flat
-        #   `(class_name, method_name) → :instance | :singleton` table produced by {Walker.walk}, aggregated
-        #   across every resolved gem in the run. The Index itself stays gem-agnostic — the per-gem
-        #   attribution that slice 3's cache descriptor needs lives on `Resolved`, not here.
-        # @param budget_exceeded [Array<String>] gem names whose {Walker} run hit the per-gem catalog cap
-        #   (slice 4). The Runner consumes this list to emit one `dynamic.dependency-source.budget-exceeded`
-        #   warning per gem.
-        # @param class_to_gem [Hash<String, String>] reverse lookup `class_name → gem_name` (slice 5b). Built
-        #   first-write-wins: when two opt-in gems re-open the same class, the first gem owns it. The
-        #   dispatcher consults this map under the `:dependency_silence` budget overrun strategy so call
-        #   sites on a budget-exceeded gem's classes degrade to `Dynamic[top]` instead of falling through to
-        #   the user-class fallback.
-        # @param gem_modes [Hash<String, Symbol>] per-gem mode table (`gem_name → :disabled | :when_missing |
-        #   :full`). ADR-10 slice 5c consults this through {#mode_for} to identify call sites where
-        #   gem-source and RBS both contribute under `mode: :full`. The map is keyed on `gem_name` (not
-        #   class) because re-opened classes belong to the first gem they appeared in per `class_to_gem`;
-        #   `mode_for(class_name)` chains the two lookups.
+        # @rbs method_catalog: Hash[[String, Symbol], Symbol] --
+        #   The flat `(class_name, method_name) → :instance | :singleton` table produced by {Walker.walk}, aggregated
+        #   across every resolved gem in the run. The Index itself stays gem-agnostic — the per-gem attribution that
+        #   slice 3's cache descriptor needs lives on `Resolved`, not here.
+        # @rbs budget_exceeded: Array[String] --
+        #   Gem names whose {Walker} run hit the per-gem catalog cap (slice 4). The Runner consumes this list to emit
+        #   one `dynamic.dependency-source.budget-exceeded` warning per gem.
+        # @rbs class_to_gem: Hash[String, String] --
+        #   Reverse lookup `class_name → gem_name` (slice 5b). Built first-write-wins: when two opt-in gems re-open
+        #   the same class, the first gem owns it. The dispatcher consults this map under the `:dependency_silence`
+        #   budget overrun strategy so call sites on a budget-exceeded gem's classes degrade to `Dynamic[top]` instead
+        #   of falling through to the user-class fallback.
+        # @rbs gem_modes: Hash[String, Symbol] --
+        #   Per-gem mode table (`gem_name → :disabled | :when_missing | :full`). ADR-10 slice 5c consults this through
+        #   {#mode_for} to identify call sites where gem-source and RBS both contribute under `mode: :full`. The map
+        #   is keyed on `gem_name` (not class) because re-opened classes belong to the first gem they appeared in per
+        #   `class_to_gem`; `mode_for(class_name)` chains the two lookups.
         def initialize(
           resolved_gems: [], unresolvable: [], method_catalog: {},
           budget_exceeded: [], class_to_gem: {},
@@ -56,8 +56,8 @@ module Rigor
         end
         private :normalize_catalog
 
-        # @return [String, nil] the gem that owns `class_name` (first-write-wins); `nil` when the class isn't
-        #   in any opt-in gem's catalog.
+        # @rbs return: String? --
+        #   The gem that owns `class_name` (first-write-wins); `nil` when the class isn't in any opt-in gem's catalog.
         def gem_for(class_name)
           @class_to_gem[class_name]
         end

--- a/lib/rigor/analysis/dependency_source_inference/return_type_heuristic.rb
+++ b/lib/rigor/analysis/dependency_source_inference/return_type_heuristic.rb
@@ -28,8 +28,9 @@ module Rigor
       module ReturnTypeHeuristic
         module_function
 
-        # @return [Rigor::Type, nil] heuristic return type, or `nil` when the body's tail expression doesn't
-        #   match any of the recognised shapes.
+        # @rbs return: Rigor::Type? --
+        #   Heuristic return type, or `nil` when the body's tail expression doesn't match any of the recognised
+        #   shapes.
         def extract(def_node)
           body = def_node.body
           return nil if body.nil?

--- a/lib/rigor/analysis/dependency_source_inference/return_type_heuristic.rb
+++ b/lib/rigor/analysis/dependency_source_inference/return_type_heuristic.rb
@@ -28,7 +28,6 @@ module Rigor
       module ReturnTypeHeuristic
         module_function
 
-        # @param def_node [Prism::DefNode]
         # @return [Rigor::Type, nil] heuristic return type, or `nil` when the body's tail expression doesn't
         #   match any of the recognised shapes.
         def extract(def_node)

--- a/lib/rigor/analysis/dependency_source_inference/walker.rb
+++ b/lib/rigor/analysis/dependency_source_inference/walker.rb
@@ -55,15 +55,18 @@ module Rigor
 
         module_function
 
-        # @param gem_dir [String, Pathname] absolute path to the gem's installation directory.
-        # @param roots [Array<String>] subdirectory names within the gem to walk (defaults to `["lib"]` per
+        # @rbs gem_dir: String | Pathname -- Absolute path to the gem's installation directory.
+        # @rbs roots: Array[String] --
+        #   Subdirectory names within the gem to walk (defaults to `["lib"]` per
         #   `Configuration::Dependencies::Entry`).
-        # @param budget [Integer, Float] per-gem catalog cap (method-definition count). When unset, defaults
-        #   to `UNBOUNDED` for backwards-compatible test paths.
-        # @return [Outcome] frozen wrapper carrying the catalog (`Hash{[class_name, method_name] =>
-        #   :instance | :singleton}`) and a `truncated?` flag set when the walker stopped harvesting because
-        #   the budget was reached. Methods of identical name on the same class with different kinds (rare;
-        #   private API mostly) carry the kind that wins the per-class first walk.
+        # @rbs budget: Integer | Float --
+        #   Per-gem catalog cap (method-definition count). When unset, defaults to `UNBOUNDED` for
+        #   backwards-compatible test paths.
+        # @rbs return: Outcome --
+        #   Frozen wrapper carrying the catalog (`Hash{[class_name, method_name] => :instance | :singleton}`) and a
+        #   `truncated?` flag set when the walker stopped harvesting because the budget was reached. Methods of
+        #   identical name on the same class with different kinds (rare; private API mostly) carry the kind that wins
+        #   the per-class first walk.
         def walk(gem_dir:, roots:, budget: UNBOUNDED)
           accumulator = {}
           truncated = false

--- a/lib/rigor/analysis/effects_cache_probe.rb
+++ b/lib/rigor/analysis/effects_cache_probe.rb
@@ -52,16 +52,16 @@ module Rigor
       # otherwise rebuild (the probe loaded the plugins to key the entry, so it already knows it).
       Served = Data.define(:table, :sources, :registry, :plugin_facts)
 
-      # @param configuration [Rigor::Configuration] with effects already enabled by the caller.
+      # @rbs configuration: Rigor::Configuration -- With effects already enabled by the caller.
       def initialize(configuration:, cache_root:)
         @configuration = configuration
         @cache_root = cache_root
       end
 
-      # @param paths [Array<String>] the analysed set — `configuration.paths` unioned with any path
-      #   arguments, exactly what {CLI::EffectsCommand#analyze} hands the runner, because the analysed
-      #   set is part of the diagnostics key.
-      # @return [Served, nil] nil to decline, on any failure whatsoever.
+      # @rbs paths: Array[String] --
+      #   The analysed set — `configuration.paths` unioned with any path arguments, exactly what
+      #   {CLI::EffectsCommand#analyze} hands the runner, because the analysed set is part of the diagnostics key.
+      # @rbs return: Served? -- Nil to decline, on any failure whatsoever.
       def serve(paths)
         return nil if @cache_root.nil? || !@configuration.effects_check?
 

--- a/lib/rigor/analysis/effects_cache_probe.rb
+++ b/lib/rigor/analysis/effects_cache_probe.rb
@@ -53,7 +53,6 @@ module Rigor
       Served = Data.define(:table, :sources, :registry, :plugin_facts)
 
       # @param configuration [Rigor::Configuration] with effects already enabled by the caller.
-      # @param cache_root [String, nil]
       def initialize(configuration:, cache_root:)
         @configuration = configuration
         @cache_root = cache_root

--- a/lib/rigor/analysis/erb_template_detector.rb
+++ b/lib/rigor/analysis/erb_template_detector.rb
@@ -19,7 +19,6 @@ module Rigor
 
       module_function
 
-      # @param parse_result [Prism::ParseResult]
       # @return [Boolean] true when the parsed source looks like an ERB template (parse errors expected;
       #   analysis should skip).
       def template?(parse_result)

--- a/lib/rigor/analysis/erb_template_detector.rb
+++ b/lib/rigor/analysis/erb_template_detector.rb
@@ -19,8 +19,8 @@ module Rigor
 
       module_function
 
-      # @return [Boolean] true when the parsed source looks like an ERB template (parse errors expected;
-      #   analysis should skip).
+      # @rbs return: bool --
+      #   True when the parsed source looks like an ERB template (parse errors expected; analysis should skip).
       def template?(parse_result)
         source = parse_result.source.source
         return false unless source.is_a?(String) && !source.empty?

--- a/lib/rigor/analysis/incremental_session.rb
+++ b/lib/rigor/analysis/incremental_session.rb
@@ -42,28 +42,29 @@ module Rigor
         end
       end
 
-      # @param paths [Array<String>, nil] explicit analysis roots; nil (the default) uses the configuration's
-      #   `paths:`.
-      # @param environment [Rigor::Environment, nil] optional shared environment to thread into each internal
-      #   Runner. Long-lived callers and specs can use this to avoid rebuilding the same RBS universe for
-      #   every baseline / recheck / oracle run.
-      # @param cache_store [Rigor::Cache::Store, nil] ADR-85 WD1 — the persistent cache each internal Runner
-      #   exposes to the RBS-env and plugin-producer tiers. A cross-process `--incremental` recheck otherwise
-      #   rebuilt a fresh runner with no store, so every plugin `#prepare` producer (the ADR-9/#74/ADR-60 WD3
-      #   record-and-validate caches) recomputed per invocation — 86% of a Rails warm incremental. Threading
-      #   the store lets those producers serve from disk. `nil` (the default) preserves the pre-#85 behaviour
-      #   the specs assert; the whole-run ADR-45 result cache stays disabled on these runs
-      #   (`Runner#run_result_cacheable?` excludes `record_dependencies` / `analyze_only`).
-      # @param plugin_requirer [#call, nil] optional gem-require hook threaded into each internal Runner
-      #   (mirrors {Runner}'s parameter). nil (the default, and what the CLI passes) uses `Kernel.require`;
-      #   embedders and specs inject a fake so a test plugin registers without touching the real load path.
-      # @param workers [Integer] ADR-46 — the resolved fork-pool worker count threaded into every internal
-      #   analyzer, so a `--incremental` recheck's closure re-analysis parallelises exactly like the standard
-      #   `check` path (the recon's audit: `--workers` / `RIGOR_RACTOR_WORKERS` / `parallel.workers:` were
-      #   silently ignored because `build_runner` passed no `workers:`). 0 (the default, and what the specs and
-      #   `--verify-incremental` gate use) keeps the sequential recording path bit-for-bit unchanged. The fork
-      #   pool records each worker's cross-file reads and marshals them back (PoolCoordinator), so the
-      #   dependency graph a pooled recheck rebuilds equals the sequential one.
+      # @rbs paths: Array[String]? -- Explicit analysis roots; nil (the default) uses the configuration's `paths:`.
+      # @rbs environment: Rigor::Environment? --
+      #   Optional shared environment to thread into each internal Runner. Long-lived callers and specs can use this
+      #   to avoid rebuilding the same RBS universe for every baseline / recheck / oracle run.
+      # @rbs cache_store: Rigor::Cache::Store? --
+      #   ADR-85 WD1 — the persistent cache each internal Runner exposes to the RBS-env and plugin-producer tiers. A
+      #   cross-process `--incremental` recheck otherwise rebuilt a fresh runner with no store, so every plugin
+      #   `#prepare` producer (the ADR-9/#74/ADR-60 WD3 record-and-validate caches) recomputed per invocation — 86% of
+      #   a Rails warm incremental. Threading the store lets those producers serve from disk. `nil` (the default)
+      #   preserves the pre-#85 behaviour the specs assert; the whole-run ADR-45 result cache stays disabled on these
+      #   runs (`Runner#run_result_cacheable?` excludes `record_dependencies` / `analyze_only`).
+      # @rbs plugin_requirer: untyped --
+      #   Optional gem-require hook threaded into each internal Runner (mirrors {Runner}'s parameter). nil (the
+      #   default, and what the CLI passes) uses `Kernel.require`; embedders and specs inject a fake so a test plugin
+      #   registers without touching the real load path.
+      # @rbs workers: Integer --
+      #   ADR-46 — the resolved fork-pool worker count threaded into every internal analyzer, so a `--incremental`
+      #   recheck's closure re-analysis parallelises exactly like the standard `check` path (the recon's audit:
+      #   `--workers` / `RIGOR_RACTOR_WORKERS` / `parallel.workers:` were silently ignored because `build_runner`
+      #   passed no `workers:`). 0 (the default, and what the specs and `--verify-incremental` gate use) keeps the
+      #   sequential recording path bit-for-bit unchanged. The fork pool records each worker's cross-file reads and
+      #   marshals them back (PoolCoordinator), so the dependency graph a pooled recheck rebuilds equals the
+      #   sequential one.
       def initialize(configuration:, paths: nil, environment: nil, cache_store: nil, plugin_requirer: nil,
                      workers: 0, buffer: nil)
         @configuration = configuration

--- a/lib/rigor/analysis/plugin_fact_fingerprint.rb
+++ b/lib/rigor/analysis/plugin_fact_fingerprint.rb
@@ -79,7 +79,7 @@ module Rigor
       #
       # Keeping the opaque decision here, rather than at each cache's call site, means a new consumer cannot
       # key on `digest` while forgetting that an opaque surface makes it meaningless.
-      # @return [String, nil]
+      # @rbs return: String?
       def self.key_digest(registry)
         result = from_registry(registry)
         result.opaque? ? nil : result.digest.to_s

--- a/lib/rigor/analysis/reachability/graph.rb
+++ b/lib/rigor/analysis/reachability/graph.rb
@@ -29,12 +29,15 @@ module Rigor
         # bucket on trust.
         Undecidable = Data.define(:fqn, :path, :line, :reason)
 
-        # @param root_fqns [Enumerable<String>] declarations that are entry points regardless of who references
-        #   them (config-declared globs in this slice; plugin-supplied roots are #349).
-        # @param foreign [#call] predicate answering "is this FQN owned by something outside the project?" —
-        #   a reopened gem or stdlib class must never be a candidate (WD6). Defaults to "nothing is foreign".
-        # @param dynamic_uses [Array<Scan::DynamicUse>] sites where a constant is reached by name at runtime.
-        #   A literal-argument site contributes a real reference; a dynamic one taints a namespace (WD4).
+        # @rbs root_fqns: Enumerable[String] --
+        #   Declarations that are entry points regardless of who references them (config-declared globs in this slice;
+        #   plugin-supplied roots are #349).
+        # @rbs foreign: untyped --
+        #   Predicate answering "is this FQN owned by something outside the project?" — a reopened gem or stdlib class
+        #   must never be a candidate (WD6). Defaults to "nothing is foreign".
+        # @rbs dynamic_uses: Array[Scan::DynamicUse] --
+        #   Sites where a constant is reached by name at runtime. A literal-argument site contributes a real
+        #   reference; a dynamic one taints a namespace (WD4).
         def initialize(declarations:, references:, root_fqns: [], dynamic_uses: [], foreign: ->(_fqn) { false })
           @declarations = declarations
           @dynamic_uses = dynamic_uses

--- a/lib/rigor/analysis/reachability/graph.rb
+++ b/lib/rigor/analysis/reachability/graph.rb
@@ -29,8 +29,6 @@ module Rigor
         # bucket on trust.
         Undecidable = Data.define(:fqn, :path, :line, :reason)
 
-        # @param declarations [Array<Scan::Declaration>]
-        # @param references [Array<Scan::Reference>]
         # @param root_fqns [Enumerable<String>] declarations that are entry points regardless of who references
         #   them (config-declared globs in this slice; plugin-supplied roots are #349).
         # @param foreign [#call] predicate answering "is this FQN owned by something outside the project?" —

--- a/lib/rigor/analysis/reachability/plugin_roots.rb
+++ b/lib/rigor/analysis/reachability/plugin_roots.rb
@@ -83,15 +83,18 @@ module Rigor
         # Loads the project's configured plugins, runs every `#prepare`, and returns the union of every
         # published `:reachability_roots` and `:reachability_references` fact.
         #
-        # @param configuration [Rigor::Configuration] the loaded project configuration.
-        # @param plugin_requirer [#call] how a plugin gem is brought into the process. The same seam
-        #   `Analysis::Runner` exposes, so a spec can register a plugin class without publishing a gem.
-        # @param cache_store [Rigor::Cache::Store, nil] when given, each plugin's `#prepare` producers read
-        #   and write the same ADR-60 record-and-validate slots they use under `rigor check`, instead of
-        #   recomputing from scratch — a routes parse or a factory discovery is a validated cache read on
-        #   every invocation after the first. Nil keeps the historical recompute-always behaviour.
-        # @return [Contribution] sorted and de-duplicated. Empty whenever the project declares no plugins, no
-        #   plugin contributes anything, or anything at all goes wrong.
+        # @rbs configuration: Rigor::Configuration -- The loaded project configuration.
+        # @rbs plugin_requirer: untyped --
+        #   How a plugin gem is brought into the process. The same seam `Analysis::Runner` exposes, so a spec can
+        #   register a plugin class without publishing a gem.
+        # @rbs cache_store: Rigor::Cache::Store? --
+        #   When given, each plugin's `#prepare` producers read and write the same ADR-60 record-and-validate slots
+        #   they use under `rigor check`, instead of recomputing from scratch — a routes parse or a factory discovery
+        #   is a validated cache read on every invocation after the first. Nil keeps the historical recompute-always
+        #   behaviour.
+        # @rbs return: Contribution --
+        #   Sorted and de-duplicated. Empty whenever the project declares no plugins, no plugin contributes anything,
+        #   or anything at all goes wrong.
         def collect(configuration:, plugin_requirer: ->(name) { require name }, cache_store: nil)
           return Contribution.empty if configuration.plugins.empty?
 

--- a/lib/rigor/analysis/reachability/project_files.rb
+++ b/lib/rigor/analysis/reachability/project_files.rb
@@ -46,8 +46,8 @@ module Rigor
           File.fnmatch?(pattern, path, File::FNM_PATHNAME)
         end
 
-        # @param relative_paths [Array<String>] paths relative to `root`.
-        # @return [Array<String>] those that belong to the project itself.
+        # @rbs relative_paths: Array[String] -- Paths relative to `root`.
+        # @rbs return: Array[String] -- Those that belong to the project itself.
         def own(relative_paths, root)
           prefixes = submodule_prefixes(root)
           relative_paths.grep_v(VENDOR_DIRS).reject { |rel| prefixes.any? { |prefix| rel.start_with?(prefix) } }

--- a/lib/rigor/analysis/reachability/scan.rb
+++ b/lib/rigor/analysis/reachability/scan.rb
@@ -70,15 +70,16 @@ module Rigor
           end
         end
 
-        # @param path [String] the file's path, as the report should render it.
-        # @param source [String] the file's bytes.
-        # @param target_ruby [String, nil] Prism version string, threaded from the project configuration.
-        # @return [Result, nil] nil when the file does not parse (a parse error is the analyzer's business, not
-        #   this scan's — it simply contributes nothing rather than half a file).
-        # A constant name is ASCII by construction, so a byte sequence that is not valid UTF-8 cannot be one.
-        # Dropping it is both correct and the only safe answer: carrying it forward crashed the whole run on
-        # the first `String#sub` downstream, which is how this surfaced — `rigor unused` on Rigor's own
-        # repository, which vendors a CRuby checkout containing deliberately ill-encoded encoding fixtures.
+        # @rbs path: String -- The file's path, as the report should render it.
+        # @rbs source: String -- The file's bytes.
+        # @rbs target_ruby: String? -- Prism version string, threaded from the project configuration.
+        # @rbs return: Result? --
+        #   Nil when the file does not parse (a parse error is the analyzer's business, not this scan's — it simply
+        #   contributes nothing rather than half a file). A constant name is ASCII by construction, so a byte sequence
+        #   that is not valid UTF-8 cannot be one. Dropping it is both correct and the only safe answer: carrying it
+        #   forward crashed the whole run on the first `String#sub` downstream, which is how this surfaced — `rigor
+        #   unused` on Rigor's own repository, which vendors a CRuby checkout containing deliberately ill-encoded
+        #   encoding fixtures.
         def self.usable_name(raw)
           return nil if raw.nil?
 

--- a/lib/rigor/analysis/reachability/scan_cache.rb
+++ b/lib/rigor/analysis/reachability/scan_cache.rb
@@ -43,9 +43,9 @@ module Rigor
         RACY_WINDOW_NS = 2_000_000_000
         private_constant :RACY_WINDOW_NS
 
-        # @param cache_path [String, nil] the configuration's cache root; nil or empty is an inert
-        #   cache (every fetch computes, nothing persists).
-        # @param target_ruby [String, nil] parse-affecting configuration, part of the identity.
+        # @rbs cache_path: String? --
+        #   The configuration's cache root; nil or empty is an inert cache (every fetch computes, nothing persists).
+        # @rbs target_ruby: String? -- Parse-affecting configuration, part of the identity.
         def self.open(cache_path, target_ruby: nil)
           return new(path: nil, header: nil) if cache_path.nil? || cache_path.to_s.empty?
 

--- a/lib/rigor/analysis/reachability/signature_scan.rb
+++ b/lib/rigor/analysis/reachability/signature_scan.rb
@@ -26,9 +26,10 @@ module Rigor
       module SignatureScan
         module_function
 
-        # @param file [String] path to a `.rbs` file.
-        # @return [Array<Scan::Reference>] one file-level reference per distinct referenced name. Empty when the
-        #   file cannot be read or parsed — a broken signature is the analyzer's business, not this scan's.
+        # @rbs file: String -- Path to a `.rbs` file.
+        # @rbs return: Array[Scan::Reference] --
+        #   One file-level reference per distinct referenced name. Empty when the file cannot be read or parsed — a
+        #   broken signature is the analyzer's business, not this scan's.
         def call(file)
           _, _, decls = ::RBS::Parser.parse_signature(::RBS::Buffer.new(name: file, content: File.read(file)))
           found = []

--- a/lib/rigor/analysis/result.rb
+++ b/lib/rigor/analysis/result.rb
@@ -43,8 +43,6 @@ module Rigor
 
       # The diagnostics {#crashed?} answers true for, so a caller can name what it saw rather than only that
       # it saw something.
-      #
-      # @return [Array<Rigor::Analysis::Diagnostic>]
       def crash_diagnostics
         diagnostics.select { |diagnostic| CrashSignature.discards_file_analysis?(diagnostic) }
       end

--- a/lib/rigor/analysis/result.rb
+++ b/lib/rigor/analysis/result.rb
@@ -7,9 +7,10 @@ module Rigor
     class Result
       attr_reader :diagnostics, :stats
 
-      # @param stats [Rigor::Analysis::RunStats, nil] end-of-run telemetry (target file count, RBS class
-      #   breakdown, wall + RSS) collected by the Runner. Nil when stats collection wasn't requested or wasn't
-      #   applicable (early-exit paths like `validate_target_ruby` failure).
+      # @rbs stats: Rigor::Analysis::RunStats? --
+      #   End-of-run telemetry (target file count, RBS class breakdown, wall + RSS) collected by the Runner. Nil when
+      #   stats collection wasn't requested or wasn't applicable (early-exit paths like `validate_target_ruby`
+      #   failure).
       def initialize(diagnostics: [], stats: nil)
         @diagnostics = diagnostics
         @stats = stats

--- a/lib/rigor/analysis/run_cache_key.rb
+++ b/lib/rigor/analysis/run_cache_key.rb
@@ -80,8 +80,9 @@ module Rigor
       # collecting project's path-set churn is the same churn, and over-evicting costs one recompute.
       EFFECTS_GENERATION_CAP = GENERATION_CAP
 
-      # @param rbs_config_entries [Array<Cache::Descriptor::ConfigEntry>] the RBS-derived config slots
-      #   (`rbs.libraries` [+ `rbs.virtual_rbs`]). nil on any failure so a malformed key disables the cache.
+      # @rbs rbs_config_entries: Array[Cache::Descriptor::ConfigEntry] --
+      #   The RBS-derived config slots (`rbs.libraries` [+ `rbs.virtual_rbs`]). nil on any failure so a malformed key
+      #   disables the cache.
       def descriptor(configuration:, files:, explain:, rbs_config_entries:)
         Cache::Descriptor.new(
           gems: [Cache::RbsDescriptor.rbs_gem_entry],

--- a/lib/rigor/analysis/run_cache_probe.rb
+++ b/lib/rigor/analysis/run_cache_probe.rb
@@ -51,18 +51,18 @@ module Rigor
     #   serves it instead. The decline is measured against the declarations alone, never against what they
     #   would judge to, so it costs one glob and never a wrong answer.
     class RunCacheProbe
-      # @param explain [Boolean] the `--explain` flag (folded into the key, as the runner does).
+      # @rbs explain: bool -- The `--explain` flag (folded into the key, as the runner does).
       def initialize(configuration:, cache_root:, explain:)
         @configuration = configuration
         @cache_root = cache_root
         @explain = explain
       end
 
-      # @param paths [Array<String>] the analysis roots (`@argv` or `configuration.paths`).
-      # @return [Analysis::Result, nil] the cached run result with the severity profile applied and no stats
-      #   (matching a cache-served `Runner#run`), or nil to DECLINE — a miss / stale / unavailable cache — so
-      #   the caller loads the engine and runs the full path. Any failure declines rather than raising: the
-      #   probe must never turn a servable run into a crash.
+      # @rbs paths: Array[String] -- The analysis roots (`@argv` or `configuration.paths`).
+      # @rbs return: Analysis::Result? --
+      #   The cached run result with the severity profile applied and no stats (matching a cache-served `Runner#run`),
+      #   or nil to DECLINE — a miss / stale / unavailable cache — so the caller loads the engine and runs the full
+      #   path. Any failure declines rather than raising: the probe must never turn a servable run into a crash.
       def serve(paths)
         files = PathExpansion.ruby_files(paths, @configuration.exclude_patterns)
         key = RunCacheKey.descriptor(

--- a/lib/rigor/analysis/run_cache_probe.rb
+++ b/lib/rigor/analysis/run_cache_probe.rb
@@ -51,8 +51,6 @@ module Rigor
     #   serves it instead. The decline is measured against the declarations alone, never against what they
     #   would judge to, so it costs one glob and never a wrong answer.
     class RunCacheProbe
-      # @param configuration [Rigor::Configuration]
-      # @param cache_root [String]
       # @param explain [Boolean] the `--explain` flag (folded into the key, as the runner does).
       def initialize(configuration:, cache_root:, explain:)
         @configuration = configuration

--- a/lib/rigor/analysis/runner.rb
+++ b/lib/rigor/analysis/runner.rb
@@ -206,42 +206,44 @@ module Rigor
         end
       end
 
-      # @param explain [Boolean] surface fail-soft fallback events as `:info` diagnostics.
-      # @param cache_store [Rigor::Cache::Store, nil] the persistent cache the runner exposes to producers
-      #   (`RbsConstantTable` and successors). Pass `nil` to disable caching for this run; the CLI's
-      #   `--no-cache` flag wires `nil` through. v0.0.9 group A slice 1 introduces the surface; later
-      #   slices route real producers through it.
-      # @param workers [Integer] ADR-15 Phase 4b — when greater than zero, per-file analysis dispatches
-      #   across a pool of N workers. Default `0` keeps the sequential code path bit-for-bit unchanged.
-      #   Controlled via the `RIGOR_RACTOR_WORKERS` env var or `.rigor.yml` `parallel.workers:` (Phase 4c,
-      #   fully wired).
-      # @param collect_stats [Boolean] when true (default), `#run` builds a {RunStats} summary exposed via
-      #   `result.stats` — this forces the RBS env build at end-of-run so the `class_decl_paths` snapshot
-      #   has real source attribution. Set to false to skip the stats summary entirely; the CLI's
-      #   `--no-stats` threads `false` through to keep trivial-fixture runs from warming `.rigor/cache`.
-      # @param prebuilt [Rigor::Analysis::ProjectScan, nil] when supplied, the runner adopts the pre-built
-      #   plugin registry / dependency-source index / scanner outputs from the snapshot and skips the
-      #   per-call pre-passes that produce them. Used by long-lived integrations
-      #   (`Rigor::LanguageServer::ProjectContext`) to keep per-buffer requests fast — scanners walk the
-      #   project once per generation rather than once per request, and plugin `#prepare` runs once per
-      #   generation rather than once per request. Watched-file invalidation is the owner's responsibility;
-      #   the runner trusts the snapshot it was given.
-      # @param environment [Rigor::Environment, nil] opt-in Environment override. When supplied, sequential
-      #   mode uses the provided env instance in `#analyze_files` instead of building a fresh one via
-      #   `Environment.for_project`, and attaches the runner's per-run reporter pair onto the env's mutable
-      #   `Reporters` slot via `Environment#attach_reporters!`. Long-lived consumers (LSP `ProjectContext`)
-      #   pass a shared env so per-publish work doesn't repeat the `Environment.for_project` build (bundler
-      #   / lockfile / collection discovery, RbsLoader construction). Pool mode ignores the override — each
-      #   worker continues to build its own Environment.
-      # @param discovery_seed [Hash, nil] issue #260 — opt-in cross-file discovery tables, keyed by
-      #   {Scope::DiscoveryIndex} slot name, seeded onto every per-file scope through
-      #   `project_scope_seed_tables`. The ONE deliberate exception to "a `prebuilt:` runner carries no
-      #   discovery tables": {Protection::DiagnosticOracle} threads the table set Tier 2's site filter already
-      #   judges anchors against, so a site admitted because a sibling-file class resolved is also a site the
-      #   oracle can kill at. nil (the default) leaves the prebuilt/LSP contract byte-identical.
-      # @param no_tolerated_effects [Boolean] ADR-103 WD1 / #385 — `rigor check --no-tolerated-effects`.
-      #   Judges effect envelopes as if `effects.tolerated:` were empty. A judgment-time switch only: the
-      #   run, its collection and its cache identity are unchanged.
+      # @rbs explain: bool -- Surface fail-soft fallback events as `:info` diagnostics.
+      # @rbs cache_store: Rigor::Cache::Store? --
+      #   The persistent cache the runner exposes to producers (`RbsConstantTable` and successors). Pass `nil` to
+      #   disable caching for this run; the CLI's `--no-cache` flag wires `nil` through. v0.0.9 group A slice 1
+      #   introduces the surface; later slices route real producers through it.
+      # @rbs workers: Integer --
+      #   ADR-15 Phase 4b — when greater than zero, per-file analysis dispatches across a pool of N workers. Default
+      #   `0` keeps the sequential code path bit-for-bit unchanged. Controlled via the `RIGOR_RACTOR_WORKERS` env var
+      #   or `.rigor.yml` `parallel.workers:` (Phase 4c, fully wired).
+      # @rbs collect_stats: bool --
+      #   When true (default), `#run` builds a {RunStats} summary exposed via `result.stats` — this forces the RBS env
+      #   build at end-of-run so the `class_decl_paths` snapshot has real source attribution. Set to false to skip the
+      #   stats summary entirely; the CLI's `--no-stats` threads `false` through to keep trivial-fixture runs from
+      #   warming `.rigor/cache`.
+      # @rbs prebuilt: Rigor::Analysis::ProjectScan? --
+      #   When supplied, the runner adopts the pre-built plugin registry / dependency-source index / scanner outputs
+      #   from the snapshot and skips the per-call pre-passes that produce them. Used by long-lived integrations
+      #   (`Rigor::LanguageServer::ProjectContext`) to keep per-buffer requests fast — scanners walk the project once
+      #   per generation rather than once per request, and plugin `#prepare` runs once per generation rather than once
+      #   per request. Watched-file invalidation is the owner's responsibility; the runner trusts the snapshot it was
+      #   given.
+      # @rbs environment: Rigor::Environment? --
+      #   Opt-in Environment override. When supplied, sequential mode uses the provided env instance in
+      #   `#analyze_files` instead of building a fresh one via `Environment.for_project`, and attaches the runner's
+      #   per-run reporter pair onto the env's mutable `Reporters` slot via `Environment#attach_reporters!`.
+      #   Long-lived consumers (LSP `ProjectContext`) pass a shared env so per-publish work doesn't repeat the
+      #   `Environment.for_project` build (bundler / lockfile / collection discovery, RbsLoader construction). Pool
+      #   mode ignores the override — each worker continues to build its own Environment.
+      # @rbs discovery_seed: Hash[untyped, untyped]? --
+      #   Issue #260 — opt-in cross-file discovery tables, keyed by {Scope::DiscoveryIndex} slot name, seeded onto
+      #   every per-file scope through `project_scope_seed_tables`. The ONE deliberate exception to "a `prebuilt:`
+      #   runner carries no discovery tables": {Protection::DiagnosticOracle} threads the table set Tier 2's site
+      #   filter already judges anchors against, so a site admitted because a sibling-file class resolved is also a
+      #   site the oracle can kill at. nil (the default) leaves the prebuilt/LSP contract byte-identical.
+      # @rbs no_tolerated_effects: bool --
+      #   ADR-103 WD1 / #385 — `rigor check --no-tolerated-effects`. Judges effect envelopes as if
+      #   `effects.tolerated:` were empty. A judgment-time switch only: the run, its collection and its cache identity
+      #   are unchanged.
       def initialize(configuration:, explain: false, # rubocop:disable Metrics/ParameterLists,Metrics/AbcSize,Metrics/MethodLength
                      cache_store: Cache::Store.new(root: DEFAULT_CACHE_ROOT),
                      plugin_requirer: nil, workers: 0, collect_stats: true,
@@ -466,8 +468,8 @@ module Rigor
       # so the result matches a one-file disk run; only the cross-file project pre-pass is empty (there is
       # one file, and the per-file indexer self-discovers its own classes / defs).
       #
-      # @param source [String] Ruby source to analyze.
-      # @param path [String] logical path for diagnostic locations.
+      # @rbs source: String -- Ruby source to analyze.
+      # @rbs path: String -- Logical path for diagnostic locations.
       def run_source(source:, path: "(source).rb")
         @in_memory_sources = { path => source }
         run([path])
@@ -593,7 +595,8 @@ module Rigor
       # arg-flooring surface). Only meaningful right after a run populated the memo (baseline / recheck),
       # before the bucket rolls. Keys are held live here; the session Marshals them for the snapshot.
       #
-      # @return [Hash] `{ [path, "Class#method" | "Class.method"] => { keys:, returns:, effects: } }`.
+      # @rbs return: Hash[untyped, untyped] --
+      #   `{ [path, "Class#method" | "Class.method"] => { keys:, returns:, effects: } }`.
       def return_summaries
         memo = Inference::ExpressionTyper.harvest_return_memo
         return {} if memo.empty?
@@ -651,9 +654,11 @@ module Rigor
       # store) exactly as a real run's setup does, then re-drives each spec's def through the ADR-84 return
       # memo. Off any hot path — invoked only when declaration-stable changed pairs carry a persisted summary.
       #
-      # @param paths [Array<String>, nil] analysis roots (nil → the configuration's `paths:`).
-      # @param specs [Array<Hash>] each `{ class_name:, method_name:, singleton:, keys: [[receiver, args], …] }`.
-      # @return [Hash] `{ [class_name, method_name, singleton] => [return_descriptor_or_nil, …] }`.
+      # @rbs paths: Array[String]? -- Analysis roots (nil → the configuration's `paths:`).
+      # @rbs specs: Array[Hash[untyped, untyped]] --
+      #   Each `{ class_name:, method_name:, singleton:, keys: [[receiver, args], …] }`.
+      # @rbs return: Hash[untyped, untyped] --
+      #   `{ [class_name, method_name, singleton] => [return_descriptor_or_nil, …] }`.
       def evaluate_return_types(paths, specs)
         return {} if specs.empty?
 
@@ -774,7 +779,7 @@ module Rigor
       # fixpoint over them, which is the pre-split behaviour and the retry the fail-soft posture wants.
       # Only when neither entry answers does the run re-analyse.
       #
-      # @return [Boolean] whether this run was served.
+      # @rbs return: bool -- Whether this run was served.
       def served_from_effect_entries?(descriptor)
         summary = peek_effect_summary(descriptor)
         if summary
@@ -1339,8 +1344,9 @@ module Rigor
         3.0.0 3.1.0 3.2.0 3.3.0 3.4.0 3.5.0 4.0.0 4.1.0 4.2.0
       ].freeze
 
-      # @return [String, nil] the lowest `target_ruby` this Prism build accepts, or nil if none of the
-      #   ladder parses. Memoised per process (the value is constant for a given Prism).
+      # @rbs return: String? --
+      #   The lowest `target_ruby` this Prism build accepts, or nil if none of the ladder parses. Memoised per process
+      #   (the value is constant for a given Prism).
       def self.prism_supported_floor
         @prism_supported_floor ||= PRISM_VERSION_LADDER.find do |candidate|
           Prism.parse("nil", version: candidate)

--- a/lib/rigor/analysis/runner.rb
+++ b/lib/rigor/analysis/runner.rb
@@ -206,7 +206,6 @@ module Rigor
         end
       end
 
-      # @param configuration [Rigor::Configuration]
       # @param explain [Boolean] surface fail-soft fallback events as `:info` diagnostics.
       # @param cache_store [Rigor::Cache::Store, nil] the persistent cache the runner exposes to producers
       #   (`RbsConstantTable` and successors). Pass `nil` to disable caching for this run; the CLI's
@@ -469,7 +468,6 @@ module Rigor
       #
       # @param source [String] Ruby source to analyze.
       # @param path [String] logical path for diagnostic locations.
-      # @return [Result]
       def run_source(source:, path: "(source).rb")
         @in_memory_sources = { path => source }
         run([path])

--- a/lib/rigor/analysis/runner/buffer_pool_dispatcher.rb
+++ b/lib/rigor/analysis/runner/buffer_pool_dispatcher.rb
@@ -75,8 +75,6 @@ module Rigor
           Integer(env_value)
         end
 
-        # @param configuration [Rigor::Configuration]
-        # @param cache_store [Rigor::Cache::Store, nil]
         # @param environment [Rigor::Environment] the warm, shared per-session Environment
         #   (`ProjectContext#environment`) every job's Runner reuses instead of rebuilding.
         # @param prebuilt [Rigor::Analysis::ProjectScan] the warm, shared pre-pass snapshot

--- a/lib/rigor/analysis/runner/buffer_pool_dispatcher.rb
+++ b/lib/rigor/analysis/runner/buffer_pool_dispatcher.rb
@@ -66,8 +66,8 @@ module Rigor
         # via `RIGOR_LSP_POOL_MIN_BATCH` (mirrors `RIGOR_RACTOR_WORKERS`'s override shape).
         DEFAULT_MIN_BATCH_SIZE = 16
 
-        # @return [Integer] `RIGOR_LSP_POOL_MIN_BATCH` when set to a non-empty value, else
-        #   {DEFAULT_MIN_BATCH_SIZE}.
+        # @rbs return: Integer --
+        #   `RIGOR_LSP_POOL_MIN_BATCH` when set to a non-empty value, else {DEFAULT_MIN_BATCH_SIZE}.
         def self.resolve_min_batch_size
           env_value = ENV.fetch("RIGOR_LSP_POOL_MIN_BATCH", nil)
           return DEFAULT_MIN_BATCH_SIZE if env_value.nil? || env_value.empty?
@@ -75,19 +75,21 @@ module Rigor
           Integer(env_value)
         end
 
-        # @param environment [Rigor::Environment] the warm, shared per-session Environment
-        #   (`ProjectContext#environment`) every job's Runner reuses instead of rebuilding.
-        # @param prebuilt [Rigor::Analysis::ProjectScan] the warm, shared pre-pass snapshot
-        #   (`ProjectContext#project_scan`) every job's Runner adopts instead of re-scanning.
-        # @param workers [Integer] pool size. `#analyze` degrades to sequential in-process execution — one
-        #   job at a time, no `fork` — when fewer than 2 bindings are submitted, fewer than `min_batch_size`
-        #   bindings are submitted, `workers` is not positive, `fork` is unavailable on this platform, or
-        #   `cache_store` is nil. The middle two are the fork-pool-is-not-worth-it-yet gate documented on
-        #   {DEFAULT_MIN_BATCH_SIZE}; the last two mirror
+        # @rbs environment: Rigor::Environment --
+        #   The warm, shared per-session Environment (`ProjectContext#environment`) every job's Runner reuses instead
+        #   of rebuilding.
+        # @rbs prebuilt: Rigor::Analysis::ProjectScan --
+        #   The warm, shared pre-pass snapshot (`ProjectContext#project_scan`) every job's Runner adopts instead of
+        #   re-scanning.
+        # @rbs workers: Integer --
+        #   Pool size. `#analyze` degrades to sequential in-process execution — one job at a time, no `fork` — when
+        #   fewer than 2 bindings are submitted, fewer than `min_batch_size` bindings are submitted, `workers` is not
+        #   positive, `fork` is unavailable on this platform, or `cache_store` is nil. The middle two are the
+        #   fork-pool-is-not-worth-it-yet gate documented on {DEFAULT_MIN_BATCH_SIZE}; the last two mirror
         #   {PoolCoordinator#analyze_files_in_pool}'s own fork-pool preconditions.
-        # @param min_batch_size [Integer] see {DEFAULT_MIN_BATCH_SIZE}. Exposed as a constructor param
-        #   (rather than read from the env internally) purely for spec control; production callers get the
-        #   resolved default.
+        # @rbs min_batch_size: Integer --
+        #   See {DEFAULT_MIN_BATCH_SIZE}. Exposed as a constructor param (rather than read from the env internally)
+        #   purely for spec control; production callers get the resolved default.
         def initialize(configuration:, cache_store:, environment:, prebuilt:, workers:,
                        min_batch_size: self.class.resolve_min_batch_size)
           @configuration = configuration
@@ -183,9 +185,10 @@ module Rigor
           degraded
         end
 
-        # @return [Hash, nil] the child's `{index => diagnostics}` payload, or nil when the child exited
-        #   abnormally or wrote no readable payload. `Marshal.load` is safe here: the blob was written by our
-        #   own forked child to a temp file we created.
+        # @rbs return: Hash[untyped, untyped]? --
+        #   The child's `{index => diagnostics}` payload, or nil when the child exited abnormally or wrote no readable
+        #   payload. `Marshal.load` is safe here: the blob was written by our own forked child to a temp file we
+        #   created.
         def fork_worker_payload(status, out_path)
           return nil unless status.success? && File.exist?(out_path)
 

--- a/lib/rigor/analysis/runner/declaration_position.rb
+++ b/lib/rigor/analysis/runner/declaration_position.rb
@@ -20,7 +20,7 @@ module Rigor
 
         module_function
 
-        # @return [Array(String, Integer)] `[path, line]`
+        # @rbs return: [String, Integer] -- `[path, line]`
         def of(finding)
           location = finding.location
           return [CONFIG_PATH, 1] if location.nil?

--- a/lib/rigor/analysis/runner/declaration_position.rb
+++ b/lib/rigor/analysis/runner/declaration_position.rb
@@ -20,7 +20,6 @@ module Rigor
 
         module_function
 
-        # @param finding [#location]
         # @return [Array(String, Integer)] `[path, line]`
         def of(finding)
           location = finding.location

--- a/lib/rigor/analysis/runner/diagnostic_aggregator.rb
+++ b/lib/rigor/analysis/runner/diagnostic_aggregator.rb
@@ -21,21 +21,22 @@ module Rigor
       # end-of-pass snapshots) is read through injected reader procs so this collaborator never calls back
       # into the {Runner} and the read happens at the exact point in the run the original inline read did.
       class DiagnosticAggregator # rubocop:disable Metrics/ClassLength
-        # @param plugin_registry [#call] reader returning the current {Plugin::Registry} (varies per run).
-        # @param dependency_source_index [#call] reader returning the current
-        #   {DependencySourceInference::Index}.
-        # @param pool_mode [#call] reader returning the pool-mode flag.
-        # @param cached_plugin_prepare_diagnostics [#call] reader returning the prepare-diagnostic snapshot.
-        # @param pre_eval_diagnostics_from_scanner [#call] reader returning the pre-eval scanner diagnostics.
-        # @param synthesized_namespaces_snapshot [#call] reader.
-        # @param quarantined_signatures_snapshot [#call] reader returning the `signature_paths:` files skipped
-        #   because they do not parse (`[path, first_error_line]` pairs).
-        # @param env_build_failure_snapshot [#call] reader returning the total RBS env-build failure tuple
-        #   (`[error_class, first_error_line, conflicting_buffer_names]`) or nil when the env built.
-        # @param definition_build_failures_snapshot [#call] issue #696 — reader returning the per-class
-        #   `RBS::DefinitionBuilder` failures the run observed, as `[class_name, error_class, member,
-        #   conflicting_buffer_names]` tuples. Empty for a healthy sig set.
-        # @param conformance_results_snapshot [#call] reader.
+        # @rbs plugin_registry: untyped -- Reader returning the current {Plugin::Registry} (varies per run).
+        # @rbs dependency_source_index: untyped -- Reader returning the current {DependencySourceInference::Index}.
+        # @rbs pool_mode: untyped -- Reader returning the pool-mode flag.
+        # @rbs cached_plugin_prepare_diagnostics: untyped -- Reader returning the prepare-diagnostic snapshot.
+        # @rbs pre_eval_diagnostics_from_scanner: untyped -- Reader returning the pre-eval scanner diagnostics.
+        # @rbs synthesized_namespaces_snapshot: untyped -- Reader.
+        # @rbs quarantined_signatures_snapshot: untyped --
+        #   Reader returning the `signature_paths:` files skipped because they do not parse (`[path,
+        #   first_error_line]` pairs).
+        # @rbs env_build_failure_snapshot: untyped --
+        #   Reader returning the total RBS env-build failure tuple (`[error_class, first_error_line,
+        #   conflicting_buffer_names]`) or nil when the env built.
+        # @rbs definition_build_failures_snapshot: untyped --
+        #   Issue #696 — reader returning the per-class `RBS::DefinitionBuilder` failures the run observed, as
+        #   `[class_name, error_class, member, conflicting_buffer_names]` tuples. Empty for a healthy sig set.
+        # @rbs conformance_results_snapshot: untyped -- Reader.
         def initialize(configuration:, rbs_extended_reporter:, boundary_cross_reporter:, # rubocop:disable Metrics/ParameterLists
                        source_rbs_synthesis_reporter:, plugin_registry:, dependency_source_index:,
                        pool_mode:, cached_plugin_prepare_diagnostics:,

--- a/lib/rigor/analysis/runner/diagnostic_aggregator.rb
+++ b/lib/rigor/analysis/runner/diagnostic_aggregator.rb
@@ -21,10 +21,6 @@ module Rigor
       # end-of-pass snapshots) is read through injected reader procs so this collaborator never calls back
       # into the {Runner} and the read happens at the exact point in the run the original inline read did.
       class DiagnosticAggregator # rubocop:disable Metrics/ClassLength
-        # @param configuration [Rigor::Configuration]
-        # @param rbs_extended_reporter [RbsExtended::Reporter]
-        # @param boundary_cross_reporter [DependencySourceInference::BoundaryCrossReporter]
-        # @param source_rbs_synthesis_reporter [Plugin::SourceRbsSynthesisReporter]
         # @param plugin_registry [#call] reader returning the current {Plugin::Registry} (varies per run).
         # @param dependency_source_index [#call] reader returning the current
         #   {DependencySourceInference::Index}.

--- a/lib/rigor/analysis/runner/effect_annotation_residual_pass.rb
+++ b/lib/rigor/analysis/runner/effect_annotation_residual_pass.rb
@@ -58,7 +58,6 @@ module Rigor
                   "every run of the project."
         private_constant :MESSAGE
 
-        # @param configuration [Rigor::Configuration]
         # @param virtual_rbs [Array<Array(String, String)>, nil] `[buffer name, RBS source]` pairs the
         #   run ALREADY resolved; never a loader built for this pass. Empty / nil simply drops the
         #   virtual-RBS stratum.

--- a/lib/rigor/analysis/runner/effect_annotation_residual_pass.rb
+++ b/lib/rigor/analysis/runner/effect_annotation_residual_pass.rb
@@ -58,15 +58,15 @@ module Rigor
                   "every run of the project."
         private_constant :MESSAGE
 
-        # @param virtual_rbs [Array<Array(String, String)>, nil] `[buffer name, RBS source]` pairs the
-        #   run ALREADY resolved; never a loader built for this pass. Empty / nil simply drops the
-        #   virtual-RBS stratum.
+        # @rbs virtual_rbs: Array[[String, String]]? --
+        #   `[buffer name, RBS source]` pairs the run ALREADY resolved; never a loader built for this pass. Empty /
+        #   nil simply drops the virtual-RBS stratum.
         def initialize(configuration:, virtual_rbs: nil)
           @configuration = configuration
           @virtual_rbs = virtual_rbs
         end
 
-        # @return [Array<Diagnostic>] zero or one.
+        # @rbs return: Array[Diagnostic] -- Zero or one.
         def diagnostics
           return NO_DIAGNOSTICS if @configuration.effects_enabled?
           return NO_DIAGNOSTICS if @configuration.disabled_rules.include?(RULE)

--- a/lib/rigor/analysis/runner/effect_envelope_pass.rb
+++ b/lib/rigor/analysis/runner/effect_envelope_pass.rb
@@ -78,7 +78,6 @@ module Rigor
         LABELS_CONSEQUENCE = "the label is not registered"
         private_constant :LABELS_CONSEQUENCE
 
-        # @param configuration [Rigor::Configuration]
         # @param rbs_loader [Rigor::Environment::RbsLoader, nil] the run's loader; nil disables the pass.
         # @param effect_table [Rigor::Effects::EffectTable] the propagated graph.
         # @param discovery [#call] forces and returns the cross-file discovery tables as

--- a/lib/rigor/analysis/runner/effect_envelope_pass.rb
+++ b/lib/rigor/analysis/runner/effect_envelope_pass.rb
@@ -78,22 +78,22 @@ module Rigor
         LABELS_CONSEQUENCE = "the label is not registered"
         private_constant :LABELS_CONSEQUENCE
 
-        # @param rbs_loader [Rigor::Environment::RbsLoader, nil] the run's loader; nil disables the pass.
-        # @param effect_table [Rigor::Effects::EffectTable] the propagated graph.
-        # @param discovery [#call] forces and returns the cross-file discovery tables as
-        #   `[def_sources, singleton_def_sources, class_sources]`. Called only when a finding needs a
-        #   position — a judged-clean envelope never forces it.
-        # @param sources [Hash{String => String}] in-memory sources, for the buffer-backed run path.
-        # @param unit_sources [Hash{String => Array<String>}] `Runner#effect_sources` — where each effect
-        #   unit is defined, which is what an `effects.envelopes[].match:` path glob selects on. Its paths
-        #   are relativised against the working directory, which is the project root for every run that
-        #   reaches here (the same assumption `Snapshot.build` makes about `reach:`).
-        # @param ancestry [#call, nil] returns the run's as-written superclass table
-        #   (`FileCollection#superclasses`) — the nominal relation `effect.liskov-widened` reads. A
-        #   lambda, and called only once an envelope exists, because merging the run's collections is
-        #   not free.
-        # @param apply_tolerated [Boolean] false runs the judgment with an empty tolerated set
-        #   (`--no-tolerated-effects`).
+        # @rbs rbs_loader: Rigor::Environment::RbsLoader? -- The run's loader; nil disables the pass.
+        # @rbs effect_table: Rigor::Effects::EffectTable -- The propagated graph.
+        # @rbs discovery: untyped --
+        #   Forces and returns the cross-file discovery tables as `[def_sources, singleton_def_sources,
+        #   class_sources]`. Called only when a finding needs a position — a judged-clean envelope never forces it.
+        # @rbs sources: Hash[String, String] -- In-memory sources, for the buffer-backed run path.
+        # @rbs unit_sources: Hash[String, Array[String]] --
+        #   `Runner#effect_sources` — where each effect unit is defined, which is what an `effects.envelopes[].match:`
+        #   path glob selects on. Its paths are relativised against the working directory, which is the project root
+        #   for every run that reaches here (the same assumption `Snapshot.build` makes about `reach:`).
+        # @rbs ancestry: untyped --
+        #   Returns the run's as-written superclass table (`FileCollection#superclasses`) — the nominal relation
+        #   `effect.liskov-widened` reads. A lambda, and called only once an envelope exists, because merging the
+        #   run's collections is not free.
+        # @rbs apply_tolerated: bool --
+        #   False runs the judgment with an empty tolerated set (`--no-tolerated-effects`).
         def initialize(configuration:, rbs_loader:, effect_table:, discovery:, # rubocop:disable Metrics/ParameterLists
                        sources: nil, unit_sources: nil, ancestry: nil, apply_tolerated: true,
                        plugin_facts: nil)
@@ -108,8 +108,8 @@ module Rigor
           @apply_tolerated = apply_tolerated
         end
 
-        # @return [Array<Diagnostic>] one per (method, exceeding label) plus one per unrecognised
-        #   label, suppression already applied.
+        # @rbs return: Array[Diagnostic] --
+        #   One per (method, exceeding label) plus one per unrecognised label, suppression already applied.
         def diagnostics
           return NO_DIAGNOSTICS unless @configuration.effects_check?
 

--- a/lib/rigor/analysis/runner/pool_coordinator.rb
+++ b/lib/rigor/analysis/runner/pool_coordinator.rb
@@ -29,16 +29,6 @@ module Rigor
       # delegated back through an injected `analyze_file` callable so the CheckRules / recorder /
       # plugin-emission machinery stays on the {Runner}.
       class PoolCoordinator # rubocop:disable Metrics/ClassLength
-        # @param configuration [Rigor::Configuration]
-        # @param cache_store [Rigor::Cache::Store, nil]
-        # @param explain [Boolean]
-        # @param workers [Integer]
-        # @param collect_stats [Boolean]
-        # @param buffer [BufferBinding, nil]
-        # @param environment_override [Rigor::Environment, nil]
-        # @param rbs_extended_reporter [RbsExtended::Reporter]
-        # @param boundary_cross_reporter [DependencySourceInference::BoundaryCrossReporter]
-        # @param source_rbs_synthesis_reporter [Plugin::SourceRbsSynthesisReporter]
         # @param snapshots [RunSnapshots] shared end-of-pass snapshot sink.
         # @param plugin_registry [#call] reader for the current registry.
         # @param dependency_source_index [#call] reader.

--- a/lib/rigor/analysis/runner/pool_coordinator.rb
+++ b/lib/rigor/analysis/runner/pool_coordinator.rb
@@ -29,14 +29,14 @@ module Rigor
       # delegated back through an injected `analyze_file` callable so the CheckRules / recorder /
       # plugin-emission machinery stays on the {Runner}.
       class PoolCoordinator # rubocop:disable Metrics/ClassLength
-        # @param snapshots [RunSnapshots] shared end-of-pass snapshot sink.
-        # @param plugin_registry [#call] reader for the current registry.
-        # @param dependency_source_index [#call] reader.
-        # @param synthetic_method_index [#call] reader.
-        # @param project_patched_methods [#call] reader.
-        # @param project_scope_seed [#call] reader for the cross-file pre-pass seed tables
-        #   (`Runner#project_scope_seed_tables`).
-        # @param analyze_file [#call] `(path, environment) -> diagnostics`.
+        # @rbs snapshots: RunSnapshots -- Shared end-of-pass snapshot sink.
+        # @rbs plugin_registry: untyped -- Reader for the current registry.
+        # @rbs dependency_source_index: untyped -- Reader.
+        # @rbs synthetic_method_index: untyped -- Reader.
+        # @rbs project_patched_methods: untyped -- Reader.
+        # @rbs project_scope_seed: untyped --
+        #   Reader for the cross-file pre-pass seed tables (`Runner#project_scope_seed_tables`).
+        # @rbs analyze_file: untyped -- `(path, environment) -> diagnostics`.
         def initialize(configuration:, cache_store:, explain:, workers:, collect_stats:, # rubocop:disable Metrics/ParameterLists
                        buffer:, environment_override:, rbs_extended_reporter:,
                        boundary_cross_reporter:, source_rbs_synthesis_reporter:,
@@ -511,9 +511,10 @@ module Rigor
           degraded
         end
 
-        # @return [Hash, nil] the child's `{results:, reporters:}` payload, or nil when the child exited
-        #   abnormally or wrote no readable payload. `Marshal.load` is safe here: the blob was written by
-        #   our own forked child to a temp file we created.
+        # @rbs return: Hash[untyped, untyped]? --
+        #   The child's `{results:, reporters:}` payload, or nil when the child exited abnormally or wrote no readable
+        #   payload. `Marshal.load` is safe here: the blob was written by our own forked child to a temp file we
+        #   created.
         def fork_worker_payload(status, out_path)
           return nil unless status.success? && File.exist?(out_path)
 

--- a/lib/rigor/analysis/runner/project_pre_passes.rb
+++ b/lib/rigor/analysis/runner/project_pre_passes.rb
@@ -35,10 +35,6 @@ module Rigor
           :pre_eval_diagnostics_from_scanner
         )
 
-        # @param configuration [Rigor::Configuration]
-        # @param cache_store [Rigor::Cache::Store, nil]
-        # @param buffer [BufferBinding, nil]
-        # @param plugin_requirer [#call, nil]
         # @param pool_mode [#call] reader returning the pool-mode flag.
         def initialize(configuration:, cache_store:, buffer:, plugin_requirer:, pool_mode:)
           @configuration = configuration

--- a/lib/rigor/analysis/runner/project_pre_passes.rb
+++ b/lib/rigor/analysis/runner/project_pre_passes.rb
@@ -35,7 +35,7 @@ module Rigor
           :pre_eval_diagnostics_from_scanner
         )
 
-        # @param pool_mode [#call] reader returning the pool-mode flag.
+        # @rbs pool_mode: untyped -- Reader returning the pool-mode flag.
         def initialize(configuration:, cache_store:, buffer:, plugin_requirer:, pool_mode:)
           @configuration = configuration
           @cache_store = cache_store

--- a/lib/rigor/analysis/worker_session.rb
+++ b/lib/rigor/analysis/worker_session.rb
@@ -72,12 +72,14 @@ module Rigor
                   :rbs_extended_reporter, :boundary_cross_reporter,
                   :prepare_diagnostics
 
-      # @param cache_store [Rigor::Cache::Store, nil] persistent cache the session exposes to plugin-side
-      #   producers and the RBS loader. Pass `nil` to disable caching.
-      # @param plugin_blueprints [Array<Rigor::Plugin::Blueprint>] replay descriptors. Empty array yields a
-      #   session with no plugin contributions.
-      # @param explain [Boolean] when true, `#analyze` additionally emits one `:info` `fallback` diagnostic
-      #   per directly-unrecognised node, mirroring {Rigor::Analysis::Runner#explain_diagnostics}.
+      # @rbs cache_store: Rigor::Cache::Store? --
+      #   Persistent cache the session exposes to plugin-side producers and the RBS loader. Pass `nil` to disable
+      #   caching.
+      # @rbs plugin_blueprints: Array[Rigor::Plugin::Blueprint] --
+      #   Replay descriptors. Empty array yields a session with no plugin contributions.
+      # @rbs explain: bool --
+      #   When true, `#analyze` additionally emits one `:info` `fallback` diagnostic per directly-unrecognised node,
+      #   mirroring {Rigor::Analysis::Runner#explain_diagnostics}.
       def initialize(configuration:, cache_store: nil, # rubocop:disable Metrics/MethodLength,Metrics/ParameterLists
                      plugin_blueprints: [], explain: false, buffer: nil,
                      synthetic_method_index: nil, project_patched_methods: nil,

--- a/lib/rigor/analysis/worker_session.rb
+++ b/lib/rigor/analysis/worker_session.rb
@@ -72,7 +72,6 @@ module Rigor
                   :rbs_extended_reporter, :boundary_cross_reporter,
                   :prepare_diagnostics
 
-      # @param configuration [Rigor::Configuration]
       # @param cache_store [Rigor::Cache::Store, nil] persistent cache the session exposes to plugin-side
       #   producers and the RBS loader. Pass `nil` to disable caching.
       # @param plugin_blueprints [Array<Rigor::Plugin::Blueprint>] replay descriptors. Empty array yields a

--- a/lib/rigor/bleeding_edge.rb
+++ b/lib/rigor/bleeding_edge.rb
@@ -76,12 +76,10 @@ module Rigor
         super
       end
 
-      # @return [Boolean]
       def severity?
         kind == :severity
       end
 
-      # @return [Boolean]
       def behaviour?
         kind == :behaviour
       end
@@ -96,8 +94,6 @@ module Rigor
       end
     end
 
-    # The overlay.
-    #
     # Feature ids are **kebab-case, and name the discipline rather than the rule** it happens to
     # promote (`reject-unparseable-signatures`, not `rbs-quarantine-error`): a discipline may grow
     # to cover more rules without its id going stale, and the id is contract vocabulary that
@@ -193,35 +189,27 @@ module Rigor
     # cleanup can lag graduation by as many releases as it takes. The id also stays in the
     # contract vocabulary the CHANGELOG migration note keys on. Entries are removed only once
     # no call site names them.
-    #
-    # @return [Array<String>]
     GRADUATED = [].freeze
 
     module_function
 
-    # @return [Array<Feature>] the whole overlay.
     def features
       FEATURES
     end
 
-    # @return [Array<String>] every feature id in the overlay.
     def feature_ids
       FEATURES.map(&:id)
     end
 
-    # @param id [String]
     # @return [Feature, nil]
     def feature(id)
       FEATURES.find { |f| f.id == id }
     end
 
-    # @param id [String]
-    # @return [Boolean] whether the id has graduated to default-on ({GRADUATED}).
     def graduated?(id)
       GRADUATED.include?(id)
     end
 
-    # @param id [String]
     # @return [Boolean] whether the id names a feature this gem knows at all — queued or
     #   graduated. Distinct from "adopted"; see {Configuration#bleeding_edge_active?}.
     def known_id?(id)
@@ -237,7 +225,6 @@ module Rigor
     # @param selector [Hash] `{ "mode" => "none" }`,
     #   `{ "mode" => "all" }`, `{ "mode" => "all", "except" => [ids] }`,
     #   or `{ "mode" => "list", "ids" => [ids] }`.
-    # @return [Array<Feature>]
     def active_features(selector)
       case selector["mode"]
       when "all"
@@ -255,7 +242,6 @@ module Rigor
     # the result is `Ractor.shareable?`.
     #
     # @param selector [Hash] see {#active_features}.
-    # @return [Hash{String => Symbol}]
     def severity_overrides_for(selector)
       active_features(selector).each_with_object({}) do |feature, acc|
         acc.merge!(feature.severity_overrides)
@@ -268,7 +254,6 @@ module Rigor
     # `Ractor.shareable?` across the worker boundary.
     #
     # @param selector [Hash] see {#active_features}.
-    # @return [Set<String>]
     def active_ids_for(selector)
       Set.new(active_features(selector).map(&:id)).freeze
     end
@@ -277,7 +262,6 @@ module Rigor
     # newer gem). Surfaced by `rigor show-bleedingedge` as a hint; never an error.
     #
     # @param selector [Hash] see {#active_features}.
-    # @return [Array<String>]
     def unknown_selected_ids(selector)
       named =
         case selector["mode"]

--- a/lib/rigor/bleeding_edge.rb
+++ b/lib/rigor/bleeding_edge.rb
@@ -51,17 +51,15 @@ module Rigor
     # migration note and a user's `bleeding_edge:` list both key on.
     #
     # @!attribute id
-    #   @return [String] the stable feature id (contract vocabulary).
-    # @!attribute summary
-    #   @return [String] a one-line description of what it changes. For a `:behaviour`
-    #     feature this is the *whole* explanation — there is no severity diff to read.
-    # @!attribute kind
-    #   @return [Symbol] one of {KINDS}.
-    # @!attribute severity_overrides
-    #   @return [Hash{String => Symbol}] canonical rule id → the severity this feature
-    #     imposes. Composed *below* the user's own `severity_overrides:` and *above* the
-    #     active `severity_profile` (see {Configuration::SeverityProfile.resolve}). Empty for
-    #     a `:behaviour` feature.
+    # @rbs return: String -- The stable feature id (contract vocabulary). @!attribute summary
+    # @rbs return: String --
+    #   A one-line description of what it changes. For a `:behaviour` feature this is the *whole* explanation — there
+    #   is no severity diff to read. @!attribute kind
+    # @rbs return: Symbol -- One of {KINDS}. @!attribute severity_overrides
+    # @rbs return: Hash[String, Symbol] --
+    #   Canonical rule id → the severity this feature imposes. Composed *below* the user's own `severity_overrides:`
+    #   and *above* the active `severity_profile` (see {Configuration::SeverityProfile.resolve}). Empty for a
+    #   `:behaviour` feature.
     Feature = Data.define(:id, :summary, :kind, :severity_overrides) do
       def initialize(id:, summary:, kind:, severity_overrides: NO_SEVERITY_OVERRIDES)
         raise ArgumentError, "kind must be one of #{KINDS.inspect}, got #{kind.inspect}" unless KINDS.include?(kind)
@@ -201,7 +199,7 @@ module Rigor
       FEATURES.map(&:id)
     end
 
-    # @return [Feature, nil]
+    # @rbs return: Feature?
     def feature(id)
       FEATURES.find { |f| f.id == id }
     end
@@ -210,8 +208,9 @@ module Rigor
       GRADUATED.include?(id)
     end
 
-    # @return [Boolean] whether the id names a feature this gem knows at all — queued or
-    #   graduated. Distinct from "adopted"; see {Configuration#bleeding_edge_active?}.
+    # @rbs return: bool --
+    #   Whether the id names a feature this gem knows at all — queued or graduated. Distinct from "adopted"; see
+    #   {Configuration#bleeding_edge_active?}.
     def known_id?(id)
       graduated?(id) || FEATURES.any? { |f| f.id == id }
     end
@@ -222,9 +221,9 @@ module Rigor
     # `severity_overrides:` keeps an unknown rule id inert until it lands (robust across gem
     # versions).
     #
-    # @param selector [Hash] `{ "mode" => "none" }`,
-    #   `{ "mode" => "all" }`, `{ "mode" => "all", "except" => [ids] }`,
-    #   or `{ "mode" => "list", "ids" => [ids] }`.
+    # @rbs selector: Hash[untyped, untyped] --
+    #   `{ "mode" => "none" }`, `{ "mode" => "all" }`, `{ "mode" => "all", "except" => [ids] }`, or `{ "mode" =>
+    #   "list", "ids" => [ids] }`.
     def active_features(selector)
       case selector["mode"]
       when "all"
@@ -241,7 +240,7 @@ module Rigor
     # The merged severity-override map the active features impose for a selector. Frozen so
     # the result is `Ractor.shareable?`.
     #
-    # @param selector [Hash] see {#active_features}.
+    # @rbs selector: Hash[untyped, untyped] -- See {#active_features}.
     def severity_overrides_for(selector)
       active_features(selector).each_with_object({}) do |feature, acc|
         acc.merge!(feature.severity_overrides)
@@ -253,7 +252,7 @@ module Rigor
     # Precomputed once per Configuration; frozen (with frozen members) so the carrier stays
     # `Ractor.shareable?` across the worker boundary.
     #
-    # @param selector [Hash] see {#active_features}.
+    # @rbs selector: Hash[untyped, untyped] -- See {#active_features}.
     def active_ids_for(selector)
       Set.new(active_features(selector).map(&:id)).freeze
     end
@@ -261,7 +260,7 @@ module Rigor
     # Feature ids named by a selector that are NOT in the overlay (typo / graduated / from a
     # newer gem). Surfaced by `rigor show-bleedingedge` as a hint; never an error.
     #
-    # @param selector [Hash] see {#active_features}.
+    # @rbs selector: Hash[untyped, untyped] -- See {#active_features}.
     def unknown_selected_ids(selector)
       named =
         case selector["mode"]

--- a/lib/rigor/builtins/hkt_builtins.rb
+++ b/lib/rigor/builtins/hkt_builtins.rb
@@ -118,18 +118,13 @@ module Rigor
         )
       end
 
-      # @return [Rigor::Inference::HktRegistry] frozen registry
-      #   pre-seeded with all bundled HKT registrations +
-      #   bodies. Allocated fresh each call rather than
-      #   memoised — memoisation through a module-level
-      #   `@registry` ivar surfaces a `Ractor::IsolationError`
-      #   in pool workers (the ivar's contents include
-      #   `HktBody::AppRef` Symbol-keyed structures that the
-      #   current Ractor shareability audit hasn't yet been
-      #   walked through). The registry is small enough that
-      #   per-Environment construction is acceptable; an
-      #   eager-frozen constant is a future optimisation
-      #   once ADR-15 phase 4b.x covers the dependency graph.
+      # @rbs return: Rigor::Inference::HktRegistry --
+      #   Frozen registry pre-seeded with all bundled HKT registrations + bodies. Allocated fresh each call rather
+      #   than memoised — memoisation through a module-level `@registry` ivar surfaces a `Ractor::IsolationError` in
+      #   pool workers (the ivar's contents include `HktBody::AppRef` Symbol-keyed structures that the current Ractor
+      #   shareability audit hasn't yet been walked through). The registry is small enough that per-Environment
+      #   construction is acceptable; an eager-frozen constant is a future optimisation once ADR-15 phase 4b.x covers
+      #   the dependency graph.
       def registry
         Rigor::Inference::HktRegistry.new(
           registrations: [json_value_registration, csv_parsed_registration, csv_row_registration],
@@ -242,14 +237,11 @@ module Rigor
         ["CSV", :parse_line, :singleton] => CSV_ROW_SPEC
       }.freeze
 
-      # @return [Rigor::Type, nil] the reduced HKT type for
-      #   the given (class_name, method_name, kind) triple,
-      #   or `nil` when no built-in override is registered.
-      #   When `arg_types` is supplied AND the entry carries a
-      #   `:discriminator` symbol, the discriminator may swap
-      #   the spec's default args for an alternate (e.g.
-      #   `JSON.parse(str, symbolize_names: true)` discriminates
-      #   `K = Symbol` instead of the default `K = String`).
+      # @rbs return: Rigor::Type? --
+      #   The reduced HKT type for the given (class_name, method_name, kind) triple, or `nil` when no built-in
+      #   override is registered. When `arg_types` is supplied AND the entry carries a `:discriminator` symbol, the
+      #   discriminator may swap the spec's default args for an alternate (e.g. `JSON.parse(str, symbolize_names:
+      #   true)` discriminates `K = Symbol` instead of the default `K = String`).
       def method_return_override(class_name:, method_name:, kind:, arg_types: nil, hkt_registry: nil)
         spec = METHOD_RETURN_OVERRIDES[[class_name, method_name.to_sym, kind]]
         return nil unless spec

--- a/lib/rigor/builtins/imported_refinements.rb
+++ b/lib/rigor/builtins/imported_refinements.rb
@@ -153,31 +153,28 @@ module Rigor
 
       module_function
 
-      # @param name [String] kebab-case refinement name.
-      # @return [Rigor::Type, nil] the matching refinement carrier, or `nil` if the name is
-      #   not registered.
+      # @rbs name: String -- Kebab-case refinement name.
+      # @rbs return: Rigor::Type? -- The matching refinement carrier, or `nil` if the name is not registered.
       def lookup(name)
         builder = REGISTRY[name.to_s]
         builder&.call
       end
 
-      # @param payload [String] the trailing payload of a `rigor:v1:return:` (or sibling)
-      #   directive. Accepts the bare-name forms `lookup` already handles plus the
-      #   parameterised forms documented on {Parser}.
-      #   ADR-13 slice 3 — when provided, the parser consults the scope's `#resolver` chain
-      #   after the built-in registry and built-in parametric forms but before the RBS
-      #   Nominal fallback. `nil` (default) preserves the slice-1 / slice-2 behaviour of
-      #   consulting only built-ins + RBS.
-      #   ADR-13 slice 3b — collector that the Resolver feeds `dynamic.shape.lossy-projection`
-      #   events into when a shape-projection head (`pick_of`, `omit_of`, `partial_of`,
-      #   `required_of`, `readonly_of`) is applied to a carrier that does not preserve shape
-      #   information. `nil` (default) suppresses event accumulation; legacy call sites that
-      #   have no reporter to thread keep the pre-slice-3b silent fall-through.
-      # @param source_location [RBS::Location, nil] location attribution for the events the
-      #   Resolver records. Carries the annotation's filename / line / column so the runner
-      #   can stamp diagnostics with the user-visible source site.
-      # @return [Rigor::Type, nil] the resolved refinement carrier, or `nil` when the payload
-      #   is unparseable or names a refinement / class no registered source resolved.
+      # @rbs payload: String --
+      #   The trailing payload of a `rigor:v1:return:` (or sibling) directive. Accepts the bare-name forms `lookup`
+      #   already handles plus the parameterised forms documented on {Parser}. ADR-13 slice 3 — when provided, the
+      #   parser consults the scope's `#resolver` chain after the built-in registry and built-in parametric forms but
+      #   before the RBS Nominal fallback. `nil` (default) preserves the slice-1 / slice-2 behaviour of consulting
+      #   only built-ins + RBS. ADR-13 slice 3b — collector that the Resolver feeds `dynamic.shape.lossy-projection`
+      #   events into when a shape-projection head (`pick_of`, `omit_of`, `partial_of`, `required_of`, `readonly_of`)
+      #   is applied to a carrier that does not preserve shape information. `nil` (default) suppresses event
+      #   accumulation; legacy call sites that have no reporter to thread keep the pre-slice-3b silent fall-through.
+      # @rbs source_location: RBS::Location? --
+      #   Location attribution for the events the Resolver records. Carries the annotation's filename / line / column
+      #   so the runner can stamp diagnostics with the user-visible source site.
+      # @rbs return: Rigor::Type? --
+      #   The resolved refinement carrier, or `nil` when the payload is unparseable or names a refinement / class no
+      #   registered source resolved.
       def parse(payload, name_scope: nil, reporter: nil, source_location: nil)
         Parser.new(
           payload.to_s,

--- a/lib/rigor/builtins/imported_refinements.rb
+++ b/lib/rigor/builtins/imported_refinements.rb
@@ -164,12 +164,10 @@ module Rigor
       # @param payload [String] the trailing payload of a `rigor:v1:return:` (or sibling)
       #   directive. Accepts the bare-name forms `lookup` already handles plus the
       #   parameterised forms documented on {Parser}.
-      # @param name_scope [Rigor::TypeNode::NameScope, nil]
       #   ADR-13 slice 3 — when provided, the parser consults the scope's `#resolver` chain
       #   after the built-in registry and built-in parametric forms but before the RBS
       #   Nominal fallback. `nil` (default) preserves the slice-1 / slice-2 behaviour of
       #   consulting only built-ins + RBS.
-      # @param reporter [Rigor::RbsExtended::Reporter, nil]
       #   ADR-13 slice 3b — collector that the Resolver feeds `dynamic.shape.lossy-projection`
       #   events into when a shape-projection head (`pick_of`, `omit_of`, `partial_of`,
       #   `required_of`, `readonly_of`) is applied to a carrier that does not preserve shape

--- a/lib/rigor/builtins/predefined_constant_refinements.rb
+++ b/lib/rigor/builtins/predefined_constant_refinements.rb
@@ -117,7 +117,7 @@ module Rigor
 
       # --- private ------------------------------------------------------
 
-      # @param value [String] a non-empty string
+      # @rbs value: String -- A non-empty string
       def self.classify_string(value)
         if Type::Refined.ruby_numeric_literal?(value)
           NUMERIC_STRING
@@ -132,8 +132,8 @@ module Rigor
       # Called ONLY with the names in {RUNTIME_STRING_CONSTANTS} — Rigor's own source — and only
       # while this file is being loaded. It is never handed a name from the analysed program.
       #
-      # @param name [String] a qualified constant path without a leading "::"
-      # @return [String, nil]
+      # @rbs name: String -- A qualified constant path without a leading "::"
+      # @rbs return: String?
       def self.runtime_string_value(name)
         mod = ::Object
         name.split("::").each do |part|
@@ -160,7 +160,7 @@ module Rigor
       end
       private_class_method :runtime_string_value
 
-      # @return [Hash{String => Rigor::Type}] frozen, built once at load time.
+      # @rbs return: Hash[String, Rigor::Type] -- Frozen, built once at load time.
       def self.build_runtime_string_refinements
         RUNTIME_STRING_CONSTANTS.each_with_object({}) do |name, table|
           value = runtime_string_value(name)
@@ -174,9 +174,8 @@ module Rigor
 
       # --- public API ---------------------------------------------------
 
-      # @param name [String] unqualified constant name (e.g. `"Math::PI"`,
-      #   `"RUBY_VERSION"`, `"Ruby::ENGINE"`)
-      # @return [Rigor::Type, nil] refined type, or nil to fall through
+      # @rbs name: String -- Unqualified constant name (e.g. `"Math::PI"`, `"RUBY_VERSION"`, `"Ruby::ENGINE"`)
+      # @rbs return: Rigor::Type? -- Refined type, or nil to fall through
       def self.lookup(name)
         FOLDED_CONSTANTS[name] || RUNTIME_STRING_REFINEMENTS[name]
       end

--- a/lib/rigor/builtins/predefined_constant_refinements.rb
+++ b/lib/rigor/builtins/predefined_constant_refinements.rb
@@ -118,7 +118,6 @@ module Rigor
       # --- private ------------------------------------------------------
 
       # @param value [String] a non-empty string
-      # @return [Rigor::Type]
       def self.classify_string(value)
         if Type::Refined.ruby_numeric_literal?(value)
           NUMERIC_STRING

--- a/lib/rigor/builtins/regex_refinement.rb
+++ b/lib/rigor/builtins/regex_refinement.rb
@@ -62,12 +62,12 @@ module Rigor
 
       module_function
 
-      # @param body [String, nil] a regex sub-pattern, typically the inner body of a
-      #   `(?<name>body)` named capture. Anchors (`\A`, `\z`, `^`, `$`) are not stripped — the
-      #   recogniser table targets bodies that the regex engine treats as anchored to the
+      # @rbs body: String? --
+      #   A regex sub-pattern, typically the inner body of a `(?<name>body)` named capture. Anchors (`\A`, `\z`, `^`,
+      #   `$`) are not stripped — the recogniser table targets bodies that the regex engine treats as anchored to the
       #   capture group bounds.
-      # @return [Rigor::Type, nil] the matching imported refinement carrier, or `nil` if
-      #   `body` is not a recognised shape.
+      # @rbs return: Rigor::Type? --
+      #   The matching imported refinement carrier, or `nil` if `body` is not a recognised shape.
       def for_capture_body(body)
         return nil if body.nil? || body.empty?
 
@@ -100,8 +100,8 @@ module Rigor
       # free-whitespace/`#`-comment flag from the `source` alone, so consumers bail on it before
       # calling here.
       #
-      # @param source [String, nil] the full regex source string.
-      # @return [Rigor::Type, nil] the matching imported refinement carrier, or `nil`.
+      # @rbs source: String? -- The full regex source string.
+      # @rbs return: Rigor::Type? -- The matching imported refinement carrier, or `nil`.
       def for_whole_pattern(source)
         return nil if source.nil?
         return nil unless source.start_with?('\A') && source.end_with?('\z')

--- a/lib/rigor/builtins/static_return_refinements.rb
+++ b/lib/rigor/builtins/static_return_refinements.rb
@@ -97,16 +97,16 @@ module Rigor
 
       # Looks up a refined return type for the given call.
       #
-      # @param owner_class_name [String, nil] the class on which the method is defined
-      #   (e.g., `"Kernel"`). Pass `nil` when the caller hasn't resolved a defining owner
-      #   yet — the lookup will then fall back to matching by `(method_name, kind)` against
-      #   entries whose owner is currently in the table.
-      # @param kind [Symbol] one of `:singleton`, `:instance`. The caller passes the shape of
-      #   the actual call site; the table stores `:both` for entries that match either.
-      # @param arg_types [Array<Rigor::Type>] positional argument types. Forwarded to the
-      #   handler so future entries can discriminate on argument shape.
-      # @return [Rigor::Type, nil] the refined return type, or `nil` when no override
-      #   matches.
+      # @rbs owner_class_name: String? --
+      #   The class on which the method is defined (e.g., `"Kernel"`). Pass `nil` when the caller hasn't resolved a
+      #   defining owner yet — the lookup will then fall back to matching by `(method_name, kind)` against entries
+      #   whose owner is currently in the table.
+      # @rbs kind: Symbol --
+      #   One of `:singleton`, `:instance`. The caller passes the shape of the actual call site; the table stores
+      #   `:both` for entries that match either.
+      # @rbs arg_types: Array[Rigor::Type] --
+      #   Positional argument types. Forwarded to the handler so future entries can discriminate on argument shape.
+      # @rbs return: Rigor::Type? -- The refined return type, or `nil` when no override matches.
       def self.lookup(owner_class_name:, method_name:, kind:, arg_types: [])
         return nil if owner_class_name.nil?
 
@@ -126,8 +126,8 @@ module Rigor
       end.freeze
       private_constant :OWNERS_BY_METHOD
 
-      # @return [Array<String>] the candidate owner class names for a bare method-name
-      #   lookup. Empty when no override names this method.
+      # @rbs return: Array[String] --
+      #   The candidate owner class names for a bare method-name lookup. Empty when no override names this method.
       NO_OWNERS = [].freeze
       private_constant :NO_OWNERS
 

--- a/lib/rigor/builtins/static_return_refinements.rb
+++ b/lib/rigor/builtins/static_return_refinements.rb
@@ -101,7 +101,6 @@ module Rigor
       #   (e.g., `"Kernel"`). Pass `nil` when the caller hasn't resolved a defining owner
       #   yet — the lookup will then fall back to matching by `(method_name, kind)` against
       #   entries whose owner is currently in the table.
-      # @param method_name [Symbol]
       # @param kind [Symbol] one of `:singleton`, `:instance`. The caller passes the shape of
       #   the actual call site; the table stores `:both` for entries that match either.
       # @param arg_types [Array<Rigor::Type>] positional argument types. Forwarded to the

--- a/lib/rigor/cache/descriptor.rb
+++ b/lib/rigor/cache/descriptor.rb
@@ -114,7 +114,7 @@ module Rigor
           new(path: path, comparator: :exists, value: PRESENT)
         end
 
-        # @return [Boolean] whether this row records the path as absent (see {.absent}).
+        # @rbs return: bool -- Whether this row records the path as absent (see {.absent}).
         def absent?
           comparator == :exists && value == ABSENT
         end
@@ -352,8 +352,8 @@ module Rigor
             dependencies: dependencies, globs: globs)
       end
 
-      # @param params [Hash] inputs the producer was called with
-      # @return [String] hex SHA-256 cache key for the value
+      # @rbs params: Hash[untyped, untyped] -- Inputs the producer was called with
+      # @rbs return: String -- Hex SHA-256 cache key for the value
       def cache_key_for(producer_id:, params: {})
         payload = {
           "schema_version" => SCHEMA_VERSION,

--- a/lib/rigor/cache/descriptor.rb
+++ b/lib/rigor/cache/descriptor.rb
@@ -352,7 +352,6 @@ module Rigor
             dependencies: dependencies, globs: globs)
       end
 
-      # @param producer_id [String]
       # @param params [Hash] inputs the producer was called with
       # @return [String] hex SHA-256 cache key for the value
       def cache_key_for(producer_id:, params: {})

--- a/lib/rigor/cache/engine_source.rb
+++ b/lib/rigor/cache/engine_source.rb
@@ -65,15 +65,15 @@ module Rigor
 
       module_function
 
-      # @return [String] the gem root — the directory holding `lib/`, three levels above this file.
+      # @rbs return: String -- The gem root — the directory holding `lib/`, three levels above this file.
       def root
         @root ||= File.expand_path("../../..", __dir__)
       end
 
-      # @param root [String] the gem root, defaulted through {.root} so a spec can relocate the tree.
-      # @return [String, nil] a digest identifying the engine's current source, or nil when the tree is
-      #   version-pinned and the caller should add no slot at all.
-      # @raise [Unavailable] when a mutable tree's source cannot be read.
+      # @rbs root: String -- The gem root, defaulted through {.root} so a spec can relocate the tree.
+      # @rbs return: String? --
+      #   A digest identifying the engine's current source, or nil when the tree is version-pinned and the caller
+      #   should add no slot at all. Raises Unavailable when a mutable tree's source cannot be read.
       def identity(root = self.root)
         return nil if version_pinned?(root)
 

--- a/lib/rigor/cache/file_digest.rb
+++ b/lib/rigor/cache/file_digest.rb
@@ -74,8 +74,9 @@ module Rigor
         memo[path] ||= Digest::SHA256.file(path).hexdigest
       end
 
-      # @return [Boolean] whether digest-always validation is forced for this run. The env var wins over the
-      #   run-scoped config flag so an operator can bypass the stat tier without editing `.rigor.yml`.
+      # @rbs return: bool --
+      #   Whether digest-always validation is forced for this run. The env var wins over the run-scoped config flag so
+      #   an operator can bypass the stat tier without editing `.rigor.yml`.
       def self.strict_validation?
         return true if ENV[STRICT_ENV] == "1"
 

--- a/lib/rigor/cache/incremental_snapshot.rb
+++ b/lib/rigor/cache/incremental_snapshot.rb
@@ -222,8 +222,8 @@ module Rigor
       # The fingerprint that matched is returned alongside the payload so the caller can mix it into ITS own
       # cache key — the snapshot's identity is exactly what "these dependency edges came from that world" means.
       #
-      # @param fingerprints [Array<String>] candidates, most-specific first.
-      # @return [Array(String, Payload), nil] `[matched fingerprint, payload]`, or nil on any miss.
+      # @rbs fingerprints: Array[String] -- Candidates, most-specific first.
+      # @rbs return: [String, Payload]? -- `[matched fingerprint, payload]`, or nil on any miss.
       def load_any(fingerprints:)
         data = read_data
         return nil if data.nil?

--- a/lib/rigor/cache/rbs_class_ancestor_table.rb
+++ b/lib/rigor/cache/rbs_class_ancestor_table.rb
@@ -20,9 +20,6 @@ module Rigor
     class RbsClassAncestorTable < RbsCacheProducer
       PRODUCER_ID = "rbs.class_ancestor_table"
 
-      # @param loader [Rigor::Environment::RbsLoader]
-      # @param store [Rigor::Cache::Store]
-      # @return [Hash{String => Array<String>}]
       def self.compute(loader)
         table = {}
         loader.each_known_class_name do |name|

--- a/lib/rigor/cache/rbs_class_type_param_names.rb
+++ b/lib/rigor/cache/rbs_class_type_param_names.rb
@@ -20,9 +20,6 @@ module Rigor
     class RbsClassTypeParamNames < RbsCacheProducer
       PRODUCER_ID = "rbs.class_type_param_names"
 
-      # @param loader [Rigor::Environment::RbsLoader]
-      # @param store [Rigor::Cache::Store]
-      # @return [Hash{String => Array<Symbol>}]
       def self.compute(loader)
         table = {}
         loader.each_known_class_name do |name|

--- a/lib/rigor/cache/rbs_constant_table.rb
+++ b/lib/rigor/cache/rbs_constant_table.rb
@@ -15,9 +15,6 @@ module Rigor
     class RbsConstantTable < RbsCacheProducer
       PRODUCER_ID = "rbs.constant_type_table"
 
-      # @param loader [Rigor::Environment::RbsLoader]
-      # @param store [Rigor::Cache::Store]
-      # @return [Hash{String => Rigor::Type}]
       def self.compute(loader)
         table = {}
         loader.each_constant_decl do |name, entry|

--- a/lib/rigor/cache/rbs_descriptor.rb
+++ b/lib/rigor/cache/rbs_descriptor.rb
@@ -12,8 +12,6 @@ module Rigor
     # slots, so factoring the construction here keeps the producers small and ensures invalidation behaves
     # identically across them.
     module RbsDescriptor
-      # @param loader [Rigor::Environment::RbsLoader]
-      # @return [Rigor::Cache::Descriptor]
       def self.build(loader)
         Descriptor.new(
           gems: [rbs_gem_entry],

--- a/lib/rigor/cache/rbs_descriptor.rb
+++ b/lib/rigor/cache/rbs_descriptor.rb
@@ -42,9 +42,10 @@ module Rigor
         Descriptor::GemEntry.new(name: "rbs", requirement: ">= 0", locked: ::RBS::VERSION.to_s)
       end
 
-      # @param comparator [Symbol] `:digest` (default) for the env-cache KEY descriptor ({.build}), where the
-      #   value must be deterministic; `:stat` (ADR-87 WD1) for the validation-only run-dependency descriptor
-      #   ({RunDescriptor#files}), where the stat tier short-circuits the SHA-256 on an unmoved file.
+      # @rbs comparator: Symbol --
+      #   `:digest` (default) for the env-cache KEY descriptor ({.build}), where the value must be deterministic;
+      #   `:stat` (ADR-87 WD1) for the validation-only run-dependency descriptor ({RunDescriptor#files}), where the
+      #   stat tier short-circuits the SHA-256 on an unmoved file.
       def self.file_entries(loader, comparator: :digest)
         roots = loader.signature_paths +
                 Rigor::Environment::RbsLoader.vendored_gem_sig_paths +
@@ -63,8 +64,9 @@ module Rigor
         end
       end
 
-      # @param library_names [Array<String, Symbol>] the loader's merged library list (or, on the WD4 probe
-      #   path, `Environment::DEFAULT_LIBRARIES + config.libraries` reconstructed without a loader).
+      # @rbs library_names: Array[String | Symbol] --
+      #   The loader's merged library list (or, on the WD4 probe path, `Environment::DEFAULT_LIBRARIES +
+      #   config.libraries` reconstructed without a loader).
       def self.libraries_entry(library_names)
         sorted = library_names.map(&:to_s).sort
         Descriptor::ConfigEntry.new(

--- a/lib/rigor/cache/rbs_environment.rb
+++ b/lib/rigor/cache/rbs_environment.rb
@@ -22,9 +22,6 @@ module Rigor
     class RbsEnvironment < RbsCacheProducer
       PRODUCER_ID = "rbs.environment"
 
-      # @param loader [Rigor::Environment::RbsLoader]
-      # @param store [Rigor::Cache::Store]
-      # @return [::RBS::Environment]
       def self.compute(loader)
         Rigor::Environment::RbsLoader.build_env_for(
           libraries: loader.libraries,

--- a/lib/rigor/cache/rbs_known_class_names.rb
+++ b/lib/rigor/cache/rbs_known_class_names.rb
@@ -18,9 +18,6 @@ module Rigor
     class RbsKnownClassNames < RbsCacheProducer
       PRODUCER_ID = "rbs.known_class_names"
 
-      # @param loader [Rigor::Environment::RbsLoader]
-      # @param store [Rigor::Cache::Store]
-      # @return [Set<String>]
       def self.compute(loader)
         names = Set.new
         loader.each_known_class_name { |name| names << name }

--- a/lib/rigor/cache/store.rb
+++ b/lib/rigor/cache/store.rb
@@ -58,14 +58,14 @@ module Rigor
 
       VALID_PRODUCER_ID = /\A[a-z][a-z0-9._-]*\z/
 
-      # @param root [String] cache root directory.
-      # @param read_only [Boolean] when true, every disk-side side-effect is suppressed: `fetch_or_compute`
-      #   still reads existing entries (hits, gated on a current `schema_version.txt` marker — see
-      #   {#ensure_schema_version!}) and still runs the producer block on miss, but it does NOT write the
-      #   produced value to disk, does NOT update the marker, and does NOT touch the on-disk root directory.
-      #   The in-process memo is still populated so repeated lookups within the same run stay cheap. Used by
-      #   editor mode so multiple buffer-mode invocations can read from the same cache concurrently without
-      #   churning it. See `docs/design/20260516-editor-mode.md` § "Cache behaviour".
+      # @rbs root: String -- Cache root directory.
+      # @rbs read_only: bool --
+      #   When true, every disk-side side-effect is suppressed: `fetch_or_compute` still reads existing entries (hits,
+      #   gated on a current `schema_version.txt` marker — see {#ensure_schema_version!}) and still runs the producer
+      #   block on miss, but it does NOT write the produced value to disk, does NOT update the marker, and does NOT
+      #   touch the on-disk root directory. The in-process memo is still populated so repeated lookups within the same
+      #   run stay cheap. Used by editor mode so multiple buffer-mode invocations can read from the same cache
+      #   concurrently without churning it. See `docs/design/20260516-editor-mode.md` § "Cache behaviour".
       def initialize(root:, read_only: false, max_bytes: nil)
         @root = root.to_s.dup.freeze
         @read_only = read_only
@@ -100,8 +100,8 @@ module Rigor
 
       attr_reader :root
 
-      # @return [Boolean] whether this Store suppresses disk writes (`schema_version.txt`, entry creation).
-      #   Reads are unaffected.
+      # @rbs return: bool --
+      #   Whether this Store suppresses disk writes (`schema_version.txt`, entry creation). Reads are unaffected.
       def read_only?
         @read_only
       end
@@ -111,7 +111,8 @@ module Rigor
       # specific instance rather than the on-disk cache state. Disk-level state is reported separately by
       # {.disk_inventory}.
       #
-      # @return [Hash] `{ hits:, misses:, writes:, by_producer: { id => { hits:, misses:, writes: } } }`
+      # @rbs return: Hash[untyped, untyped] --
+      #   `{ hits:, misses:, writes:, by_producer: { id => { hits:, misses:, writes: } } }`
       def stats
         @monitor.synchronize do
           per_producer = @by_producer.transform_values { |counts| counts.dup.freeze }.freeze
@@ -123,9 +124,10 @@ module Rigor
       # `rigor check --cache-stats` to surface cache size and per-producer entry counts without depending on
       # in-process counters (which only reflect the current run).
       #
-      # @return [Hash] `{ root:, schema_version:, total_entries:, total_bytes:, producers: [{ id:, entries:,
-      #   bytes: }, ...] }`. When the root does not exist or has no schema-version marker, `schema_version` is
-      #   nil and the producer list is empty.
+      # @rbs return: Hash[untyped, untyped] --
+      #   `{ root:, schema_version:, total_entries:, total_bytes:, producers: [{ id:, entries:, bytes: }, ...] }`.
+      #   When the root does not exist or has no schema-version marker, `schema_version` is nil and the producer list
+      #   is empty.
       #
       # The `schema_version.txt` marker content. Covers BOTH invalidation axes: the descriptor schema and the
       # on-disk byte layout ({FORMAT_VERSION}, ADR-54). A format bump leaves the old entries permanently
@@ -169,27 +171,27 @@ module Rigor
       end
       private_class_method :collect_producers
 
-      # @param producer_id [String] stable cache namespace; only `[a-z][a-z0-9._-]*` is accepted.
-      # @param generation_cap [Integer, Symbol] how many generations of this producer survive a compaction
-      #   pass — a positive `Integer` for a whole-project producer (one live entry, older ones unreachable),
-      #   or {UNBOUNDED_GENERATIONS} for a producer with many simultaneously-live entries. REQUIRED, and
-      #   sourced from the producer's own declaration (`RbsCacheProducer.generation_cap`,
-      #   `RunCacheKey::GENERATION_CAP`, `Plugin::Base.producer generation_cap:`) rather than invented at the
-      #   call site. See {#evict!}.
-      # @param params [Hash] producer inputs; mixed into the cache key via {Descriptor#cache_key_for}.
-      # @param descriptor [Rigor::Cache::Descriptor] the invalidation descriptor for the value being cached.
-      # @param serialize [#call, nil] optional callable that turns the producer's return value into a binary
-      #   `String`. Defaults to `Marshal.dump(value).b`. Producers whose return values are not
-      #   `Marshal`-clean (RBS-native objects with `RBS::Location` members, raw `IO`, …) MUST provide a
-      #   serialiser. The pair `(serialize, deserialize)` MUST round-trip — a producer that reads with one
-      #   strategy and writes with another corrupts its own cache slice.
-      # @param deserialize [#call, nil] optional callable that turns bytes back into the producer's value.
-      #   Defaults to `Marshal.load`. Any exception (`StandardError`) raised by the deserialiser is treated as
-      #   a cache miss — the entry is considered corrupt, the producer block reruns, and the next write
-      #   overwrites it. This is consistent with the fault-tolerance contract for the default `Marshal.load`
-      #   path.
-      # @yieldreturn the value to cache.
-      # @return the cached value (loaded from disk on hit; produced by the block on miss).
+      # @rbs producer_id: String -- Stable cache namespace; only `[a-z][a-z0-9._-]*` is accepted.
+      # @rbs generation_cap: Integer | Symbol --
+      #   How many generations of this producer survive a compaction pass — a positive `Integer` for a whole-project
+      #   producer (one live entry, older ones unreachable), or {UNBOUNDED_GENERATIONS} for a producer with many
+      #   simultaneously-live entries. REQUIRED, and sourced from the producer's own declaration
+      #   (`RbsCacheProducer.generation_cap`, `RunCacheKey::GENERATION_CAP`, `Plugin::Base.producer generation_cap:`)
+      #   rather than invented at the call site. See {#evict!}.
+      # @rbs params: Hash[untyped, untyped] --
+      #   Producer inputs; mixed into the cache key via {Descriptor#cache_key_for}.
+      # @rbs descriptor: Rigor::Cache::Descriptor -- The invalidation descriptor for the value being cached.
+      # @rbs serialize: untyped --
+      #   Optional callable that turns the producer's return value into a binary `String`. Defaults to
+      #   `Marshal.dump(value).b`. Producers whose return values are not `Marshal`-clean (RBS-native objects with
+      #   `RBS::Location` members, raw `IO`, …) MUST provide a serialiser. The pair `(serialize, deserialize)` MUST
+      #   round-trip — a producer that reads with one strategy and writes with another corrupts its own cache slice.
+      # @rbs deserialize: untyped --
+      #   Optional callable that turns bytes back into the producer's value. Defaults to `Marshal.load`. Any exception
+      #   (`StandardError`) raised by the deserialiser is treated as a cache miss — the entry is considered corrupt,
+      #   the producer block reruns, and the next write overwrites it. This is consistent with the fault-tolerance
+      #   contract for the default `Marshal.load` path. Value to cache. Cached value (loaded from disk on hit;
+      #   produced by the block on miss).
       def fetch_or_compute(producer_id:, params:, descriptor:, generation_cap:,
                            serialize: nil, deserialize: nil, &block)
         validate_producer_id!(producer_id)

--- a/lib/rigor/cache/store.rb
+++ b/lib/rigor/cache/store.rb
@@ -508,8 +508,6 @@ module Rigor
       # (permission, disk full, deleted root) also reports unavailable, degrading this Store instance to
       # in-memory-memo-only for the rest of its lifetime — the producer block still runs, its result still
       # lands in `@memo`, and disk reads/writes are simply skipped.
-      #
-      # @return [Boolean]
       def ensure_schema_version!
         return @disk_available unless @disk_available.nil?
 

--- a/lib/rigor/cli/annotate_command.rb
+++ b/lib/rigor/cli/annotate_command.rb
@@ -43,7 +43,7 @@ module Rigor
       # paging stays off because the CLI may itself sit in a pipeline.
       BAT_ARGS = %w[--language=ruby --style=plain --paging=never --color=always].freeze
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         options = parse_options
         file = @argv.shift
@@ -220,7 +220,7 @@ module Rigor
         @scope_index = scope_index
       end
 
-      # @return [Hash{Integer => Rigor::Type}] 1-indexed line => type.
+      # @rbs return: Hash[Integer, Rigor::Type] -- 1-indexed line => type.
       def collect(program)
         by_line = {}
         each_statement(program) do |statement|

--- a/lib/rigor/cli/annotate_command.rb
+++ b/lib/rigor/cli/annotate_command.rb
@@ -220,7 +220,6 @@ module Rigor
         @scope_index = scope_index
       end
 
-      # @param program [Prism::ProgramNode]
       # @return [Hash{Integer => Rigor::Type}] 1-indexed line => type.
       def collect(program)
         by_line = {}

--- a/lib/rigor/cli/check_command.rb
+++ b/lib/rigor/cli/check_command.rb
@@ -32,7 +32,7 @@ module Rigor
     # The class-length budget is relaxed (as on `Rigor::CLI` itself) because `check` aggregates several independent
     # concerns that are clearer read together than split across micro-classes.
     class CheckCommand < Command # rubocop:disable Metrics/ClassLength
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       #
       # Deferred YJIT enablement (Runtime::Jit) is armed by `CLI#dispatch` for every command, this
       # one included, before any analysis work runs.

--- a/lib/rigor/cli/check_invocation.rb
+++ b/lib/rigor/cli/check_invocation.rb
@@ -42,12 +42,9 @@ module Rigor
 
       # Runs the analysis the way `rigor check` does and returns the runner + its raw result.
       #
-      # @param configuration [Rigor::Configuration]
       # @param options [Hash] at least `:no_cache`, `:explain`, `:stats`, `:workers` (see {CheckRunnerFactory.build}).
       # @param paths [Array<String>, nil] analysed paths; nil falls back to the configuration's `paths:`.
-      # @param buffer [Rigor::Analysis::BufferBinding, nil]
       # @param cache_root [String, nil] nil falls back to the configuration's cache path.
-      # @return [Invocation]
       def run(configuration:, options:, paths: nil, buffer: nil, cache_root: nil)
         require_relative "check_runner_factory"
         runner = CheckRunnerFactory.build(
@@ -70,8 +67,6 @@ module Rigor
       #
       # @param config_path [String, nil] path to the config file; nil uses {Configuration.discover}.
       # @param options [Hash] runner options (defaults to {DEEP_OPTIONS}).
-      # @param paths [Array<String>, nil]
-      # @return [Outcome]
       def attempt(config_path: nil, options: DEEP_OPTIONS, paths: nil)
         require_relative "../configuration"
         configuration = Configuration.load(config_path)

--- a/lib/rigor/cli/check_invocation.rb
+++ b/lib/rigor/cli/check_invocation.rb
@@ -22,7 +22,7 @@ module Rigor
       # The outcome of {.attempt} — the best-effort variant. Exactly one of the two is non-nil, so a caller can never
       # read "the check could not run" as "the check ran clean": `result` is nil precisely when `error` is set.
       Outcome = Data.define(:result, :error) do
-        # @return [Boolean] true when an analysis actually completed.
+        # @rbs return: bool -- True when an analysis actually completed.
         def ran?
           !result.nil?
         end
@@ -42,9 +42,10 @@ module Rigor
 
       # Runs the analysis the way `rigor check` does and returns the runner + its raw result.
       #
-      # @param options [Hash] at least `:no_cache`, `:explain`, `:stats`, `:workers` (see {CheckRunnerFactory.build}).
-      # @param paths [Array<String>, nil] analysed paths; nil falls back to the configuration's `paths:`.
-      # @param cache_root [String, nil] nil falls back to the configuration's cache path.
+      # @rbs options: Hash[untyped, untyped] --
+      #   At least `:no_cache`, `:explain`, `:stats`, `:workers` (see {CheckRunnerFactory.build}).
+      # @rbs paths: Array[String]? -- Analysed paths; nil falls back to the configuration's `paths:`.
+      # @rbs cache_root: String? -- Nil falls back to the configuration's cache path.
       def run(configuration:, options:, paths: nil, buffer: nil, cache_root: nil)
         require_relative "check_runner_factory"
         runner = CheckRunnerFactory.build(
@@ -65,8 +66,8 @@ module Rigor
       # routing hint is outside the false-positive envelope, but a crash in it is not — `describe` must stay a command
       # an agent can run freely.
       #
-      # @param config_path [String, nil] path to the config file; nil uses {Configuration.discover}.
-      # @param options [Hash] runner options (defaults to {DEEP_OPTIONS}).
+      # @rbs config_path: String? -- Path to the config file; nil uses {Configuration.discover}.
+      # @rbs options: Hash[untyped, untyped] -- Runner options (defaults to {DEEP_OPTIONS}).
       def attempt(config_path: nil, options: DEEP_OPTIONS, paths: nil)
         require_relative "../configuration"
         configuration = Configuration.load(config_path)

--- a/lib/rigor/cli/check_runner_factory.rb
+++ b/lib/rigor/cli/check_runner_factory.rb
@@ -14,8 +14,8 @@ module Rigor
 
       # Builds a runner matching the configuration/plugin/cache resolution that `rigor check` itself uses.
       #
-      # @param options [Hash] parsed CLI options (must contain at least
-      #   `:no_cache`, `:explain`, `:stats`, `:workers`)
+      # @rbs options: Hash[untyped, untyped] --
+      #   Parsed CLI options (must contain at least `:no_cache`, `:explain`, `:stats`, `:workers`)
       def build(configuration:, options:, buffer:, cache_root:)
         cache_store = if options.fetch(:no_cache)
                         nil

--- a/lib/rigor/cli/check_runner_factory.rb
+++ b/lib/rigor/cli/check_runner_factory.rb
@@ -14,12 +14,8 @@ module Rigor
 
       # Builds a runner matching the configuration/plugin/cache resolution that `rigor check` itself uses.
       #
-      # @param configuration [Rigor::Configuration]
       # @param options [Hash] parsed CLI options (must contain at least
       #   `:no_cache`, `:explain`, `:stats`, `:workers`)
-      # @param buffer [Rigor::Analysis::BufferBinding, nil]
-      # @param cache_root [String]
-      # @return [Rigor::Analysis::Runner]
       def build(configuration:, options:, buffer:, cache_root:)
         cache_store = if options.fetch(:no_cache)
                         nil

--- a/lib/rigor/cli/coverage_command.rb
+++ b/lib/rigor/cli/coverage_command.rb
@@ -53,7 +53,7 @@ module Rigor
       # `--test-command`.
       DEFAULT_TEST_COMMAND = %w[bundle exec rake].freeze
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       #
       # Deferred YJIT enablement (Runtime::Jit) is armed by `CLI#dispatch` for every command, this
       # one included: a scan long enough to amortize JIT compile cost enables mid-flight; a short one

--- a/lib/rigor/cli/coverage_mutation.rb
+++ b/lib/rigor/cli/coverage_mutation.rb
@@ -48,8 +48,6 @@ module Rigor
       # Both measurement-integrity warnings, and the escalation rule between them, live in
       # {MeasurementIntegrityWarning}. Only the floor stays here: it is this command's policy, and
       # `coverage_command_spec` reads it off this module.
-      #
-      # @param report [MutationProtectionReport, FusedProtectionReport]
       def warn_harness_errors(report)
         MeasurementIntegrityWarning.emit(report, err: @err, floor: HARNESS_ERROR_WARN_FLOOR)
       end

--- a/lib/rigor/cli/coverage_scan.rb
+++ b/lib/rigor/cli/coverage_scan.rb
@@ -21,7 +21,7 @@ module Rigor
     module CoverageScan
       module_function
 
-      # @param files [Array<String>] explicit `.rb` file paths to scan.
+      # @rbs files: Array[String] -- Explicit `.rb` file paths to scan.
       #
       # Issue #513 — the environment is PLUGIN-AWARE (`LanguageServer::ProjectContext`, the same builder
       # `--protection` uses), not the bare RBS environment this path carried until 2026-09-01. Without the

--- a/lib/rigor/cli/coverage_scan.rb
+++ b/lib/rigor/cli/coverage_scan.rb
@@ -22,8 +22,6 @@ module Rigor
       module_function
 
       # @param files [Array<String>] explicit `.rb` file paths to scan.
-      # @param configuration [Rigor::Configuration]
-      # @return [Rigor::CLI::CoverageReport]
       #
       # Issue #513 — the environment is PLUGIN-AWARE (`LanguageServer::ProjectContext`, the same builder
       # `--protection` uses), not the bare RBS environment this path carried until 2026-09-01. Without the
@@ -57,8 +55,6 @@ module Rigor
       # the precision lens must mirror the walk it describes (`check` leaves the table empty unless
       # `parameter_inference:` is on, ADR-67 WD6a), while `--protection` seeds it unconditionally by ADR-67's own
       # wiring — it only ever reclassifies sites it already counted.
-      #
-      # @return [Rigor::Scope]
       def discovery_seeded_scope(files:, configuration:, environment:, parameter_inference:, workers: nil)
         base = Scope.empty(environment: environment)
         seed = Protection::DiscoverySeed.discovery_tables(files).dup

--- a/lib/rigor/cli/diff_command.rb
+++ b/lib/rigor/cli/diff_command.rb
@@ -26,7 +26,7 @@ module Rigor
     class DiffCommand < Command
       USAGE = "Usage: rigor diff [options] <baseline.json> [paths...]"
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         options = parse_options
 

--- a/lib/rigor/cli/doc_links.rb
+++ b/lib/rigor/cli/doc_links.rb
@@ -36,9 +36,9 @@ module Rigor
 
       module_function
 
-      # @param body [String] the page as it is stored.
-      # @param from [String] its absolute path, so relative targets resolve.
-      # @return [String] the page with every relative link turned into a `rigor docs` key.
+      # @rbs body: String -- The page as it is stored.
+      # @rbs from: String -- Its absolute path, so relative targets resolve.
+      # @rbs return: String -- The page with every relative link turned into a `rigor docs` key.
       def rewrite(body, from:)
         dir = File.dirname(from)
         body.gsub(MARKDOWN_LINK) do

--- a/lib/rigor/cli/docs_command.rb
+++ b/lib/rigor/cli/docs_command.rb
@@ -52,7 +52,7 @@ module Rigor
       HANDBOOK_ROOT = File.join(DOCS_ROOT, "handbook")
       LLMS_INDEX = File.join(DOCS_ROOT, "llms.txt")
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         case @argv.first
         when nil
@@ -136,8 +136,8 @@ module Rigor
       # Resolve a query to a single doc. Exact relative-path and prefixed-basename aliases are unique; a short
       # (prefix-stripped) name is accepted only when one category owns it.
       #
-      # @return [Hash, Integer] the doc entry, or an error exit status
-      #   after the error has been written to `@err`.
+      # @rbs return: Hash[untyped, untyped] | Integer --
+      #   The doc entry, or an error exit status after the error has been written to `@err`.
       def resolve_doc(query)
         # A key printed by a rendered page may carry the section it pointed at; resolve the page and say
         # where to look inside it, rather than refusing a key this command handed out.

--- a/lib/rigor/cli/doctor_command.rb
+++ b/lib/rigor/cli/doctor_command.rb
@@ -43,7 +43,7 @@ module Rigor
         rigor-rails-routes rigor-rails-i18n rigor-actioncable rigor-activestorage rigor-rails
       ].freeze
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         options = parse_options
         configuration = Configuration.load(options.fetch(:config))

--- a/lib/rigor/cli/effects_command.rb
+++ b/lib/rigor/cli/effects_command.rb
@@ -41,7 +41,7 @@ module Rigor
     class EffectsCommand < Command
       USAGE = "Usage: rigor effects [options] [paths]"
 
-      # @return [Integer] CLI exit status: 0 on success, 1 on `check` drift, 64 on a usage error.
+      # @rbs return: Integer -- CLI exit status: 0 on success, 1 on `check` drift, 64 on a usage error.
       def run
         verb = @argv.first
         return run_verb(verb) if EffectsSnapshotCommand::VERBS.include?(verb)
@@ -231,8 +231,9 @@ module Rigor
       # project does — still analyses it. Inside a project the argument is already under `paths:` and the
       # union is the configured set unchanged.
       #
-      # @return [Array(Rigor::Effects::EffectTable, Hash{String=>Array<String>})] the table, and which
-      #   file each unit was defined in — the map {EffectsReport} needs to answer a path argument.
+      # @rbs return: [Rigor::Effects::EffectTable, Hash[String, Array[String]]] --
+      #   The table, and which file each unit was defined in — the map {EffectsReport} needs to answer a path
+      #   argument.
       def analyze(configuration, scope)
         require_relative "../analysis/runner"
         runner = Analysis::Runner.new(

--- a/lib/rigor/cli/effects_diff_renderer.rb
+++ b/lib/rigor/cli/effects_diff_renderer.rb
@@ -50,12 +50,12 @@ module Rigor
       REGENERATION_CLOSING_LINE = "Run `rigor effects update` to regenerate the record under the current " \
                                   "rules."
 
-      # @param sources [Hash{String=>Array<String>}] `Runner#effect_sources` — where each unit is defined.
-      #   A drift row names `file:line` so a reviewer does not have to search for the method (#435). The
-      #   file rides the cached summary entry and is free; the line is resolved by parsing the row's own
-      #   file ({Effects::DefinitionLines}), which is why a fresh report — no rows — still parses nothing
-      #   and the whole-project parse ADR-104 removed from this command stays removed.
-      # @param lines [Effects::DefinitionLines] seam for the specs; the default parses on demand.
+      # @rbs sources: Hash[String, Array[String]] --
+      #   `Runner#effect_sources` — where each unit is defined. A drift row names `file:line` so a reviewer does not
+      #   have to search for the method (#435). The file rides the cached summary entry and is free; the line is
+      #   resolved by parsing the row's own file ({Effects::DefinitionLines}), which is why a fresh report — no rows —
+      #   still parses nothing and the whole-project parse ADR-104 removed from this command stays removed.
+      # @rbs lines: Effects::DefinitionLines -- Seam for the specs; the default parses on demand.
       def initialize(out:, path:, sources: nil, lines: Effects::DefinitionLines.new)
         @out = out
         @path = path
@@ -121,8 +121,9 @@ module Rigor
       # method that no longer exists was not defined by it. Such a row renders exactly as it did before
       # this suffix existed.
       #
-      # @return [Array<Array(String, Integer)>] `[relative path, line]` per file, the line nil when that
-      #   file spells the key with no `def` — an accessor, or a definition the nesting cannot name.
+      # @rbs return: Array[[String, Integer]] --
+      #   `[relative path, line]` per file, the line nil when that file spells the key with no `def` — an accessor, or
+      #   a definition the nesting cannot name.
       def sources_of(symbol)
         Array(@sources[symbol]).map do |path|
           [Effects::Snapshot.relativize(path, Dir.pwd), @lines.for(key: symbol, path: path)]

--- a/lib/rigor/cli/effects_snapshot_command.rb
+++ b/lib/rigor/cli/effects_snapshot_command.rb
@@ -51,7 +51,7 @@ module Rigor
         @verb = verb
       end
 
-      # @return [Integer] 0 fresh / written, 1 on drift under `check`, 64 on a usage error.
+      # @rbs return: Integer -- 0 fresh / written, 1 on drift under `check`, 64 on a usage error.
       def run
         options = parse_options
         return usage_error("unsupported format: #{options.fetch(:format)}") unless

--- a/lib/rigor/cli/explain_command.rb
+++ b/lib/rigor/cli/explain_command.rb
@@ -18,7 +18,7 @@ module Rigor
     class ExplainCommand < Command
       USAGE = "Usage: rigor explain [options] [<rule>]"
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         options = parse_options
 

--- a/lib/rigor/cli/lsp_command.rb
+++ b/lib/rigor/cli/lsp_command.rb
@@ -15,7 +15,7 @@ module Rigor
     class LspCommand < Command
       USAGE = "Usage: rigor lsp [options]"
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         options = parse_options
         return CLI::EXIT_USAGE if options == :usage_error

--- a/lib/rigor/cli/mcp_command.rb
+++ b/lib/rigor/cli/mcp_command.rb
@@ -17,7 +17,7 @@ module Rigor
     class McpCommand < Command
       USAGE = "Usage: rigor mcp [options]"
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         options = parse_options
         return CLI::EXIT_USAGE if options == :usage_error

--- a/lib/rigor/cli/measurement_integrity_warning.rb
+++ b/lib/rigor/cli/measurement_integrity_warning.rb
@@ -20,14 +20,14 @@ module Rigor
     module MeasurementIntegrityWarning
       module_function
 
-      # @param report [MutationProtectionReport, FusedProtectionReport] both expose the two counts.
-      # @param err [IO] the stream to warn on.
-      # @param floor [Integer] {CoverageMutation::HARNESS_ERROR_WARN_FLOOR}.
+      # @rbs report: MutationProtectionReport | FusedProtectionReport -- Both expose the two counts.
+      # @rbs err: IO -- The stream to warn on.
+      # @rbs floor: Integer -- {CoverageMutation::HARNESS_ERROR_WARN_FLOOR}.
       def emit(report, err:, floor:)
         lines_for(report, floor: floor).each { |line| err.puts(line) }
       end
 
-      # @return [Array<String>] the warnings this report earns, widest consequence first.
+      # @rbs return: Array[String] -- The warnings this report earns, widest consequence first.
       def lines_for(report, floor:)
         lines = []
         unmeasured = report.respond_to?(:unmeasured_files) ? report.unmeasured_files : 0 # see CoverageCommand

--- a/lib/rigor/cli/measurement_integrity_warning.rb
+++ b/lib/rigor/cli/measurement_integrity_warning.rb
@@ -23,7 +23,6 @@ module Rigor
       # @param report [MutationProtectionReport, FusedProtectionReport] both expose the two counts.
       # @param err [IO] the stream to warn on.
       # @param floor [Integer] {CoverageMutation::HARNESS_ERROR_WARN_FLOOR}.
-      # @return [void]
       def emit(report, err:, floor:)
         lines_for(report, floor: floor).each { |line| err.puts(line) }
       end

--- a/lib/rigor/cli/mutation_fork_scan.rb
+++ b/lib/rigor/cli/mutation_fork_scan.rb
@@ -32,12 +32,12 @@ module Rigor
       # reliably marshalable, and the accumulator only needs the count).
       ParseError = Data.define(:count)
 
-      # @param paths [Array<String>] the files to measure, in caller order.
-      # @param scanner [Protection::MutationScanner] built on the parent; COW-inherited by workers.
-      # @param environment [Rigor::Environment] the scanner's environment, prewarmed here before forking.
-      # @param configuration [Rigor::Configuration] for the Prism `target_ruby` version.
-      # @param workers [Integer] resolved worker count (≤1 → sequential).
-      # @return [Hash{String => Protection::MutationScanner::FileResult, ParseError}] one entry per path.
+      # @rbs paths: Array[String] -- The files to measure, in caller order.
+      # @rbs scanner: Protection::MutationScanner -- Built on the parent; COW-inherited by workers.
+      # @rbs environment: Rigor::Environment -- The scanner's environment, prewarmed here before forking.
+      # @rbs configuration: Rigor::Configuration -- For the Prism `target_ruby` version.
+      # @rbs workers: Integer -- Resolved worker count (≤1 → sequential).
+      # @rbs return: Hash[String, Protection::MutationScanner::FileResult | ParseError] -- One entry per path.
       def run(paths:, scanner:, environment:, configuration:, workers:)
         # Force the full RBS load on the parent so children copy-on-write inherit a warm environment rather
         # than each rebuilding it after the fork. A no-op on the sequential path but cheap.

--- a/lib/rigor/cli/plugin_command.rb
+++ b/lib/rigor/cli/plugin_command.rb
@@ -64,7 +64,7 @@ module Rigor
       PLUGINS_ROOT = File.join(GEM_ROOT, "plugins")
       EXAMPLES_ROOT = File.join(GEM_ROOT, "examples")
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         subcommand = @argv.shift || "list"
 

--- a/lib/rigor/cli/plugins_command.rb
+++ b/lib/rigor/cli/plugins_command.rb
@@ -62,7 +62,7 @@ module Rigor
     class PluginsCommand < Command # rubocop:disable Metrics/ClassLength
       USAGE = "Usage: rigor plugins [options]"
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         options = parse_options
         config_path = options.fetch(:config) || Configuration.discover

--- a/lib/rigor/cli/prism_colorizer.rb
+++ b/lib/rigor/cli/prism_colorizer.rb
@@ -35,9 +35,9 @@ module Rigor
 
       VARIABLE_TOKENS = %i[INSTANCE_VARIABLE CLASS_VARIABLE GLOBAL_VARIABLE].freeze
 
-      # @param source [String] Ruby source.
-      # @return [String] the source with ANSI colour escapes, or
-      #   the input unchanged when lexing surfaces an error.
+      # @rbs source: String -- Ruby source.
+      # @rbs return: String --
+      #   The source with ANSI colour escapes, or the input unchanged when lexing surfaces an error.
       def colorize(source)
         # Sources read under a POSIX locale arrive tagged US-ASCII even when they carry UTF-8 bytes; retag so the token
         # regexes below do not raise on multibyte comments.

--- a/lib/rigor/cli/probe_environment.rb
+++ b/lib/rigor/cli/probe_environment.rb
@@ -43,7 +43,6 @@ module Rigor
       #   ADR-93 auto-wired `rigor-rbs-inline` entry when the library is resolvable).
       # @param source_files [Array<String>] the file(s) the probe inspects. Threaded so each loaded plugin's
       #   `source_rbs_synthesizer` runs over them at env-build time; an empty list contributes no synthesized RBS.
-      # @return [Rigor::Environment]
       def build(configuration:, source_files:)
         Environment.for_project(
           libraries: configuration.libraries,

--- a/lib/rigor/cli/probe_environment.rb
+++ b/lib/rigor/cli/probe_environment.rb
@@ -39,10 +39,12 @@ module Rigor
 
       # Builds the plugin-aware {Rigor::Environment} a probe types against.
       #
-      # @param configuration [Rigor::Configuration] the loaded project configuration (already carries the
-      #   ADR-93 auto-wired `rigor-rbs-inline` entry when the library is resolvable).
-      # @param source_files [Array<String>] the file(s) the probe inspects. Threaded so each loaded plugin's
-      #   `source_rbs_synthesizer` runs over them at env-build time; an empty list contributes no synthesized RBS.
+      # @rbs configuration: Rigor::Configuration --
+      #   The loaded project configuration (already carries the ADR-93 auto-wired `rigor-rbs-inline` entry when the
+      #   library is resolvable).
+      # @rbs source_files: Array[String] --
+      #   The file(s) the probe inspects. Threaded so each loaded plugin's `source_rbs_synthesizer` runs over them at
+      #   env-build time; an empty list contributes no synthesized RBS.
       def build(configuration:, source_files:)
         Environment.for_project(
           libraries: configuration.libraries,

--- a/lib/rigor/cli/protection_fork_scan.rb
+++ b/lib/rigor/cli/protection_fork_scan.rb
@@ -23,12 +23,12 @@ module Rigor
       # reliably marshalable, and the accumulator only needs the count).
       ParseError = Data.define(:count)
 
-      # @param paths [Array<String>] the files to scan, in caller order.
-      # @param scanner [Inference::ProtectionScanner] built on the parent; COW-inherited by workers.
-      # @param environment [Rigor::Environment] the scanner's environment, prewarmed here before forking.
-      # @param configuration [Rigor::Configuration] for the Prism `target_ruby` version.
-      # @param workers [Integer] resolved worker count (≤1 → sequential).
-      # @return [Hash{String => Inference::ProtectionScanner::FileResult, ParseError}] one entry per path.
+      # @rbs paths: Array[String] -- The files to scan, in caller order.
+      # @rbs scanner: Inference::ProtectionScanner -- Built on the parent; COW-inherited by workers.
+      # @rbs environment: Rigor::Environment -- The scanner's environment, prewarmed here before forking.
+      # @rbs configuration: Rigor::Configuration -- For the Prism `target_ruby` version.
+      # @rbs workers: Integer -- Resolved worker count (≤1 → sequential).
+      # @rbs return: Hash[String, Inference::ProtectionScanner::FileResult | ParseError] -- One entry per path.
       def run(paths:, scanner:, environment:, configuration:, workers:)
         # Force the full RBS load on the parent so children copy-on-write inherit a warm environment rather
         # than each rebuilding it after the fork (mirrors the check fork pool's parent-side prewarm). A

--- a/lib/rigor/cli/show_bleedingedge_command.rb
+++ b/lib/rigor/cli/show_bleedingedge_command.rb
@@ -21,7 +21,7 @@ module Rigor
     class ShowBleedingedgeCommand < Command
       USAGE = "Usage: rigor show-bleedingedge [options]"
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         options = parse_options
         configuration = load_configuration(options)

--- a/lib/rigor/cli/sig_gen_command.rb
+++ b/lib/rigor/cli/sig_gen_command.rb
@@ -33,7 +33,7 @@ module Rigor
       VALID_PARAM_POLICIES = %w[untyped observed observed-strict].freeze
       VALID_FORMATS = %w[text json].freeze
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         options = parse_options
         return CLI::EXIT_USAGE if options.nil?
@@ -106,7 +106,7 @@ module Rigor
         )
       end
 
-      # @return [Integer] exit status — non-zero when a file the user asked to write could not be written.
+      # @rbs return: Integer -- Exit status — non-zero when a file the user asked to write could not be written.
       def dispatch_write(candidates, configuration, options)
         layout_index = SigGen::LayoutIndex.new(signature_paths: configuration.signature_paths)
         path_mapper = SigGen::PathMapper.new(configuration: configuration, layout_index: layout_index)

--- a/lib/rigor/cli/skill_command.rb
+++ b/lib/rigor/cli/skill_command.rb
@@ -76,7 +76,7 @@ module Rigor
       # up.
       SKILLS_ROOT = File.expand_path("../../../skills", __dir__)
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         case @argv.first
         when nil

--- a/lib/rigor/cli/skill_deep_probe.rb
+++ b/lib/rigor/cli/skill_deep_probe.rb
@@ -37,23 +37,25 @@ module Rigor
       #   that could not run is NOT a clean check and the report must never let it read as one.
       # - `route` / `reason` — the headline override, or nil to leave the presence-only recommendation standing.
       Report = Data.define(:status, :detail, :route, :reason) do
-        # @return [Boolean] true when the check did not complete — the caller must then say so rather than let the
-        #   fallback recommendation read as an all-clear.
+        # @rbs return: bool --
+        #   True when the check did not complete — the caller must then say so rather than let the fallback
+        #   recommendation read as an all-clear.
         def failed?
           status == :error
         end
       end
 
-      # @param config [String, nil] the config filename the presence probe found, relative to `root`.
-      # @param root [String] project root (the analysis itself resolves paths against the process cwd, as
-      #   `rigor check` does).
+      # @rbs config: String? -- The config filename the presence probe found, relative to `root`.
+      # @rbs root: String --
+      #   Project root (the analysis itself resolves paths against the process cwd, as `rigor check` does).
       def initialize(config:, root: Dir.pwd)
         @config = config
         @root = root
       end
 
-      # @return [Report] never raises — every failure degrades to a `:error`/`:skipped` report whose `route` is nil,
-      #   leaving the presence-only headline in charge.
+      # @rbs return: Report --
+      #   Never raises — every failure degrades to a `:error`/`:skipped` report whose `route` is nil, leaving the
+      #   presence-only headline in charge.
       def run
         if @config.nil?
           return Report.new(

--- a/lib/rigor/cli/skill_describe.rb
+++ b/lib/rigor/cli/skill_describe.rb
@@ -29,7 +29,7 @@ module Rigor
         @root = root
       end
 
-      # @return [Hash] the presence-only state the recommendation routes on.
+      # @rbs return: Hash[untyped, untyped] -- The presence-only state the recommendation routes on.
       def to_h
         config = CONFIG_FILENAMES.find { |name| File.file?(File.join(@root, name)) }
         {
@@ -140,18 +140,19 @@ module Rigor
         rigor-ask
       ].freeze
 
-      # @param skills [Array<Hash>] discovered skills, each `{name:, path:}`.
-      # @param root [String] project root to probe (defaults to the cwd).
-      # @param deep [Boolean] opt into `--deep`: run a real `rigor check` and let its result pick the headline. Off by
-      #   default, and off is ADR-73 WD2's contract — see {SkillDeepProbe} for why the whole analysis path lives
-      #   behind this one flag and in its own file.
+      # @rbs skills: Array[Hash[untyped, untyped]] -- Discovered skills, each `{name:, path:}`.
+      # @rbs root: String -- Project root to probe (defaults to the cwd).
+      # @rbs deep: bool --
+      #   Opt into `--deep`: run a real `rigor check` and let its result pick the headline. Off by default, and off is
+      #   ADR-73 WD2's contract — see {SkillDeepProbe} for why the whole analysis path lives behind this one flag and
+      #   in its own file.
       def initialize(skills:, root: Dir.pwd, deep: false)
         @skills = skills
         @root = root
         @deep = deep
       end
 
-      # @return [String] the full describe report.
+      # @rbs return: String -- The full describe report.
       def render
         catalog = catalog_skills
         state = ProjectStateProbe.new(@root).to_h

--- a/lib/rigor/cli/trace_command.rb
+++ b/lib/rigor/cli/trace_command.rb
@@ -30,7 +30,7 @@ module Rigor
       DEFAULT_KINDS = %i[bind union dispatch].freeze
       VERBOSE_KINDS = (%i[enter result] + DEFAULT_KINDS).freeze
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         options = parse_options
         file = @argv.first

--- a/lib/rigor/cli/trace_renderer.rb
+++ b/lib/rigor/cli/trace_renderer.rb
@@ -28,8 +28,8 @@ module Rigor
       BODY_HEIGHT_MIN = 3    # never shrink the source window below this
       DEFAULT_SIZE = [24, 80].freeze
 
-      # @param source [String] the traced file's source.
-      # @param file [String] display path.
+      # @rbs source: String -- The traced file's source.
+      # @rbs file: String -- Display path.
       def initialize(out:, source:, file:)
         @out = out
         @source = source
@@ -37,11 +37,10 @@ module Rigor
         @lines = source.lines.map(&:chomp)
       end
 
-      # @param events [Array<Rigor::Inference::FlowTracer::Event>] the
-      #   pre-filtered frame list (the command owns kind filtering).
-      # @param delay [Float, nil] seconds between frames (autoplay);
-      #   nil = step on key press when interactive.
-      # @param interactive [Boolean] whether to clear/redraw and wait.
+      # @rbs events: Array[Rigor::Inference::FlowTracer::Event] --
+      #   The pre-filtered frame list (the command owns kind filtering).
+      # @rbs delay: Float? -- Seconds between frames (autoplay); nil = step on key press when interactive.
+      # @rbs interactive: bool -- Whether to clear/redraw and wait.
       def play(events, delay: nil, interactive: false)
         @rows, @cols = interactive ? terminal_size : DEFAULT_SIZE
         @interactive = interactive

--- a/lib/rigor/cli/trace_renderer.rb
+++ b/lib/rigor/cli/trace_renderer.rb
@@ -28,7 +28,6 @@ module Rigor
       BODY_HEIGHT_MIN = 3    # never shrink the source window below this
       DEFAULT_SIZE = [24, 80].freeze
 
-      # @param out [IO]
       # @param source [String] the traced file's source.
       # @param file [String] display path.
       def initialize(out:, source:, file:)

--- a/lib/rigor/cli/triage_command.rb
+++ b/lib/rigor/cli/triage_command.rb
@@ -22,7 +22,7 @@ module Rigor
       USAGE = "Usage: rigor triage [options] [paths]"
       DEFAULT_SECTIONS = %i[distribution selectors hotspots hints].freeze
 
-      # @return [Integer] CLI exit status (always 0).
+      # @rbs return: Integer -- CLI exit status (always 0).
       def run
         options = parse_options
         configuration = Configuration.load(options.fetch(:config))

--- a/lib/rigor/cli/type_of_command.rb
+++ b/lib/rigor/cli/type_of_command.rb
@@ -46,7 +46,7 @@ module Rigor
       LINE_ENUMERATION_CAP = 40
       private_constant :LINE_ENUMERATION_CAP
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         options = parse_options
         buffer = Options.resolve_buffer_binding(options, err: @err)

--- a/lib/rigor/cli/type_scan_command.rb
+++ b/lib/rigor/cli/type_scan_command.rb
@@ -26,7 +26,7 @@ module Rigor
 
       LocatedEvent = Data.define(:file, :event)
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         options = parse_options
         paths = collect_paths(@argv, command_name: "type-scan")

--- a/lib/rigor/cli/upgrade_command.rb
+++ b/lib/rigor/cli/upgrade_command.rb
@@ -13,7 +13,7 @@ module Rigor
     class UpgradeCommand < Command
       USAGE = "Usage: rigor upgrade [options]"
 
-      # @return [Integer] CLI exit status.
+      # @rbs return: Integer -- CLI exit status.
       def run
         @out.puts("rigor upgrade: No migration target available yet (ADR-50 WD7, queued).")
         @out.puts("Current version: #{Rigor::VERSION}")

--- a/lib/rigor/config_audit.rb
+++ b/lib/rigor/config_audit.rb
@@ -36,8 +36,9 @@ module Rigor
       end
     end
 
-    # @param project_root [String] the directory the run's relative bundler / collection
-    #   paths resolve against (the CLI's CWD), used only by the explicit-path checks.
+    # @rbs project_root: String --
+    #   The directory the run's relative bundler / collection paths resolve against (the CLI's CWD), used only by the
+    #   explicit-path checks.
     def self.warnings(configuration, project_root: Dir.pwd)
       unknown_key_warnings(configuration) +
         signature_path_warnings(configuration) +

--- a/lib/rigor/config_audit.rb
+++ b/lib/rigor/config_audit.rb
@@ -36,10 +36,8 @@ module Rigor
       end
     end
 
-    # @param configuration [Rigor::Configuration]
     # @param project_root [String] the directory the run's relative bundler / collection
     #   paths resolve against (the CLI's CWD), used only by the explicit-path checks.
-    # @return [Array<Warning>]
     def self.warnings(configuration, project_root: Dir.pwd)
       unknown_key_warnings(configuration) +
         signature_path_warnings(configuration) +

--- a/lib/rigor/configuration.rb
+++ b/lib/rigor/configuration.rb
@@ -466,14 +466,14 @@ module Rigor
 
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     #
-    # @param effects_key_present [Boolean] ADR-103 WD15 — whether the file this `data` came from carried an
-    #   `effects:` key at all, independent of its value. Defaults to `data.key?("effects")`, which is the
-    #   right answer for a caller that passes a raw (non-`DEFAULTS`-merged) hash directly — the common shape
-    #   in specs — but is always `true` once `data` has been through `DEFAULTS.merge`, because `DEFAULTS`
-    #   itself carries the key; {.load} therefore computes this from the pre-merge file and passes it
-    #   explicitly. See {#coerce_effects}. **Positional, deliberately not a keyword**: a bare (unbraced)
-    #   `"key" => value` hash literal — this class's usual call shape, all over the spec suite — is coerced
-    #   into keyword arguments by Ruby whenever the method declares ANY keyword parameter, which would break
+    # @rbs effects_key_present: bool --
+    #   ADR-103 WD15 — whether the file this `data` came from carried an `effects:` key at all, independent of its
+    #   value. Defaults to `data.key?("effects")`, which is the right answer for a caller that passes a raw
+    #   (non-`DEFAULTS`-merged) hash directly — the common shape in specs — but is always `true` once `data` has been
+    #   through `DEFAULTS.merge`, because `DEFAULTS` itself carries the key; {.load} therefore computes this from the
+    #   pre-merge file and passes it explicitly. See {#coerce_effects}. **Positional, deliberately not a keyword**: a
+    #   bare (unbraced) `"key" => value` hash literal — this class's usual call shape, all over the spec suite — is
+    #   coerced into keyword arguments by Ruby whenever the method declares ANY keyword parameter, which would break
     #   every `Configuration.new("some_key" => value)` call site with an "unknown keyword" `ArgumentError`.
     def initialize(data = DEFAULTS, effects_key_present = data.key?("effects"))
       # Record before the per-key fetches below discard the evidence. Top level only, deliberately —
@@ -626,8 +626,9 @@ module Rigor
     #   the same checkout: a typo is a bug, and reading it as `false` would ship the feature permanently off
     #   with no signal.
     #
-    # @param id [String] a feature id from {BleedingEdge::FEATURES} or {BleedingEdge::GRADUATED}.
-    # @raise [ArgumentError] if `id` names no known feature.
+    # @rbs id: String --
+    #   A feature id from {BleedingEdge::FEATURES} or {BleedingEdge::GRADUATED}. Raises ArgumentError if `id` names no
+    #   known feature.
     def bleeding_edge_active?(id)
       return true if BleedingEdge.graduated?(id)
       unless BleedingEdge.known_id?(id)

--- a/lib/rigor/configuration.rb
+++ b/lib/rigor/configuration.rb
@@ -627,7 +627,6 @@ module Rigor
     #   with no signal.
     #
     # @param id [String] a feature id from {BleedingEdge::FEATURES} or {BleedingEdge::GRADUATED}.
-    # @return [Boolean]
     # @raise [ArgumentError] if `id` names no known feature.
     def bleeding_edge_active?(id)
       return true if BleedingEdge.graduated?(id)

--- a/lib/rigor/configuration/severity_profile.rb
+++ b/lib/rigor/configuration/severity_profile.rb
@@ -167,20 +167,20 @@ module Rigor
       # Resolves the configured severity for a diagnostic given the active profile and any per-rule
       # overrides.
       #
-      # @param rule [String, nil] canonical rule id (`call.undefined-method`).
-      # @param authored_severity [Symbol] severity the rule emitted the diagnostic with (`:error`, `:warning`,
-      #   `:info`).
-      # @param profile [Symbol] one of {VALID_PROFILES}; falls back to {DEFAULT_PROFILE} for unknown values.
-      # @param overrides [Hash{String => Symbol}] per-rule severity overrides from `.rigor.yml`'s
-      #   `severity_overrides:` map. Keys are canonical rule ids; values are {VALID_SEVERITIES} symbols.
-      #   Family-wildcard keys (`call`) match every rule under that prefix.
-      # @param bleeding_edge_overrides [Hash{String => Symbol}] the severity map imposed by the active ADR-50
-      #   § WD2 bleeding-edge features ({Rigor::BleedingEdge.severity_overrides_for}). Consulted *below* the
-      #   user's own `overrides` (so an explicit `severity_overrides:` entry, exact or family wildcard,
-      #   always wins) and *above* the profile table. Exact rule ids only — the overlay never carries family
-      #   wildcards. Empty while the overlay is unpopulated, so the default leaves resolution bit-for-bit
-      #   unchanged.
-      # @return [Symbol] the resolved severity. Returns `:off` to mean "drop the diagnostic entirely".
+      # @rbs rule: String? -- Canonical rule id (`call.undefined-method`).
+      # @rbs authored_severity: Symbol --
+      #   Severity the rule emitted the diagnostic with (`:error`, `:warning`, `:info`).
+      # @rbs profile: Symbol -- One of {VALID_PROFILES}; falls back to {DEFAULT_PROFILE} for unknown values.
+      # @rbs overrides: Hash[String, Symbol] --
+      #   Per-rule severity overrides from `.rigor.yml`'s `severity_overrides:` map. Keys are canonical rule ids;
+      #   values are {VALID_SEVERITIES} symbols. Family-wildcard keys (`call`) match every rule under that prefix.
+      # @rbs bleeding_edge_overrides: Hash[String, Symbol] --
+      #   The severity map imposed by the active ADR-50 § WD2 bleeding-edge features
+      #   ({Rigor::BleedingEdge.severity_overrides_for}). Consulted *below* the user's own `overrides` (so an explicit
+      #   `severity_overrides:` entry, exact or family wildcard, always wins) and *above* the profile table. Exact
+      #   rule ids only — the overlay never carries family wildcards. Empty while the overlay is unpopulated, so the
+      #   default leaves resolution bit-for-bit unchanged.
+      # @rbs return: Symbol -- The resolved severity. Returns `:off` to mean "drop the diagnostic entirely".
       def resolve(rule:, authored_severity:, profile: DEFAULT_PROFILE, overrides: {}, bleeding_edge_overrides: {})
         return authored_severity if rule.nil?
 

--- a/lib/rigor/effects/attribution.rb
+++ b/lib/rigor/effects/attribution.rb
@@ -30,8 +30,9 @@ module Rigor
         @empty ||= new({})
       end
 
-      # @param table [Hash{String => Array<String>}] `Configuration#effects_attribution` — method key to
-      #   label list, both already shape-validated at load (tier 2).
+      # @rbs table: Hash[String, Array[String]] --
+      #   `Configuration#effects_attribution` — method key to label list, both already shape-validated at load (tier
+      #   2).
       def self.build(table)
         return empty if table.nil? || table.empty?
 
@@ -50,7 +51,7 @@ module Rigor
       # The labels attributed to a method key (`Net::HTTP.get`), or nil when the table says nothing about
       # it. The key is spelled by the caller, which already builds the same string for the catalogue.
       #
-      # @return [LabelSet, nil]
+      # @rbs return: LabelSet?
       def [](key)
         @rows[key]
       end

--- a/lib/rigor/effects/config_envelopes.rb
+++ b/lib/rigor/effects/config_envelopes.rb
@@ -71,7 +71,6 @@ module Rigor
       #
       # @param entries [Array<Hash>] the loaded, shape-validated entries
       # @param registry [Registry] the vocabulary, project extensions included
-      # @return [Array<Entry>]
       def build(entries:, registry:)
         entries.each_with_index.map do |entry, index|
           labels = Array(entry["effect"]).map(&:to_s)
@@ -86,7 +85,6 @@ module Rigor
 
       # The class-level envelopes the entries put on a project.
       #
-      # @param entries [Array<Entry>]
       # @param class_names [Enumerable<String>] every class the run collected units for
       # @param sources [Hash{String => Array<String>}] `Runner#effect_sources` — `{method key => [path]}`
       # @param project_root [String] what `sources` paths are relativised against

--- a/lib/rigor/effects/config_envelopes.rb
+++ b/lib/rigor/effects/config_envelopes.rb
@@ -69,8 +69,8 @@ module Rigor
 
       # Resolves `Configuration#effects_envelopes` against a registry.
       #
-      # @param entries [Array<Hash>] the loaded, shape-validated entries
-      # @param registry [Registry] the vocabulary, project extensions included
+      # @rbs entries: Array[Hash[untyped, untyped]] -- The loaded, shape-validated entries
+      # @rbs registry: Registry -- The vocabulary, project extensions included
       def build(entries:, registry:)
         entries.each_with_index.map do |entry, index|
           labels = Array(entry["effect"]).map(&:to_s)
@@ -85,10 +85,10 @@ module Rigor
 
       # The class-level envelopes the entries put on a project.
       #
-      # @param class_names [Enumerable<String>] every class the run collected units for
-      # @param sources [Hash{String => Array<String>}] `Runner#effect_sources` — `{method key => [path]}`
-      # @param project_root [String] what `sources` paths are relativised against
-      # @return [Hash{String => Envelope}] one envelope per selected class, keyed by class name
+      # @rbs class_names: Enumerable[String] -- Every class the run collected units for
+      # @rbs sources: Hash[String, Array[String]] -- `Runner#effect_sources` — `{method key => [path]}`
+      # @rbs project_root: String -- What `sources` paths are relativised against
+      # @rbs return: Hash[String, Envelope] -- One envelope per selected class, keyed by class name
       def for_classes(entries:, class_names:, sources: {}, project_root: Dir.pwd)
         return NO_ENVELOPES if entries.empty?
 

--- a/lib/rigor/effects/definition_lines.rb
+++ b/lib/rigor/effects/definition_lines.rb
@@ -30,10 +30,11 @@ module Rigor
       NO_LINES = {}.freeze
       private_constant :NO_LINES
 
-      # @param key [String] an effect unit key — `Tracer::Loud#emit`, `Net::HTTP.get`.
-      # @param path [String] the file the key was traced to.
-      # @return [Integer, nil] the `def`'s line, or nil when this file does not spell that key with a
-      #   `def` — an unreadable file, a syntax error, and a synthesized method all land here.
+      # @rbs key: String -- An effect unit key — `Tracer::Loud#emit`, `Net::HTTP.get`.
+      # @rbs path: String -- The file the key was traced to.
+      # @rbs return: Integer? --
+      #   The `def`'s line, or nil when this file does not spell that key with a `def` — an unreadable file, a syntax
+      #   error, and a synthesized method all land here.
       def for(key:, path:)
         index_for(path)[key]
       end

--- a/lib/rigor/effects/effect_table.rb
+++ b/lib/rigor/effects/effect_table.rb
@@ -61,7 +61,6 @@ module Rigor
         @empty ||= new(EMPTY_ENTRIES)
       end
 
-      # @param entries [Hash{String => Entry}]
       def initialize(entries)
         @entries = entries.sort_by { |key, _| key }.to_h.freeze
         freeze

--- a/lib/rigor/effects/entry_points.rb
+++ b/lib/rigor/effects/entry_points.rb
@@ -117,8 +117,6 @@ module Rigor
         # one message: the unregistered-preset error (#433) and the note `rigor effects update` prints
         # when `reach:` is empty (#436) have to give the same answer, and neither can hard-code a list
         # that moves with `plugins:`.
-        #
-        # @return [String]
         def availability
           if @presets.empty?
             return "no plugin in this project registers an entry-point preset — a preset is named by the " \

--- a/lib/rigor/effects/envelope_check.rb
+++ b/lib/rigor/effects/envelope_check.rb
@@ -61,7 +61,7 @@ module Rigor
         # It lives on the value rather than in {EnvelopeCheck} because {LiskovCheck} positions its
         # findings identically, and two spellings of "where the fix goes" would eventually disagree.
         #
-        # @return [Array(String, Integer)] `[path, line]`; `[nil, 1]` for a key with no owner.
+        # @rbs return: [String, Integer] -- `[path, line]`; `[nil, 1]` for a key with no owner.
         def for(key)
           class_name, separator, selector = MethodKey.split(key)
           return [nil, 1] if class_name.nil?
@@ -103,17 +103,18 @@ module Rigor
 
       module_function
 
-      # @param table [EffectTable] the run's propagated graph.
-      # @param method_envelopes [Hash{String => Envelope}] per-method envelopes, as written.
-      # @param class_envelopes [Hash{String => Envelope}] class- / module-level envelopes, to distribute.
-      # @param config_envelopes [Hash{String => Envelope}] `effects.envelopes:` entries already resolved
-      #   to the classes they select ({ConfigEnvelopes.for_classes}), to distribute at the lowest precedence.
-      # @param positions [Positions, DeferredPositions] the discovery tables a finding's `def`
-      #   position is read from — consulted only when a finding is built, so a deferred value's
-      #   discovery force is reached exactly as often as a finding exists.
-      # @param apply_tolerated [Boolean] false judges against the undischarged-by-policy `proven` lane —
-      #   the `--no-tolerated-effects` audit switch.
-      # @return [Array<Finding>] sorted by position then key then label, so a run explains identically twice.
+      # @rbs table: EffectTable -- The run's propagated graph.
+      # @rbs method_envelopes: Hash[String, Envelope] -- Per-method envelopes, as written.
+      # @rbs class_envelopes: Hash[String, Envelope] -- Class- / module-level envelopes, to distribute.
+      # @rbs config_envelopes: Hash[String, Envelope] --
+      #   `effects.envelopes:` entries already resolved to the classes they select ({ConfigEnvelopes.for_classes}), to
+      #   distribute at the lowest precedence.
+      # @rbs positions: Positions | DeferredPositions --
+      #   The discovery tables a finding's `def` position is read from — consulted only when a finding is built, so a
+      #   deferred value's discovery force is reached exactly as often as a finding exists.
+      # @rbs apply_tolerated: bool --
+      #   False judges against the undischarged-by-policy `proven` lane — the `--no-tolerated-effects` audit switch.
+      # @rbs return: Array[Finding] -- Sorted by position then key then label, so a run explains identically twice.
       def run(table:, method_envelopes:, class_envelopes:, config_envelopes: {},
               positions: Positions.empty, apply_tolerated: true)
         envelopes = distribute(table, method_envelopes, class_envelopes, config_envelopes)

--- a/lib/rigor/effects/envelope_index.rb
+++ b/lib/rigor/effects/envelope_index.rb
@@ -56,13 +56,14 @@ module Rigor
 
       # Reads every stratum this index serves, once per process.
       #
-      # @param plugin_facts [Rigor::Effects::PluginFacts, nil] the loaded plugins' effect contributions
-      #   (#387); their `effect_labels:` join the vocabulary an annotation is read against, so a gem's
-      #   `%a{rigor:v1:effect rails.activejob.enqueue}` resolves rather than reading as unknown.
-      # @param environment [Rigor::Environment, nil] the run's environment. Its loader supplies the
-      #   rbs-inline / plugin `virtual_rbs` buffers and the built RBS environment the accepted stratum is
-      #   read from; without one, both are simply absent (the fail-quiet direction — a missing `≤` bound
-      #   costs precision, never a finding).
+      # @rbs plugin_facts: Rigor::Effects::PluginFacts? --
+      #   The loaded plugins' effect contributions (#387); their `effect_labels:` join the vocabulary an annotation is
+      #   read against, so a gem's `%a{rigor:v1:effect rails.activejob.enqueue}` resolves rather than reading as
+      #   unknown.
+      # @rbs environment: Rigor::Environment? --
+      #   The run's environment. Its loader supplies the rbs-inline / plugin `virtual_rbs` buffers and the built RBS
+      #   environment the accepted stratum is read from; without one, both are simply absent (the fail-quiet direction
+      #   — a missing `≤` bound costs precision, never a finding).
       def self.build(configuration:, environment: nil, plugin_facts: nil)
         # Required here rather than at the top of the file: the reader pulls in the whole
         # `RbsExtended` surface, and this build runs only under an `effects:` block.
@@ -120,10 +121,11 @@ module Rigor
 
       # The envelope bounding `owner`'s `selector`, or nil.
       #
-      # @param owner [String] the receiver's static class name, as the typer projected it
-      # @param singleton [Boolean] whether the call is `Owner.selector` rather than `Owner#selector`
-      # @return [Envelope, nil] never a ⊤ envelope: a bound that bounds nothing is not a bound, and
-      #   importing it would both add nothing and discharge a taint on the strength of a typo.
+      # @rbs owner: String -- The receiver's static class name, as the typer projected it
+      # @rbs singleton: bool -- Whether the call is `Owner.selector` rather than `Owner#selector`
+      # @rbs return: Envelope? --
+      #   Never a ⊤ envelope: a bound that bounds nothing is not a bound, and importing it would both add nothing and
+      #   discharge a taint on the strength of a typo.
       def [](owner, singleton, selector)
         return nil if owner.nil? || empty?
 

--- a/lib/rigor/effects/envelope_index.rb
+++ b/lib/rigor/effects/envelope_index.rb
@@ -56,7 +56,6 @@ module Rigor
 
       # Reads every stratum this index serves, once per process.
       #
-      # @param configuration [Rigor::Configuration]
       # @param plugin_facts [Rigor::Effects::PluginFacts, nil] the loaded plugins' effect contributions
       #   (#387); their `effect_labels:` join the vocabulary an annotation is read against, so a gem's
       #   `%a{rigor:v1:effect rails.activejob.enqueue}` resolves rather than reading as unknown.
@@ -64,7 +63,6 @@ module Rigor
       #   rbs-inline / plugin `virtual_rbs` buffers and the built RBS environment the accepted stratum is
       #   read from; without one, both are simply absent (the fail-quiet direction — a missing `≤` bound
       #   costs precision, never a finding).
-      # @return [EnvelopeIndex]
       def self.build(configuration:, environment: nil, plugin_facts: nil)
         # Required here rather than at the top of the file: the reader pulls in the whole
         # `RbsExtended` surface, and this build runs only under an `effects:` block.
@@ -124,7 +122,6 @@ module Rigor
       #
       # @param owner [String] the receiver's static class name, as the typer projected it
       # @param singleton [Boolean] whether the call is `Owner.selector` rather than `Owner#selector`
-      # @param selector [String]
       # @return [Envelope, nil] never a ⊤ envelope: a bound that bounds nothing is not a bound, and
       #   importing it would both add nothing and discharge a taint on the strength of a typo.
       def [](owner, singleton, selector)

--- a/lib/rigor/effects/framework_units.rb
+++ b/lib/rigor/effects/framework_units.rb
@@ -76,13 +76,14 @@ module Rigor
 
       # Every synthetic unit `class_name` earns, as `[key, Summary, edges]` triples.
       #
-      # @param instance_methods [Array<String>] the instance methods the class body defines, in source order
-      # @param macros [Hash{String=>Array<String>}] receiver-less class-body calls to their literal symbol
-      #   arguments, as the scanner harvested them
-      # @param uniqueness [Boolean] whether the class body declares a uniqueness validator
-      # @param own_units [Hash{String=>Boolean}] the units the class body itself defines, keyed by the
-      #   suffix a synthetic key carries (`"#save"`, `".create"`), each mapped to whether that body
-      #   reaches `super`. Read by {.framework_row} and by nothing else.
+      # @rbs instance_methods: Array[String] -- The instance methods the class body defines, in source order
+      # @rbs macros: Hash[String, Array[String]] --
+      #   Receiver-less class-body calls to their literal symbol arguments, as the scanner harvested them
+      # @rbs uniqueness: bool -- Whether the class body declares a uniqueness validator
+      # @rbs own_units: Hash[String, bool] --
+      #   The units the class body itself defines, keyed by the suffix a synthetic key carries (`"#save"`,
+      #   `".create"`), each mapped to whether that body reaches `super`. Read by {.framework_row} and by nothing
+      #   else.
       def synthesize(class_name:, instance_methods:, macros:, uniqueness:, plugin_facts:, own_units: {})
         units = []
         plugin_facts.edges_for(:activerecord_callbacks).each do |edge|

--- a/lib/rigor/effects/framework_units.rb
+++ b/lib/rigor/effects/framework_units.rb
@@ -76,12 +76,10 @@ module Rigor
 
       # Every synthetic unit `class_name` earns, as `[key, Summary, edges]` triples.
       #
-      # @param class_name [String]
       # @param instance_methods [Array<String>] the instance methods the class body defines, in source order
       # @param macros [Hash{String=>Array<String>}] receiver-less class-body calls to their literal symbol
       #   arguments, as the scanner harvested them
       # @param uniqueness [Boolean] whether the class body declares a uniqueness validator
-      # @param plugin_facts [PluginFacts]
       # @param own_units [Hash{String=>Boolean}] the units the class body itself defines, keyed by the
       #   suffix a synthetic key carries (`"#save"`, `".create"`), each mapped to whether that body
       #   reaches `super`. Read by {.framework_row} and by nothing else.

--- a/lib/rigor/effects/identity.rb
+++ b/lib/rigor/effects/identity.rb
@@ -45,7 +45,6 @@ module Rigor
       # The effects identity as a hex digest — the form a store with no descriptor of its own (the ADR-46
       # incremental snapshot) carries alongside its payload, and compares verbatim on restore.
       #
-      # @param configuration [Rigor::Configuration]
       # @param registry [Registry] the vocabulary whose version participates
       # @param catalog [Catalog] the catalogue whose identity participates
       # @return [String] hex SHA-256
@@ -67,7 +66,6 @@ module Rigor
       # things" is a property of the code rather than a claim about it.
       #
       # @param base [Cache::Descriptor] the run's diagnostics key descriptor
-      # @return [Cache::Descriptor]
       def descriptor(base:, configuration:, registry: Registry.default, catalog: Catalog.default,
                      plugin_facts: nil)
         Cache::Descriptor.compose(

--- a/lib/rigor/effects/identity.rb
+++ b/lib/rigor/effects/identity.rb
@@ -45,9 +45,9 @@ module Rigor
       # The effects identity as a hex digest — the form a store with no descriptor of its own (the ADR-46
       # incremental snapshot) carries alongside its payload, and compares verbatim on restore.
       #
-      # @param registry [Registry] the vocabulary whose version participates
-      # @param catalog [Catalog] the catalogue whose identity participates
-      # @return [String] hex SHA-256
+      # @rbs registry: Registry -- The vocabulary whose version participates
+      # @rbs catalog: Catalog -- The catalogue whose identity participates
+      # @rbs return: String -- Hex SHA-256
       def digest(configuration:, registry: Registry.default, catalog: Catalog.default, plugin_facts: nil)
         Digest::SHA256.hexdigest(
           [
@@ -65,7 +65,7 @@ module Rigor
       # the analyzed-path set — for free, so "the effects identity is the diagnostics identity plus three
       # things" is a property of the code rather than a claim about it.
       #
-      # @param base [Cache::Descriptor] the run's diagnostics key descriptor
+      # @rbs base: Cache::Descriptor -- The run's diagnostics key descriptor
       def descriptor(base:, configuration:, registry: Registry.default, catalog: Catalog.default,
                      plugin_facts: nil)
         Cache::Descriptor.compose(

--- a/lib/rigor/effects/inline_anchor.rb
+++ b/lib/rigor/effects/inline_anchor.rb
@@ -49,10 +49,11 @@ module Rigor
       SPELLING_PATTERN = /%a\{[^}]*\}/
       private_constant :SPELLING_PATTERN
 
-      # @param path [String] the buffer's readable path, as {SignatureSources.source_path} renders it.
-      # @param buffer [String] the synthesized RBS the position was read out of.
-      # @return [InlineAnchor, nil] nil when `path` is not a Ruby file — a real `.rbs` needs no mapping,
-      #   and its own line numbers are already the ones a reader can open.
+      # @rbs path: String -- The buffer's readable path, as {SignatureSources.source_path} renders it.
+      # @rbs buffer: String -- The synthesized RBS the position was read out of.
+      # @rbs return: InlineAnchor? --
+      #   Nil when `path` is not a Ruby file — a real `.rbs` needs no mapping, and its own line numbers are already
+      #   the ones a reader can open.
       def self.for(path:, buffer:)
         return nil unless path.to_s.end_with?(RUBY_EXTENSION)
 
@@ -61,7 +62,7 @@ module Rigor
 
       # One-shot form, for a caller that holds a `[path, buffer, line]` triple and no anchor.
       #
-      # @return [Integer] the `.rb` line, or `buffer_line` unchanged when there is nothing to map.
+      # @rbs return: Integer -- The `.rb` line, or `buffer_line` unchanged when there is nothing to map.
       def self.ruby_line(path:, buffer:, buffer_line:, spelling: nil)
         anchor = self.for(path: path, buffer: buffer)
         return buffer_line if anchor.nil?
@@ -75,10 +76,10 @@ module Rigor
         @ruby_lines = nil
       end
 
-      # @param buffer_line [Integer] 1-based, counting into the synthesized buffer.
-      # @param spelling [String, nil] the annotation's own text (`"%a{pure}"`); read off the buffer line
-      #   when the caller does not already hold it.
-      # @return [Integer] the 1-based line of the same annotation in the Ruby file.
+      # @rbs buffer_line: Integer -- 1-based, counting into the synthesized buffer.
+      # @rbs spelling: String? --
+      #   The annotation's own text (`"%a{pure}"`); read off the buffer line when the caller does not already hold it.
+      # @rbs return: Integer -- The 1-based line of the same annotation in the Ruby file.
       def line_for(buffer_line, spelling: nil)
         spelling = normalize(spelling) || spelling_at(buffer_line)
         return buffer_line if spelling.nil?

--- a/lib/rigor/effects/label_intent.rb
+++ b/lib/rigor/effects/label_intent.rb
@@ -37,10 +37,11 @@ module Rigor
 
       # Whether reporting `token` as an unknown label is justified.
       #
-      # @param token [String] the spelling as written.
-      # @param registry [Rigor::Effects::Registry, nil] the vocabulary AFTER plugin load; `nil` (no
-      #   vocabulary at all) makes every token unjudgeable and therefore silent.
-      # @param siblings [Array<String>] the other tokens of the same list / the same config value.
+      # @rbs token: String -- The spelling as written.
+      # @rbs registry: Rigor::Effects::Registry? --
+      #   The vocabulary AFTER plugin load; `nil` (no vocabulary at all) makes every token unjudgeable and therefore
+      #   silent.
+      # @rbs siblings: Array[String] -- The other tokens of the same list / the same config value.
       def evident?(token, registry, siblings: [])
         return false if registry.nil?
         return false unless Label.valid?(token)

--- a/lib/rigor/effects/label_intent.rb
+++ b/lib/rigor/effects/label_intent.rb
@@ -41,7 +41,6 @@ module Rigor
       # @param registry [Rigor::Effects::Registry, nil] the vocabulary AFTER plugin load; `nil` (no
       #   vocabulary at all) makes every token unjudgeable and therefore silent.
       # @param siblings [Array<String>] the other tokens of the same list / the same config value.
-      # @return [Boolean]
       def evident?(token, registry, siblings: [])
         return false if registry.nil?
         return false unless Label.valid?(token)

--- a/lib/rigor/effects/liskov_check.rb
+++ b/lib/rigor/effects/liskov_check.rb
@@ -56,16 +56,16 @@ module Rigor
 
       module_function
 
-      # @param table [EffectTable] the run's propagated graph.
-      # @param superclasses [Hash{String => Array<String>}] the collector's as-written superclass
-      #   candidate lists (`FileCollection#superclasses`).
-      # @param method_envelopes [Hash{String => Envelope}] per-method envelopes, as written.
-      # @param class_envelopes [Hash{String => Envelope}] class- / module-level envelopes, to distribute.
-      # @param config_envelopes [Hash{String => Envelope}] `effects.envelopes:` entries already resolved
-      #   to the classes they select.
-      # @param positions [EnvelopeCheck::Positions] where the override's `def` is.
-      # @param apply_tolerated [Boolean] false judges against `proven` — `--no-tolerated-effects`.
-      # @return [Array<Finding>] sorted by position then key then label.
+      # @rbs table: EffectTable -- The run's propagated graph.
+      # @rbs superclasses: Hash[String, Array[String]] --
+      #   The collector's as-written superclass candidate lists (`FileCollection#superclasses`).
+      # @rbs method_envelopes: Hash[String, Envelope] -- Per-method envelopes, as written.
+      # @rbs class_envelopes: Hash[String, Envelope] -- Class- / module-level envelopes, to distribute.
+      # @rbs config_envelopes: Hash[String, Envelope] --
+      #   `effects.envelopes:` entries already resolved to the classes they select.
+      # @rbs positions: EnvelopeCheck::Positions -- Where the override's `def` is.
+      # @rbs apply_tolerated: bool -- False judges against `proven` — `--no-tolerated-effects`.
+      # @rbs return: Array[Finding] -- Sorted by position then key then label.
       def run(table:, superclasses:, method_envelopes:, class_envelopes:, config_envelopes: {},
               positions: EnvelopeCheck::Positions.empty, apply_tolerated: true)
         # The distributed strata, over a base of the raw per-method annotations: a base class whose method

--- a/lib/rigor/effects/method_key.rb
+++ b/lib/rigor/effects/method_key.rb
@@ -14,8 +14,8 @@ module Rigor
     module MethodKey
       module_function
 
-      # @return [Array(String, String, String), nil] `[owner, separator, selector]`, or nil when `key` is
-      #   not a method key at all.
+      # @rbs return: [String, String, String]? --
+      #   `[owner, separator, selector]`, or nil when `key` is not a method key at all.
       def split(key)
         text = key.to_s
         index = text.index("#") || text.index(".")

--- a/lib/rigor/effects/plugin_facts.rb
+++ b/lib/rigor/effects/plugin_facts.rb
@@ -77,12 +77,12 @@ module Rigor
         @empty ||= new(contributions: [], superclasses: NO_ROWS, includes: NO_ROWS)
       end
 
-      # @param superclasses [Hash{String=>String,Array<String>}] the project's as-written superclass table
-      #   (`Scope::DiscoveryIndex#discovered_superclasses`). Empty is legal and simply means no row matches
-      #   through inheritance.
-      # @param includes [Hash{String=>Array<String>}] the project's as-written include / prepend table
-      #   (`Scope::DiscoveryIndex#discovered_includes`), for the frameworks whose contract is a module
-      #   rather than a base class (#456).
+      # @rbs superclasses: Hash[String, String | Array[String]] --
+      #   The project's as-written superclass table (`Scope::DiscoveryIndex#discovered_superclasses`). Empty is legal
+      #   and simply means no row matches through inheritance.
+      # @rbs includes: Hash[String, Array[String]] --
+      #   The project's as-written include / prepend table (`Scope::DiscoveryIndex#discovered_includes`), for the
+      #   frameworks whose contract is a module rather than a base class (#456).
       def self.build(plugin_registry, superclasses: NO_ROWS, includes: NO_ROWS)
         contributions = plugin_registry&.effect_contributions || []
         return empty if contributions.empty?
@@ -143,9 +143,9 @@ module Rigor
 
       # The row colouring `owner`'s `selector`, found on `owner` itself or on a project ancestor of it.
       #
-      # @param owner [String, nil] the receiver's class name as the syntax or the typer named it
-      # @param singleton [Boolean] whether the call is `Owner.selector`
-      # @return [Row, nil]
+      # @rbs owner: String? -- The receiver's class name as the syntax or the typer named it
+      # @rbs singleton: bool -- Whether the call is `Owner.selector`
+      # @rbs return: Row?
       def class_row(owner, singleton, selector)
         return nil if owner.nil? || @class_rows.empty?
 

--- a/lib/rigor/effects/plugin_facts.rb
+++ b/lib/rigor/effects/plugin_facts.rb
@@ -77,7 +77,6 @@ module Rigor
         @empty ||= new(contributions: [], superclasses: NO_ROWS, includes: NO_ROWS)
       end
 
-      # @param plugin_registry [Rigor::Plugin::Registry, nil]
       # @param superclasses [Hash{String=>String,Array<String>}] the project's as-written superclass table
       #   (`Scope::DiscoveryIndex#discovered_superclasses`). Empty is legal and simply means no row matches
       #   through inheritance.

--- a/lib/rigor/effects/propagator.rb
+++ b/lib/rigor/effects/propagator.rb
@@ -45,9 +45,10 @@ module Rigor
 
       module_function
 
-      # @param collection [FileCollection] the run's merged per-file collections
-      # @param discharge [Discharge] the `effects.tolerated:` policy the undischarged lane is computed
-      #   under; {Discharge.none} makes the two lanes equal.
+      # @rbs collection: FileCollection -- The run's merged per-file collections
+      # @rbs discharge: Discharge --
+      #   The `effects.tolerated:` policy the undischarged lane is computed under; {Discharge.none} makes the two
+      #   lanes equal.
       def propagate(collection, discharge: Discharge.none)
         return EffectTable.empty if collection.summaries.empty?
 

--- a/lib/rigor/effects/propagator.rb
+++ b/lib/rigor/effects/propagator.rb
@@ -48,7 +48,6 @@ module Rigor
       # @param collection [FileCollection] the run's merged per-file collections
       # @param discharge [Discharge] the `effects.tolerated:` policy the undischarged lane is computed
       #   under; {Discharge.none} makes the two lanes equal.
-      # @return [EffectTable]
       def propagate(collection, discharge: Discharge.none)
         return EffectTable.empty if collection.summaries.empty?
 

--- a/lib/rigor/effects/scanner.rb
+++ b/lib/rigor/effects/scanner.rb
@@ -184,7 +184,7 @@ module Rigor
       # per unit (ADR-103 WD13): a unit the scanner cannot finish is recorded as non-exhaustive with
       # `collector-error` and its siblings are unaffected.
       #
-      # @return [UnitScan, nil] the finished scan, or nil when the unit failed soft
+      # @rbs return: UnitScan? -- The finished scan, or nil when the unit failed soft
       def add_unit(class_name, method_name, singleton, body, parameters)
         key = "#{class_name}#{singleton ? '.' : '#'}#{method_name}"
         names = parameter_names(parameters)

--- a/lib/rigor/effects/signature_sources.rb
+++ b/lib/rigor/effects/signature_sources.rb
@@ -52,8 +52,8 @@ module Rigor
         stripped.start_with?(root) ? stripped[root.length..] : stripped
       end
 
-      # @param signature_paths [Array<String>, nil] the configured roots; empty / nil takes the default.
-      # @param virtual_rbs [Array<Array(String, String)>, nil] the loader's virtual entries.
+      # @rbs signature_paths: Array[String]? -- The configured roots; empty / nil takes the default.
+      # @rbs virtual_rbs: Array[[String, String]]? -- The loader's virtual entries.
       def collect(signature_paths:, virtual_rbs: nil)
         files = roots(signature_paths).flat_map { |root| Dir.glob(File.join(root.to_s, "**", "*.rbs")).sort }
         sources = files.filter_map do |path|
@@ -75,7 +75,7 @@ module Rigor
       # residual reports one annotation per run, so the carrier a run holds past the environment's own
       # lifetime is a single synthesized buffer rather than the project's whole virtual tree.
       #
-      # @return [Array<Array(String, String)>] zero or one pair.
+      # @rbs return: Array[[String, String]] -- Zero or one pair.
       def annotated_carrier(virtual_rbs)
         Array(virtual_rbs).each do |name, content|
           return [[name.to_s, content.to_s]] if ANNOTATION_HINT.match?(content)

--- a/lib/rigor/effects/signature_sources.rb
+++ b/lib/rigor/effects/signature_sources.rb
@@ -54,7 +54,6 @@ module Rigor
 
       # @param signature_paths [Array<String>, nil] the configured roots; empty / nil takes the default.
       # @param virtual_rbs [Array<Array(String, String)>, nil] the loader's virtual entries.
-      # @return [Array<Array(String, String)>]
       def collect(signature_paths:, virtual_rbs: nil)
         files = roots(signature_paths).flat_map { |root| Dir.glob(File.join(root.to_s, "**", "*.rbs")).sort }
         sources = files.filter_map do |path|
@@ -76,7 +75,6 @@ module Rigor
       # residual reports one annotation per run, so the carrier a run holds past the environment's own
       # lifetime is a single synthesized buffer rather than the project's whole virtual tree.
       #
-      # @param virtual_rbs [Array<Array(String, String)>, nil]
       # @return [Array<Array(String, String)>] zero or one pair.
       def annotated_carrier(virtual_rbs)
         Array(virtual_rbs).each do |name, content|

--- a/lib/rigor/effects/snapshot.rb
+++ b/lib/rigor/effects/snapshot.rb
@@ -117,12 +117,12 @@ module Rigor
       class << self
         # Builds the snapshot a run's effect table describes.
         #
-        # @param table [EffectTable] the propagated graph
-        # @param configuration [Rigor::Configuration] supplies the reach globs and the digested block
-        # @param sources [Hash{String=>Array<String>}] `Runner#effect_sources` — where each unit is defined
-        # @param full [Boolean] keep the rows {#omit?} drops
-        # @param registry [Registry] the vocabulary whose version the header carries
-        # @param project_root [String] what `sources` paths are relativised against for glob matching
+        # @rbs table: EffectTable -- The propagated graph
+        # @rbs configuration: Rigor::Configuration -- Supplies the reach globs and the digested block
+        # @rbs sources: Hash[String, Array[String]] -- `Runner#effect_sources` — where each unit is defined
+        # @rbs full: bool -- Keep the rows {#omit?} drops
+        # @rbs registry: Registry -- The vocabulary whose version the header carries
+        # @rbs project_root: String -- What `sources` paths are relativised against for glob matching
         def build(table:, configuration:, sources: {}, full: false, registry: Registry.default,
                   project_root: Dir.pwd)
           globs = expand_reach(configuration.effects_snapshot_reach)
@@ -146,10 +146,10 @@ module Rigor
         # It is built beside the snapshot and never inside it: the file stays flat and undischarged, and
         # this index exists only for the duration of one comparison ({SnapshotDiff}).
         #
-        # @param snapshot [Snapshot] the current side, already built
-        # @param table [EffectTable] the run that produced it
-        # @param discharge [Discharge] the policy
-        # @return [Hash, nil] nil when the policy discharges nothing, which is the common case
+        # @rbs snapshot: Snapshot -- The current side, already built
+        # @rbs table: EffectTable -- The run that produced it
+        # @rbs discharge: Discharge -- The policy
+        # @rbs return: Hash[untyped, untyped]? -- Nil when the policy discharges nothing, which is the common case
         def undischarged_index(snapshot:, table:, discharge:)
           return nil if discharge.inert?
 

--- a/lib/rigor/effects/snapshot_diff.rb
+++ b/lib/rigor/effects/snapshot_diff.rb
@@ -86,9 +86,9 @@ module Rigor
       # Compares `current` against `recorded`. `recorded` may be nil — no snapshot on disk at all, which
       # is drift with a routed message rather than an error.
       #
-      # @param undischarged [Hash] `{table name => {symbol => [label]}}` — the current side's labels that
-      #   survive per-origin discharge ({Snapshot.undischarged_index}). Optional; omitting it judges every
-      #   event by label.
+      # @rbs undischarged: Hash[untyped, untyped] --
+      #   `{table name => {symbol => [label]}}` — the current side's labels that survive per-origin discharge
+      #   ({Snapshot.undischarged_index}). Optional; omitting it judges every event by label.
       def self.compare(recorded:, current:, tolerated: [], gate: :symmetric, strict_tolerated: false,
                        undischarged: nil)
         new(recorded: recorded, current: current, tolerated: tolerated, gate: gate,

--- a/lib/rigor/effects/unit_scan.rb
+++ b/lib/rigor/effects/unit_scan.rb
@@ -87,7 +87,7 @@ module Rigor
       # the enclosing method contains. A non-literal name has no key to file the block under, so it stays
       # contained in the enclosing method and this returns nil.
       #
-      # @return [Array, nil] `[name, singleton, body, parameters]`
+      # @rbs return: Array[untyped]? -- `[name, singleton, body, parameters]`
       def self.define_method_unit(node)
         return nil unless node.name == :define_method && node.receiver.nil?
 
@@ -100,19 +100,21 @@ module Rigor
         [first.unescaped, false, block.body, block.parameters]
       end
 
-      # @param singleton [Boolean] whether the unit's `self` is the class object (`def self.x`,
-      #   `class << self`) — the axis that separates `mutate.self` from `mutate.static` on an ivar write
-      # @param block_parameter [String, nil] the unit's `&blk` parameter name, if any; a call on it is
-      #   forwarding, not an opaque callable
-      # @param calls [Hash] node-identity table of {Collector::CallRecord}s
-      # @param attribution [Attribution] the project's `effects.attribution:` table
-      # @param envelopes [EnvelopeIndex] the envelopes a call site may import as a `≤` bound (#386)
-      # @param plugin_facts [PluginFacts] the loaded plugins' `effect_attributions:` (#387)
-      # @param owner_class [String, nil] the class this unit is defined on — the carrier an
-      #   implicit-self call's envelope is looked up under, since the syntax spells `Kernel#name`
-      # @param method_name [String, nil] this unit's own selector — what a `super` in its body names as
-      #   the target the propagator resolves above `owner_class` (#446). With no name to state, a `super`
-      #   taints instead.
+      # @rbs singleton: bool --
+      #   Whether the unit's `self` is the class object (`def self.x`, `class << self`) — the axis that separates
+      #   `mutate.self` from `mutate.static` on an ivar write
+      # @rbs block_parameter: String? --
+      #   The unit's `&blk` parameter name, if any; a call on it is forwarding, not an opaque callable
+      # @rbs calls: Hash[untyped, untyped] -- Node-identity table of {Collector::CallRecord}s
+      # @rbs attribution: Attribution -- The project's `effects.attribution:` table
+      # @rbs envelopes: EnvelopeIndex -- The envelopes a call site may import as a `≤` bound (#386)
+      # @rbs plugin_facts: PluginFacts -- The loaded plugins' `effect_attributions:` (#387)
+      # @rbs owner_class: String? --
+      #   The class this unit is defined on — the carrier an implicit-self call's envelope is looked up under, since
+      #   the syntax spells `Kernel#name`
+      # @rbs method_name: String? --
+      #   This unit's own selector — what a `super` in its body names as the target the propagator resolves above
+      #   `owner_class` (#446). With no name to state, a `super` taints instead.
       def initialize(singleton:, parameters:, block_parameter:, owned_locals:, calls:, # rubocop:disable Metrics/ParameterLists
                      attribution: Attribution.empty, envelopes: EnvelopeIndex.empty,
                      plugin_facts: PluginFacts.empty, owner_class: nil, method_name: nil)
@@ -283,7 +285,7 @@ module Rigor
       # Three receiver shapes, tried nearest-syntax first — a written receiver path (`Rails.cache.read`),
       # a receiver rooted at implicit self inside a framework class (`session[:x] = 1`), and the receiver's
       # class through the project's inheritance chain (`user.save`).
-      # @return [PluginFacts::Row, nil] the row that claimed this call, for {#visit_call} to read as a bound
+      # @rbs return: PluginFacts::Row? -- The row that claimed this call, for {#visit_call} to read as a bound
       def attribute_plugin(node, record)
         return nil unless @plugin_facts.attributions?
 

--- a/lib/rigor/effects/unknown_label_check.rb
+++ b/lib/rigor/effects/unknown_label_check.rb
@@ -30,10 +30,6 @@ module Rigor
 
       module_function
 
-      # @param method_envelopes [Hash{String => Envelope}]
-      # @param class_envelopes [Hash{String => Envelope}]
-      # @param registry [Rigor::Effects::Registry]
-      # @return [Array<Finding>]
       def for_envelopes(method_envelopes:, class_envelopes:, registry:)
         seen = {}
         declarations(method_envelopes, class_envelopes).each do |envelope|
@@ -52,7 +48,6 @@ module Rigor
       # @param labels [Array<String>] the list as written, in source order.
       # @param key_path [String] the `.rigor.yml` key, for the message (`effects.tolerated`).
       # @param consequence [String] what the degradation cost, for the message.
-      # @return [Array<Finding>]
       def for_config(labels:, key_path:, consequence:, registry:)
         tokens = Array(labels).map(&:to_s)
         tokens.filter_map do |token|

--- a/lib/rigor/effects/unknown_label_check.rb
+++ b/lib/rigor/effects/unknown_label_check.rb
@@ -45,9 +45,9 @@ module Rigor
         seen.values
       end
 
-      # @param labels [Array<String>] the list as written, in source order.
-      # @param key_path [String] the `.rigor.yml` key, for the message (`effects.tolerated`).
-      # @param consequence [String] what the degradation cost, for the message.
+      # @rbs labels: Array[String] -- The list as written, in source order.
+      # @rbs key_path: String -- The `.rigor.yml` key, for the message (`effects.tolerated`).
+      # @rbs consequence: String -- What the degradation cost, for the message.
       def for_config(labels:, key_path:, consequence:, registry:)
         tokens = Array(labels).map(&:to_s)
         tokens.filter_map do |token|

--- a/lib/rigor/effects/unknown_label_report.rb
+++ b/lib/rigor/effects/unknown_label_report.rb
@@ -17,10 +17,10 @@ module Rigor
     # {.for} answers `nil` unless {LabelIntent} says the spelling is evidently a label — the whole
     # point of the diagnostic is that it fires where intent is evident and nowhere else.
     class UnknownLabelReport < Data.define(:token, :suggestion, :retirement)
-      # @param token [String] the spelling as written.
-      # @param registry [Rigor::Effects::Registry, nil] the vocabulary after plugin load.
-      # @param siblings [Array<String>] the other tokens written alongside it.
-      # @return [UnknownLabelReport, nil]
+      # @rbs token: String -- The spelling as written.
+      # @rbs registry: Rigor::Effects::Registry? -- The vocabulary after plugin load.
+      # @rbs siblings: Array[String] -- The other tokens written alongside it.
+      # @rbs return: UnknownLabelReport?
       def self.for(token:, registry:, siblings: [])
         return nil unless LabelIntent.evident?(token, registry, siblings: siblings)
 

--- a/lib/rigor/environment.rb
+++ b/lib/rigor/environment.rb
@@ -47,7 +47,6 @@ module Rigor
                 :reporters, :name_scope,
                 :synthetic_method_index, :project_patched_methods
 
-    # @param class_registry [Rigor::Environment::ClassRegistry]
     # @param rbs_loader [Rigor::Environment::RbsLoader, nil] when nil the environment is "RBS-blind"; useful
     #   in tests that want to assert how the engine behaves without RBS data. The default Environment wires
     #   the shared core loader, which is itself lazy: requesting an environment instance does NOT load RBS
@@ -189,7 +188,6 @@ module Rigor
       # @param cache_store [Rigor::Cache::Store, nil] persistent cache threaded into the underlying
       #   {Environment::RbsLoader} so constant lookups (and, in later v0.0.9 slices, other reflection
       #   artefacts) consult the cache. Pass `nil` (the default) to skip caching for this environment.
-      # @return [Rigor::Environment]
       # rubocop:disable-next Metrics/MethodLength, Metrics/ParameterLists
       def for_project(root: Dir.pwd, libraries: [], signature_paths: nil, cache_store: nil,
                       plugin_registry: nil, dependency_source_index: nil,

--- a/lib/rigor/environment.rb
+++ b/lib/rigor/environment.rb
@@ -47,17 +47,17 @@ module Rigor
                 :reporters, :name_scope,
                 :synthetic_method_index, :project_patched_methods
 
-    # @param rbs_loader [Rigor::Environment::RbsLoader, nil] when nil the environment is "RBS-blind"; useful
-    #   in tests that want to assert how the engine behaves without RBS data. The default Environment wires
-    #   the shared core loader, which is itself lazy: requesting an environment instance does NOT load RBS
-    #   until a method or class query actually consults the loader.
-    # @param plugin_registry [Rigor::Plugin::Registry, nil] v0.1.1 Track 2 slice 7. The per-run plugin
-    #   registry the inference engine consults at call sites for plugin `dynamic_return` rules. When nil
-    #   (the default), no plugin-level return-type contribution participates — useful for tests, the
-    #   `Environment.default` facade, and analyses that don't load plugins.
-    # @param dependency_source_index [Rigor::Analysis::DependencySourceInference::Index, nil] ADR-10 slice
-    #   2b-ii. The per-run index of opt-in gem sources the dispatcher consults BELOW RBS dispatch. When nil
-    #   (the default), no dep-source contribution participates and the dispatcher tier is a no-op.
+    # @rbs rbs_loader: Rigor::Environment::RbsLoader? --
+    #   When nil the environment is "RBS-blind"; useful in tests that want to assert how the engine behaves without
+    #   RBS data. The default Environment wires the shared core loader, which is itself lazy: requesting an
+    #   environment instance does NOT load RBS until a method or class query actually consults the loader.
+    # @rbs plugin_registry: Rigor::Plugin::Registry? --
+    #   v0.1.1 Track 2 slice 7. The per-run plugin registry the inference engine consults at call sites for plugin
+    #   `dynamic_return` rules. When nil (the default), no plugin-level return-type contribution participates — useful
+    #   for tests, the `Environment.default` facade, and analyses that don't load plugins.
+    # @rbs dependency_source_index: Rigor::Analysis::DependencySourceInference::Index? --
+    #   ADR-10 slice 2b-ii. The per-run index of opt-in gem sources the dispatcher consults BELOW RBS dispatch. When
+    #   nil (the default), no dep-source contribution participates and the dispatcher tier is a no-op.
     def initialize(class_registry: ClassRegistry.default, rbs_loader: nil, # rubocop:disable Metrics/ParameterLists
                    plugin_registry: nil, dependency_source_index: nil,
                    rbs_extended_reporter: nil, boundary_cross_reporter: nil,
@@ -177,17 +177,18 @@ module Rigor
       # Builds an Environment that consults the project's local signatures and any opt-in stdlib libraries on
       # top of RBS core.
       #
-      # @param root [String, Pathname] project root used to auto-detect the default signature path. Defaults
-      #   to the current working directory.
-      # @param libraries [Array<String, Symbol>] additional stdlib libraries to load on top of
-      #   {DEFAULT_LIBRARIES}. The final list is the union of the two, de-duplicated while preserving order.
-      #   Pass an empty array (the default) to load only the defaults.
-      # @param signature_paths [Array<String, Pathname>, nil] explicit list of `sig/`-style directories. When
-      #   `nil` (the default), the canonical project layout `<root>/sig` is used if it exists, otherwise no
-      #   signature path is loaded.
-      # @param cache_store [Rigor::Cache::Store, nil] persistent cache threaded into the underlying
-      #   {Environment::RbsLoader} so constant lookups (and, in later v0.0.9 slices, other reflection
-      #   artefacts) consult the cache. Pass `nil` (the default) to skip caching for this environment.
+      # @rbs root: String | Pathname --
+      #   Project root used to auto-detect the default signature path. Defaults to the current working directory.
+      # @rbs libraries: Array[String | Symbol] --
+      #   Additional stdlib libraries to load on top of {DEFAULT_LIBRARIES}. The final list is the union of the two,
+      #   de-duplicated while preserving order. Pass an empty array (the default) to load only the defaults.
+      # @rbs signature_paths: Array[String | Pathname]? --
+      #   Explicit list of `sig/`-style directories. When `nil` (the default), the canonical project layout
+      #   `<root>/sig` is used if it exists, otherwise no signature path is loaded.
+      # @rbs cache_store: Rigor::Cache::Store? --
+      #   Persistent cache threaded into the underlying {Environment::RbsLoader} so constant lookups (and, in later
+      #   v0.0.9 slices, other reflection artefacts) consult the cache. Pass `nil` (the default) to skip caching for
+      #   this environment.
       # rubocop:disable-next Metrics/MethodLength, Metrics/ParameterLists
       def for_project(root: Dir.pwd, libraries: [], signature_paths: nil, cache_store: nil,
                       plugin_registry: nil, dependency_source_index: nil,

--- a/lib/rigor/environment/bundle_sig_discovery.rb
+++ b/lib/rigor/environment/bundle_sig_discovery.rb
@@ -46,26 +46,27 @@ module Rigor
         "bundler", "rubygems"
       ].freeze
 
-      # @param bundle_path [String, Pathname, nil] explicit path to the bundler install root. When `nil`,
-      #   falls back to `auto_detect` if `auto_detect:` is true.
-      # @param project_root [String] resolution base for relative `bundle_path:` and the auto-detect search.
-      # @param auto_detect [Boolean] when true and `bundle_path:` is nil, try `.bundle/config`'s
-      #   `BUNDLE_PATH:` and `vendor/bundle/` under `project_root`.
-      # @param skip_gems [Set<String>] gem names to exclude from discovery. Defaults to
-      #   {SKIPPED_GEMS_BY_DEFAULT}.
-      # @param locked_gems [Hash{String => LockfileResolver::LockedGem}, nil] Optional O4-Layer-3 filter.
-      #   When non-nil and non-empty, only `sig/` directories whose gem `(name, version, platform)` tuple
-      #   matches a lockfile entry are returned. Bundle entries absent from the lockfile (or at a drifted
-      #   version) are silently dropped — the lockfile is treated as the source of truth for "what gems this
+      # @rbs bundle_path: (String | Pathname)? --
+      #   Explicit path to the bundler install root. When `nil`, falls back to `auto_detect` if `auto_detect:` is
+      #   true.
+      # @rbs project_root: String -- Resolution base for relative `bundle_path:` and the auto-detect search.
+      # @rbs auto_detect: bool --
+      #   When true and `bundle_path:` is nil, try `.bundle/config`'s `BUNDLE_PATH:` and `vendor/bundle/` under
+      #   `project_root`.
+      # @rbs skip_gems: Set[String] -- Gem names to exclude from discovery. Defaults to {SKIPPED_GEMS_BY_DEFAULT}.
+      # @rbs locked_gems: Hash[String, LockfileResolver::LockedGem]? --
+      #   Optional O4-Layer-3 filter. When non-nil and non-empty, only `sig/` directories whose gem `(name, version,
+      #   platform)` tuple matches a lockfile entry are returned. Bundle entries absent from the lockfile (or at a
+      #   drifted version) are silently dropped — the lockfile is treated as the source of truth for "what gems this
       #   project actually declares". A git-sourced directory carries no version to compare (see
-      #   {.gem_name_from_sig_path}), so for those the filter instead requires the matching `locked_gems`
-      #   entry to have `git_source: true` — name alone is not enough, since a gem that moved off a `git:`
-      #   source keeps its stale `bundler/gems/` directory under the SAME name until a `bundle clean`. Pass
-      #   `nil` (the default) to keep the pre-Layer-3 behaviour of returning every non-skipped `sig/` under
-      #   the bundle.
-      # @return [Array<Pathname>] every `<gem-dir>/sig` directory under the resolved bundle path, minus any
-      #   whose gem name is in `skip_gems` and (when `locked_gems` is supplied) minus any whose `(name,
-      #   version, platform)` does not match a lockfile entry.
+      #   {.gem_name_from_sig_path}), so for those the filter instead requires the matching `locked_gems` entry to
+      #   have `git_source: true` — name alone is not enough, since a gem that moved off a `git:` source keeps its
+      #   stale `bundler/gems/` directory under the SAME name until a `bundle clean`. Pass `nil` (the default) to keep
+      #   the pre-Layer-3 behaviour of returning every non-skipped `sig/` under the bundle.
+      # @rbs return: Array[Pathname] --
+      #   Every `<gem-dir>/sig` directory under the resolved bundle path, minus any whose gem name is in `skip_gems`
+      #   and (when `locked_gems` is supplied) minus any whose `(name, version, platform)` does not match a lockfile
+      #   entry.
       def self.discover(bundle_path:, project_root: Dir.pwd, auto_detect: true,
                         skip_gems: SKIPPED_GEMS_BY_DEFAULT, locked_gems: nil, home: nil)
         resolved = resolve_bundle_path(

--- a/lib/rigor/environment/lockfile_resolver.rb
+++ b/lib/rigor/environment/lockfile_resolver.rb
@@ -39,15 +39,13 @@ module Rigor
         end
       end
 
-      # @param lockfile_path [String, Pathname, nil] explicit path to the Gemfile.lock. When `nil`, falls
-      #   back to `auto_detect` if `auto_detect:` is true.
-      # @param project_root [String] resolution base for a relative `lockfile_path:` and the auto-detect
-      #   search.
-      # @param auto_detect [Boolean] when true and `lockfile_path:` is nil, look for
-      #   `<project_root>/Gemfile.lock`.
-      # @return [Hash{String => LockedGem}] frozen map of gem name → locked entry. Returns the empty frozen
-      #   hash when no lockfile is resolvable, when the file is unreadable, or when Bundler refuses to parse
-      #   it.
+      # @rbs lockfile_path: (String | Pathname)? --
+      #   Explicit path to the Gemfile.lock. When `nil`, falls back to `auto_detect` if `auto_detect:` is true.
+      # @rbs project_root: String -- Resolution base for a relative `lockfile_path:` and the auto-detect search.
+      # @rbs auto_detect: bool -- When true and `lockfile_path:` is nil, look for `<project_root>/Gemfile.lock`.
+      # @rbs return: Hash[String, LockedGem] --
+      #   Frozen map of gem name → locked entry. Returns the empty frozen hash when no lockfile is resolvable, when
+      #   the file is unreadable, or when Bundler refuses to parse it.
       def self.locked_gems(lockfile_path:, project_root: Dir.pwd, auto_detect: true)
         resolved = resolve_lockfile_path(
           lockfile_path: lockfile_path,

--- a/lib/rigor/environment/missing_gem_constant_index.rb
+++ b/lib/rigor/environment/missing_gem_constant_index.rb
@@ -37,14 +37,15 @@ module Rigor
     module MissingGemConstantIndex
       module_function
 
-      # @param gems [Enumerable<Array(String, String)>] `[gem_name, version]` pairs (the `:missing` rows of
-      #   {RbsCoverageReport}).
-      # @param bundle_path [String, Pathname, nil] the target's resolved bundler install root, or nil.
-      # @param spec_resolver [#call] `(name, version) -> String?` fallback dir resolver. Injectable for
-      #   specs; the default is the RubyGems-metadata lookup (no code load).
-      # @return [Hash{String => String}] frozen `root constant name => gem name`. On a collision (two gems
-      #   declaring the same top-level constant) the first gem wins — the CAUSE recorded downstream
-      #   (external gem without RBS) is true under either owner.
+      # @rbs gems: Enumerable[[String, String]] --
+      #   `[gem_name, version]` pairs (the `:missing` rows of {RbsCoverageReport}).
+      # @rbs bundle_path: (String | Pathname)? -- The target's resolved bundler install root, or nil.
+      # @rbs spec_resolver: untyped --
+      #   `(name, version) -> String?` fallback dir resolver. Injectable for specs; the default is the
+      #   RubyGems-metadata lookup (no code load).
+      # @rbs return: Hash[String, String] --
+      #   Frozen `root constant name => gem name`. On a collision (two gems declaring the same top-level constant) the
+      #   first gem wins — the CAUSE recorded downstream (external gem without RBS) is true under either owner.
       def build(gems, bundle_path: nil, spec_resolver: method(:installed_gem_dir))
         bundle_dirs = bundle_gem_dirs(bundle_path)
         git_dirs = git_gem_dirs(bundle_path)

--- a/lib/rigor/environment/rbs_collection_discovery.rb
+++ b/lib/rigor/environment/rbs_collection_discovery.rb
@@ -37,20 +37,21 @@ module Rigor
       DEFAULT_COLLECTION_PATH = ".gem_rbs_collection"
       private_constant :DEFAULT_COLLECTION_PATH
 
-      # @param lockfile_path [String, Pathname, nil] explicit path to `rbs_collection.lock.yaml`. When `nil`,
-      #   falls back to `auto_detect` if `auto_detect:` is true.
-      # @param project_root [String] resolution base for relative `lockfile_path:` and the auto-detect
-      #   search.
-      # @param auto_detect [Boolean] when true and `lockfile_path:` is nil, look for
-      #   `<project_root>/rbs_collection.lock.yaml`.
-      # @param skip_gem_names [Array<String>, Set<String>] gem names rigor already loads from its bundled
-      #   stdlib (the merged `DEFAULT_LIBRARIES + libraries:` set). Entries whose `name` is in this set are
-      #   dropped regardless of `source.type` to avoid `RBS::DuplicatedDeclarationError` on
-      #   stdlib-extracted default gems. Defaults to empty.
-      # @return [Array<Pathname>] every `<collection_path>/<gem-name>/<gem-version>/` directory listed in the
-      #   lockfile whose entry has a non-skipped source type, whose `name` is not in `skip_gem_names:`, and
-      #   whose directory exists on disk. Returns `[]` when no lockfile is resolvable, when the YAML is
-      #   unreadable, or when the collection path doesn't exist.
+      # @rbs lockfile_path: (String | Pathname)? --
+      #   Explicit path to `rbs_collection.lock.yaml`. When `nil`, falls back to `auto_detect` if `auto_detect:` is
+      #   true.
+      # @rbs project_root: String -- Resolution base for relative `lockfile_path:` and the auto-detect search.
+      # @rbs auto_detect: bool --
+      #   When true and `lockfile_path:` is nil, look for `<project_root>/rbs_collection.lock.yaml`.
+      # @rbs skip_gem_names: Array[String>, Set<String] --
+      #   Gem names rigor already loads from its bundled stdlib (the merged `DEFAULT_LIBRARIES + libraries:` set).
+      #   Entries whose `name` is in this set are dropped regardless of `source.type` to avoid
+      #   `RBS::DuplicatedDeclarationError` on stdlib-extracted default gems. Defaults to empty.
+      # @rbs return: Array[Pathname] --
+      #   Every `<collection_path>/<gem-name>/<gem-version>/` directory listed in the lockfile whose entry has a
+      #   non-skipped source type, whose `name` is not in `skip_gem_names:`, and whose directory exists on disk.
+      #   Returns `[]` when no lockfile is resolvable, when the YAML is unreadable, or when the collection path
+      #   doesn't exist.
       def self.discover(lockfile_path:, project_root: Dir.pwd, auto_detect: true, skip_gem_names: [])
         resolved = resolve_lockfile_path(
           lockfile_path: lockfile_path,

--- a/lib/rigor/environment/rbs_coverage_report.rb
+++ b/lib/rigor/environment/rbs_coverage_report.rb
@@ -35,16 +35,16 @@ module Rigor
         "idn-ruby", "mysql2", "nokogiri", "pg", "prism", "racc", "redis", "rubygems"
       ].freeze
 
-      # @param locked_gems [Hash{String => LockfileResolver::LockedGem}] The lockfile-resolved gem set. Empty
-      #   hash → no coverage analysis to do.
-      # @param default_libraries [Array<String>] gem names rigor auto-loads through
-      #   `RBS::EnvironmentLoader#add(library:)`. Pass `Rigor::Environment::DEFAULT_LIBRARIES` from callers
-      #   running in a project context.
-      # @param bundle_sig_paths [Array<Pathname, String>] the discovered `<bundle>/.../gems/<name>-<ver>/sig`
-      #   paths from {BundleSigDiscovery.discover}.
-      # @param rbs_collection_paths [Array<Pathname, String>] the discovered `<collection>/<name>/<version>/`
-      #   paths from {RbsCollectionDiscovery.discover}.
-      # @return [Array<Coverage>] one row per locked gem; sorted by gem name for deterministic output.
+      # @rbs locked_gems: Hash[String, LockfileResolver::LockedGem] --
+      #   The lockfile-resolved gem set. Empty hash → no coverage analysis to do.
+      # @rbs default_libraries: Array[String] --
+      #   Gem names rigor auto-loads through `RBS::EnvironmentLoader#add(library:)`. Pass
+      #   `Rigor::Environment::DEFAULT_LIBRARIES` from callers running in a project context.
+      # @rbs bundle_sig_paths: Array[Pathname | String] --
+      #   The discovered `<bundle>/.../gems/<name>-<ver>/sig` paths from {BundleSigDiscovery.discover}.
+      # @rbs rbs_collection_paths: Array[Pathname | String] --
+      #   The discovered `<collection>/<name>/<version>/` paths from {RbsCollectionDiscovery.discover}.
+      # @rbs return: Array[Coverage] -- One row per locked gem; sorted by gem name for deterministic output.
       def self.classify(locked_gems:, default_libraries:,
                         bundle_sig_paths:, rbs_collection_paths:)
         default_set = default_libraries.to_set

--- a/lib/rigor/environment/rbs_loader.rb
+++ b/lib/rigor/environment/rbs_loader.rb
@@ -119,9 +119,9 @@ module Rigor
         BIG_MATH_SIG_BASENAME = "big_math.rbs"
         private_constant :BIG_MATH_SIG_BASENAME
 
-        # @param libraries [Array<String>] the resolved library list, `DEFAULT_LIBRARIES` included.
-        # @return [Array<String>] the same list, minus `bigdecimal-math` when `bigdecimal` already brings
-        #   `BigMath` in.
+        # @rbs libraries: Array[String] -- The resolved library list, `DEFAULT_LIBRARIES` included.
+        # @rbs return: Array[String] --
+        #   The same list, minus `bigdecimal-math` when `bigdecimal` already brings `BigMath` in.
         def libraries_without_shadowed_bigdecimal_math(libraries)
           return libraries unless libraries.include?(BIGDECIMAL_LIBRARY) && libraries.include?(BIGDECIMAL_MATH_LIBRARY)
           return libraries unless bigdecimal_library_declares_big_math?
@@ -809,6 +809,7 @@ module Rigor
 
             buffer = ::RBS::Buffer.new(name: filename.to_s, content: content.to_s)
             _, directives, decls = ::RBS::Parser.parse_signature(buffer)
+            strip_methods_already_in_env!(env, decls)
             add_parsed_decls(env, buffer, directives, decls)
           rescue ::RBS::BaseError
             # WD6 fail-soft: a single broken virtual RBS contribution does not pull the whole env down — for
@@ -826,6 +827,69 @@ module Rigor
             # under the 3.x API this degrades to today's behaviour.
             env.sources.reject! { |source| source.buffer.name == buffer.name } if env.respond_to?(:sources)
           end
+        end
+
+        # Drop synthesized `def` members that `signature_paths:` already declared. Reopening the class
+        # with the same method is `DuplicatedMethodDefinitionError` (the class then degrades to
+        # `Dynamic[top]`); the explicit `.rbs` wins, matching the file-level collision stand-down.
+        # Inline annotations on methods *not* in `sig/` still bind.
+        def strip_methods_already_in_env!(env, decls, namespace = "")
+          existing = existing_rbs_method_keys(env)
+          strip_existing_method_members!(decls, existing, namespace)
+        end
+
+        def existing_rbs_method_keys(env)
+          keys = Set.new
+          return keys unless env.respond_to?(:class_decls)
+
+          env.class_decls.each do |type_name, entry|
+            entry_declarations(entry).each do |decl|
+              next unless decl.respond_to?(:members)
+
+              decl.members.each do |member|
+                method_keys_for_rbs_member(member).each do |name, kind|
+                  keys << [type_name.to_s.sub(/\A::/, ""), name, kind]
+                end
+              end
+            end
+          end
+          keys
+        end
+
+        def strip_existing_method_members!(decls, existing, namespace)
+          Array(decls).each do |decl|
+            next unless decl.is_a?(::RBS::AST::Declarations::Class) ||
+                        decl.is_a?(::RBS::AST::Declarations::Module)
+            next unless decl.respond_to?(:members)
+
+            qualified = qualify_rbs_type_name(namespace, decl.name)
+            decl.members.reject! do |member|
+              method_keys_for_rbs_member(member).any? do |name, kind|
+                existing.include?([qualified, name, kind])
+              end
+            end
+            strip_existing_method_members!(decl.members, existing, qualified)
+          end
+        end
+
+        def method_keys_for_rbs_member(member)
+          case member
+          when ::RBS::AST::Members::MethodDefinition
+            [[member.name, member.kind]]
+          when ::RBS::AST::Members::AttrReader, ::RBS::AST::Members::AttrAccessor,
+               ::RBS::AST::Members::AttrWriter
+            kind = member.respond_to?(:kind) ? member.kind : :instance
+            [[member.name, kind]]
+          else
+            []
+          end
+        end
+
+        def qualify_rbs_type_name(namespace, type_name)
+          spelling = type_name.to_s.sub(/\A::/, "")
+          return spelling if namespace.empty? || type_name.absolute?
+
+          "#{namespace}::#{spelling}"
         end
 
         # Per-gem `data/vendored_gem_sigs/<gem>/` directories that ship with Rigor. Each subdirectory is one
@@ -890,7 +954,7 @@ module Rigor
         # that Rigor's arithmetic-chain widening produces). The overlay is added per-file, not
         # per-directory, because the `LIBRARY_SUPPLEMENT_CORE_OVERLAYS` files must be gated individually.
         #
-        # @param loaded_library_names [Set<String>] libraries that actually resolved on this loader.
+        # @rbs loaded_library_names: Set[String] -- Libraries that actually resolved on this loader.
         def add_bundled_signatures(rbs_loader, loaded_library_names)
           vendored_gem_sig_paths.each do |path|
             next unless path.directory?
@@ -910,10 +974,10 @@ module Rigor
           end
         end
 
-        # @param supplements [Hash{String => String}] basename → gating library map.
-        # @param path [Pathname] the vendored directory or overlay file to test.
-        # @param loaded_library_names [Set<String>] libraries that actually resolved on this loader.
-        # @return [Boolean] true when `path` carries no library dependency, or its library loaded.
+        # @rbs supplements: Hash[String, String] -- Basename → gating library map.
+        # @rbs path: Pathname -- The vendored directory or overlay file to test.
+        # @rbs loaded_library_names: Set[String] -- Libraries that actually resolved on this loader.
+        # @rbs return: bool -- True when `path` carries no library dependency, or its library loaded.
         def supplement_dependency_loaded?(supplements, path, loaded_library_names)
           library = supplements[path.basename.to_s]
           library.nil? || loaded_library_names.include?(library)
@@ -929,10 +993,12 @@ module Rigor
           __dir__
         ).freeze
 
-        # @param gem_names [Enumerable<String>] overlay-eligible Gemfile.lock gem names (the caller filters
-        #   to the `:missing`-coverage, no-conflicting-plugin set).
-        # @return [Array<Pathname>] the bundled overlay directory for each gem that ships one; empty when
-        #   none match or the overlay root is absent.
+        # @rbs gem_names: Enumerable[String] --
+        #   Overlay-eligible Gemfile.lock gem names (the caller filters to the `:missing`-coverage,
+        #   no-conflicting-plugin set).
+        # @rbs return: Array[Pathname] --
+        #   The bundled overlay directory for each gem that ships one; empty when none match or the overlay root is
+        #   absent.
         def gem_overlay_sig_paths(gem_names)
           return [] unless File.directory?(GEM_OVERLAY_SIGS_ROOT)
 
@@ -942,15 +1008,14 @@ module Rigor
           end
         end
 
-        # @param path [String, Pathname] typically an entry from an {RbsLoader} instance's
-        #   {#signature_paths}.
-        # @return [Boolean] whether `path` sits under the bundled gem-overlay root — what
-        #   `CheckRules::GEM_OVERLAY_OPEN_RECEIVERS`'s gate consults so that a class name's membership in
-        #   that list alone never grants the open-receiver exemption; the overlay directory that made the
-        #   entry true must have actually loaded THIS run too (issue #632, tracked further by #660).
-        #   `GEM_OVERLAY_SIGS_ROOT` is defined inside this `class << self` block, so it is reachable from
-        #   here directly but NOT as `RbsLoader::GEM_OVERLAY_SIGS_ROOT` from outside — this method is the
-        #   public seam callers outside this class use instead of reaching for the constant themselves.
+        # @rbs path: String | Pathname -- Typically an entry from an {RbsLoader} instance's {#signature_paths}.
+        # @rbs return: bool --
+        #   Whether `path` sits under the bundled gem-overlay root — what `CheckRules::GEM_OVERLAY_OPEN_RECEIVERS`'s
+        #   gate consults so that a class name's membership in that list alone never grants the open-receiver
+        #   exemption; the overlay directory that made the entry true must have actually loaded THIS run too (issue
+        #   #632, tracked further by #660). `GEM_OVERLAY_SIGS_ROOT` is defined inside this `class << self` block, so
+        #   it is reachable from here directly but NOT as `RbsLoader::GEM_OVERLAY_SIGS_ROOT` from outside — this
+        #   method is the public seam callers outside this class use instead of reaching for the constant themselves.
         def under_gem_overlay_root?(path)
           path.to_s.start_with?("#{GEM_OVERLAY_SIGS_ROOT}/")
         end
@@ -982,9 +1047,9 @@ module Rigor
         # answer to the very same question, on the class that already owns the overlay's layout
         # ({GEM_OVERLAY_SIGS_ROOT}, {.gem_overlay_sig_paths}).
         #
-        # @param signature_paths [Array<String, Pathname>] typically an {RbsLoader} instance's
-        #   {#signature_paths}. Takes the whole list rather than one entry so the twin's file set resolves
-        #   once per question — `CheckRules` asks it per `ActiveSupport::Duration` receiver.
+        # @rbs signature_paths: Array[String | Pathname] --
+        #   Typically an {RbsLoader} instance's {#signature_paths}. Takes the whole list rather than one entry so the
+        #   twin's file set resolves once per question — `CheckRules` asks it per `ActiveSupport::Duration` receiver.
         def gem_overlay_twin_signatures_loaded?(signature_paths)
           # `GEM_OVERLAY_PLUGIN_IDS` is ADR-72 eligibility policy and stays owned by `Environment`; it is
           # read here only to enumerate which bundled plugins HAVE an overlay twin.
@@ -997,7 +1062,7 @@ module Rigor
         # id mapping and passes the id; this resolves the id to the engine's own bundled `sig/` and answers
         # the filesystem question.
         #
-        # @param plugin_id [String] a manifest id, e.g. `"activesupport-core-ext"`.
+        # @rbs plugin_id: String -- A manifest id, e.g. `"activesupport-core-ext"`.
         def bundled_overlay_twin_signatures_loaded?(plugin_id, signature_paths)
           return false if signature_paths.nil? || signature_paths.empty?
 
@@ -1067,21 +1132,22 @@ module Rigor
 
       attr_reader :libraries, :signature_paths, :cache_store, :virtual_rbs
 
-      # @param libraries [Array<String, Symbol>] stdlib library names to load on top of core (e.g.,
-      #   `["pathname", "json"]`). Empty by default. Each entry MUST correspond to a directory under the
-      #   `rbs` gem's `stdlib/` tree; unknown names are silently dropped on environment build (the underlying
-      #   `RBS::EnvironmentLoader` raises and we fail-soft).
-      # @param signature_paths [Array<String, Pathname>] additional directories of `.rbs` files to load
-      #   (typically the project's `sig/` tree). Non-existent or non-directory paths are filtered out at
-      #   build time so the loader stays robust to fixtures and bare repositories.
-      # @param cache_store [Rigor::Cache::Store, nil] the persistent cache the loader threads through to
-      #   `RbsEnvironment`, `RbsKnownClassNames`, `RbsConstantTable`, `RbsClassAncestorTable`, and
-      #   `RbsClassTypeParamNames` producers. Pass `nil` (the default) to skip caching; the runner threads
-      #   its own Store through here when enabled.
-      # @param virtual_rbs [Array<[String, String]>] ADR-32 WD4 — `[virtual_filename, rbs_source]` pairs
-      #   synthesised from project source by a plugin's `Manifest#source_rbs_synthesizer`. Merged into the
-      #   env after `signature_paths:` and the vendored stubs. Pass `[]` (the default) when no
-      #   synthesizer-emitting plugin is loaded.
+      # @rbs libraries: Array[String | Symbol] --
+      #   Stdlib library names to load on top of core (e.g., `["pathname", "json"]`). Empty by default. Each entry
+      #   MUST correspond to a directory under the `rbs` gem's `stdlib/` tree; unknown names are silently dropped on
+      #   environment build (the underlying `RBS::EnvironmentLoader` raises and we fail-soft).
+      # @rbs signature_paths: Array[String | Pathname] --
+      #   Additional directories of `.rbs` files to load (typically the project's `sig/` tree). Non-existent or
+      #   non-directory paths are filtered out at build time so the loader stays robust to fixtures and bare
+      #   repositories.
+      # @rbs cache_store: Rigor::Cache::Store? --
+      #   The persistent cache the loader threads through to `RbsEnvironment`, `RbsKnownClassNames`,
+      #   `RbsConstantTable`, `RbsClassAncestorTable`, and `RbsClassTypeParamNames` producers. Pass `nil` (the
+      #   default) to skip caching; the runner threads its own Store through here when enabled.
+      # @rbs virtual_rbs: Array[[String, String]] --
+      #   ADR-32 WD4 — `[virtual_filename, rbs_source]` pairs synthesised from project source by a plugin's
+      #   `Manifest#source_rbs_synthesizer`. Merged into the env after `signature_paths:` and the vendored stubs. Pass
+      #   `[]` (the default) when no synthesizer-emitting plugin is loaded.
       def initialize(libraries: [], signature_paths: [], cache_store: nil, virtual_rbs: [],
                      deferred_signature_paths: [])
         @libraries = libraries.map(&:to_s).freeze
@@ -1127,7 +1193,7 @@ module Rigor
       # the stderr banner) reads it, and a cache HIT reaches it too — the env was built with the file already
       # quarantined, so the condition is invisible in the cached env itself.
       #
-      # @return [Array<Array(String, String)>] empty when every `signature_paths:` file parses.
+      # @rbs return: Array[[String, String]] -- Empty when every `signature_paths:` file parses.
       def quarantined_signatures
         @state[:quarantined] ||= begin
           parse_quarantined = self.class.quarantined_project_signatures(@signature_paths)
@@ -1199,8 +1265,9 @@ module Rigor
       # persisted, so every run re-attempts and re-raises), so this is captured directly in {#env}'s rescue
       # rather than re-derived. Forcing `env` (any query does) populates it.
       #
-      # @return [Array(String, String, Array<String>), nil] `[error_class_name, first_error_line,
-      #   conflicting_buffer_names]`, or nil when the environment built successfully.
+      # @rbs return: [String, String, Array[String]]? --
+      #   `[error_class_name, first_error_line, conflicting_buffer_names]`, or nil when the environment built
+      #   successfully.
       def env_build_failure
         env unless @state[:env_loaded]
         @state[:env_build_failure]
@@ -1223,9 +1290,9 @@ module Rigor
       # definition-build failure leaves no trace in the env at all — the env is fine; it is the BUILD over it
       # that raised — so the rescue is the only place that ever knows.
       #
-      # @return [Array<Array(String, String, String, Array<String>)>] `[class_name, error_class_name,
-      #   first_error_line, conflicting_buffer_names]`, one per class, in first-failure order. Empty for a
-      #   healthy sig set, which is the common case.
+      # @rbs return: Array[[String, String, String, Array[String]]] --
+      #   `[class_name, error_class_name, first_error_line, conflicting_buffer_names]`, one per class, in
+      #   first-failure order. Empty for a healthy sig set, which is the common case.
       def definition_build_failures
         (@state[:definition_build_failures] || []).dup.freeze
       end
@@ -1237,7 +1304,7 @@ module Rigor
       # the {#quarantined_signatures} trick — so a cache HIT, which never runs the build, reports the same
       # condition: the marshalled env simply lacks the dropped buffers.
       #
-      # @return [Array<String>] virtual buffer names (source-file paths) whose contribution was dropped.
+      # @rbs return: Array[String] -- Virtual buffer names (source-file paths) whose contribution was dropped.
       def virtual_rbs_collision_quarantined
         @state[:virtual_rbs_collisions] ||= begin
           built = @state[:env]
@@ -1415,9 +1482,9 @@ module Rigor
         {}.freeze
       end
 
-      # @return [RBS::Definition, nil] the resolved instance definition for `class_name`, or nil when the
-      #   class is unknown or its definition cannot be built (RBS may raise on broken hierarchies; we
-      #   fail-soft and return nil so the caller can fall back).
+      # @rbs return: RBS::Definition? --
+      #   The resolved instance definition for `class_name`, or nil when the class is unknown or its definition cannot
+      #   be built (RBS may raise on broken hierarchies; we fail-soft and return nil so the caller can fall back).
       #
       # Built on demand from the (possibly cache-loaded) env; the in-memory `@instance_definition_cache`
       # keeps the per-process short-circuit. ADR-54 WD1 retired the definitions disk blob: given a cached
@@ -1441,7 +1508,7 @@ module Rigor
         definition
       end
 
-      # @return [RBS::Definition::Method, nil]
+      # @rbs return: RBS::Definition::Method?
       def instance_method(class_name:, method_name:)
         definition = instance_definition(class_name)
         return nil unless definition
@@ -1449,10 +1516,11 @@ module Rigor
         definition.methods[method_name.to_sym]
       end
 
-      # @return [Array<Symbol>, nil] every instance-method name on `class_name` — own, inherited, and
-      #   included — as resolved by `RBS::DefinitionBuilder`. Returns `nil` (NOT `[]`) when the class
-      #   definition cannot be built so callers can tell "no methods" apart from "unknown class". Used by the
-      #   `rigor:v1:conforms-to` presence check ({Rigor::RbsExtended::ConformanceChecker}).
+      # @rbs return: Array[Symbol]? --
+      #   Every instance-method name on `class_name` — own, inherited, and included — as resolved by
+      #   `RBS::DefinitionBuilder`. Returns `nil` (NOT `[]`) when the class definition cannot be built so callers can
+      #   tell "no methods" apart from "unknown class". Used by the `rigor:v1:conforms-to` presence check
+      #   ({Rigor::RbsExtended::ConformanceChecker}).
       def instance_method_names(class_name)
         definition = instance_definition(class_name)
         return nil unless definition
@@ -1460,10 +1528,11 @@ module Rigor
         definition.methods.keys
       end
 
-      # @return [RBS::Definition, nil] the built definition for the RBS interface `interface_name`
-      #   (`_RewindableStream`), whose `.methods` are the required members (including interface-ancestor
-      #   members). Returns `nil` when the name does not resolve to a loaded interface (a typo, or the
-      #   defining library / sig set is not on the load path). Fail-soft on RBS build errors.
+      # @rbs return: RBS::Definition? --
+      #   The built definition for the RBS interface `interface_name` (`_RewindableStream`), whose `.methods` are the
+      #   required members (including interface-ancestor members). Returns `nil` when the name does not resolve to a
+      #   loaded interface (a typo, or the defining library / sig set is not on the load path). Fail-soft on RBS build
+      #   errors.
       def interface_definition(interface_name)
         rbs_name = parse_type_name(interface_name)
         return nil unless rbs_name
@@ -1475,20 +1544,21 @@ module Rigor
         nil
       end
 
-      # @return [Array<Symbol>, nil] every method name required by the RBS interface `interface_name`, or nil
-      #   when it does not resolve. Thin accessor over {#interface_definition} for the presence check.
+      # @rbs return: Array[Symbol]? --
+      #   Every method name required by the RBS interface `interface_name`, or nil when it does not resolve. Thin
+      #   accessor over {#interface_definition} for the presence check.
       def interface_method_names(interface_name)
         interface_definition(interface_name)&.methods&.keys
       end
 
-      # @param rbs_alias [RBS::Types::Alias] a type-alias reference (`string`, `int`, `range[int?]`, …)
-      #   appearing in a method signature.
-      # @return [RBS::Types::t, nil] the alias's aliased type one level out, with type arguments substituted
-      #   for a generic alias (`string` → `::String | ::_ToStr`; `range[int?]` → `::Range[int?] |
-      #   ::_Range[int?]`), or nil for an unresolved name. Lets a caller see through the alias that
-      #   {Inference::RbsTypeTranslator} otherwise degrades to `untyped`, which is why an interface/alias
-      #   parameter does not reject `nil`. `expand_alias2` handles the (rarer) generic case — a `range[T]`
-      #   param previously fell back to "admits", which suppressed e.g. `MatchData#[](nil)`.
+      # @rbs rbs_alias: RBS::Types::Alias --
+      #   A type-alias reference (`string`, `int`, `range[int?]`, …) appearing in a method signature.
+      # @rbs return: RBS::Types::t? --
+      #   The alias's aliased type one level out, with type arguments substituted for a generic alias (`string` →
+      #   `::String | ::_ToStr`; `range[int?]` → `::Range[int?] | ::_Range[int?]`), or nil for an unresolved name.
+      #   Lets a caller see through the alias that {Inference::RbsTypeTranslator} otherwise degrades to `untyped`,
+      #   which is why an interface/alias parameter does not reject `nil`. `expand_alias2` handles the (rarer) generic
+      #   case — a `range[T]` param previously fell back to "admits", which suppressed e.g. `MatchData#[](nil)`.
       def expand_type_alias(rbs_alias)
         return nil if env.nil?
 
@@ -1508,10 +1578,10 @@ module Rigor
         nil
       end
 
-      # @return [RBS::Definition, nil] the resolved singleton (class object) definition for `class_name`. The
-      #   methods on this definition are the *class methods* of `class_name`, including those inherited from
-      #   `Class` and `Module` for class types. Returns nil for unknown names and on RBS build errors
-      #   (fail-soft).
+      # @rbs return: RBS::Definition? --
+      #   The resolved singleton (class object) definition for `class_name`. The methods on this definition are the
+      #   *class methods* of `class_name`, including those inherited from `Class` and `Module` for class types.
+      #   Returns nil for unknown names and on RBS build errors (fail-soft).
       #
       # Built on demand from the env with a per-process memo; the same on-demand discipline as
       # {#instance_definition} (ADR-54 WD1).
@@ -1529,10 +1599,10 @@ module Rigor
         definition
       end
 
-      # @return [RBS::Definition::Method, nil] the class method on `class_name`. For example,
-      #   `singleton_method(class_name: "Integer", method_name: :sqrt)` returns the definition for
-      #   `Integer.sqrt`, while `singleton_method(class_name: "Foo", method_name: :new)` returns Class#new
-      #   for any class type.
+      # @rbs return: RBS::Definition::Method? --
+      #   The class method on `class_name`. For example, `singleton_method(class_name: "Integer", method_name: :sqrt)`
+      #   returns the definition for `Integer.sqrt`, while `singleton_method(class_name: "Foo", method_name: :new)`
+      #   returns Class#new for any class type.
       def singleton_method(class_name:, method_name:)
         definition = singleton_definition(class_name)
         return nil unless definition
@@ -1595,7 +1665,7 @@ module Rigor
       # way, and both yield `[]` for an unknown or unbuildable class. Pinned by spec across all three cache
       # states.
       #
-      # @return [Array<String>] `::`-stripped ancestor names, or `[]` for an unknown or unbuildable class.
+      # @rbs return: Array[String] -- `::`-stripped ancestor names, or `[]` for an unknown or unbuildable class.
       def ancestor_names_for(class_name)
         key = class_name.to_s.delete_prefix("::")
         during_internal_demand do
@@ -1610,9 +1680,10 @@ module Rigor
         [].freeze
       end
 
-      # @return [Array<String>] every RBS-declared constant name (top-level prefixed, e.g., `"::Math::PI"`)
-      #   currently loaded into the environment. Used by the cache producer that materialises the
-      #   constant-type table; ordinary callers should keep using {#constant_type} for point lookups.
+      # @rbs return: Array[String] --
+      #   Every RBS-declared constant name (top-level prefixed, e.g., `"::Math::PI"`) currently loaded into the
+      #   environment. Used by the cache producer that materialises the constant-type table; ordinary callers should
+      #   keep using {#constant_type} for point lookups.
       def constant_names
         return [] if env.nil?
 
@@ -2277,7 +2348,7 @@ module Rigor
       # `SuperclassMismatchError` has `#name`. `RecursiveAncestorError` has none of them and yields nil, and
       # the diagnostic then omits the clause rather than inventing one.
       #
-      # @return [String, nil]
+      # @rbs return: String?
       def definition_build_member(error)
         return error.qualified_method_name.to_s if error.respond_to?(:qualified_method_name)
 

--- a/lib/rigor/flow_contribution.rb
+++ b/lib/rigor/flow_contribution.rb
@@ -49,25 +49,26 @@ module Rigor
 
     attr_reader(*SLOT_NAMES, :provenance)
 
-    # @param return_type [Object, nil] normal-edge return type. Use `nil` when the contribution does not
-    #   refine the return type selected from the RBS contract.
-    # @param truthy_facts [Array, nil] facts that hold only on the truthy control-flow edge. Edge-local: a
-    #   truthy-edge fact does NOT imply its falsey-edge complement (ADR-2 § "Plugin Contribution Merging").
-    # @param falsey_facts [Array, nil] dual of `truthy_facts`.
-    # @param post_return_facts [Array, nil] facts that hold after the call returns normally on every edge —
-    #   the carrier for assertion-style contributions.
-    # @param mutations [Array, nil] receiver and argument mutation effects.
-    # @param invalidations [Array, nil] targeted fact invalidations beyond what mutation effects already
-    #   imply.
-    # @param exceptional [Object, nil] non-returning, raising, or unreachable effect.
-    # @param role_conformance [Array, nil] capability-role conformance facts the contribution provides.
-    # @param effects [Rigor::Effects::LabelSet, nil] ADR-103 WD5 — the effect labels this call edge
-    #   attributes to its callee, as an upper bound. `nil` means "says nothing about effects", which is
-    #   NOT the same as the empty set (which asserts the call performs none). Merged by union, the
-    #   conservative direction: two sources that each name part of a call's footprint together name
-    #   more of it, and neither can shrink the other's claim.
-    # @param provenance [Provenance] source-family, plugin-id, node, and cache-descriptor metadata. Defaults
-    #   to `Provenance.builtin`.
+    # @rbs return_type: untyped? --
+    #   Normal-edge return type. Use `nil` when the contribution does not refine the return type selected from the RBS
+    #   contract.
+    # @rbs truthy_facts: Array[untyped]? --
+    #   Facts that hold only on the truthy control-flow edge. Edge-local: a truthy-edge fact does NOT imply its
+    #   falsey-edge complement (ADR-2 § "Plugin Contribution Merging").
+    # @rbs falsey_facts: Array[untyped]? -- Dual of `truthy_facts`.
+    # @rbs post_return_facts: Array[untyped]? --
+    #   Facts that hold after the call returns normally on every edge — the carrier for assertion-style contributions.
+    # @rbs mutations: Array[untyped]? -- Receiver and argument mutation effects.
+    # @rbs invalidations: Array[untyped]? -- Targeted fact invalidations beyond what mutation effects already imply.
+    # @rbs exceptional: untyped? -- Non-returning, raising, or unreachable effect.
+    # @rbs role_conformance: Array[untyped]? -- Capability-role conformance facts the contribution provides.
+    # @rbs effects: Rigor::Effects::LabelSet? --
+    #   ADR-103 WD5 — the effect labels this call edge attributes to its callee, as an upper bound. `nil` means "says
+    #   nothing about effects", which is NOT the same as the empty set (which asserts the call performs none). Merged
+    #   by union, the conservative direction: two sources that each name part of a call's footprint together name more
+    #   of it, and neither can shrink the other's claim.
+    # @rbs provenance: Provenance --
+    #   Source-family, plugin-id, node, and cache-descriptor metadata. Defaults to `Provenance.builtin`.
     # rubocop:disable Metrics/ParameterLists
     def initialize(return_type: nil, truthy_facts: nil, falsey_facts: nil,
                    post_return_facts: nil, mutations: nil, invalidations: nil,
@@ -87,8 +88,9 @@ module Rigor
       freeze
     end
 
-    # @return [Boolean] true when every content slot is unset (nil or an empty collection). Provenance does
-    #   not count toward emptiness — an empty bundle still carries source attribution.
+    # @rbs return: bool --
+    #   True when every content slot is unset (nil or an empty collection). Provenance does not count toward emptiness
+    #   — an empty bundle still carries source attribution.
     def empty?
       SLOT_NAMES.all? { |slot| slot_empty?(slot, public_send(slot)) }
     end

--- a/lib/rigor/flow_contribution.rb
+++ b/lib/rigor/flow_contribution.rb
@@ -116,8 +116,6 @@ module Rigor
     # | exceptional         | exceptional   | exception           | :raise                  |
     # | role_conformance    | normal        | role                | (per-role target)       |
     # | effects             | normal        | effects             | :effects                |
-    #
-    # @return [Array<Element>]
     def to_element_list # rubocop:disable Metrics/AbcSize
       elements = []
       elements << element_for(:return, :normal, :return_type, return_type) unless return_type.nil?

--- a/lib/rigor/flow_contribution/merger.rb
+++ b/lib/rigor/flow_contribution/merger.rb
@@ -53,8 +53,6 @@ module Rigor
 
       module_function
 
-      # @param contributions [Array<FlowContribution>]
-      # @return [MergeResult]
       def merge(contributions)
         contributions = Array(contributions)
         return MergeResult.new if contributions.empty?

--- a/lib/rigor/inference/acceptance.rb
+++ b/lib/rigor/inference/acceptance.rb
@@ -27,10 +27,7 @@ module Rigor
     module Acceptance
       module_function
 
-      # @param self_type [Rigor::Type]
-      # @param other_type [Rigor::Type]
       # @param mode [Symbol] `:gradual` (default) or `:strict`.
-      # @return [Rigor::Type::AcceptsResult]
       def accepts(self_type, other_type, mode: :gradual)
         raise ArgumentError, "Acceptance mode #{mode.inspect} is not implemented yet" unless mode == :gradual
 

--- a/lib/rigor/inference/acceptance.rb
+++ b/lib/rigor/inference/acceptance.rb
@@ -27,7 +27,7 @@ module Rigor
     module Acceptance
       module_function
 
-      # @param mode [Symbol] `:gradual` (default) or `:strict`.
+      # @rbs mode: :gradual | :strict
       def accepts(self_type, other_type, mode: :gradual)
         raise ArgumentError, "Acceptance mode #{mode.inspect} is not implemented yet" unless mode == :gradual
 

--- a/lib/rigor/inference/block_parameter_binder.rb
+++ b/lib/rigor/inference/block_parameter_binder.rb
@@ -41,7 +41,6 @@ module Rigor
         @expected_param_types = expected_param_types
       end
 
-      # @param block_node [Prism::BlockNode]
       # @return [Hash{Symbol => Rigor::Type}] ordered map from parameter name to bound type. Anonymous
       #   parameters are skipped; MultiTargetNode destructuring slots delegate to {MultiTargetBinder} and
       #   contribute every named local in declaration order. Numbered-parameter forms (`_1`, `_2`, ...) bind

--- a/lib/rigor/inference/block_parameter_binder.rb
+++ b/lib/rigor/inference/block_parameter_binder.rb
@@ -34,17 +34,19 @@ module Rigor
     #
     # See docs/internal-spec/inference-engine.md for the binding contract.
     class BlockParameterBinder
-      # @param expected_param_types [Array<Rigor::Type>] positional block parameter types in order. Indices
-      #   the binder cannot fill from this array (because the array is shorter than the parameter list, or
-      #   because the slot is a kind we do not pull from the array) default to `Dynamic[Top]`.
+      # @rbs expected_param_types: Array[Rigor::Type] --
+      #   Positional block parameter types in order. Indices the binder cannot fill from this array (because the array
+      #   is shorter than the parameter list, or because the slot is a kind we do not pull from the array) default to
+      #   `Dynamic[Top]`.
       def initialize(expected_param_types: [])
         @expected_param_types = expected_param_types
       end
 
-      # @return [Hash{Symbol => Rigor::Type}] ordered map from parameter name to bound type. Anonymous
-      #   parameters are skipped; MultiTargetNode destructuring slots delegate to {MultiTargetBinder} and
-      #   contribute every named local in declaration order. Numbered-parameter forms (`_1`, `_2`, ...) bind
-      #   `:_1`, `:_2`, ... up to the maximum the block body refers to.
+      # @rbs return: Hash[Symbol, Rigor::Type] --
+      #   Ordered map from parameter name to bound type. Anonymous parameters are skipped; MultiTargetNode
+      #   destructuring slots delegate to {MultiTargetBinder} and contribute every named local in declaration order.
+      #   Numbered-parameter forms (`_1`, `_2`, ...) bind `:_1`, `:_2`, ... up to the maximum the block body refers
+      #   to.
       def bind(block_node)
         params_root = block_node.parameters
         return {} if params_root.nil?

--- a/lib/rigor/inference/body_fixpoint.rb
+++ b/lib/rigor/inference/body_fixpoint.rb
@@ -26,12 +26,13 @@ module Rigor
 
       module_function
 
-      # @param names [Array<Symbol>] the outer locals the body can rebind.
-      # @param seed_bindings [Hash{Symbol=>Type}] pre-state binding per name.
-      # @param widen [#call] value-pinned widener (Constant -> Nominal).
-      # @param evaluate_body [#call] `bindings -> exit_bindings` — evaluates the body once from `bindings`
-      #   (the per-name current assumption) and returns the per-name exit binding it produced.
-      # @return [Hash{Symbol=>Type}] the continuation binding per name.
+      # @rbs names: Array[Symbol] -- The outer locals the body can rebind.
+      # @rbs seed_bindings: Hash[Symbol, Type] -- Pre-state binding per name.
+      # @rbs widen: untyped -- Value-pinned widener (Constant -> Nominal).
+      # @rbs evaluate_body: untyped --
+      #   `bindings -> exit_bindings` — evaluates the body once from `bindings` (the per-name current assumption) and
+      #   returns the per-name exit binding it produced.
+      # @rbs return: Hash[Symbol, Type] -- The continuation binding per name.
       def converge(names:, seed_bindings:, widen:, evaluate_body:)
         return {} if names.empty?
 

--- a/lib/rigor/inference/builtins/proc_catalog.rb
+++ b/lib/rigor/inference/builtins/proc_catalog.rb
@@ -69,11 +69,9 @@ module Rigor
             :to_proc,
             # `#unbind` allocates a fresh `UnboundMethod` whose identity differs every call.
             :unbind,
-            # Identity-based equality and hashing.
             :hash,
             :==,
             :eql?,
-            # `initialize_copy` is blocklisted by convention.
             :initialize_copy
           ],
           "UnboundMethod" => Set[
@@ -81,11 +79,9 @@ module Rigor
             # the bound method (already classified `:block_dependent`).
             :bind,
             :bind_call,
-            # Identity-based equality and hashing.
             :hash,
             :==,
             :eql?,
-            # `initialize_copy` is blocklisted by convention.
             :initialize_copy
           ]
         }

--- a/lib/rigor/inference/captured_locals.rb
+++ b/lib/rigor/inference/captured_locals.rb
@@ -30,7 +30,6 @@ module Rigor
 
       module_function
 
-      # @param block_node [Prism::BlockNode]
       # @param base_scope [Rigor::Scope] the call-site scope the block closes over.
       # @return [Array<Symbol>] the captured names the body writes, each once, in first-write order.
       def writes(block_node, base_scope)

--- a/lib/rigor/inference/captured_locals.rb
+++ b/lib/rigor/inference/captured_locals.rb
@@ -30,8 +30,8 @@ module Rigor
 
       module_function
 
-      # @param base_scope [Rigor::Scope] the call-site scope the block closes over.
-      # @return [Array<Symbol>] the captured names the body writes, each once, in first-write order.
+      # @rbs base_scope: Rigor::Scope -- The call-site scope the block closes over.
+      # @rbs return: Array[Symbol] -- The captured names the body writes, each once, in first-write order.
       def writes(block_node, base_scope)
         body = block_node.body
         return [] if body.nil?

--- a/lib/rigor/inference/closure_escape_analyzer.rb
+++ b/lib/rigor/inference/closure_escape_analyzer.rb
@@ -51,8 +51,6 @@ module Rigor
     module ClosureEscapeAnalyzer
       module_function
 
-      # @param receiver_type [Rigor::Type, nil]
-      # @param method_name [Symbol]
       # @param environment [Rigor::Environment, nil] reserved for the future sub-phase that consults
       #   `RBS::Extended` call-timing effects; sub-phase 3a ignores it.
       # @return [Symbol] one of `:non_escaping`, `:escaping`, `:unknown`.

--- a/lib/rigor/inference/closure_escape_analyzer.rb
+++ b/lib/rigor/inference/closure_escape_analyzer.rb
@@ -51,9 +51,10 @@ module Rigor
     module ClosureEscapeAnalyzer
       module_function
 
-      # @param environment [Rigor::Environment, nil] reserved for the future sub-phase that consults
-      #   `RBS::Extended` call-timing effects; sub-phase 3a ignores it.
-      # @return [Symbol] one of `:non_escaping`, `:escaping`, `:unknown`.
+      # @rbs environment: Rigor::Environment? --
+      #   Reserved for the future sub-phase that consults `RBS::Extended` call-timing effects; sub-phase 3a ignores
+      #   it.
+      # @rbs return: Symbol -- One of `:non_escaping`, `:escaping`, `:unknown`.
       def classify(receiver_type:, method_name:, environment: nil) # rubocop:disable Lint/UnusedMethodArgument
         return :unknown if receiver_type.nil?
 

--- a/lib/rigor/inference/coverage_scanner.rb
+++ b/lib/rigor/inference/coverage_scanner.rb
@@ -46,8 +46,6 @@ module Rigor
         @scope = scope || Scope.empty
       end
 
-      # @param root [Prism::Node]
-      # @return [Result]
       def scan(root)
         visits = Hash.new(0)
         unrecognized = Hash.new(0)

--- a/lib/rigor/inference/coverage_scanner.rb
+++ b/lib/rigor/inference/coverage_scanner.rb
@@ -22,17 +22,17 @@ module Rigor
     # a tracer per visited node and discards the inferred type values.
     class CoverageScanner
       class Result < Data.define(:visits, :unrecognized, :events)
-        # @return [Integer] sum of all visits across node classes.
+        # @rbs return: Integer -- Sum of all visits across node classes.
         def visited_count
           visits.values.sum
         end
 
-        # @return [Integer] sum of directly-unrecognized counts across classes.
+        # @rbs return: Integer -- Sum of directly-unrecognized counts across classes.
         def unrecognized_count
           unrecognized.values.sum
         end
 
-        # @return [Float] unrecognized_count / visited_count, or 0.0 when empty.
+        # @rbs return: Float -- Unrecognized_count / visited_count, or 0.0 when empty.
         def unrecognized_ratio
           total = visited_count
           return 0.0 if total.zero?
@@ -41,7 +41,7 @@ module Rigor
         end
       end
 
-      # @param scope [Rigor::Scope] base scope used for every type_of call. Defaults to `Scope.empty`.
+      # @rbs scope: Rigor::Scope -- Base scope used for every type_of call. Defaults to `Scope.empty`.
       def initialize(scope: nil)
         @scope = scope || Scope.empty
       end

--- a/lib/rigor/inference/dynamic_origin.rb
+++ b/lib/rigor/inference/dynamic_origin.rb
@@ -60,8 +60,7 @@ module Rigor
 
       module_function
 
-      # @return [Symbol, nil] the tractability category for a cause, or nil when the cause is unknown /
-      #   absent.
+      # @rbs return: Symbol? -- The tractability category for a cause, or nil when the cause is unknown / absent.
       def tractability(cause)
         TRACTABILITY[cause]
       end

--- a/lib/rigor/inference/expression_typer.rb
+++ b/lib/rigor/inference/expression_typer.rb
@@ -3558,7 +3558,7 @@ module Rigor
       # computation, so a block that both accumulates and mutates captured state keeps its write-back
       # regardless of which arm answers here.
       #
-      # @return [Rigor::Type, nil]
+      # @rbs return: Rigor::Type?
       def try_block_inject_fold(call_node, receiver, arg_types)
         return nil unless INJECT_METHODS.include?(call_node.name)
 
@@ -3577,7 +3577,7 @@ module Rigor
       # Splits the positional args into the optional seed. A Symbol final arg (`inject(seed, :*)`) is the
       # no-block Symbol form and never reaches here (the block guard already failed for it).
       #
-      # @return [Array(Rigor::Type, nil), Boolean] `[seed, has_seed]`
+      # @rbs return: [Rigor::Type, nil] | bool -- `[seed, has_seed]`
       def inject_seed(arg_types)
         case arg_types.size
         when 0 then [nil, false]
@@ -3637,7 +3637,7 @@ module Rigor
       # member is folded; without a seed the first member seeds the memo and the rest are folded. The
       # accumulator is carried as a `Constant` type (so the block body sees a value-pinned param).
       #
-      # @return [Array(Rigor::Type::Constant, nil), Array] `[acc, rest]`
+      # @rbs return: [Rigor::Type::Constant, nil] | Array[untyped] -- `[acc, rest]`
       def inject_constant_start(members, seed, has_seed)
         if has_seed
           return [nil, []] unless seed.is_a?(Type::Constant) && inject_foldable?(seed.value)

--- a/lib/rigor/inference/fork_map.rb
+++ b/lib/rigor/inference/fork_map.rb
@@ -22,10 +22,11 @@ module Rigor
     module ForkMap
       module_function
 
-      # @param items [Array] work items (file paths, or `[path, ast]` pairs), in caller order.
-      # @param workers [Integer] resolved worker count (≤1, empty items, or no `fork` → sequential).
-      # @yield [Array] a contiguous slice of `items`; must return a **marshalable** object.
-      # @return [Array] the per-slice block results, in original slice order.
+      # @rbs items: Array[untyped] -- Work items (file paths, or `[path, ast]` pairs), in caller order.
+      # @rbs workers: Integer --
+      #   Resolved worker count (≤1, empty items, or no `fork` → sequential). A contiguous slice of `items`; must
+      #   return a **marshalable** object.
+      # @rbs return: Array[untyped] -- The per-slice block results, in original slice order.
       def call(items:, workers:, &block)
         worker_count = [workers, items.size].min
         return [block.call(items)] unless parallel?(worker_count) && !items.empty?
@@ -56,7 +57,7 @@ module Rigor
       # parent still has the directory open, and answering `nil` once it is gone degrades to `Dir.tmpdir`
       # instead of raising `Errno::ENOENT` somewhere far from here.
       #
-      # @return [String, nil]
+      # @rbs return: String?
       def child_scratch_dir
         return nil unless @child_scratch_dir && File.directory?(@child_scratch_dir)
 
@@ -120,9 +121,9 @@ module Rigor
         end
       end
 
-      # @return [Hash{value: Object}, nil] the child's payload wrapped so a legitimately-nil block result is
-      #   distinguishable from an abnormal exit. `Marshal.load` is safe: the blob was written by our own
-      #   forked child to a temp file we created.
+      # @rbs return: Hash{value: Object}? --
+      #   The child's payload wrapped so a legitimately-nil block result is distinguishable from an abnormal exit.
+      #   `Marshal.load` is safe: the blob was written by our own forked child to a temp file we created.
       def worker_payload(status, out_path)
         return nil unless status.success? && File.exist?(out_path)
 

--- a/lib/rigor/inference/hkt_reducer.rb
+++ b/lib/rigor/inference/hkt_reducer.rb
@@ -41,7 +41,6 @@ module Rigor
 
       # Reduce `app` against the registry.
       #
-      # @param app [Rigor::Type::App]
       # @param fuel [Integer] reduction-step budget (default 64 per ADR-20 WD3). Each visited
       #   body node costs one unit. On exhaustion the reduction returns `app.bound`.
       # @return [Rigor::Type] the reduced type, or `app.bound` when reduction is impossible (URI

--- a/lib/rigor/inference/hkt_reducer.rb
+++ b/lib/rigor/inference/hkt_reducer.rb
@@ -41,10 +41,12 @@ module Rigor
 
       # Reduce `app` against the registry.
       #
-      # @param fuel [Integer] reduction-step budget (default 64 per ADR-20 WD3). Each visited
-      #   body node costs one unit. On exhaustion the reduction returns `app.bound`.
-      # @return [Rigor::Type] the reduced type, or `app.bound` when reduction is impossible (URI
-      #   not defined, arity mismatch, body_tree absent, fuel exhausted).
+      # @rbs fuel: Integer --
+      #   Reduction-step budget (default 64 per ADR-20 WD3). Each visited body node costs one unit. On exhaustion the
+      #   reduction returns `app.bound`.
+      # @rbs return: Rigor::Type --
+      #   The reduced type, or `app.bound` when reduction is impossible (URI not defined, arity mismatch, body_tree
+      #   absent, fuel exhausted).
       def reduce(app, fuel: DEFAULT_FUEL)
         raise ArgumentError, "expected a Rigor::Type::App, got #{app.class}" unless app.is_a?(Type::App)
 

--- a/lib/rigor/inference/hkt_registry.rb
+++ b/lib/rigor/inference/hkt_registry.rb
@@ -99,8 +99,6 @@ module Rigor
 
       attr_reader :registrations, :definitions
 
-      # @param registrations [Array<Registration>]
-      # @param definitions [Array<Definition>]
       def initialize(registrations: [], definitions: [])
         @registrations = registrations.to_h { |r| [r.uri, r] }.freeze
         @definitions = definitions.to_h { |d| [d.uri, d] }.freeze
@@ -152,7 +150,6 @@ module Rigor
       # collisions per {#merge}'s contract. Fail-soft on per-annotation parse errors (the reporter
       # records an `:info` entry; the other annotations still apply).
       #
-      # @param rbs_loader [Rigor::Environment::RbsLoader]
       # @param base [HktRegistry] starting registry (typically the bundled
       #   `Rigor::Builtins::HktBuiltins.registry`).
       # @param name_scope [Rigor::Environment::NameScope, nil] threaded through to the bound

--- a/lib/rigor/inference/hkt_registry.rb
+++ b/lib/rigor/inference/hkt_registry.rb
@@ -121,8 +121,9 @@ module Rigor
         @definitions[uri]
       end
 
-      # @return [HktRegistry] a new registry whose entries are the union of this registry's and
-      #   `other`'s. On URI collisions `other`'s entries win (last-write-wins; OQ3 tentative).
+      # @rbs return: HktRegistry --
+      #   A new registry whose entries are the union of this registry's and `other`'s. On URI collisions `other`'s
+      #   entries win (last-write-wins; OQ3 tentative).
       def merge(other)
         raise ArgumentError, "merge target must be an HktRegistry, got #{other.class}" unless other.is_a?(HktRegistry)
 
@@ -150,13 +151,11 @@ module Rigor
       # collisions per {#merge}'s contract. Fail-soft on per-annotation parse errors (the reporter
       # records an `:info` entry; the other annotations still apply).
       #
-      # @param base [HktRegistry] starting registry (typically the bundled
-      #   `Rigor::Builtins::HktBuiltins.registry`).
-      # @param name_scope [Rigor::Environment::NameScope, nil] threaded through to the bound
-      #   resolver for class-name lookups; safe to omit during scanning since hkt bounds are
-      #   typically `untyped` or stdlib classes.
-      # @param reporter [#record, nil] same fail-soft reporter contract the other RBS-extended
-      #   parsers use.
+      # @rbs base: HktRegistry -- Starting registry (typically the bundled `Rigor::Builtins::HktBuiltins.registry`).
+      # @rbs name_scope: Rigor::Environment::NameScope? --
+      #   Threaded through to the bound resolver for class-name lookups; safe to omit during scanning since hkt bounds
+      #   are typically `untyped` or stdlib classes.
+      # @rbs reporter: untyped -- Same fail-soft reporter contract the other RBS-extended parsers use.
 
       # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/BlockLength
       def self.scan_rbs_loader(rbs_loader, base: EMPTY, name_scope: nil, reporter: nil)

--- a/lib/rigor/inference/index_write_widening.rb
+++ b/lib/rigor/inference/index_write_widening.rb
@@ -35,7 +35,7 @@ module Rigor
       # the widening joins the stored value into the carrier's content evidence exactly as a real `[]=` does
       # (issue #560). Empty means "no evidence" and widens without joining.
       #
-      # @param node          [Prism::Node] one of {NODE_CLASSES}
+      # @rbs node: Prism::Node -- One of {NODE_CLASSES}
       def widen(node:, current_scope:, arg_types: MutationWidening::NO_ARG_TYPES)
         MutationWidening.widen_receiver_aliases(node.receiver, MUTATOR, current_scope, arg_types: arg_types)
       end

--- a/lib/rigor/inference/index_write_widening.rb
+++ b/lib/rigor/inference/index_write_widening.rb
@@ -27,7 +27,6 @@ module Rigor
 
       module_function
 
-      # @param node [Prism::Node]
       def index_write?(node)
         NODE_CLASSES.any? { |klass| node.is_a?(klass) }
       end
@@ -37,9 +36,6 @@ module Rigor
       # (issue #560). Empty means "no evidence" and widens without joining.
       #
       # @param node          [Prism::Node] one of {NODE_CLASSES}
-      # @param current_scope [Rigor::Scope]
-      # @param arg_types     [Array<Rigor::Type::Base>]
-      # @return              [Rigor::Scope]
       def widen(node:, current_scope:, arg_types: MutationWidening::NO_ARG_TYPES)
         MutationWidening.widen_receiver_aliases(node.receiver, MUTATOR, current_scope, arg_types: arg_types)
       end

--- a/lib/rigor/inference/macro_block_self_type.rb
+++ b/lib/rigor/inference/macro_block_self_type.rb
@@ -28,8 +28,7 @@ module Rigor
     module MacroBlockSelfType
       module_function
 
-      # @return [Rigor::Type, nil] the narrowed self-type, or
-      #   `nil` when no registered entry matches the call shape.
+      # @rbs return: Rigor::Type? -- The narrowed self-type, or `nil` when no registered entry matches the call shape.
       def narrow_self_type_for(scope:, call_node:, receiver_type:)
         return nil if receiver_type.nil?
 

--- a/lib/rigor/inference/macro_block_self_type.rb
+++ b/lib/rigor/inference/macro_block_self_type.rb
@@ -28,9 +28,6 @@ module Rigor
     module MacroBlockSelfType
       module_function
 
-      # @param scope         [Rigor::Scope]
-      # @param call_node     [Prism::CallNode]
-      # @param receiver_type [Rigor::Type, nil]
       # @return [Rigor::Type, nil] the narrowed self-type, or
       #   `nil` when no registered entry matches the call shape.
       def narrow_self_type_for(scope:, call_node:, receiver_type:)

--- a/lib/rigor/inference/method_dispatcher.rb
+++ b/lib/rigor/inference/method_dispatcher.rb
@@ -54,18 +54,15 @@ module Rigor
     module MethodDispatcher # rubocop:disable Metrics/ModuleLength
       module_function
 
-      # @param receiver_type [Rigor::Type, nil] type of the receiver expression, or
-      #   `nil` for an implicit-self call.
-      # @param arg_types [Array<Rigor::Type>] positional argument types.
-      # @param block_type [Rigor::Type, nil] inferred return type of the
-      #   accompanying `do ... end` / `{ ... }` block (Slice 6 phase C
-      #   sub-phase 2). When non-nil, the dispatcher prefers an
-      #   overload that declares a block, and binds the method's
-      #   block-return type variable to `block_type` so a return type
-      #   like `Array[U]` resolves to `Array[block_type]`.
-      # @param environment [Rigor::Environment, nil] required for
-      #   RBS-backed dispatch; when nil only constant folding can fire.
-      # @return [Rigor::Type, nil] inferred result type, or `nil` for "no rule".
+      # @rbs receiver_type: Rigor::Type? -- Type of the receiver expression, or `nil` for an implicit-self call.
+      # @rbs arg_types: Array[Rigor::Type] -- Positional argument types.
+      # @rbs block_type: Rigor::Type? --
+      #   Inferred return type of the accompanying `do ... end` / `{ ... }` block (Slice 6 phase C sub-phase 2). When
+      #   non-nil, the dispatcher prefers an overload that declares a block, and binds the method's block-return type
+      #   variable to `block_type` so a return type like `Array[U]` resolves to `Array[block_type]`.
+      # @rbs environment: Rigor::Environment? --
+      #   Required for RBS-backed dispatch; when nil only constant folding can fire.
+      # @rbs return: Rigor::Type? -- Inferred result type, or `nil` for "no rule".
       def dispatch(receiver_type:, method_name:, arg_types:,
                    block_type: nil, environment: nil,
                    call_node: nil, scope: nil)

--- a/lib/rigor/inference/method_dispatcher.rb
+++ b/lib/rigor/inference/method_dispatcher.rb
@@ -56,7 +56,6 @@ module Rigor
 
       # @param receiver_type [Rigor::Type, nil] type of the receiver expression, or
       #   `nil` for an implicit-self call.
-      # @param method_name [Symbol]
       # @param arg_types [Array<Rigor::Type>] positional argument types.
       # @param block_type [Rigor::Type, nil] inferred return type of the
       #   accompanying `do ... end` / `{ ... }` block (Slice 6 phase C
@@ -1350,12 +1349,6 @@ module Rigor
       # method definition, or selected overload does not provide statically declared block
       # parameter types. Callers MUST treat the empty array as "no information"; the binder
       # falls back to `Dynamic[Top]` for every parameter slot in that case.
-      #
-      # @param receiver_type [Rigor::Type, nil]
-      # @param method_name [Symbol]
-      # @param arg_types [Array<Rigor::Type>]
-      # @param environment [Rigor::Environment, nil]
-      # @return [Array<Rigor::Type>]
       def expected_block_param_types(receiver_type:, method_name:, arg_types:, environment: nil)
         return [] if receiver_type.nil?
 

--- a/lib/rigor/inference/method_dispatcher/block_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/block_folding.rb
@@ -46,9 +46,6 @@ module Rigor
         # a finitely-sized receiver it is `Constant[size]`.
         COUNT_METHOD = :count
 
-        # @param receiver    [Rigor::Type, nil]
-        # @param method_name [Symbol]
-        # @param args        [Array<Rigor::Type>]
         # @param block_type  [Rigor::Type, nil] inferred return type of
         #   the call's block. `nil` means "no block at the call site"
         #   and disqualifies every rule here.
@@ -167,7 +164,6 @@ module Rigor
           )
         end
 
-        # @return [:empty, :non_empty, :unknown]
         def receiver_emptiness(receiver)
           case receiver
           when Type::Tuple

--- a/lib/rigor/inference/method_dispatcher/block_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/block_folding.rb
@@ -46,10 +46,10 @@ module Rigor
         # a finitely-sized receiver it is `Constant[size]`.
         COUNT_METHOD = :count
 
-        # @param block_type  [Rigor::Type, nil] inferred return type of
-        #   the call's block. `nil` means "no block at the call site"
-        #   and disqualifies every rule here.
-        # @return [Rigor::Type, nil]
+        # @rbs block_type: Rigor::Type? --
+        #   Inferred return type of the call's block. `nil` means "no block at the call site" and disqualifies every
+        #   rule here.
+        # @rbs return: Rigor::Type?
         def try_dispatch(context)
           receiver = context.receiver
           method_name = context.method_name
@@ -132,7 +132,7 @@ module Rigor
           end
         end
 
-        # @return [:always_true, :always_false, :bool, nil]
+        # @rbs return: (:always_true | :always_false | :bool)?
         # rubocop:disable-next Metrics/CyclomaticComplexity
         def predicate_decision(method_name, truthiness, emptiness)
           case method_name

--- a/lib/rigor/inference/method_dispatcher/cgi_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/cgi_folding.rb
@@ -55,7 +55,7 @@ module Rigor
 
         module_function
 
-        # @return [Rigor::Type, nil] folded result, or nil to defer.
+        # @rbs return: Rigor::Type? -- Folded result, or nil to defer.
         def try_dispatch(context)
           receiver = context.receiver
           method_name = context.method_name

--- a/lib/rigor/inference/method_dispatcher/constant_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/constant_folding.rb
@@ -214,7 +214,7 @@ module Rigor
         # survives the call.
         CONSTANT_SELF_RETURNERS = %i[freeze itself dup clone].to_set.freeze
 
-        # @return [Rigor::Type::Constant, Rigor::Type::Union, Rigor::Type::IntegerRange, nil]
+        # @rbs return: (Rigor::Type::Constant | Rigor::Type::Union | Rigor::Type::IntegerRange)?
         def try_dispatch(context)
           receiver = context.receiver
           method_name = context.method_name

--- a/lib/rigor/inference/method_dispatcher/data_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/data_folding.rb
@@ -31,7 +31,7 @@ module Rigor
         # and the reader-redefinition guard are shared with {StructFolding}.
         extend MemberShapeProjection
 
-        # @return [Rigor::Type, nil] the folded result, or nil to defer.
+        # @rbs return: Rigor::Type? -- The folded result, or nil to defer.
         def try_dispatch(context)
           receiver = context.receiver
 

--- a/lib/rigor/inference/method_dispatcher/file_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/file_folding.rb
@@ -73,8 +73,7 @@ module Rigor
 
         module_function
 
-        # @return [Rigor::Type, nil] folded result, or nil to defer
-        #   to the next dispatcher tier.
+        # @rbs return: Rigor::Type? -- Folded result, or nil to defer to the next dispatcher tier.
         def try_dispatch(context)
           receiver = context.receiver
           method_name = context.method_name

--- a/lib/rigor/inference/method_dispatcher/iterator_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/iterator_dispatch.rb
@@ -25,8 +25,7 @@ module Rigor
       module IteratorDispatch
         module_function
 
-        # @return [Array<Rigor::Type>, nil] block-param types, or
-        #   nil to fall through to the next tier.
+        # @rbs return: Array[Rigor::Type]? -- Block-param types, or nil to fall through to the next tier.
         def block_param_types(context)
           receiver = context.receiver
           method_name = context.method_name

--- a/lib/rigor/inference/method_dispatcher/json_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/json_folding.rb
@@ -41,7 +41,7 @@ module Rigor
 
         module_function
 
-        # @return [Rigor::Type, nil] folded result, or nil to defer.
+        # @rbs return: Rigor::Type? -- Folded result, or nil to defer.
         def try_dispatch(context)
           receiver = context.receiver
           method_name = context.method_name

--- a/lib/rigor/inference/method_dispatcher/math_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/math_folding.rb
@@ -48,7 +48,7 @@ module Rigor
 
         module_function
 
-        # @return [Rigor::Type, nil] folded result, or nil to defer.
+        # @rbs return: Rigor::Type? -- Folded result, or nil to defer.
         def try_dispatch(context)
           receiver = context.receiver
           method_name = context.method_name

--- a/lib/rigor/inference/method_dispatcher/method_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/method_folding.rb
@@ -29,11 +29,10 @@ module Rigor
         # `.method("name")` with a precisely-known Symbol / String argument. Declines on every other shape
         # so the RBS tier still answers `Method` for non-folding cases.
         #
-        # @param receiver [Rigor::Type] caller's receiver
-        # @param method_name [Symbol] the method being dispatched on `receiver` — only `:method` triggers
-        #   the fold.
-        # @param args [Array<Rigor::Type>] caller's argument types in order. Only the single-argument case
-        #   matches; other arities decline.
+        # @rbs receiver: Rigor::Type -- Caller's receiver
+        # @rbs method_name: Symbol -- The method being dispatched on `receiver` — only `:method` triggers the fold.
+        # @rbs args: Array[Rigor::Type] --
+        #   Caller's argument types in order. Only the single-argument case matches; other arities decline.
         def try_dispatch(context)
           receiver = context.receiver
           method_name = context.method_name

--- a/lib/rigor/inference/method_dispatcher/overload_selector.rb
+++ b/lib/rigor/inference/method_dispatcher/overload_selector.rb
@@ -64,7 +64,6 @@ module Rigor
         }.freeze
         private_constant :ALIAS_STRICT_NOMINALS
 
-        # @param method_definition [RBS::Definition::Method]
         # @param arg_types [Array<Rigor::Type>] caller-provided types in positional order. Empty when
         #   there are no arguments.
         # @param self_type [Rigor::Type] substitute for `Bases::Self`.

--- a/lib/rigor/inference/method_dispatcher/overload_selector.rb
+++ b/lib/rigor/inference/method_dispatcher/overload_selector.rb
@@ -64,21 +64,20 @@ module Rigor
         }.freeze
         private_constant :ALIAS_STRICT_NOMINALS
 
-        # @param arg_types [Array<Rigor::Type>] caller-provided types in positional order. Empty when
-        #   there are no arguments.
-        # @param self_type [Rigor::Type] substitute for `Bases::Self`.
-        # @param instance_type [Rigor::Type] substitute for `Bases::Instance`.
-        # @param type_vars [Hash{Symbol => Rigor::Type}] substitution map for class-level type variables
-        #   (Slice 4 phase 2d). The selector threads it through to {RbsTypeTranslator} so parameter types
-        #   like `::Array[Elem]` substitute Elem before the accepts check, instead of degrading the param
-        #   to `Array[Dynamic[Top]]`.
-        # @param block_required [Boolean] when `true`, only overloads that declare a block clause are
-        #   considered (Slice 6 phase C sub-phase 1). The fallback also prefers a block-bearing overload
-        #   over `method_types.first`. When `false` (the Slice 4 phase 2c default) the selector behaves
-        #   exactly as before: `find` over arity-compatible overloads, falling back to the first
-        #   declaration.
-        # @return [RBS::MethodType, nil] the chosen overload, or nil when the definition has no method
-        #   types at all.
+        # @rbs arg_types: Array[Rigor::Type] --
+        #   Caller-provided types in positional order. Empty when there are no arguments.
+        # @rbs self_type: Rigor::Type -- Substitute for `Bases::Self`.
+        # @rbs instance_type: Rigor::Type -- Substitute for `Bases::Instance`.
+        # @rbs type_vars: Hash[Symbol, Rigor::Type] --
+        #   Substitution map for class-level type variables (Slice 4 phase 2d). The selector threads it through to
+        #   {RbsTypeTranslator} so parameter types like `::Array[Elem]` substitute Elem before the accepts check,
+        #   instead of degrading the param to `Array[Dynamic[Top]]`.
+        # @rbs block_required: bool --
+        #   When `true`, only overloads that declare a block clause are considered (Slice 6 phase C sub-phase 1). The
+        #   fallback also prefers a block-bearing overload over `method_types.first`. When `false` (the Slice 4 phase
+        #   2c default) the selector behaves exactly as before: `find` over arity-compatible overloads, falling back
+        #   to the first declaration.
+        # @rbs return: RBS::MethodType? -- The chosen overload, or nil when the definition has no method types at all.
         def select(method_definition, **) = select_candidates(method_definition, **).first
 
         # Issue #521 — like {.select}, but when a `Dynamic[Top]` argument reaches the gradual pass it
@@ -90,7 +89,7 @@ module Rigor
         # alias-resolved, typed-gradual, arity fallback) still yields exactly one candidate, so `select`
         # keeps its historical single answer.
         #
-        # @return [Array<RBS::MethodType>] matching overloads; empty when the definition declares none.
+        # @rbs return: Array[RBS::MethodType] -- Matching overloads; empty when the definition declares none.
         def select_candidates(method_definition, arg_types:, self_type:, instance_type:, type_vars: {},
                               block_required: false, environment: nil)
           overloads = method_definition.method_types

--- a/lib/rigor/inference/method_dispatcher/rbs_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/rbs_dispatch.rb
@@ -72,26 +72,28 @@ module Rigor
         EMPTY_TYPE_PARAM_NAMES = [].freeze
         private_constant :EMPTY_TYPE_PARAM_NAMES
 
-        # @param block_type [Rigor::Type, nil] inferred block return type, propagated from
-        #   `MethodDispatcher.dispatch`. When non-nil, the selector prefers a block-bearing overload and
-        #   binds the method-level type parameter that the block's return type references to `block_type`
-        #   (Slice 6 phase C sub-phase 2).
-        # @param self_type_override [Rigor::Type, nil] when set, the substitution for `Bases::Self` in the
-        #   method's return type. Used by `MethodDispatcher#try_user_class_fallback` to preserve the
-        #   ORIGINAL receiver as the substitute for `self` even though the dispatch is routed through
-        #   `Nominal[Object]` — so that `Bundler::URI::Generic.dup` (which resolves through the `Object`
-        #   fallback because `Bundler::URI::Generic` lacks RBS) returns `Bundler::URI::Generic` per
-        #   `Kernel#dup: () -> self` rather than `Object`. Defaults to nil (compute self from the resolved
-        #   class_name as before).
-        # @param public_only [Boolean] when true, a method whose RBS accessibility is `:private` does not
-        #   resolve (the call yields `nil`, i.e. "no rule"). Set by the explicit-non-`self`-receiver
-        #   user-class fallback so a call like `Favourite.select(...)` does not adopt the private
-        #   `Kernel#select` signature.
-        # @return [Rigor::Type, nil] inferred return type, or `nil` when no rule resolves (no class name,
-        #   no method, dispatch on a Top/Dynamic[Top] receiver, etc.).
-        # @param scope [Rigor::Scope, nil] when supplied, enables ADR-43 RBS-complete-ancestor resolution
-        #   against `ALLOWED_RBS_COMPLETE_ANCESTORS`. `nil` keeps inherited calls unresolved
-        #   (`Dynamic[Top]`) — the FP-safe default for open hierarchies (`< ActionController::Base`, …).
+        # @rbs block_type: Rigor::Type? --
+        #   Inferred block return type, propagated from `MethodDispatcher.dispatch`. When non-nil, the selector
+        #   prefers a block-bearing overload and binds the method-level type parameter that the block's return type
+        #   references to `block_type` (Slice 6 phase C sub-phase 2).
+        # @rbs self_type_override: Rigor::Type? --
+        #   When set, the substitution for `Bases::Self` in the method's return type. Used by
+        #   `MethodDispatcher#try_user_class_fallback` to preserve the ORIGINAL receiver as the substitute for `self`
+        #   even though the dispatch is routed through `Nominal[Object]` — so that `Bundler::URI::Generic.dup` (which
+        #   resolves through the `Object` fallback because `Bundler::URI::Generic` lacks RBS) returns
+        #   `Bundler::URI::Generic` per `Kernel#dup: () -> self` rather than `Object`. Defaults to nil (compute self
+        #   from the resolved class_name as before).
+        # @rbs public_only: bool --
+        #   When true, a method whose RBS accessibility is `:private` does not resolve (the call yields `nil`, i.e.
+        #   "no rule"). Set by the explicit-non-`self`-receiver user-class fallback so a call like
+        #   `Favourite.select(...)` does not adopt the private `Kernel#select` signature.
+        # @rbs return: Rigor::Type? --
+        #   Inferred return type, or `nil` when no rule resolves (no class name, no method, dispatch on a
+        #   Top/Dynamic[Top] receiver, etc.).
+        # @rbs scope: Rigor::Scope? --
+        #   When supplied, enables ADR-43 RBS-complete-ancestor resolution against `ALLOWED_RBS_COMPLETE_ANCESTORS`.
+        #   `nil` keeps inherited calls unresolved (`Dynamic[Top]`) — the FP-safe default for open hierarchies (`<
+        #   ActionController::Base`, …).
         def try_dispatch(context)
           environment = context.environment
           return nil if environment.nil?
@@ -126,7 +128,7 @@ module Rigor
         #
         # This deliberately does NOT differentiate "no overload had a block" from "the block is untyped";
         # the binder treats both the same way (every parameter defaults to `Dynamic[Top]`).
-        # @return [Array<Rigor::Type>] positional block parameter types.
+        # @rbs return: Array[Rigor::Type] -- Positional block parameter types.
         def block_param_types(context)
           environment = context.environment
           return [] if environment.nil?

--- a/lib/rigor/inference/method_dispatcher/rbs_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/rbs_dispatch.rb
@@ -72,10 +72,6 @@ module Rigor
         EMPTY_TYPE_PARAM_NAMES = [].freeze
         private_constant :EMPTY_TYPE_PARAM_NAMES
 
-        # @param receiver [Rigor::Type]
-        # @param method_name [Symbol]
-        # @param args [Array<Rigor::Type>]
-        # @param environment [Rigor::Environment]
         # @param block_type [Rigor::Type, nil] inferred block return type, propagated from
         #   `MethodDispatcher.dispatch`. When non-nil, the selector prefers a block-bearing overload and
         #   binds the method-level type parameter that the block's return type references to `block_type`

--- a/lib/rigor/inference/method_dispatcher/reduce_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/reduce_folding.rb
@@ -58,7 +58,7 @@ module Rigor
         CONSTANT_FOLD_BIT_CAP = 256
         private_constant :CONSTANT_FOLD_ELEMENT_CAP, :CONSTANT_FOLD_BIT_CAP
 
-        # @return [Rigor::Type, nil]
+        # @rbs return: Rigor::Type?
         def try_dispatch(context)
           return nil unless REDUCE_METHODS.include?(context.method_name)
           return nil if context.block_type
@@ -84,9 +84,9 @@ module Rigor
         # Executes the reduction on real constant values, or returns nil to decline. The caller falls
         # through to the nominal fold on a nil return, so every guard here is precision-additive only.
         #
-        # @param seed [Rigor::Type, nil] the optional seed type; only a foldable `Constant` seed is
-        #   honoured, any other seed declines.
-        # @return [Rigor::Type::Constant, nil]
+        # @rbs seed: Rigor::Type? --
+        #   The optional seed type; only a foldable `Constant` seed is honoured, any other seed declines.
+        # @rbs return: Rigor::Type::Constant?
         def try_constant_reduce(receiver, operator, seed)
           return nil unless CONSTANT_FOLD_OPERATORS.include?(operator)
 
@@ -103,7 +103,7 @@ module Rigor
         # Checks the size cap BEFORE enumerating so an unbounded / huge `Constant[Range]` (e.g.
         # `(1..1_000_000)`) never calls `to_a`.
         #
-        # @return [Array, nil]
+        # @rbs return: Array[untyped]?
         def constant_members(receiver)
           case receiver
           when Type::Constant
@@ -140,9 +140,9 @@ module Rigor
           elements.map(&:value)
         end
 
-        # @return [Array(Object, Boolean)] `[seed_value, present?]`. A nil seed type yields `[nil, false]`
-        #   (no-seed form). A foldable `Constant` seed yields `[value, true]`. Any other seed yields
-        #   `[nil, false]` so the caller can decline.
+        # @rbs return: [untyped, bool] --
+        #   `[seed_value, present?]`. A nil seed type yields `[nil, false]` (no-seed form). A foldable `Constant` seed
+        #   yields `[value, true]`. Any other seed yields `[nil, false]` so the caller can decline.
         def constant_seed(seed)
           return [nil, false] if seed.nil?
           return [nil, false] unless seed.is_a?(Type::Constant) && foldable?(seed.value)
@@ -154,7 +154,7 @@ module Rigor
         # semantics match Ruby: `[].reduce(s, :op) == s` (seed form) and `[].reduce(:op) == nil` (no-seed
         # form → declines so the nominal fold's no-nil contract stands; see `fold_result`).
         #
-        # @return [Rigor::Type::Constant, nil]
+        # @rbs return: Rigor::Type::Constant?
         def execute_constant_reduce(members, operator, seed_value, seed_present)
           result =
             if seed_present

--- a/lib/rigor/inference/method_dispatcher/regexp_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/regexp_folding.rb
@@ -48,7 +48,7 @@ module Rigor
 
         module_function
 
-        # @return [Rigor::Type, nil] folded result, or nil to defer.
+        # @rbs return: Rigor::Type? -- Folded result, or nil to defer.
         def try_dispatch(context)
           receiver = context.receiver
           method_name = context.method_name

--- a/lib/rigor/inference/method_dispatcher/set_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/set_folding.rb
@@ -27,7 +27,7 @@ module Rigor
       module SetFolding
         module_function
 
-        # @return [Rigor::Type, nil] folded result, or nil to defer.
+        # @rbs return: Rigor::Type? -- Folded result, or nil to defer.
         def try_dispatch(context)
           receiver = context.receiver
           method_name = context.method_name

--- a/lib/rigor/inference/method_dispatcher/shape_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/shape_dispatch.rb
@@ -186,10 +186,10 @@ module Rigor
           itself: :shape_self
         }.freeze
 
-        # @return [Rigor::Type, nil] the precise element/value type, or `nil` to defer to the next
-        #   dispatcher tier.
-        # Per-carrier dispatch table. Adding a new carrier here is a one-row change; the helper methods
-        # stay private. Anonymous Type subclasses are not expected.
+        # @rbs return: Rigor::Type? --
+        #   The precise element/value type, or `nil` to defer to the next dispatcher tier. Per-carrier dispatch table.
+        #   Adding a new carrier here is a one-row change; the helper methods stay private. Anonymous Type subclasses
+        #   are not expected.
         RECEIVER_HANDLERS = {
           Type::Tuple => :dispatch_tuple,
           Type::HashShape => :dispatch_hash_shape,

--- a/lib/rigor/inference/method_dispatcher/shellwords_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/shellwords_folding.rb
@@ -54,7 +54,7 @@ module Rigor
 
         module_function
 
-        # @return [Rigor::Type, nil] folded result, or nil to defer.
+        # @rbs return: Rigor::Type? -- Folded result, or nil to defer.
         def try_dispatch(context)
           receiver = context.receiver
           method_name = context.method_name

--- a/lib/rigor/inference/method_dispatcher/singleton_mixin_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/singleton_mixin_dispatch.rb
@@ -31,7 +31,7 @@ module Rigor
 
         module_function
 
-        # @return [Rigor::Type, nil] `Nominal[C]` for `C.instance`, or nil to decline.
+        # @rbs return: Rigor::Type? -- `Nominal[C]` for `C.instance`, or nil to decline.
         def try_dispatch(context)
           return nil unless context.method_name == SELECTOR
           return nil unless context.args.empty?

--- a/lib/rigor/inference/method_dispatcher/singleton_mixin_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/singleton_mixin_dispatch.rb
@@ -31,7 +31,6 @@ module Rigor
 
         module_function
 
-        # @param context [CallContext]
         # @return [Rigor::Type, nil] `Nominal[C]` for `C.instance`, or nil to decline.
         def try_dispatch(context)
           return nil unless context.method_name == SELECTOR

--- a/lib/rigor/inference/method_dispatcher/struct_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/struct_folding.rb
@@ -45,7 +45,7 @@ module Rigor
         # Issue #595 / #525 — the shared materialisation test; see {StructMaterialization}.
         extend StructMaterialization
 
-        # @return [Rigor::Type, nil] the folded result, or nil to defer.
+        # @rbs return: Rigor::Type? -- The folded result, or nil to defer.
         def try_dispatch(context)
           receiver = context.receiver
 
@@ -344,9 +344,9 @@ module Rigor
         # local's true member state at every later read on the path. A non-fold-safe local is left untouched
         # (its reads do not fold, so the binding is never consulted for folding).
         #
-        # @param call_node    [Prism::CallNode]  the `local.member = v` call
-        # @param assigned_type [Rigor::Type, nil] the setter's assigned value type (the call's own result)
-        # @return             [Rigor::Scope]     the (possibly) rebound scope
+        # @rbs call_node: Prism::CallNode -- The `local.member = v` call
+        # @rbs assigned_type: Rigor::Type? -- The setter's assigned value type (the call's own result)
+        # @rbs return: Rigor::Scope -- The (possibly) rebound scope
         def apply_setter_writeback(call_node:, assigned_type:, scope:)
           return scope if scope.nil? || assigned_type.nil?
 

--- a/lib/rigor/inference/method_dispatcher/struct_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/struct_folding.rb
@@ -346,7 +346,6 @@ module Rigor
         #
         # @param call_node    [Prism::CallNode]  the `local.member = v` call
         # @param assigned_type [Rigor::Type, nil] the setter's assigned value type (the call's own result)
-        # @param scope        [Rigor::Scope, nil]
         # @return             [Rigor::Scope]     the (possibly) rebound scope
         def apply_setter_writeback(call_node:, assigned_type:, scope:)
           return scope if scope.nil? || assigned_type.nil?

--- a/lib/rigor/inference/method_dispatcher/struct_materialization.rb
+++ b/lib/rigor/inference/method_dispatcher/struct_materialization.rb
@@ -33,8 +33,8 @@ module Rigor
         # firing off a receiver the other gate should never have called fresh.
         #
         #
-        # @param node [Prism::Node, nil] the receiver EXPRESSION.
-        # @param receiver [Rigor::Type, nil] the carrier the expression produced.
+        # @rbs node: Prism::Node? -- The receiver EXPRESSION.
+        # @rbs receiver: Rigor::Type? -- The carrier the expression produced.
         def materialization_call?(node, receiver, scope)
           return false unless node.is_a?(Prism::CallNode)
 

--- a/lib/rigor/inference/method_dispatcher/struct_materialization.rb
+++ b/lib/rigor/inference/method_dispatcher/struct_materialization.rb
@@ -35,7 +35,6 @@ module Rigor
         #
         # @param node [Prism::Node, nil] the receiver EXPRESSION.
         # @param receiver [Rigor::Type, nil] the carrier the expression produced.
-        # @param scope [Rigor::Scope, nil]
         def materialization_call?(node, receiver, scope)
           return false unless node.is_a?(Prism::CallNode)
 

--- a/lib/rigor/inference/method_dispatcher/time_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/time_folding.rb
@@ -28,7 +28,7 @@ module Rigor
 
         module_function
 
-        # @return [Rigor::Type, nil] folded result, or nil to defer.
+        # @rbs return: Rigor::Type? -- Folded result, or nil to defer.
         def try_dispatch(context)
           receiver = context.receiver
           method_name = context.method_name

--- a/lib/rigor/inference/method_dispatcher/universal_object_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/universal_object_dispatch.rb
@@ -68,7 +68,7 @@ module Rigor
 
         module_function
 
-        # @return [Rigor::Type, nil] the receiver-independent return type, or nil to decline.
+        # @rbs return: Rigor::Type? -- The receiver-independent return type, or nil to decline.
         def try_dispatch(context)
           return nil unless context.receiver.is_a?(Type::Dynamic)
 

--- a/lib/rigor/inference/method_dispatcher/universal_object_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/universal_object_dispatch.rb
@@ -68,7 +68,6 @@ module Rigor
 
         module_function
 
-        # @param context [CallContext]
         # @return [Rigor::Type, nil] the receiver-independent return type, or nil to decline.
         def try_dispatch(context)
           return nil unless context.receiver.is_a?(Type::Dynamic)

--- a/lib/rigor/inference/method_dispatcher/uri_folding.rb
+++ b/lib/rigor/inference/method_dispatcher/uri_folding.rb
@@ -61,7 +61,7 @@ module Rigor
 
         module_function
 
-        # @return [Rigor::Type, nil] folded result, or nil to defer.
+        # @rbs return: Rigor::Type? -- Folded result, or nil to defer.
         def try_dispatch(context)
           receiver = context.receiver
           method_name = context.method_name

--- a/lib/rigor/inference/method_parameter_binder.rb
+++ b/lib/rigor/inference/method_parameter_binder.rb
@@ -55,7 +55,6 @@ module Rigor
     end
 
     class MethodParameterBinder
-      # @param environment [Rigor::Environment]
       # @param class_path [String, nil] the qualified name of the class the method is defined in
       #   (e.g., `"Foo::Bar"`), or `nil` for a top-level `def` outside any class. When `nil` (or
       #   when the class is unknown to RBS), every parameter falls back to `Dynamic[Top]`.
@@ -72,7 +71,6 @@ module Rigor
         @source_path = source_path
       end
 
-      # @param def_node [Prism::DefNode]
       # @return [Hash{Symbol => Rigor::Type}] ordered map from parameter name to bound type.
       #   Anonymous parameters (`*` and `**` without a name) are skipped.
       def bind(def_node)

--- a/lib/rigor/inference/method_parameter_binder.rb
+++ b/lib/rigor/inference/method_parameter_binder.rb
@@ -55,15 +55,16 @@ module Rigor
     end
 
     class MethodParameterBinder
-      # @param class_path [String, nil] the qualified name of the class the method is defined in
-      #   (e.g., `"Foo::Bar"`), or `nil` for a top-level `def` outside any class. When `nil` (or
-      #   when the class is unknown to RBS), every parameter falls back to `Dynamic[Top]`.
-      # @param singleton [Boolean] `true` when the def is a singleton method (either `def
-      #   self.foo` or a `def foo` inside `class << self`); routes the lookup through
-      #   `RbsLoader#singleton_method`.
-      # @param source_path [String, nil] the project-relative path of the file the method is
-      #   defined in. Used to match ADR-28 path-scoped protocol contracts; `nil` (the default
-      #   for synthetic / probe scopes) disables the contract tier.
+      # @rbs class_path: String? --
+      #   The qualified name of the class the method is defined in (e.g., `"Foo::Bar"`), or `nil` for a top-level
+      #   `def` outside any class. When `nil` (or when the class is unknown to RBS), every parameter falls back to
+      #   `Dynamic[Top]`.
+      # @rbs singleton: bool --
+      #   `true` when the def is a singleton method (either `def self.foo` or a `def foo` inside `class << self`);
+      #   routes the lookup through `RbsLoader#singleton_method`.
+      # @rbs source_path: String? --
+      #   The project-relative path of the file the method is defined in. Used to match ADR-28 path-scoped protocol
+      #   contracts; `nil` (the default for synthetic / probe scopes) disables the contract tier.
       def initialize(environment:, class_path:, singleton:, source_path: nil)
         @environment = environment
         @class_path = class_path
@@ -71,8 +72,9 @@ module Rigor
         @source_path = source_path
       end
 
-      # @return [Hash{Symbol => Rigor::Type}] ordered map from parameter name to bound type.
-      #   Anonymous parameters (`*` and `**` without a name) are skipped.
+      # @rbs return: Hash[Symbol, Rigor::Type] --
+      #   Ordered map from parameter name to bound type. Anonymous parameters (`*` and `**` without a name) are
+      #   skipped.
       def bind(def_node)
         slots = collect_slots(def_node.parameters)
         types = default_types_for(slots)

--- a/lib/rigor/inference/multi_target_binder.rb
+++ b/lib/rigor/inference/multi_target_binder.rb
@@ -50,7 +50,7 @@ module Rigor
     module MultiTargetBinder
       module_function
 
-      # @param rhs_type [Rigor::Type] type of the right-hand side
+      # @rbs rhs_type: Rigor::Type -- Type of the right-hand side
       def bind(target_node, rhs_type)
         bindings = {}
         visit(target_node, rhs_type, bindings)

--- a/lib/rigor/inference/multi_target_binder.rb
+++ b/lib/rigor/inference/multi_target_binder.rb
@@ -50,9 +50,7 @@ module Rigor
     module MultiTargetBinder
       module_function
 
-      # @param target_node [Prism::MultiWriteNode, Prism::MultiTargetNode]
       # @param rhs_type [Rigor::Type] type of the right-hand side
-      # @return [Hash{Symbol => Rigor::Type}]
       def bind(target_node, rhs_type)
         bindings = {}
         visit(target_node, rhs_type, bindings)

--- a/lib/rigor/inference/mutation_widening.rb
+++ b/lib/rigor/inference/mutation_widening.rb
@@ -126,10 +126,6 @@ module Rigor
       # pre-join behaviour exactly.
       NO_ARG_TYPES = [].freeze
 
-      # @param call_node     [Prism::CallNode]
-      # @param current_scope [Rigor::Scope]
-      # @param arg_types     [Array<Rigor::Type::Base>]
-      # @return              [Rigor::Scope]
       def widen_after_call(call_node:, current_scope:, arg_types: NO_ARG_TYPES)
         return current_scope if pure_self_returner?(call_node.name)
 

--- a/lib/rigor/inference/narrowing.rb
+++ b/lib/rigor/inference/narrowing.rb
@@ -337,10 +337,6 @@ module Rigor
 
       # Public predicate analyser. Returns `[truthy_scope, falsey_scope]`, always; when no
       # narrowing rule matches the predicate node both entries are the receiver scope unchanged.
-      #
-      # @param node [Prism::Node, nil]
-      # @param scope [Rigor::Scope]
-      # @return [Array(Rigor::Scope, Rigor::Scope)]
       def predicate_scopes(node, scope)
         return [scope, scope] if node.nil?
 
@@ -369,8 +365,6 @@ module Rigor
       # @param subject [Prism::Node, nil] the `case` subject.
       # @param conditions [Array<Prism::Node>] the `when`
       #   clause's `conditions` array.
-      # @param scope [Rigor::Scope]
-      # @return [Array(Rigor::Scope, Rigor::Scope)]
       def case_when_scopes(subject, conditions, scope)
         # C1 — `case x when /re/` runs `/re/ === x`, which sets the regex match-data globals
         # exactly as a successful `=~` does. Narrow `$~`/`$&`/`$1..$N` on the clause body (the

--- a/lib/rigor/inference/narrowing.rb
+++ b/lib/rigor/inference/narrowing.rb
@@ -362,9 +362,8 @@ module Rigor
       # constants narrow as `is_a?`; integer/float-endpoint ranges narrow to `Numeric`;
       # string-endpoint ranges and regexp literals narrow to `String`.
       #
-      # @param subject [Prism::Node, nil] the `case` subject.
-      # @param conditions [Array<Prism::Node>] the `when`
-      #   clause's `conditions` array.
+      # @rbs subject: Prism::Node? -- The `case` subject.
+      # @rbs conditions: Array[Prism::Node] -- The `when` clause's `conditions` array.
       def case_when_scopes(subject, conditions, scope)
         # C1 — `case x when /re/` runs `/re/ === x`, which sets the regex match-data globals
         # exactly as a successful `=~` does. Narrow `$~`/`$&`/`$1..$N` on the clause body (the

--- a/lib/rigor/inference/optimistic_origin.rb
+++ b/lib/rigor/inference/optimistic_origin.rb
@@ -54,8 +54,6 @@ module Rigor
       # a write in value position, `if (x = MAP[k])`) resolves through, then the predicate-fold derivation
       # issue #313 added.
       #
-      # @param node [Prism::Node, nil]
-      # @param scope [Rigor::Scope, nil]
       # @return [Symbol, nil]
       def resolve(node, scope)
         return nil if node.nil? || scope.nil?
@@ -97,9 +95,7 @@ module Rigor
       # per-overload, which is what makes it precise: `Array#first` is optimistic while `Array#first(3)` is
       # not, and `String#[]` / `Enumerable#find` are honest because they already spell the miss as `?`.
       #
-      # @param method_definition [RBS::Definition::Method]
       # @param method_type [RBS::MethodType] the overload {OverloadSelector.select} returned
-      # @return [Boolean]
       def optimistic_overload?(method_definition, method_type)
         type_def = matching_type_def(method_definition, method_type)
         return false unless type_def.respond_to?(:overload_annotations)

--- a/lib/rigor/inference/optimistic_origin.rb
+++ b/lib/rigor/inference/optimistic_origin.rb
@@ -54,7 +54,7 @@ module Rigor
       # a write in value position, `if (x = MAP[k])`) resolves through, then the predicate-fold derivation
       # issue #313 added.
       #
-      # @return [Symbol, nil]
+      # @rbs return: Symbol?
       def resolve(node, scope)
         return nil if node.nil? || scope.nil?
 
@@ -95,7 +95,7 @@ module Rigor
       # per-overload, which is what makes it precise: `Array#first` is optimistic while `Array#first(3)` is
       # not, and `String#[]` / `Enumerable#find` are honest because they already spell the miss as `?`.
       #
-      # @param method_type [RBS::MethodType] the overload {OverloadSelector.select} returned
+      # @rbs method_type: RBS::MethodType -- The overload {OverloadSelector.select} returned
       def optimistic_overload?(method_definition, method_type)
         type_def = matching_type_def(method_definition, method_type)
         return false unless type_def.respond_to?(:overload_annotations)

--- a/lib/rigor/inference/origin_lookup.rb
+++ b/lib/rigor/inference/origin_lookup.rb
@@ -18,7 +18,6 @@ module Rigor
     module OriginLookup
       module_function
 
-      # @param scope [Rigor::Scope]
       # @param node [Prism::Node, nil] the receiver expression's node (nil for an implicit-self receiver)
       # @return [Symbol, nil] the effective dynamic-origin cause, or nil when none is known
       def origin_for(scope, node)

--- a/lib/rigor/inference/origin_lookup.rb
+++ b/lib/rigor/inference/origin_lookup.rb
@@ -18,8 +18,8 @@ module Rigor
     module OriginLookup
       module_function
 
-      # @param node [Prism::Node, nil] the receiver expression's node (nil for an implicit-self receiver)
-      # @return [Symbol, nil] the effective dynamic-origin cause, or nil when none is known
+      # @rbs node: Prism::Node? -- The receiver expression's node (nil for an implicit-self receiver)
+      # @rbs return: Symbol? -- The effective dynamic-origin cause, or nil when none is known
       def origin_for(scope, node)
         return nil if node.nil?
 

--- a/lib/rigor/inference/parameter_inference_collector.rb
+++ b/lib/rigor/inference/parameter_inference_collector.rb
@@ -117,7 +117,6 @@ module Rigor
       DEFAULT_ROUNDS = 3
 
       # @param files [Array<String>] project `.rb` paths to scan for call sites.
-      # @param environment [Rigor::Environment]
       # @param target_ruby [String, nil] Prism parse target.
       # @param max_rounds [Integer] the WD5 fixpoint cap (1 = single-level).
       # @return [Hash{[String,Symbol,Symbol] => Hash{Symbol => Rigor::Type}}] frozen.

--- a/lib/rigor/inference/parameter_inference_collector.rb
+++ b/lib/rigor/inference/parameter_inference_collector.rb
@@ -116,10 +116,10 @@ module Rigor
       # single-level pass.
       DEFAULT_ROUNDS = 3
 
-      # @param files [Array<String>] project `.rb` paths to scan for call sites.
-      # @param target_ruby [String, nil] Prism parse target.
-      # @param max_rounds [Integer] the WD5 fixpoint cap (1 = single-level).
-      # @return [Hash{[String,Symbol,Symbol] => Hash{Symbol => Rigor::Type}}] frozen.
+      # @rbs files: Array[String] -- Project `.rb` paths to scan for call sites.
+      # @rbs target_ruby: String? -- Prism parse target.
+      # @rbs max_rounds: Integer -- The WD5 fixpoint cap (1 = single-level).
+      # @rbs return: Hash[[String, Symbol, Symbol], Hash[Symbol, Rigor::Type]] -- Frozen.
       def self.collect(files:, environment:, target_ruby: nil, max_rounds: DEFAULT_ROUNDS, workers: 0)
         new(files: files, environment: environment, target_ruby: target_ruby,
             max_rounds: max_rounds, workers: workers).collect
@@ -329,7 +329,7 @@ module Rigor
           arg.is_a?(Prism::AssocSplatNode)
       end
 
-      # @return [[String, Symbol, Symbol, Prism::DefNode], nil]
+      # @rbs return: [String, Symbol, Symbol, Prism::DefNode]?
       def resolve_callee(call_node, scope, index)
         if call_node.receiver.nil?
           class_name, kind = implicit_self_target(scope)

--- a/lib/rigor/inference/pre_eval_constants.rb
+++ b/lib/rigor/inference/pre_eval_constants.rb
@@ -92,13 +92,15 @@ module Rigor
 
       # Collects and widens the constants every `pre_eval:` file declares.
       #
-      # @param paths [Array<String>] absolute paths to the `pre_eval:` files that exist on disk.
-      # @param scope_builder [#call] `path -> Rigor::Scope`; the caller supplies a project-seeded, environment-
-      #   bound scope so the rvalue typer resolves cross-file classes exactly as per-file analysis would.
-      # @param target_ruby [String, nil] the Prism parse version (`Configuration#target_ruby`).
-      # @param buffer [Rigor::Analysis::BufferBinding, nil] editor-mode binding; when set, a listed file that
-      #   matches the in-flight buffer is read from its physical bytes.
-      # @return [Hash{String => Rigor::Type}] frozen qualified-name -> published type table.
+      # @rbs paths: Array[String] -- Absolute paths to the `pre_eval:` files that exist on disk.
+      # @rbs scope_builder: untyped --
+      #   `path -> Rigor::Scope`; the caller supplies a project-seeded, environment- bound scope so the rvalue typer
+      #   resolves cross-file classes exactly as per-file analysis would.
+      # @rbs target_ruby: String? -- The Prism parse version (`Configuration#target_ruby`).
+      # @rbs buffer: Rigor::Analysis::BufferBinding? --
+      #   Editor-mode binding; when set, a listed file that matches the in-flight buffer is read from its physical
+      #   bytes.
+      # @rbs return: Hash[String, Rigor::Type] -- Frozen qualified-name -> published type table.
       def collect(paths:, scope_builder:, target_ruby: nil, buffer: nil)
         published = {}
         conflicted = {}

--- a/lib/rigor/inference/precision_scanner.rb
+++ b/lib/rigor/inference/precision_scanner.rb
@@ -122,12 +122,12 @@ module Rigor
         end
       end
 
-      # @param scope [Rigor::Scope] base scope for type inference.
+      # @rbs scope: Rigor::Scope -- Base scope for type inference.
       def initialize(scope: nil)
         @scope = scope || Scope.empty
       end
 
-      # @param root [Prism::Node] the parsed AST
+      # @rbs root: Prism::Node -- The parsed AST
       def scan(root)
         scope_index = ScopeIndexer.index(root, default_scope: @scope)
         tier_counts = TIERS.to_h { |t| [t, 0] }

--- a/lib/rigor/inference/precision_scanner.rb
+++ b/lib/rigor/inference/precision_scanner.rb
@@ -128,7 +128,6 @@ module Rigor
       end
 
       # @param root [Prism::Node] the parsed AST
-      # @return [FileResult]
       def scan(root)
         scope_index = ScopeIndexer.index(root, default_scope: @scope)
         tier_counts = TIERS.to_h { |t| [t, 0] }

--- a/lib/rigor/inference/project_patched_methods.rb
+++ b/lib/rigor/inference/project_patched_methods.rb
@@ -28,9 +28,10 @@ module Rigor
 
       attr_reader :by_key
 
-      # @param entries [Array<Entry>] flat list of declarations observed during the pre-pass.
-      #   First-write-wins on `(class_name, method_name, kind)` duplicates so the
-      #   `pre-eval.duplicate-declaration` diagnostic emission stays decoupled from registry behaviour.
+      # @rbs entries: Array[Entry] --
+      #   Flat list of declarations observed during the pre-pass. First-write-wins on `(class_name, method_name,
+      #   kind)` duplicates so the `pre-eval.duplicate-declaration` diagnostic emission stays decoupled from registry
+      #   behaviour.
       def initialize(entries: [])
         @by_key = entries.each_with_object({}) do |entry, acc|
           key = [entry.class_name, entry.method_name, entry.kind]
@@ -39,8 +40,9 @@ module Rigor
         freeze
       end
 
-      # @return [Entry, nil] the recorded entry for the given `(class_name, method_name, kind)` triple,
-      #   or `nil` when no pre-eval file declared it.
+      # @rbs return: Entry? --
+      #   The recorded entry for the given `(class_name, method_name, kind)` triple, or `nil` when no pre-eval file
+      #   declared it.
       def lookup(class_name:, method_name:, kind:)
         @by_key[[class_name, method_name, kind]]
       end

--- a/lib/rigor/inference/project_patched_scanner.rb
+++ b/lib/rigor/inference/project_patched_scanner.rb
@@ -31,13 +31,13 @@ module Rigor
 
       module_function
 
-      # @param paths [Array<String>] absolute paths to the pre-eval files. The runner has already
-      #   validated that each path exists (slice-1 `pre-eval.file-not-found` `:error` covers missing
-      #   entries); the scanner does NOT re-check existence.
-      # @param buffer [Rigor::Analysis::BufferBinding, nil] editor-mode buffer binding. When set, the
-      #   scanner reads the buffer's physical bytes if a pre-eval entry matches the logical path, so
-      #   users editing a monkey-patch file see the in-flight version in their analysis.
-      # @return [Result] the populated registry plus any per-file warnings.
+      # @rbs paths: Array[String] --
+      #   Absolute paths to the pre-eval files. The runner has already validated that each path exists (slice-1
+      #   `pre-eval.file-not-found` `:error` covers missing entries); the scanner does NOT re-check existence.
+      # @rbs buffer: Rigor::Analysis::BufferBinding? --
+      #   Editor-mode buffer binding. When set, the scanner reads the buffer's physical bytes if a pre-eval entry
+      #   matches the logical path, so users editing a monkey-patch file see the in-flight version in their analysis.
+      # @rbs return: Result -- The populated registry plus any per-file warnings.
       def scan(paths, buffer: nil)
         entries = []
         diagnostics = []

--- a/lib/rigor/inference/protection_scanner.rb
+++ b/lib/rigor/inference/protection_scanner.rb
@@ -38,7 +38,6 @@ module Rigor
       end
 
       # @param root [Prism::Node] the parsed AST
-      # @return [FileResult]
       def scan(root)
         index = ScopeIndexer.index(root, default_scope: @scope)
         protected_count = 0

--- a/lib/rigor/inference/protection_scanner.rb
+++ b/lib/rigor/inference/protection_scanner.rb
@@ -37,7 +37,7 @@ module Rigor
         @scope = scope || Scope.empty
       end
 
-      # @param root [Prism::Node] the parsed AST
+      # @rbs root: Prism::Node -- The parsed AST
       def scan(root)
         index = ScopeIndexer.index(root, default_scope: @scope)
         protected_count = 0

--- a/lib/rigor/inference/rbs_type_translator.rb
+++ b/lib/rigor/inference/rbs_type_translator.rb
@@ -101,14 +101,15 @@ module Rigor
       private_constant :ALIAS_EXPANSION_LIMIT
 
       class << self
-        # @param self_type [Rigor::Type, nil] substitute for `Bases::Self`.
-        # @param instance_type [Rigor::Type, nil] substitute for `Bases::Instance`. Defaults to `nil`,
-        #   which degrades to Dynamic[Top].
-        # @param type_vars [Hash{Symbol => Rigor::Type}] substitution map for `Bases::Variable`. Keys
-        #   are the RBS variable names (e.g., `:Elem`); values are Rigor types that replace the
-        #   variable. Variables that are not bound in the map degrade to Dynamic[Top].
-        # @param alias_expander [#expand_type_alias, nil] resolves `RBS::Types::Alias` one level out —
-        #   in practice the environment's `RbsLoader`. When nil, aliases degrade to Dynamic[Top].
+        # @rbs self_type: Rigor::Type? -- Substitute for `Bases::Self`.
+        # @rbs instance_type: Rigor::Type? --
+        #   Substitute for `Bases::Instance`. Defaults to `nil`, which degrades to Dynamic[Top].
+        # @rbs type_vars: Hash[Symbol, Rigor::Type] --
+        #   Substitution map for `Bases::Variable`. Keys are the RBS variable names (e.g., `:Elem`); values are Rigor
+        #   types that replace the variable. Variables that are not bound in the map degrade to Dynamic[Top].
+        # @rbs alias_expander: untyped --
+        #   Resolves `RBS::Types::Alias` one level out — in practice the environment's `RbsLoader`. When nil, aliases
+        #   degrade to Dynamic[Top].
         def translate(rbs_type, self_type: nil, instance_type: nil, type_vars: EMPTY_TYPE_VARS,
                       alias_expander: nil)
           translate_in(rbs_type, Context.new(self_type, instance_type, type_vars, alias_expander, 0))

--- a/lib/rigor/inference/rbs_type_translator.rb
+++ b/lib/rigor/inference/rbs_type_translator.rb
@@ -101,7 +101,6 @@ module Rigor
       private_constant :ALIAS_EXPANSION_LIMIT
 
       class << self
-        # @param rbs_type [RBS::Types::Bases::Base, RBS::Types::ClassInstance, ...]
         # @param self_type [Rigor::Type, nil] substitute for `Bases::Self`.
         # @param instance_type [Rigor::Type, nil] substitute for `Bases::Instance`. Defaults to `nil`,
         #   which degrades to Dynamic[Top].
@@ -110,7 +109,6 @@ module Rigor
         #   variable. Variables that are not bound in the map degrade to Dynamic[Top].
         # @param alias_expander [#expand_type_alias, nil] resolves `RBS::Types::Alias` one level out —
         #   in practice the environment's `RbsLoader`. When nil, aliases degrade to Dynamic[Top].
-        # @return [Rigor::Type]
         def translate(rbs_type, self_type: nil, instance_type: nil, type_vars: EMPTY_TYPE_VARS,
                       alias_expander: nil)
           translate_in(rbs_type, Context.new(self_type, instance_type, type_vars, alias_expander, 0))

--- a/lib/rigor/inference/receiver_alias.rb
+++ b/lib/rigor/inference/receiver_alias.rb
@@ -30,10 +30,10 @@ module Rigor
 
       module_function
 
-      # @param node  [Prism::Node, nil] the receiver expression.
-      # @param depth [Integer] recursion depth, internal.
-      # @return [Array<Prism::LocalVariableReadNode, Prism::InstanceVariableReadNode>] every variable
-      #   read the expression can evaluate to; empty when it can evaluate to none.
+      # @rbs node: Prism::Node? -- The receiver expression.
+      # @rbs depth: Integer -- Recursion depth, internal.
+      # @rbs return: Array[Prism::LocalVariableReadNode | Prism::InstanceVariableReadNode] --
+      #   Every variable read the expression can evaluate to; empty when it can evaluate to none.
       def candidates(node, depth = 0)
         return [] if node.nil? || depth > WALK_DEPTH_CAP
 

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -50,18 +50,16 @@ module Rigor
 
       # Build the scope index for a Prism program subtree.
       #
-      # @param root [Prism::Node] usually a `Prism::ProgramNode`, but any
-      #   subtree the caller wants the indexer to walk works.
-      # @param default_scope [Rigor::Scope] the scope used for the root,
-      #   and the fallback returned for any Prism node not contained in
-      #   `root`'s subtree.
-      # @param converged_loop_recording [Boolean] display-path flag —
-      #   when true the evaluator re-records fixpoint-tracked loop
-      #   bodies from their CONVERGED bindings so per-line probes
-      #   (`rigor annotate`) reflect the post-writeback state, not the
-      #   cap-N intermediate constants. Off for the check path.
-      # @return [Hash{Prism::Node => Rigor::Scope}] identity-comparing
-      #   table whose default value is `default_scope`.
+      # @rbs root: Prism::Node --
+      #   Usually a `Prism::ProgramNode`, but any subtree the caller wants the indexer to walk works.
+      # @rbs default_scope: Rigor::Scope --
+      #   The scope used for the root, and the fallback returned for any Prism node not contained in `root`'s subtree.
+      # @rbs converged_loop_recording: bool --
+      #   Display-path flag — when true the evaluator re-records fixpoint-tracked loop bodies from their CONVERGED
+      #   bindings so per-line probes (`rigor annotate`) reflect the post-writeback state, not the cap-N intermediate
+      #   constants. Off for the check path.
+      # @rbs return: Hash[Prism::Node, Rigor::Scope] --
+      #   Identity-comparing table whose default value is `default_scope`.
       def index(root, default_scope:, converged_loop_recording: false) # rubocop:disable Metrics/AbcSize
         # Slice A-declarations. Build the declaration overrides first so every scope handed to the StatementEvaluator
         # already carries the table; structural sharing through `Scope#with_local` / `#with_fact` / `#with_self_type`
@@ -1476,9 +1474,10 @@ module Rigor
       # is a known in-place mutator (`MutationWidening`'s tables) or a plain attribute/index writer
       # (`name=` / `[]=`). Non-mutating reads never register, so `VERSION`-style constants keep their fold.
       #
-      # @return [Hash{Symbol => Object}] `:constants` — a Set of candidate qualified names (each mutation
-      #   contributes every lexical-resolution candidate, `A::B::C` outward to bare `C`, mirroring how the
-      #   reads resolve); `:cvars` — `{class_name => Set[Symbol]}`.
+      # @rbs return: Hash[Symbol, untyped] --
+      #   `:constants` — a Set of candidate qualified names (each mutation contributes every lexical-resolution
+      #   candidate, `A::B::C` outward to bare `C`, mirroring how the reads resolve); `:cvars` — `{class_name =>
+      #   Set[Symbol]}`.
       def collect_literal_receiver_mutations(root)
         census = { constants: Set.new, cvars: Hash.new { |h, k| h[k] = Set.new } }
         walk_literal_receiver_mutations(root, [], census, EMPTY_NESTING)
@@ -2450,7 +2449,7 @@ module Rigor
       # the enclosing cref — `[]` for the first spelling, `["Admin"]` for the second. A class reopened under two
       # spellings keeps the LAST one walked, matching how `superclasses` itself merges.
       #
-      # @return [Array(Hash{String=>String}, Hash{String=>Array[String]})] `[superclasses, header_nestings]`
+      # @rbs return: [Hash[String, String], Hash[String, Array[String]]] -- `[superclasses, header_nestings]`
       def build_superclass_tables(root, source_path = nil)
         accumulator = { superclasses: {}, header_nestings: {} }
         walk_class_superclasses(root, [], accumulator, source_path)
@@ -3190,7 +3189,7 @@ module Rigor
       # `Singleton[Object]` fallback anyway. The residual leak is `Class`-only (`M.new`, `M.superclass`), which mistypes
       # only code that raises `NoMethodError` at runtime.
       #
-      # @param paths [Array<String>] project file paths.
+      # @rbs paths: Array[String] -- Project file paths.
       def discovered_classes_for_paths(paths, buffer: nil)
         accumulator = {}
         paths.each do |path|
@@ -3218,8 +3217,8 @@ module Rigor
       # monkey-patch on a core/stdlib/gem class is called cross-file (ADR-17). First write wins, matching `def_nodes`'
       # own merge order.
       #
-      # @param paths [Array<String>] project file paths.
-      #   `{ def_nodes:, def_sources:, superclasses:, includes:, class_sources: }`
+      # @rbs paths: Array[String] --
+      #   Project file paths. `{ def_nodes:, def_sources:, superclasses:, includes:, class_sources: }`
       def discovered_def_index_for_paths(paths, buffer: nil)
         acc = new_def_index_accumulator
         paths.each do |path|
@@ -3241,7 +3240,7 @@ module Rigor
       # all of them (recon §2 dedup). A per-file live index (built + folded, exactly as
       # {#discovered_project_index_incremental}'s changed-file branch) yields the live def nodes the signature
       # reads their parameter structure from.
-      # @return [Hash{Symbol => Object}] `{ def_index:, code_fingerprints:, declaration_signatures: }`.
+      # @rbs return: Hash[Symbol, untyped] -- `{ def_index:, code_fingerprints:, declaration_signatures: }`.
       def scan_summary_for_paths(paths, buffer: nil)
         acc = new_def_index_accumulator
         code_fingerprints = {}
@@ -3431,8 +3430,8 @@ module Rigor
       # rescue's real target) contributes nothing to either table. The subset-scoped callers
       # ({IncrementalSession}, `coverage --protection`) keep calling the individual methods unchanged.
       #
-      # @param paths [Array<String>] project file paths.
-      # @return [Hash{Symbol => Object}] `{ classes: Hash, def_index: Hash }`.
+      # @rbs paths: Array[String] -- Project file paths.
+      # @rbs return: Hash[Symbol, untyped] -- `{ classes: Hash, def_index: Hash }`.
       def discovered_project_index_for_paths(paths, buffer: nil)
         classes = {}
         acc = new_def_index_accumulator
@@ -3461,9 +3460,10 @@ module Rigor
       # lazily. On a cold run (`seed_bundles` empty) every file is re-walked, so the index is entirely live —
       # identical to {#discovered_project_index_for_paths} — while the bundles are built for the next run.
       #
-      # @param paths [Array<String>] project file paths, in canonical order.
-      # @param seed_bundles [Hash{String => Hash}] the prior run's per-file bundles, keyed by logical path.
-      # @return [Hash{Symbol => Object}] `{ classes:, def_index:, bundles: }`.
+      # @rbs paths: Array[String] -- Project file paths, in canonical order.
+      # @rbs seed_bundles: Hash[String, Hash[untyped, untyped]] --
+      #   The prior run's per-file bundles, keyed by logical path.
+      # @rbs return: Hash[Symbol, untyped] -- `{ classes:, def_index:, bundles: }`.
       def discovered_project_index_incremental(paths, seed_bundles:, buffer: nil)
         classes = {}
         acc = new_def_index_accumulator
@@ -3975,7 +3975,7 @@ module Rigor
       # fold time) so the fold stays order-independent, which is what lets the ADR-85 incremental path re-fold
       # a changed file's contribution in place.
       #
-      # @return [Array(Hash, Hash)] `[{name => Type}, {name => Set[path]}]`.
+      # @rbs return: [Hash[untyped, untyped], Hash[untyped, untyped]] -- `[{name => Type}, {name => Set[path]}]`.
       def finalize_constant_writes(writes)
         values = {}
         sources = {}

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -3191,8 +3191,6 @@ module Rigor
       # only code that raises `NoMethodError` at runtime.
       #
       # @param paths [Array<String>] project file paths.
-      # @param buffer [Rigor::Analysis::BufferBinding, nil]
-      # @return [Hash{String => Rigor::Type::Singleton}]
       def discovered_classes_for_paths(paths, buffer: nil)
         accumulator = {}
         paths.each do |path|
@@ -3221,8 +3219,6 @@ module Rigor
       # own merge order.
       #
       # @param paths [Array<String>] project file paths.
-      # @param buffer [Rigor::Analysis::BufferBinding, nil]
-      # @return [Hash{Symbol => Hash}]
       #   `{ def_nodes:, def_sources:, superclasses:, includes:, class_sources: }`
       def discovered_def_index_for_paths(paths, buffer: nil)
         acc = new_def_index_accumulator
@@ -3436,7 +3432,6 @@ module Rigor
       # ({IncrementalSession}, `coverage --protection`) keep calling the individual methods unchanged.
       #
       # @param paths [Array<String>] project file paths.
-      # @param buffer [Rigor::Analysis::BufferBinding, nil]
       # @return [Hash{Symbol => Object}] `{ classes: Hash, def_index: Hash }`.
       def discovered_project_index_for_paths(paths, buffer: nil)
         classes = {}
@@ -3468,7 +3463,6 @@ module Rigor
       #
       # @param paths [Array<String>] project file paths, in canonical order.
       # @param seed_bundles [Hash{String => Hash}] the prior run's per-file bundles, keyed by logical path.
-      # @param buffer [Rigor::Analysis::BufferBinding, nil]
       # @return [Hash{Symbol => Object}] `{ classes:, def_index:, bundles: }`.
       def discovered_project_index_incremental(paths, seed_bundles:, buffer: nil)
         classes = {}

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -3231,7 +3231,6 @@ module Rigor
           root = Prism.parse(File.read(physical), filepath: path).value
           accumulate_project_index(acc, path, root)
         rescue StandardError
-          # Skip files that fail to parse or read; the per-file analyzer surfaces the parse error separately.
           next
         end
         finalize_def_index(acc)
@@ -3448,7 +3447,6 @@ module Rigor
           collect_class_decls(root, [], classes)
           accumulate_project_index(acc, path, root)
         rescue StandardError
-          # Skip files that fail to parse or read; the per-file analyzer surfaces the parse error separately.
           next
         end
         { classes: classes.freeze, def_index: finalize_def_index(acc) }

--- a/lib/rigor/inference/statement_evaluator.rb
+++ b/lib/rigor/inference/statement_evaluator.rb
@@ -145,8 +145,6 @@ module Rigor
       EMPTY_NESTING = [].freeze
       private_constant :EMPTY_NESTING
 
-      # @param scope [Rigor::Scope]
-      # @param tracer [Rigor::Inference::FallbackTracer, nil]
       # @param on_enter [#call, nil] optional `(node, scope) ->` callable
       #   invoked once at the start of every {#evaluate} call (the node
       #   itself, *before* its handler runs). Threaded through every
@@ -195,9 +193,6 @@ module Rigor
 
       # Evaluate `node` under the receiver scope. Returns `[type, scope']` where `type` is the value the node produces
       # and `scope'` is the scope observable after the node has run. The receiver scope is never mutated.
-      #
-      # @param node [Prism::Node]
-      # @return [Array(Rigor::Type, Rigor::Scope)]
       def evaluate(node)
         @on_enter&.call(node, @scope)
 

--- a/lib/rigor/inference/statement_evaluator.rb
+++ b/lib/rigor/inference/statement_evaluator.rb
@@ -145,25 +145,20 @@ module Rigor
       EMPTY_NESTING = [].freeze
       private_constant :EMPTY_NESTING
 
-      # @param on_enter [#call, nil] optional `(node, scope) ->` callable
-      #   invoked once at the start of every {#evaluate} call (the node
-      #   itself, *before* its handler runs). Threaded through every
-      #   recursive `sub_eval` so the tooling that builds a per-node
-      #   scope index (`Rigor::Inference::ScopeIndexer`) can record the
-      #   entry scope for every Prism node the evaluator visits without
-      #   the StatementEvaluator carrying any additional state itself.
-      # @param class_context [Array<ClassFrame>] lexical class scope used
-      #   by {#eval_def} to look up the method's RBS signature. Each
-      #   `ClassNode`/`ModuleNode` entry pushes a frame; `SingletonClassNode`
-      #   over `self` flips the innermost frame to singleton mode.
-      # @param converged_loop_recording [Boolean] when true (and an
-      #   `on_enter` recorder is installed), {#eval_loop} re-evaluates a
-      #   fixpoint-tracked loop body ONE extra time from the CONVERGED
-      #   bindings so the last-visit-wins per-node scope index reflects
-      #   the post-writeback state instead of the cap-N intermediate
-      #   assumption (`result *= i` annotating `1 | 2` rather than
-      #   `Integer`). Display-path only — `rigor check` leaves it off,
-      #   keeping its diagnostics and wall-clock unchanged.
+      # @rbs on_enter: untyped --
+      #   Optional `(node, scope) ->` callable invoked once at the start of every {#evaluate} call (the node itself,
+      #   *before* its handler runs). Threaded through every recursive `sub_eval` so the tooling that builds a
+      #   per-node scope index (`Rigor::Inference::ScopeIndexer`) can record the entry scope for every Prism node the
+      #   evaluator visits without the StatementEvaluator carrying any additional state itself.
+      # @rbs class_context: Array[ClassFrame] --
+      #   Lexical class scope used by {#eval_def} to look up the method's RBS signature. Each `ClassNode`/`ModuleNode`
+      #   entry pushes a frame; `SingletonClassNode` over `self` flips the innermost frame to singleton mode.
+      # @rbs converged_loop_recording: bool --
+      #   When true (and an `on_enter` recorder is installed), {#eval_loop} re-evaluates a fixpoint-tracked loop body
+      #   ONE extra time from the CONVERGED bindings so the last-visit-wins per-node scope index reflects the
+      #   post-writeback state instead of the cap-N intermediate assumption (`result *= i` annotating `1 | 2` rather
+      #   than `Integer`). Display-path only — `rigor check` leaves it off, keeping its diagnostics and wall-clock
+      #   unchanged.
       def initialize(scope:, tracer: nil, on_enter: nil, class_context: [].freeze,
                      lexical_nesting: EMPTY_NESTING, converged_loop_recording: false)
         @scope = scope

--- a/lib/rigor/inference/struct_fold_safety.rb
+++ b/lib/rigor/inference/struct_fold_safety.rb
@@ -208,7 +208,6 @@ module Rigor
       # Nested `def` / `class` / `module` bodies are skipped: their statements do not run during THIS body's
       # evaluation. Blocks are descended into — they share `self`.
       #
-      # @param body [Prism::Node, nil]
       # @param member_names [Enumerable<Symbol>] the receiver carrier's member names.
       # @yieldparam name [Symbol] an unrecognised self-call selector.
       # @yieldreturn [Boolean] whether that sibling method is itself self-fold-safe.

--- a/lib/rigor/inference/struct_fold_safety.rb
+++ b/lib/rigor/inference/struct_fold_safety.rb
@@ -55,10 +55,10 @@ module Rigor
           node.is_a?(Prism::ModuleNode) || node.is_a?(Prism::SingletonClassNode)
       end
 
-      # @param root [Prism::Node, nil] the local-variable scope to scan.
-      # @param layout_lookup [#call] a `String -> Array[Symbol] | nil` resolver mapping a constant receiver name to its
-      #   struct member list.
-      # @return [Set<Symbol>] the fold-safe local names.
+      # @rbs root: Prism::Node? -- The local-variable scope to scan.
+      # @rbs layout_lookup: untyped --
+      #   A `String -> Array[Symbol] | nil` resolver mapping a constant receiver name to its struct member list.
+      # @rbs return: Set[Symbol] -- The fold-safe local names.
       def fold_safe_locals(root, layout_lookup)
         return EMPTY if root.nil?
 
@@ -208,9 +208,9 @@ module Rigor
       # Nested `def` / `class` / `module` bodies are skipped: their statements do not run during THIS body's
       # evaluation. Blocks are descended into — they share `self`.
       #
-      # @param member_names [Enumerable<Symbol>] the receiver carrier's member names.
-      # @yieldparam name [Symbol] an unrecognised self-call selector.
-      # @yieldreturn [Boolean] whether that sibling method is itself self-fold-safe.
+      # @rbs member_names: Enumerable[Symbol] --
+      #   The receiver carrier's member names. An unrecognised self-call selector. Whether that sibling method is
+      #   itself self-fold-safe.
       def self_fold_safe_body?(body, member_names, &sibling_pure)
         return false if body.nil?
 

--- a/lib/rigor/inference/synthetic_method_index.rb
+++ b/lib/rigor/inference/synthetic_method_index.rb
@@ -22,11 +22,11 @@ module Rigor
     class SyntheticMethodIndex
       attr_reader :entries, :class_names
 
-      # @param class_names [Array<String>, Set<String>] names of classes the substrate synthesises wholesale (ADR-36
-      #   nested-class emission — the variant subclasses that have no RBS/source declaration of their own). Recorded so
-      #   `Environment#class_known?` can resolve them as classes (their constant reference + `.new` dispatch) even
-      #   though nothing else in the type universe declares them. Tier B/C method emissions leave this empty (their
-      #   receiver classes are already real).
+      # @rbs class_names: Array[String>, Set<String] --
+      #   Names of classes the substrate synthesises wholesale (ADR-36 nested-class emission — the variant subclasses
+      #   that have no RBS/source declaration of their own). Recorded so `Environment#class_known?` can resolve them
+      #   as classes (their constant reference + `.new` dispatch) even though nothing else in the type universe
+      #   declares them. Tier B/C method emissions leave this empty (their receiver classes are already real).
       def initialize(entries: [], class_names: [])
         unless entries.is_a?(Array) && entries.all?(SyntheticMethod)
           raise ArgumentError,

--- a/lib/rigor/inference/synthetic_method_index.rb
+++ b/lib/rigor/inference/synthetic_method_index.rb
@@ -22,7 +22,6 @@ module Rigor
     class SyntheticMethodIndex
       attr_reader :entries, :class_names
 
-      # @param entries [Array<SyntheticMethod>]
       # @param class_names [Array<String>, Set<String>] names of classes the substrate synthesises wholesale (ADR-36
       #   nested-class emission — the variant subclasses that have no RBS/source declaration of their own). Recorded so
       #   `Environment#class_known?` can resolve them as classes (their constant reference + `.new` dispatch) even

--- a/lib/rigor/inference/synthetic_method_scanner.rb
+++ b/lib/rigor/inference/synthetic_method_scanner.rb
@@ -40,22 +40,14 @@ module Rigor
     module SyntheticMethodScanner # rubocop:disable Metrics/ModuleLength
       module_function
 
-      # @param paths [Array<String>] absolute paths to the project
-      #   source files to scan.
-      # @param environment [Rigor::Environment, nil] used for
-      #   inheritance resolution against RBS-known classes
-      #   (ActiveRecord::Base, Dry::Struct, etc.) that aren't
-      #   declared in project source.
-      #   the per-run cross-plugin fact store. ADR-18 lookups
-      #   (`Plugin::Macro::HeredocTemplate::Emit#returns_from_arg`)
-      #   consult this at scan time to resolve per-call-site
-      #   return types from published facts; without it, those
-      #   emit rows fall back to their static `returns:` (or
-      #   `"untyped"` → `Dynamic[Top]`).
-      #   editor-mode buffer binding. When set, reads for the
-      #   logical path resolve to the buffer's physical path so
-      #   the pre-pass sees the in-flight bytes instead of the
-      #   on-disk copy.
+      # @rbs paths: Array[String] -- Absolute paths to the project source files to scan.
+      # @rbs environment: Rigor::Environment? --
+      #   Used for inheritance resolution against RBS-known classes (ActiveRecord::Base, Dry::Struct, etc.) that
+      #   aren't declared in project source. the per-run cross-plugin fact store. ADR-18 lookups
+      #   (`Plugin::Macro::HeredocTemplate::Emit#returns_from_arg`) consult this at scan time to resolve per-call-site
+      #   return types from published facts; without it, those emit rows fall back to their static `returns:` (or
+      #   `"untyped"` → `Dynamic[Top]`). editor-mode buffer binding. When set, reads for the logical path resolve to
+      #   the buffer's physical path so the pre-pass sees the in-flight bytes instead of the on-disk copy.
       def scan(plugin_registry:, paths:, environment: nil, fact_store: nil, buffer: nil)
         templates = collect_templates(plugin_registry)
         registries = collect_trait_registries(plugin_registry)

--- a/lib/rigor/inference/synthetic_method_scanner.rb
+++ b/lib/rigor/inference/synthetic_method_scanner.rb
@@ -40,26 +40,22 @@ module Rigor
     module SyntheticMethodScanner # rubocop:disable Metrics/ModuleLength
       module_function
 
-      # @param plugin_registry [Rigor::Plugin::Registry]
       # @param paths [Array<String>] absolute paths to the project
       #   source files to scan.
       # @param environment [Rigor::Environment, nil] used for
       #   inheritance resolution against RBS-known classes
       #   (ActiveRecord::Base, Dry::Struct, etc.) that aren't
       #   declared in project source.
-      # @param fact_store [Rigor::Plugin::FactStore, nil]
       #   the per-run cross-plugin fact store. ADR-18 lookups
       #   (`Plugin::Macro::HeredocTemplate::Emit#returns_from_arg`)
       #   consult this at scan time to resolve per-call-site
       #   return types from published facts; without it, those
       #   emit rows fall back to their static `returns:` (or
       #   `"untyped"` → `Dynamic[Top]`).
-      # @param buffer [Rigor::Analysis::BufferBinding, nil]
       #   editor-mode buffer binding. When set, reads for the
       #   logical path resolve to the buffer's physical path so
       #   the pre-pass sees the in-flight bytes instead of the
       #   on-disk copy.
-      # @return [Rigor::Inference::SyntheticMethodIndex]
       def scan(plugin_registry:, paths:, environment: nil, fact_store: nil, buffer: nil)
         templates = collect_templates(plugin_registry)
         registries = collect_trait_registries(plugin_registry)

--- a/lib/rigor/inference/version_guard.rb
+++ b/lib/rigor/inference/version_guard.rb
@@ -88,9 +88,10 @@ module Rigor
       GEM_VERSION_PATH = "Gem::Version"
       private_constant :GEM_VERSION_PATH
 
-      # @param node [Prism::Node, nil] an `if` / `unless` predicate
-      # @return [Symbol, nil] `:truthy` / `:falsey` when the guard is decidable on the analyzer's Ruby,
-      #   otherwise nil (both arms stay live)
+      # @rbs node: Prism::Node? -- An `if` / `unless` predicate
+      # @rbs return: Symbol? --
+      #   `:truthy` / `:falsey` when the guard is decidable on the analyzer's Ruby, otherwise nil (both arms stay
+      #   live)
       def verdict(node)
         return nil unless node.is_a?(Prism::CallNode)
 
@@ -110,7 +111,7 @@ module Rigor
 
       # Reads one side of the comparison into `[kind, value]`, or nil when it is not readable.
       #
-      # @return [Array(Symbol, Object), nil]
+      # @rbs return: [Symbol, untyped]?
       def read_operand(node)
         case node
         when Prism::StringNode then [:literal_string, node.unescaped]
@@ -165,7 +166,7 @@ module Rigor
       # `const_get` would execute the target file inside the analyzer. `Module#autoload?` is what
       # separates the two ([#680](https://github.com/rigortype/rigor/issues/680)).
       #
-      # @return [String, nil] the constant's value when it is a non-empty String
+      # @rbs return: String? -- The constant's value when it is a non-empty String
       def runtime_value(path)
         mod = ::Object
         path.split("::").each do |part|

--- a/lib/rigor/inference/void_tail_summary.rb
+++ b/lib/rigor/inference/void_tail_summary.rb
@@ -75,9 +75,9 @@ module Rigor
       # consult; the memo persists across consults for the run. The memo is probed before the visited
       # set is allocated so the common post-warmup hit path allocates nothing.
       #
-      # @param owner [String] the qualified receiver class the `def` belongs to.
-      # @param kind [Symbol] `:instance` or `:singleton`.
-      # @return [Inference::VoidOrigin, nil]
+      # @rbs owner: String -- The qualified receiver class the `def` belongs to.
+      # @rbs kind: :instance | :singleton
+      # @rbs return: Inference::VoidOrigin?
       def origin_for(def_node, owner, kind)
         return nil if def_node.nil?
 

--- a/lib/rigor/inference/void_tail_summary.rb
+++ b/lib/rigor/inference/void_tail_summary.rb
@@ -75,7 +75,6 @@ module Rigor
       # consult; the memo persists across consults for the run. The memo is probed before the visited
       # set is allocated so the common post-warmup hit path allocates nothing.
       #
-      # @param def_node [Prism::DefNode]
       # @param owner [String] the qualified receiver class the `def` belongs to.
       # @param kind [Symbol] `:instance` or `:singleton`.
       # @return [Inference::VoidOrigin, nil]

--- a/lib/rigor/language_server/buffer_table.rb
+++ b/lib/rigor/language_server/buffer_table.rb
@@ -51,7 +51,7 @@ module Rigor
       # computed from the stale text would be wrong. Consumers check {#desynchronized?} and decline to answer
       # rather than answering wrongly; the mark clears on the next `didOpen` or full-text change.
       #
-      # @return [Boolean] true when the changes were applied.
+      # @rbs return: bool -- True when the changes were applied.
       def apply_changes(uri:, changes:, version:)
         text = IncrementalSync.apply_all(@entries[uri]&.bytes, changes)
         @desynchronized.delete(uri)
@@ -63,13 +63,14 @@ module Rigor
         false
       end
 
-      # @return [Boolean] true when the last `didChange` for `uri` could not be applied, so the held text no
-      #   longer matches the editor's.
+      # @rbs return: bool --
+      #   True when the last `didChange` for `uri` could not be applied, so the held text no longer matches the
+      #   editor's.
       def desynchronized?(uri)
         @desynchronized.key?(uri)
       end
 
-      # @return [String, nil] why `uri` is desynchronised, for the log line; nil when it is in sync.
+      # @rbs return: String? -- Why `uri` is desynchronised, for the log line; nil when it is in sync.
       def desynchronization_reason(uri)
         @desynchronized[uri]
       end
@@ -91,9 +92,9 @@ module Rigor
         @dirty.delete(uri)
       end
 
-      # @return [Boolean] true when `uri` has unsaved changes. A buffer that is dirty may only be published
-      #   from an analysis that bound ITS bytes — see the publish-set invariant in
-      #   `docs/design/20260517-language-server.md`.
+      # @rbs return: bool --
+      #   True when `uri` has unsaved changes. A buffer that is dirty may only be published from an analysis that
+      #   bound ITS bytes — see the publish-set invariant in `docs/design/20260517-language-server.md`.
       def dirty?(uri)
         @dirty.key?(uri)
       end

--- a/lib/rigor/language_server/completion_provider.rb
+++ b/lib/rigor/language_server/completion_provider.rb
@@ -42,12 +42,10 @@ module Rigor
         @project_context = project_context
       end
 
-      # @return [Array<Hash>, nil] LSP `CompletionItem[]` or nil
-      #   when the cursor isn't at a position the provider can
-      #   enumerate completions for. Returning nil maps to
-      #   `result: null` per the LSP spec — clients treat it as
-      #   "no completions available," distinct from `[]` which
-      #   means "we tried and got nothing".
+      # @rbs return: Array[Hash[untyped, untyped]]? --
+      #   LSP `CompletionItem[]` or nil when the cursor isn't at a position the provider can enumerate completions
+      #   for. Returning nil maps to `result: null` per the LSP spec — clients treat it as "no completions available,"
+      #   distinct from `[]` which means "we tried and got nothing".
       def provide(uri:, line:, character:, trigger_character: nil)
         _ = trigger_character # Trigger info logged-not-routed in v1.
         path, entry = buffer_for(uri)

--- a/lib/rigor/language_server/debouncer.rb
+++ b/lib/rigor/language_server/debouncer.rb
@@ -68,7 +68,7 @@ module Rigor
         end
       end
 
-      # @return [Integer] number of currently-pending tasks.
+      # @rbs return: Integer -- Number of currently-pending tasks.
       def pending_size
         @mutex.synchronize { @tasks.size }
       end

--- a/lib/rigor/language_server/diagnostic_publisher.rb
+++ b/lib/rigor/language_server/diagnostic_publisher.rb
@@ -30,7 +30,6 @@ module Rigor
         hint: 4
       }.freeze
 
-      # @param debouncer [Rigor::LanguageServer::Debouncer, nil]
       #   when present, `publish_for` schedules its work through
       #   the debouncer (cancels prior pending task for the same
       #   URI, fires after `debounce_seconds` quiet-time). Nil

--- a/lib/rigor/language_server/diagnostic_publisher.rb
+++ b/lib/rigor/language_server/diagnostic_publisher.rb
@@ -35,12 +35,11 @@ module Rigor
       #   URI, fires after `debounce_seconds` quiet-time). Nil
       #   keeps the slice 4-7 synchronous behaviour — primarily
       #   useful for specs.
-      # @param debounce_seconds [Numeric] quiet-time before the
-      #   debounced publish fires. 0 with a debouncer means
-      #   "schedule on next-tick" (still async); without a
-      #   debouncer the value is unused.
-      # The single Debouncer key every save round shares (#246). Per-URI keys would let two saves start two
-      # concurrent rounds; one key means a burst collapses into the last one.
+      # @rbs debounce_seconds: Numeric --
+      #   Quiet-time before the debounced publish fires. 0 with a debouncer means "schedule on next-tick" (still
+      #   async); without a debouncer the value is unused. The single Debouncer key every save round shares (#246).
+      #   Per-URI keys would let two saves start two concurrent rounds; one key means a burst collapses into the last
+      #   one.
       PROJECT_ROUND_KEY = :__rigor_project_round__
 
       def initialize(writer:, buffer_table:, project_context:,
@@ -211,10 +210,11 @@ module Rigor
         notify(uri, diagnostics)
       end
 
-      # @return [Hash, nil] `{ uri:, path:, bytes: }` when `uri` is eligible for the batch, or nil to
-      #   exclude it. Mirrors `#run_and_notify`'s own guards: a buffer closed during the debounce window is
-      #   dropped silently (its didClose empty publish already cleared the markers); a desynchronised buffer
-      #   publishes an EMPTY set immediately (same as the single-buffer path) rather than joining the batch.
+      # @rbs return: Hash[untyped, untyped]? --
+      #   `{ uri:, path:, bytes: }` when `uri` is eligible for the batch, or nil to exclude it. Mirrors
+      #   `#run_and_notify`'s own guards: a buffer closed during the debounce window is dropped silently (its didClose
+      #   empty publish already cleared the markers); a desynchronised buffer publishes an EMPTY set immediately (same
+      #   as the single-buffer path) rather than joining the batch.
       def eligible_job(uri)
         entry = @buffer_table[uri]
         return nil if entry.nil?
@@ -319,10 +319,9 @@ module Rigor
         end
       end
 
-      # @return [Hash, nil] the LSP `Diagnostic` Hash, or nil to
-      #   skip diagnostics outside the buffer's own path (e.g.
-      #   `.rigor.yml`-anchored info diagnostics get filtered —
-      #   they belong to the project, not the buffer).
+      # @rbs return: Hash[untyped, untyped]? --
+      #   The LSP `Diagnostic` Hash, or nil to skip diagnostics outside the buffer's own path (e.g.
+      #   `.rigor.yml`-anchored info diagnostics get filtered — they belong to the project, not the buffer).
       def to_lsp_diagnostic(diagnostic, buffer_path)
         return nil if diagnostic.path != buffer_path
 

--- a/lib/rigor/language_server/document_symbol_provider.rb
+++ b/lib/rigor/language_server/document_symbol_provider.rb
@@ -30,10 +30,9 @@ module Rigor
         @project_context = project_context
       end
 
-      # @return [Array<Hash>, nil] LSP `DocumentSymbol[]` for the
-      #   buffer at `uri`. Returns nil when the URI isn't open or
-      #   doesn't parse cleanly enough to surface symbols — LSP
-      #   clients fall back to no-outline in that case.
+      # @rbs return: Array[Hash[untyped, untyped]]? --
+      #   LSP `DocumentSymbol[]` for the buffer at `uri`. Returns nil when the URI isn't open or doesn't parse cleanly
+      #   enough to surface symbols — LSP clients fall back to no-outline in that case.
       def provide(uri)
         path, entry = buffer_for(uri)
         return nil if entry.nil?

--- a/lib/rigor/language_server/folding_range_provider.rb
+++ b/lib/rigor/language_server/folding_range_provider.rb
@@ -23,8 +23,8 @@ module Rigor
         @project_context = project_context
       end
 
-      # @return [Array<Hash>, nil] LSP `FoldingRange[]` for the
-      #   buffer, or nil when the URI isn't open / parseable.
+      # @rbs return: Array[Hash[untyped, untyped]]? --
+      #   LSP `FoldingRange[]` for the buffer, or nil when the URI isn't open / parseable.
       def provide(uri)
         path, entry = buffer_for(uri)
         return nil if entry.nil?

--- a/lib/rigor/language_server/hover_provider.rb
+++ b/lib/rigor/language_server/hover_provider.rb
@@ -29,10 +29,9 @@ module Rigor
         @renderer = renderer
       end
 
-      # @return [Hash, nil] an LSP `Hover` payload or nil when no
-      #   expression sits at the queried position. Returning nil
-      #   maps to `result: null` per the LSP spec — clients
-      #   suppress the hover popup in that case.
+      # @rbs return: Hash[untyped, untyped]? --
+      #   An LSP `Hover` payload or nil when no expression sits at the queried position. Returning nil maps to
+      #   `result: null` per the LSP spec — clients suppress the hover popup in that case.
       def provide(uri:, line:, character:)
         path, entry = buffer_for(uri)
         return nil if entry.nil?

--- a/lib/rigor/language_server/hover_renderer.rb
+++ b/lib/rigor/language_server/hover_renderer.rb
@@ -13,10 +13,10 @@ module Rigor
     # (method call, constant, local, ivar, literal) gets the most relevant type-aware presentation per
     # `docs/design/20260517-lsp-hover-completion.md`.
     class HoverRenderer
-      # @param node_scope_lookup [#[]] node-to-scope table built by `ScopeIndexer.index`. The renderer indexes
-      #   into it to retrieve the receiver's narrow scope when specialising on `CallNode`. The lookup never
-      #   returns nil (the indexer's Hash carries `default_scope` as its default value), so the renderer trusts
-      #   the lookup result.
+      # @rbs node_scope_lookup: untyped --
+      #   Node-to-scope table built by `ScopeIndexer.index`. The renderer indexes into it to retrieve the receiver's
+      #   narrow scope when specialising on `CallNode`. The lookup never returns nil (the indexer's Hash carries
+      #   `default_scope` as its default value), so the renderer trusts the lookup result.
       def render(node:, type:, node_scope_lookup:)
         body = render_body(node, type, node_scope_lookup)
         result = { contents: { kind: "markdown", value: body } }
@@ -83,9 +83,10 @@ module Rigor
         )
       end
 
-      # @return [[RBS::Definition::Method, String, Symbol], nil] the resolved method definition, the receiver
-      #   class name, and the dispatch kind (`:instance` or `:singleton`); nil when the receiver shape isn't
-      #   yet supported or the method doesn't resolve through the RBS env.
+      # @rbs return: [RBS::Definition::Method, String, Symbol]? --
+      #   The resolved method definition, the receiver class name, and the dispatch kind (`:instance` or
+      #   `:singleton`); nil when the receiver shape isn't yet supported or the method doesn't resolve through the RBS
+      #   env.
       def lookup_method(receiver_type, method_name, scope)
         case receiver_type
         when Type::Singleton

--- a/lib/rigor/language_server/incremental_sync.rb
+++ b/lib/rigor/language_server/incremental_sync.rb
@@ -46,10 +46,9 @@ module Rigor
       # Applies every change in order, each against the result of the previous — the LSP contract for a
       # multi-change `didChange` notification.
       #
-      # @param text [String, nil] the held buffer text; nil when no buffer is open for the URI.
-      # @param changes [Array<Hash>] the `contentChanges` array.
-      # @return [String] the new buffer text.
-      # @raise [UnappliableChange] if any change cannot be applied.
+      # @rbs text: String? -- The held buffer text; nil when no buffer is open for the URI.
+      # @rbs changes: Array[Hash[untyped, untyped]] -- The `contentChanges` array.
+      # @rbs return: String -- The new buffer text. Raises UnappliableChange if any change cannot be applied.
       def apply_all(text, changes)
         raise UnappliableChange, "contentChanges must be an Array, got #{changes.class}" unless changes.is_a?(Array)
 
@@ -64,7 +63,7 @@ module Rigor
       # companion to `range` and is accepted-but-ignored: it is redundant with `range`, historically ambiguous
       # about its units, and `range` is the authoritative field.
       #
-      # @raise [UnappliableChange]
+      # Raises UnappliableChange
       def apply(text, change)
         raise UnappliableChange, "contentChanges entry must be a Hash, got #{change.class}" unless change.is_a?(Hash)
 
@@ -95,10 +94,11 @@ module Rigor
         raise UnappliableChange, "held text is not valid UTF-8: #{e.message}"
       end
 
-      # @return [Array<Array(Integer, Integer)>] one `[content_start, content_end]` pair per line, in Ruby
-      #   character indices. `content_end` excludes the line terminator, so it doubles as the clamp target for
-      #   an over-long `character`. A trailing terminator yields a final empty span — the virtual last line an
-      #   editor puts the cursor on, and the anchor for an end-of-document insert.
+      # @rbs return: Array[[Integer, Integer]] --
+      #   One `[content_start, content_end]` pair per line, in Ruby character indices. `content_end` excludes the line
+      #   terminator, so it doubles as the clamp target for an over-long `character`. A trailing terminator yields a
+      #   final empty span — the virtual last line an editor puts the cursor on, and the anchor for an end-of-document
+      #   insert.
       def line_spans(text)
         spans = []
         scanner = StringScanner.new(text)

--- a/lib/rigor/language_server/publish_batcher.rb
+++ b/lib/rigor/language_server/publish_batcher.rb
@@ -15,14 +15,15 @@ module Rigor
     # dropped. The same claim/consume shape `DiagnosticPublisher#run_project_round` already uses for the
     # whole-project save round (#246), generalised to an arbitrary key type and an arbitrary batch action.
     class PublishBatcher
-      # @param on_batch [#call] `(keys) -> void`, called with the deduplicated Array of keys pending at the
-      #   start of one round. May be called more than once in a row when keys keep arriving while a round
-      #   runs.
-      # @param on_error [#call, nil] `(exception) -> void`, called when `on_batch` raises. A round must
-      #   never wedge the coalescing lock for every future `#enqueue` call — ownership is always released
-      #   before this fires. Whatever was mid-flight when the round raised is lost; anything enqueued by a
-      #   concurrent `#enqueue` call after this round's drain but before the rescue stays pending and rides
-      #   the NEXT round instead. Defaults to a no-op (the exception is swallowed silently).
+      # @rbs on_batch: untyped --
+      #   `(keys) -> void`, called with the deduplicated Array of keys pending at the start of one round. May be
+      #   called more than once in a row when keys keep arriving while a round runs.
+      # @rbs on_error: untyped --
+      #   `(exception) -> void`, called when `on_batch` raises. A round must never wedge the coalescing lock for every
+      #   future `#enqueue` call — ownership is always released before this fires. Whatever was mid-flight when the
+      #   round raised is lost; anything enqueued by a concurrent `#enqueue` call after this round's drain but before
+      #   the rescue stays pending and rides the NEXT round instead. Defaults to a no-op (the exception is swallowed
+      #   silently).
       def initialize(on_batch:, on_error: nil)
         @on_batch = on_batch
         @on_error = on_error

--- a/lib/rigor/language_server/selection_range_provider.rb
+++ b/lib/rigor/language_server/selection_range_provider.rb
@@ -20,10 +20,9 @@ module Rigor
         @project_context = project_context
       end
 
-      # @param positions [Array<Hash>] LSP `Position[]` — each
-      #   `{ line:, character: }` 0-based.
-      # @return [Array<Hash>, nil] one `SelectionRange` per
-      #   position, or nil when the URI / buffer isn't resolvable.
+      # @rbs positions: Array[Hash[untyped, untyped]] -- LSP `Position[]` — each `{ line:, character: }` 0-based.
+      # @rbs return: Array[Hash[untyped, untyped]]? --
+      #   One `SelectionRange` per position, or nil when the URI / buffer isn't resolvable.
       def provide(uri, positions)
         path, entry = buffer_for(uri)
         return nil if entry.nil?

--- a/lib/rigor/language_server/server.rb
+++ b/lib/rigor/language_server/server.rb
@@ -44,11 +44,10 @@ module Rigor
 
       #   resolves `textDocument/completion`. Nil → `MethodNotFound`.
       #   resolves `textDocument/signatureHelp`. Nil → `MethodNotFound`.
-      # @param project_context [Rigor::LanguageServer::ProjectContext, nil] the per-session cache of
-      #   `Environment` + `Cache::Store` the providers read on every request. When present,
-      #   `workspace/didChangeWatchedFiles` and `workspace/didChangeConfiguration` invalidate the cache; nil
-      #   means "no project context": each request rebuilds env from scratch (mainly for specs and backward
-      #   compatibility).
+      # @rbs project_context: Rigor::LanguageServer::ProjectContext? --
+      #   The per-session cache of `Environment` + `Cache::Store` the providers read on every request. When present,
+      #   `workspace/didChangeWatchedFiles` and `workspace/didChangeConfiguration` invalidate the cache; nil means "no
+      #   project context": each request rebuilds env from scratch (mainly for specs and backward compatibility).
       def initialize(buffer_table: BufferTable.new, publisher: nil, # rubocop:disable Metrics/ParameterLists
                      hover_provider: nil, document_symbol_provider: nil,
                      completion_provider: nil, signature_help_provider: nil,
@@ -67,22 +66,21 @@ module Rigor
         @project_context = project_context
       end
 
-      # @return [Boolean] true once the client has called `exit` and
-      #   the server has set its terminal exit code. The CLI loop
-      #   reads this between dispatches to know when to stop.
+      # @rbs return: bool --
+      #   True once the client has called `exit` and the server has set its terminal exit code. The CLI loop reads
+      #   this between dispatches to know when to stop.
       def exited?
         @state == :exited
       end
 
       # Routes one LSP method call.
       #
-      # @param method [String] the LSP method name (e.g. "initialize").
-      # @param params [Hash, nil] the LSP `params` payload (Hash for
-      #   request / notification methods; nil for the empty case).
-      # @return [Hash, nil] one of:
-      #   - the response result Hash for request methods,
-      #   - nil for notification methods,
-      #   - { error: { code:, message: } } for state / shape errors.
+      # @rbs method: String -- The LSP method name (e.g. "initialize").
+      # @rbs params: Hash[untyped, untyped]? --
+      #   The LSP `params` payload (Hash for request / notification methods; nil for the empty case).
+      # @rbs return: Hash[untyped, untyped]? --
+      #   One of: - the response result Hash for request methods, - nil for notification methods, - { error: { code:,
+      #   message: } } for state / shape errors.
       def dispatch(method, params = nil) # rubocop:disable Metrics/CyclomaticComplexity
         return state_violation_response(method) unless method_allowed_in_state?(method)
 

--- a/lib/rigor/language_server/server.rb
+++ b/lib/rigor/language_server/server.rb
@@ -42,9 +42,7 @@ module Rigor
                   :signature_help_provider, :folding_range_provider,
                   :selection_range_provider, :project_context
 
-      # @param completion_provider [Rigor::LanguageServer::CompletionProvider, nil]
       #   resolves `textDocument/completion`. Nil → `MethodNotFound`.
-      # @param signature_help_provider [Rigor::LanguageServer::SignatureHelpProvider, nil]
       #   resolves `textDocument/signatureHelp`. Nil → `MethodNotFound`.
       # @param project_context [Rigor::LanguageServer::ProjectContext, nil] the per-session cache of
       #   `Environment` + `Cache::Store` the providers read on every request. When present,

--- a/lib/rigor/language_server/signature_help_provider.rb
+++ b/lib/rigor/language_server/signature_help_provider.rb
@@ -44,8 +44,8 @@ module Rigor
         @project_context = project_context
       end
 
-      # @return [Hash, nil] LSP `SignatureHelp` payload or nil
-      #   when the cursor isn't inside a resolvable method call.
+      # @rbs return: Hash[untyped, untyped]? --
+      #   LSP `SignatureHelp` payload or nil when the cursor isn't inside a resolvable method call.
       def provide(uri:, line:, character:, context: nil)
         _ = context # Trigger info accepted but not routed in v1.
         path, entry = buffer_for(uri)

--- a/lib/rigor/language_server/uri.rb
+++ b/lib/rigor/language_server/uri.rb
@@ -14,8 +14,7 @@ module Rigor
       FILE_SCHEME = "file://"
       private_constant :FILE_SCHEME
 
-      # @return [String, nil] absolute filesystem path for a
-      #   `file://` URI, or nil for unsupported schemes.
+      # @rbs return: String? -- Absolute filesystem path for a `file://` URI, or nil for unsupported schemes.
       def to_path(uri)
         return nil unless uri.is_a?(String) && uri.start_with?(FILE_SCHEME)
 

--- a/lib/rigor/plugin/base.rb
+++ b/lib/rigor/plugin/base.rb
@@ -806,7 +806,6 @@ module Rigor
       # @param roots    [Array<String>] search roots (relative to the project root, or absolute paths)
       # @param patterns [Array<String>] glob suffixes joined under each root via `File.join(root, pattern)`.
       #   Multiple patterns union into one descriptor (`"**/*.erb", "**/*.html"` etc.).
-      # @return [Rigor::Cache::Descriptor]
       def glob_descriptor(roots, *patterns)
         files = collect_glob_files(Array(roots), patterns)
         entries = files.map do |path|

--- a/lib/rigor/plugin/base.rb
+++ b/lib/rigor/plugin/base.rb
@@ -803,9 +803,10 @@ module Rigor
       # survives only as the building block for the rare producer that needs `FileEntry` rows directly;
       # plugin code calls `watch:`.
       #
-      # @param roots    [Array<String>] search roots (relative to the project root, or absolute paths)
-      # @param patterns [Array<String>] glob suffixes joined under each root via `File.join(root, pattern)`.
-      #   Multiple patterns union into one descriptor (`"**/*.erb", "**/*.html"` etc.).
+      # @rbs roots: Array[String] -- Search roots (relative to the project root, or absolute paths)
+      # @rbs patterns: Array[String] --
+      #   Glob suffixes joined under each root via `File.join(root, pattern)`. Multiple patterns union into one
+      #   descriptor (`"**/*.erb", "**/*.html"` etc.).
       def glob_descriptor(roots, *patterns)
         files = collect_glob_files(Array(roots), patterns)
         entries = files.map do |path|

--- a/lib/rigor/plugin/effect_attribution.rb
+++ b/lib/rigor/plugin/effect_attribution.rb
@@ -77,16 +77,19 @@ module Rigor
       # callable whose body is supplied by the application.
       TAINT_CAUSES = %w[template-not-analysed opaque-callable].freeze
 
-      # @param receiver [String] a class name or a receiver path (see above)
-      # @param method [Symbol, String] the selector this row colours
-      # @param singleton [Boolean] whether the row is `Receiver.method` rather than `Receiver#method`.
-      #   Meaningless — and ignored — for a receiver path, whose head already fixes the receiver object.
-      # @param labels [Array<String>] the effect labels the call contributes
-      # @param narrow [String, nil] a {Rigor::Effects::Narrowing} handler name, when the call's own
-      #   argument literals settle a question the row cannot (`connection.execute("SELECT …")`)
-      # @param discharge [Boolean] see above; honoured only for a first-party bundled plugin
-      # @param why [String] the audit justification, required exactly as `data/effects/core.yml` requires
-      #   one of every row: a label with no stated reason is a claim nobody can review.
+      # @rbs receiver: String -- A class name or a receiver path (see above)
+      # @rbs method: Symbol | String -- The selector this row colours
+      # @rbs singleton: bool --
+      #   Whether the row is `Receiver.method` rather than `Receiver#method`. Meaningless — and ignored — for a
+      #   receiver path, whose head already fixes the receiver object.
+      # @rbs labels: Array[String] -- The effect labels the call contributes
+      # @rbs narrow: String? --
+      #   A {Rigor::Effects::Narrowing} handler name, when the call's own argument literals settle a question the row
+      #   cannot (`connection.execute("SELECT …")`)
+      # @rbs discharge: bool -- See above; honoured only for a first-party bundled plugin
+      # @rbs why: String --
+      #   The audit justification, required exactly as `data/effects/core.yml` requires one of every row: a label with
+      #   no stated reason is a claim nobody can review.
       def initialize(receiver:, method:, labels:, why:, singleton: false, narrow: nil, discharge: false, # rubocop:disable Metrics/ParameterLists
                      within: nil, on_result: false, taint: nil)
         @receiver = validate_receiver!(receiver)

--- a/lib/rigor/plugin/effect_entry_points.rb
+++ b/lib/rigor/plugin/effect_entry_points.rb
@@ -21,10 +21,11 @@ module Rigor
     class EffectEntryPoints
       attr_reader :name, :globs, :why
 
-      # @param name [String, Symbol] the token `reach:` adopts. Must satisfy
-      #   {Rigor::Effects::EntryPoints::NAME_PATTERN}, checked at registration.
-      # @param globs [Array<String>] project-relative path globs
-      # @param why [String] what the preset stands for, for the plugin's README and `rigor effects`' help
+      # @rbs name: String | Symbol --
+      #   The token `reach:` adopts. Must satisfy {Rigor::Effects::EntryPoints::NAME_PATTERN}, checked at
+      #   registration.
+      # @rbs globs: Array[String] -- Project-relative path globs
+      # @rbs why: String -- What the preset stands for, for the plugin's README and `rigor effects`' help
       def initialize(name:, globs:, why: "")
         @name = name.to_s.dup.freeze
         @globs = Array(globs).map { |glob| glob.to_s.dup.freeze }.uniq.sort.freeze

--- a/lib/rigor/plugin/fact_store.rb
+++ b/lib/rigor/plugin/fact_store.rb
@@ -42,10 +42,9 @@ module Rigor
       # Writes a `(plugin_id, name) -> value` triple. Idempotent if the same value is published twice (`==`);
       # raises {Conflict} if the values differ.
       #
-      # @param plugin_id [String] producing plugin's manifest id.
-      # @param name [Symbol, String] fact name (canonicalised to Symbol for lookup).
-      # @param value [Object] frozen-shape value object the producer chose to publish. The value is stored
-      #   as-is.
+      # @rbs plugin_id: String -- Producing plugin's manifest id.
+      # @rbs name: Symbol | String -- Fact name (canonicalised to Symbol for lookup).
+      # @rbs value: untyped -- Frozen-shape value object the producer chose to publish. The value is stored as-is.
       def publish(plugin_id:, name:, value:)
         plugin_id = plugin_id.to_s
         name = name.to_sym
@@ -60,19 +59,20 @@ module Rigor
         nil
       end
 
-      # @return [Object, nil] the published value, or `nil` when no fact is registered. Reads do NOT establish
-      #   a dependency — `manifest(consumes:)` (slice 4) is the dependency declaration mechanism.
+      # @rbs return: untyped? --
+      #   The published value, or `nil` when no fact is registered. Reads do NOT establish a dependency —
+      #   `manifest(consumes:)` (slice 4) is the dependency declaration mechanism.
       def read(plugin_id:, name:)
         fact = @mutex.synchronize { @facts[[plugin_id.to_s, name.to_sym]] }
         fact&.value
       end
 
-      # @return [Boolean] whether a fact is registered.
+      # @rbs return: bool -- Whether a fact is registered.
       def published?(plugin_id:, name:)
         @mutex.synchronize { @facts.key?([plugin_id.to_s, name.to_sym]) }
       end
 
-      # @yield [Fact] every published fact in publication order.
+      # Every published fact in publication order.
       def each_fact(&)
         snapshot = @mutex.synchronize { @facts.values }
         snapshot.each(&)

--- a/lib/rigor/plugin/io_boundary.rb
+++ b/lib/rigor/plugin/io_boundary.rb
@@ -93,8 +93,8 @@ module Rigor
       # `return nil unless File.file?(config)` gate: the miss shaped the result and left no edge for the
       # file's later appearance.
       #
-      # @param path [String] project path; relative paths expand against the working directory
-      # @return [Boolean] `File.file?`'s answer, unchanged
+      # @rbs path: String -- Project path; relative paths expand against the working directory
+      # @rbs return: bool -- `File.file?`'s answer, unchanged
       def file?(path)
         probe(path) { |absolute| File.file?(absolute) }
       end
@@ -103,8 +103,8 @@ module Rigor
       # existence row. The discovery shape (`next [] unless directory?(root)` before a `Dir.glob`) depends
       # on the root existing exactly as a config read depends on the config file existing.
       #
-      # @param path [String] project path; relative paths expand against the working directory
-      # @return [Boolean] `File.directory?`'s answer, unchanged
+      # @rbs path: String -- Project path; relative paths expand against the working directory
+      # @rbs return: bool -- `File.directory?`'s answer, unchanged
       def directory?(path)
         probe(path) { |absolute| File.directory?(absolute) }
       end
@@ -131,9 +131,9 @@ module Rigor
         body
       end
 
-      # @return [Rigor::Cache::Descriptor] frozen snapshot of every file / URL the boundary has read so far.
-      #   Calling this multiple times yields equal descriptors; subsequent reads expand the underlying record
-      #   tables.
+      # @rbs return: Rigor::Cache::Descriptor --
+      #   Frozen snapshot of every file / URL the boundary has read so far. Calling this multiple times yields equal
+      #   descriptors; subsequent reads expand the underlying record tables.
       def cache_descriptor
         files, configs = @mutex.synchronize { [@file_entries.values.dup, @config_entries.values.dup] }
         Cache::Descriptor.new(files: files, configs: configs)

--- a/lib/rigor/plugin/loader.rb
+++ b/lib/rigor/plugin/loader.rb
@@ -43,7 +43,6 @@ module Rigor
       # the engine's own bundled plugin copies.
       ENGINE_ROOT = File.expand_path("../../..", __dir__)
 
-      # @param services [Rigor::Plugin::Services]
       # @param requirer [#call] takes a gem name OR an absolute file path (#194 slice 2 — a bundled plugin is
       #   required by its {.bundled_plugin_path}) and returns truthy on successful require. Defaulted to
       #   `Kernel.require` via a lambda, which accepts both forms; the spec injects a fake to avoid touching
@@ -91,7 +90,6 @@ module Rigor
       end
 
       # @param entries [Array<String, Hash>] the raw `plugins:` list from the configuration.
-      # @return [Registry]
       def load(entries)
         plugins = []
         load_errors = []

--- a/lib/rigor/plugin/loader.rb
+++ b/lib/rigor/plugin/loader.rb
@@ -43,13 +43,13 @@ module Rigor
       # the engine's own bundled plugin copies.
       ENGINE_ROOT = File.expand_path("../../..", __dir__)
 
-      # @param requirer [#call] takes a gem name OR an absolute file path (#194 slice 2 — a bundled plugin is
-      #   required by its {.bundled_plugin_path}) and returns truthy on successful require. Defaulted to
-      #   `Kernel.require` via a lambda, which accepts both forms; the spec injects a fake to avoid touching
-      #   the real load path.
-      # @param feature_resolver [#call] takes a gem name and returns the absolute path `require` resolved it
-      #   to (or nil). Defaulted to {FEATURE_RESOLVER}; the spec injects a fake so it never has to mutate the
-      #   real `$LOADED_FEATURES` global.
+      # @rbs requirer: untyped --
+      #   Takes a gem name OR an absolute file path (#194 slice 2 — a bundled plugin is required by its
+      #   {.bundled_plugin_path}) and returns truthy on successful require. Defaulted to `Kernel.require` via a
+      #   lambda, which accepts both forms; the spec injects a fake to avoid touching the real load path.
+      # @rbs feature_resolver: untyped --
+      #   Takes a gem name and returns the absolute path `require` resolved it to (or nil). Defaulted to
+      #   {FEATURE_RESOLVER}; the spec injects a fake so it never has to mutate the real `$LOADED_FEATURES` global.
       def initialize(services:, requirer: ->(name) { require name }, feature_resolver: FEATURE_RESOLVER)
         @services = services
         @requirer = requirer
@@ -89,7 +89,7 @@ module Rigor
         File.directory?(path) ? path : nil
       end
 
-      # @param entries [Array<String, Hash>] the raw `plugins:` list from the configuration.
+      # @rbs entries: Array[String | Hash[untyped, untyped]] -- The raw `plugins:` list from the configuration.
       def load(entries)
         plugins = []
         load_errors = []

--- a/lib/rigor/plugin/macro/heredoc_template.rb
+++ b/lib/rigor/plugin/macro/heredoc_template.rb
@@ -152,8 +152,9 @@ module Rigor
         class ReturnsFromArg
           attr_reader :position, :plugin_id, :fact
 
-          # @return [ReturnsFromArg, nil] coerced value class for a Hash / nil / ReturnsFromArg input. Raises
-          #   on any other shape so manifest authoring failures surface at construction time.
+          # @rbs return: ReturnsFromArg? --
+          #   Coerced value class for a Hash / nil / ReturnsFromArg input. Raises on any other shape so manifest
+          #   authoring failures surface at construction time.
           def self.coerce(value)
             return nil if value.nil?
             return value if value.is_a?(ReturnsFromArg)

--- a/lib/rigor/plugin/macro/trait_registry.rb
+++ b/lib/rigor/plugin/macro/trait_registry.rb
@@ -105,9 +105,9 @@ module Rigor
           to_h.hash
         end
 
-        # @return [String, nil] fully-qualified module name for the given trait symbol, or nil when the
-        #   registry doesn't know the symbol (caller emits a tier_b.unknown-trait provenance marker and falls
-        #   through).
+        # @rbs return: String? --
+        #   Fully-qualified module name for the given trait symbol, or nil when the registry doesn't know the symbol
+        #   (caller emits a tier_b.unknown-trait provenance marker and falls through).
         def module_for(symbol)
           modules_by_symbol[symbol.to_sym]
         end

--- a/lib/rigor/plugin/registry.rb
+++ b/lib/rigor/plugin/registry.rb
@@ -217,16 +217,16 @@ module Rigor
     class Registry
       attr_reader :plugins, :load_errors, :blueprints, :contribution_index, :resolved_gem_paths
 
-      # @param plugins [Array<Rigor::Plugin::Base>] instantiated plugin instances in deterministic order.
-      # @param load_errors [Array<Rigor::Plugin::LoadError>] failures surfaced during loading. Each error is
-      #   also turned into a diagnostic by the runner.
-      # @param blueprints [Array<Rigor::Plugin::Blueprint>] frozen, Ractor-shareable replay descriptors
-      #   aligned 1:1 with `plugins`. The loader fills this in; callers that construct Registry manually MAY
-      #   pass `[]` and accept that {.materialize} cannot replay the set.
-      # @param resolved_gem_paths [Hash{String=>String,nil}] #194 slice 1 — `gem name => resolved file path`
-      #   for each successfully required plugin gem, so `rigor plugins` can print where a loaded (and
-      #   possibly frozen) plugin actually loaded from. Defaults to empty; a worker registry built by
-      #   {.materialize} carries none (the provenance surface runs only on the coordinator).
+      # @rbs plugins: Array[Rigor::Plugin::Base] -- Instantiated plugin instances in deterministic order.
+      # @rbs load_errors: Array[Rigor::Plugin::LoadError] --
+      #   Failures surfaced during loading. Each error is also turned into a diagnostic by the runner.
+      # @rbs blueprints: Array[Rigor::Plugin::Blueprint] --
+      #   Frozen, Ractor-shareable replay descriptors aligned 1:1 with `plugins`. The loader fills this in; callers
+      #   that construct Registry manually MAY pass `[]` and accept that {.materialize} cannot replay the set.
+      # @rbs resolved_gem_paths: Hash[String, String?] --
+      #   #194 slice 1 — `gem name => resolved file path` for each successfully required plugin gem, so `rigor
+      #   plugins` can print where a loaded (and possibly frozen) plugin actually loaded from. Defaults to empty; a
+      #   worker registry built by {.materialize} carries none (the provenance surface runs only on the coordinator).
       def initialize(plugins: [], load_errors: [], blueprints: [], resolved_gem_paths: {})
         @plugins = plugins.dup.freeze
         @load_errors = load_errors.dup.freeze

--- a/lib/rigor/plugin/trust_policy.rb
+++ b/lib/rigor/plugin/trust_policy.rb
@@ -45,7 +45,6 @@ module Rigor
         freeze
       end
 
-      # @param path [String]
       # @return [Boolean] true when the absolute path falls inside any allowed read root. Symlinks are
       #   resolved through `File.expand_path` only (no `realpath`); plugins with adversarial intent are out of
       #   scope per ADR-2.
@@ -58,7 +57,6 @@ module Rigor
         @network_policy != :disabled
       end
 
-      # @param url [String, URI]
       # @return [Boolean] true when the URL scheme is `https` and the parsed hostname is in
       #   `allowed_url_hosts`. Always `false` while `network_policy` is `:disabled`.
       def allow_url?(url)

--- a/lib/rigor/plugin/trust_policy.rb
+++ b/lib/rigor/plugin/trust_policy.rb
@@ -45,9 +45,9 @@ module Rigor
         freeze
       end
 
-      # @return [Boolean] true when the absolute path falls inside any allowed read root. Symlinks are
-      #   resolved through `File.expand_path` only (no `realpath`); plugins with adversarial intent are out of
-      #   scope per ADR-2.
+      # @rbs return: bool --
+      #   True when the absolute path falls inside any allowed read root. Symlinks are resolved through
+      #   `File.expand_path` only (no `realpath`); plugins with adversarial intent are out of scope per ADR-2.
       def allow_read?(path)
         absolute = File.expand_path(path.to_s)
         @allowed_read_roots.any? { |root| inside?(absolute, root) }
@@ -57,8 +57,9 @@ module Rigor
         @network_policy != :disabled
       end
 
-      # @return [Boolean] true when the URL scheme is `https` and the parsed hostname is in
-      #   `allowed_url_hosts`. Always `false` while `network_policy` is `:disabled`.
+      # @rbs return: bool --
+      #   True when the URL scheme is `https` and the parsed hostname is in `allowed_url_hosts`. Always `false` while
+      #   `network_policy` is `:disabled`.
       def allow_url?(url)
         return false if @network_policy == :disabled
         return false if @allowed_url_hosts.empty?

--- a/lib/rigor/plugin/type_node_resolver.rb
+++ b/lib/rigor/plugin/type_node_resolver.rb
@@ -28,11 +28,11 @@ module Rigor
     # Resolvers SHOULD be stateless and re-entrant; the registry builds the chain once per
     # `Analysis::Runner.run` and may consult any resolver multiple times for the same node.
     class TypeNodeResolver
-      # @param node [Rigor::TypeNode::Identifier, Rigor::TypeNode::Generic] the parser-emitted node the chain is
-      #   asking about.
-      # @param scope [Rigor::TypeNode::NameScope] companion value object (slice 3); slice 2 invocations MAY pass
-      #   `nil` because the chain doesn't exist yet.
-      # @return [Rigor::Type::Base, nil] resolved type, or `nil` to fall through.
+      # @rbs node: Rigor::TypeNode::Identifier | Rigor::TypeNode::Generic --
+      #   The parser-emitted node the chain is asking about.
+      # @rbs scope: Rigor::TypeNode::NameScope --
+      #   Companion value object (slice 3); slice 2 invocations MAY pass `nil` because the chain doesn't exist yet.
+      # @rbs return: Rigor::Type::Base? -- Resolved type, or `nil` to fall through.
       def resolve(node, scope) # rubocop:disable Lint/UnusedMethodArgument
         nil
       end

--- a/lib/rigor/protection/analysis_guard.rb
+++ b/lib/rigor/protection/analysis_guard.rb
@@ -43,10 +43,10 @@ module Rigor
       # {Analysis::Result#crashed?} — the same predicate the spec-side guard reads, off the same
       # {Analysis::CrashSignature} table. Hands back the diagnostics, which is all a kill comparison wants.
       #
-      # @param result [Rigor::Analysis::Result] one analysis run.
-      # @param context [String] which oracle call produced it, so the raise points at the right seam.
-      # @return [Array<Rigor::Analysis::Diagnostic>] the run's diagnostics, when the run was healthy.
-      # @raise [AnalyzerCrashed]
+      # @rbs result: Rigor::Analysis::Result -- One analysis run.
+      # @rbs context: String -- Which oracle call produced it, so the raise points at the right seam.
+      # @rbs return: Array[Rigor::Analysis::Diagnostic] --
+      #   The run's diagnostics, when the run was healthy. Raises AnalyzerCrashed
       def checked(result, context:)
         return result.diagnostics unless result.crashed?
 

--- a/lib/rigor/protection/closure_kill_oracle.rb
+++ b/lib/rigor/protection/closure_kill_oracle.rb
@@ -55,20 +55,21 @@ module Rigor
       # knowledge the single-file run does not have) must not mask a kill the shipped oracle would report.
       Baseline = Data.define(:own, :dependents)
 
-      # @param environment [Rigor::Environment] built once by the caller.
-      # @param project_scan [Rigor::Analysis::ProjectScan] built once by the caller; adopted per analysis
-      #   through `prebuilt:`, exactly as {DiagnosticOracle} does.
-      # @param paths [Array<String>] the measured file set, in canonical order (the seed's span: a class
-      #   declared outside it stays unknown, as it does for Tier 1's seed and for {DiscoverySeed}).
-      # @param dependents [Hash{String => Array<String>}] {DependencyClosure} map, restricted to `paths`.
-      # @param seed_bundles [Hash{String => Hash}] {DiscoverySeed.bundles} over the same `paths`.
-      # @param discovery_seed [Hash, nil] the `discovery-seeded-mutation-sites` seed when that feature is also
-      #   adopted, nil otherwise. It goes to the delegated {DiagnosticOracle} verbatim, so the mutated file's
-      #   verdict is byte-for-byte the verdict that feature combination produces without this one; its
-      #   `param_inferred_types` slot additionally rides the per-mutant closure seed, so an admitted site is
-      #   judged with the knowledge that admitted it (issue #260's amended decision). The table is not
-      #   refreshed per mutant — the collector is a whole-project pre-pass, and one mutated method body does
-      #   not justify re-running it thousands of times.
+      # @rbs environment: Rigor::Environment -- Built once by the caller.
+      # @rbs project_scan: Rigor::Analysis::ProjectScan --
+      #   Built once by the caller; adopted per analysis through `prebuilt:`, exactly as {DiagnosticOracle} does.
+      # @rbs paths: Array[String] --
+      #   The measured file set, in canonical order (the seed's span: a class declared outside it stays unknown, as it
+      #   does for Tier 1's seed and for {DiscoverySeed}).
+      # @rbs dependents: Hash[String, Array[String]] -- {DependencyClosure} map, restricted to `paths`.
+      # @rbs seed_bundles: Hash[String, Hash[untyped, untyped]] -- {DiscoverySeed.bundles} over the same `paths`.
+      # @rbs discovery_seed: Hash[untyped, untyped]? --
+      #   The `discovery-seeded-mutation-sites` seed when that feature is also adopted, nil otherwise. It goes to the
+      #   delegated {DiagnosticOracle} verbatim, so the mutated file's verdict is byte-for-byte the verdict that
+      #   feature combination produces without this one; its `param_inferred_types` slot additionally rides the
+      #   per-mutant closure seed, so an admitted site is judged with the knowledge that admitted it (issue #260's
+      #   amended decision). The table is not refreshed per mutant — the collector is a whole-project pre-pass, and
+      #   one mutated method body does not justify re-running it thousands of times.
       def initialize(configuration:, environment:, project_scan:, paths:, dependents:, seed_bundles:,
                      discovery_seed: nil)
         @configuration = configuration

--- a/lib/rigor/protection/closure_kill_oracle.rb
+++ b/lib/rigor/protection/closure_kill_oracle.rb
@@ -55,7 +55,6 @@ module Rigor
       # knowledge the single-file run does not have) must not mask a kill the shipped oracle would report.
       Baseline = Data.define(:own, :dependents)
 
-      # @param configuration [Rigor::Configuration]
       # @param environment [Rigor::Environment] built once by the caller.
       # @param project_scan [Rigor::Analysis::ProjectScan] built once by the caller; adopted per analysis
       #   through `prebuilt:`, exactly as {DiagnosticOracle} does.

--- a/lib/rigor/protection/dependency_closure.rb
+++ b/lib/rigor/protection/dependency_closure.rb
@@ -25,7 +25,6 @@ module Rigor
       module_function
 
       # @param paths [Array<String>] the measured file set, in caller order.
-      # @param configuration [Rigor::Configuration]
       # @param environment [Rigor::Environment] built once by the caller.
       # @param cache_store [Rigor::Cache::Store, nil] threaded to the recording run only (its RBS-env and
       #   plugin-producer tiers); the per-mutant analyses stay `cache_store: nil` regardless.
@@ -45,8 +44,6 @@ module Rigor
       # not being measured, so re-analysing it would report a diagnostic against a file the run never
       # baselined. Self-edges are dropped (the mutated file is the closure's own head), and each list is
       # sorted so a `--threshold` gate reads the same number whatever order the recording pass finished in.
-      #
-      # @return [Hash{String => Array<String>}]
       def index(dependents, paths)
         measured = Set.new(paths)
         paths.to_h do |path|

--- a/lib/rigor/protection/dependency_closure.rb
+++ b/lib/rigor/protection/dependency_closure.rb
@@ -24,13 +24,15 @@ module Rigor
     module DependencyClosure
       module_function
 
-      # @param paths [Array<String>] the measured file set, in caller order.
-      # @param environment [Rigor::Environment] built once by the caller.
-      # @param cache_store [Rigor::Cache::Store, nil] threaded to the recording run only (its RBS-env and
-      #   plugin-producer tiers); the per-mutant analyses stay `cache_store: nil` regardless.
-      # @param workers [Integer] fork-pool workers for the recording pass (the pool records per worker and
-      #   marshals the records back, so a pooled graph equals the sequential one).
-      # @return [Hash{String => Array<String>}] frozen `path => sorted dependents`, restricted to `paths`.
+      # @rbs paths: Array[String] -- The measured file set, in caller order.
+      # @rbs environment: Rigor::Environment -- Built once by the caller.
+      # @rbs cache_store: Rigor::Cache::Store? --
+      #   Threaded to the recording run only (its RBS-env and plugin-producer tiers); the per-mutant analyses stay
+      #   `cache_store: nil` regardless.
+      # @rbs workers: Integer --
+      #   Fork-pool workers for the recording pass (the pool records per worker and marshals the records back, so a
+      #   pooled graph equals the sequential one).
+      # @rbs return: Hash[String, Array[String]] -- Frozen `path => sorted dependents`, restricted to `paths`.
       def build(paths:, configuration:, environment:, cache_store: nil, workers: 0)
         runner = Analysis::Runner.new(
           configuration: configuration, environment: environment, cache_store: cache_store,

--- a/lib/rigor/protection/diagnostic_oracle.rb
+++ b/lib/rigor/protection/diagnostic_oracle.rb
@@ -17,12 +17,13 @@ module Rigor
     # disk write). Passing `prebuilt:` disables the run-result cache (whose key digests the *disk* file), so a
     # mutant is never served a stale clean hit.
     class DiagnosticOracle
-      # @param discovery_seed [Hash, nil] issue #260 — the cross-file discovery tables (see {DiscoverySeed})
-      #   the per-mutant analysis is seeded with, threaded through to `Runner.new(discovery_seed:)`. Without
-      #   it the runner's `prebuilt:` path carries frozen-empty discovery tables, so a receiver whose class is
-      #   declared in a *sibling* file reads `Dynamic` and NO mutation at that site can produce a diagnostic —
-      #   a site the caller's site filter may nonetheless have admitted, and then measured as an unkillable
-      #   survivor. nil (the default) keeps the shipped single-file oracle.
+      # @rbs discovery_seed: Hash[untyped, untyped]? --
+      #   Issue #260 — the cross-file discovery tables (see {DiscoverySeed}) the per-mutant analysis is seeded with,
+      #   threaded through to `Runner.new(discovery_seed:)`. Without it the runner's `prebuilt:` path carries
+      #   frozen-empty discovery tables, so a receiver whose class is declared in a *sibling* file reads `Dynamic` and
+      #   NO mutation at that site can produce a diagnostic — a site the caller's site filter may nonetheless have
+      #   admitted, and then measured as an unkillable survivor. nil (the default) keeps the shipped single-file
+      #   oracle.
       def initialize(configuration:, environment:, project_scan:, discovery_seed: nil)
         @configuration = configuration
         @environment = environment

--- a/lib/rigor/protection/discovery_seed.rb
+++ b/lib/rigor/protection/discovery_seed.rb
@@ -30,12 +30,13 @@ module Rigor
     module DiscoverySeed
       module_function
 
-      # @param paths [Array<String>] the measured file set; the seed spans these files only, exactly as Tier 1's
-      #   seed does. A class declared outside them stays unknown.
-      # @param environment [Rigor::Environment] the plugin-aware environment, built once by the caller.
-      # @param target_ruby [String] Prism parse version for the parameter-inference pre-pass.
-      # @param workers [Integer] worker count for that pre-pass (0 keeps it sequential).
-      # @return [Hash{Symbol => Object}] frozen seed tables; empty when the paths yield nothing.
+      # @rbs paths: Array[String] --
+      #   The measured file set; the seed spans these files only, exactly as Tier 1's seed does. A class declared
+      #   outside them stays unknown.
+      # @rbs environment: Rigor::Environment -- The plugin-aware environment, built once by the caller.
+      # @rbs target_ruby: String -- Prism parse version for the parameter-inference pre-pass.
+      # @rbs workers: Integer -- Worker count for that pre-pass (0 keeps it sequential).
+      # @rbs return: Hash[Symbol, untyped] -- Frozen seed tables; empty when the paths yield nothing.
       def build(paths:, environment:, target_ruby:, workers: 0)
         tables = discovery_tables(paths)
         params = Inference::ParameterInferenceCollector.collect(
@@ -51,8 +52,9 @@ module Rigor
       # builds. Built ONCE on the parent (before {CLI::MutationForkScan} forks, so children copy-on-write
       # inherit it), and cheap: ≈0.36s over Rigor's own 349-file `lib`.
       #
-      # @param paths [Array<String>] the measured file set, in canonical (caller) order.
-      # @return [Hash{String => Hash}] per-path bundles, the input {#tables_for_buffer} re-folds.
+      # @rbs paths: Array[String] -- The measured file set, in canonical (caller) order.
+      # @rbs return: Hash[String, Hash[untyped, untyped]] --
+      #   Per-path bundles, the input {#tables_for_buffer} re-folds.
       def bundles(paths:)
         Inference::ScopeIndexer.discovered_project_index_incremental(paths, seed_bundles: {}).fetch(:bundles)
       end
@@ -69,10 +71,10 @@ module Rigor
       #
       # ≈15ms over 349 files (one re-walk plus a whole-set fold), against ≈210ms for one mutant's analysis.
       #
-      # @param paths [Array<String>] the measured file set, in the same order {#bundles} was built from.
-      # @param bundles [Hash{String => Hash}] that bundle set.
-      # @param buffer [Rigor::Analysis::BufferBinding] the mutant binding (logical path → mutant bytes).
-      # @return [Hash{Symbol => Object}] frozen seed tables.
+      # @rbs paths: Array[String] -- The measured file set, in the same order {#bundles} was built from.
+      # @rbs bundles: Hash[String, Hash[untyped, untyped]] -- That bundle set.
+      # @rbs buffer: Rigor::Analysis::BufferBinding -- The mutant binding (logical path → mutant bytes).
+      # @rbs return: Hash[Symbol, untyped] -- Frozen seed tables.
       def tables_for_buffer(paths:, bundles:, buffer:)
         index = Inference::ScopeIndexer.discovered_project_index_incremental(
           paths, seed_bundles: bundles, buffer: buffer

--- a/lib/rigor/protection/kill_signature.rb
+++ b/lib/rigor/protection/kill_signature.rb
@@ -15,12 +15,12 @@ module Rigor
     module KillSignature
       module_function
 
-      # @return [Array] the comparison key.
+      # @rbs return: Array[untyped] -- The comparison key.
       def of(diagnostic)
         [diagnostic.rule, diagnostic.path, diagnostic.line, diagnostic.column, diagnostic.message]
       end
 
-      # @return [Set<Array>] the signature set of `diagnostics`.
+      # @rbs return: Set[Array[untyped]] -- The signature set of `diagnostics`.
       def signatures_of(diagnostics)
         diagnostics.to_set { |diagnostic| of(diagnostic) }
       end

--- a/lib/rigor/protection/kill_signature.rb
+++ b/lib/rigor/protection/kill_signature.rb
@@ -15,13 +15,11 @@ module Rigor
     module KillSignature
       module_function
 
-      # @param diagnostic [Rigor::Analysis::Diagnostic]
       # @return [Array] the comparison key.
       def of(diagnostic)
         [diagnostic.rule, diagnostic.path, diagnostic.line, diagnostic.column, diagnostic.message]
       end
 
-      # @param diagnostics [Enumerable<Rigor::Analysis::Diagnostic>]
       # @return [Set<Array>] the signature set of `diagnostics`.
       def signatures_of(diagnostics)
         diagnostics.to_set { |diagnostic| of(diagnostic) }

--- a/lib/rigor/protection/measurement_integrity.rb
+++ b/lib/rigor/protection/measurement_integrity.rb
@@ -26,8 +26,6 @@ module Rigor
 
       # The report-level companion: a project ratio computed over nothing, where something went wrong.
       # Distinct from an empty project, which is legitimately vacuous.
-      #
-      # @return [Boolean]
       def ratio_unmeasurable?(grand_total:, unmeasured_files:)
         grand_total.zero? && unmeasured_files.positive?
       end

--- a/lib/rigor/protection/measurement_integrity.rb
+++ b/lib/rigor/protection/measurement_integrity.rb
@@ -19,7 +19,7 @@ module Rigor
     module MeasurementIntegrity
       module_function
 
-      # @return [Boolean] false only when nothing could be measured AND something failed trying.
+      # @rbs return: bool -- False only when nothing could be measured AND something failed trying.
       def measured?(total:, harness_errors:)
         !(total.zero? && harness_errors.positive?)
       end

--- a/lib/rigor/protection/mutation_cache.rb
+++ b/lib/rigor/protection/mutation_cache.rb
@@ -89,11 +89,9 @@ module Rigor
       UNIDENTIFIED_ENGINE = "the engine's own source tree could not be digested"
 
       class << self
-        # @param configuration [Rigor::Configuration]
         # @param roots [Array<String>] the analysis roots to look for a snapshot under, most-specific first
         #   (the command's own path arguments, then the configured `paths:`).
         # @param project_scan [Rigor::Analysis::ProjectScan] the prepared whole-project scan.
-        # @param sampling [Sampling]
         # @param feature_ids [Array<String>] the ADOPTED bleeding-edge ids that change this measurement.
         # @param seed_inputs [Array<String>, nil] the files the {DiscoverySeed} was built over when it is
         #   active, nil when it is not. The CLI stays the only place that knows a feature id exists.

--- a/lib/rigor/protection/mutation_cache.rb
+++ b/lib/rigor/protection/mutation_cache.rb
@@ -89,15 +89,17 @@ module Rigor
       UNIDENTIFIED_ENGINE = "the engine's own source tree could not be digested"
 
       class << self
-        # @param roots [Array<String>] the analysis roots to look for a snapshot under, most-specific first
-        #   (the command's own path arguments, then the configured `paths:`).
-        # @param project_scan [Rigor::Analysis::ProjectScan] the prepared whole-project scan.
-        # @param feature_ids [Array<String>] the ADOPTED bleeding-edge ids that change this measurement.
-        # @param seed_inputs [Array<String>, nil] the files the {DiscoverySeed} was built over when it is
-        #   active, nil when it is not. The CLI stays the only place that knows a feature id exists.
-        # @param bypass_reason [String, nil] a caller-side reason to run uncached (`--no-cache`, the closure
-        #   oracle). Reported verbatim.
-        # @return [MutationCache] enabled, or a disabled instance carrying `#reason`.
+        # @rbs roots: Array[String] --
+        #   The analysis roots to look for a snapshot under, most-specific first (the command's own path arguments,
+        #   then the configured `paths:`).
+        # @rbs project_scan: Rigor::Analysis::ProjectScan -- The prepared whole-project scan.
+        # @rbs feature_ids: Array[String] -- The ADOPTED bleeding-edge ids that change this measurement.
+        # @rbs seed_inputs: Array[String]? --
+        #   The files the {DiscoverySeed} was built over when it is active, nil when it is not. The CLI stays the only
+        #   place that knows a feature id exists.
+        # @rbs bypass_reason: String? --
+        #   A caller-side reason to run uncached (`--no-cache`, the closure oracle). Reported verbatim.
+        # @rbs return: MutationCache -- Enabled, or a disabled instance carrying `#reason`.
         def build(configuration:, roots:, project_scan:, sampling:, feature_ids:, seed_inputs: nil,
                   bypass_reason: nil)
           return disabled(bypass_reason) if bypass_reason
@@ -261,7 +263,7 @@ module Rigor
       end
 
       # The cached result for `path`, or nil on any miss (including "this cache is disabled").
-      # @return [MutationScanner::FileResult, nil]
+      # @rbs return: MutationScanner::FileResult?
       def fetch(path)
         return nil unless enabled?
         # A path the snapshot never analysed has no recorded `deps[A]`, which means "depends on every project

--- a/lib/rigor/protection/mutation_scanner.rb
+++ b/lib/rigor/protection/mutation_scanner.rb
@@ -87,7 +87,6 @@ module Rigor
         end
       end
 
-      # @param configuration [Rigor::Configuration]
       # @param environment [Rigor::Environment] pre-built once by the caller
       # @param project_scan [Rigor::Analysis::ProjectScan] pre-built once
       # @param limit [Integer, nil] optional per-file mutation cap (sampled with
@@ -129,7 +128,6 @@ module Rigor
 
       # @param path [String] the file to measure (used as the in-memory bind path)
       # @param source [String, nil] the file's source; read from disk when nil
-      # @return [FileResult]
       def scan_file(path, source: nil)
         source ||= File.read(path, encoding: Encoding::UTF_8)
         kept = kept_mutations(source, path)
@@ -156,8 +154,6 @@ module Rigor
       # mutant the type checker did **not** kill, asks `test_oracle` whether the project's test suite catches it.
       # The expensive suite run is paid only for type-survivors (the gradual short-circuit), so the cost is
       # proportional to the protection hole.
-      # @param test_oracle [TestSuiteOracle]
-      # @return [FusedFileResult]
       def scan_file_fused(path, test_oracle:, source: nil)
         source ||= File.read(path, encoding: Encoding::UTF_8)
         kept = kept_mutations(source, path)

--- a/lib/rigor/protection/mutation_scanner.rb
+++ b/lib/rigor/protection/mutation_scanner.rb
@@ -183,7 +183,6 @@ module Rigor
               sites << fused_site(mut, :none)
             end
           when :harness_error then harness_errors += 1
-            # :invalid — a parse-broken mutant; not a measurement, skip it.
           end
         end
         FusedFileResult.new(path: path, type_killed: type_killed, test_killed: test_killed, sites: sites,

--- a/lib/rigor/protection/mutation_scanner.rb
+++ b/lib/rigor/protection/mutation_scanner.rb
@@ -87,29 +87,28 @@ module Rigor
         end
       end
 
-      # @param environment [Rigor::Environment] pre-built once by the caller
-      # @param project_scan [Rigor::Analysis::ProjectScan] pre-built once
-      # @param limit [Integer, nil] optional per-file mutation cap (sampled with
-      #   `seed`); nil analyses every type-relevant mutation (deterministic).
-      # @param seed [Integer] RNG seed for the optional sample.
-      # @param oracle [#baseline, #killed?, nil] the kill oracle (ADR-69 Seam 1);
-      #   defaults to the {DiagnosticOracle} (the ADR-62/63 behaviour).
-      # @param site_selector [:biteable, :all] which sites to mutate (ADR-69
-      #   Seam 2). `:biteable` (default) keeps only concrete-type sites Rigor can
-      #   bite; `:all` also mutates Dynamic-receiver dispatch sites — use only
-      #   with a {TestSuiteOracle} (the fused overlay), never the diagnostic path.
-      # @param base_scope [Rigor::Scope, nil] the scope site selection judges
-      #   anchor types against, built once by the caller (see
-      #   {Mutator#anchor_base_scope}). `nil` — the default — keeps the bare
-      #   single-file empty scope. A caller that seeds cross-file discovery
-      #   passes it here; this class stays free of {Rigor::Configuration} and of
+      # @rbs environment: Rigor::Environment -- Pre-built once by the caller
+      # @rbs project_scan: Rigor::Analysis::ProjectScan -- Pre-built once
+      # @rbs limit: Integer? --
+      #   Optional per-file mutation cap (sampled with `seed`); nil analyses every type-relevant mutation
+      #   (deterministic).
+      # @rbs seed: Integer -- RNG seed for the optional sample.
+      # @rbs oracle: untyped --
+      #   The kill oracle (ADR-69 Seam 1); defaults to the {DiagnosticOracle} (the ADR-62/63 behaviour).
+      # @rbs site_selector: :biteable | :all --
+      #   Which sites to mutate (ADR-69 Seam 2). `:biteable` (default) keeps only concrete-type sites Rigor can bite;
+      #   `:all` also mutates Dynamic-receiver dispatch sites — use only with a {TestSuiteOracle} (the fused overlay),
+      #   never the diagnostic path.
+      # @rbs base_scope: Rigor::Scope? --
+      #   The scope site selection judges anchor types against, built once by the caller (see
+      #   {Mutator#anchor_base_scope}). `nil` — the default — keeps the bare single-file empty scope. A caller that
+      #   seeds cross-file discovery passes it here; this class stays free of {Rigor::Configuration} and of
       #   bleeding-edge feature ids, which live one layer up in the CLI.
-      # @param discovery_seed [Hash, nil] issue #260 — the SAME cross-file table
-      #   set `base_scope` was built from, threaded to the default
-      #   {DiagnosticOracle} so an admitted cross-file site is one the oracle can
-      #   also kill at. Pass both or neither: a `base_scope` without it measures
-      #   sites no mutation can ever break. Ignored when `oracle` is supplied
-      #   (that caller owns its oracle's knowledge).
+      # @rbs discovery_seed: Hash[untyped, untyped]? --
+      #   Issue #260 — the SAME cross-file table set `base_scope` was built from, threaded to the default
+      #   {DiagnosticOracle} so an admitted cross-file site is one the oracle can also kill at. Pass both or neither:
+      #   a `base_scope` without it measures sites no mutation can ever break. Ignored when `oracle` is supplied (that
+      #   caller owns its oracle's knowledge).
       # rubocop:disable Metrics/ParameterLists -- every one is an independently-defaulted collaborator or knob;
       # bundling them into an options object would only move the list behind a name.
       def initialize(configuration:, environment:, project_scan:, limit: nil, seed: 1, oracle: nil,
@@ -126,8 +125,8 @@ module Rigor
         )
       end
 
-      # @param path [String] the file to measure (used as the in-memory bind path)
-      # @param source [String, nil] the file's source; read from disk when nil
+      # @rbs path: String -- The file to measure (used as the in-memory bind path)
+      # @rbs source: String? -- The file's source; read from disk when nil
       def scan_file(path, source: nil)
         source ||= File.read(path, encoding: Encoding::UTF_8)
         kept = kept_mutations(source, path)

--- a/lib/rigor/protection/mutator.rb
+++ b/lib/rigor/protection/mutator.rb
@@ -171,8 +171,9 @@ module Rigor
       # only removes provably-Dynamic sites. Returns [kept, dropped_count]. Builds the scope index from THIS
       # mutator's parse so anchor node identity matches the keys.
       #
-      # @param base_scope [Rigor::Scope, nil] a pre-seeded scope to judge anchors against (see
-      #   {#anchor_base_scope}); nil builds the bare empty scope, which is the shipped default.
+      # @rbs base_scope: Rigor::Scope? --
+      #   A pre-seeded scope to judge anchors against (see {#anchor_base_scope}); nil builds the bare empty scope,
+      #   which is the shipped default.
       def filter_by_type(mutations, environment:, path:, base_scope: nil)
         base = anchor_base_scope(environment, path, base_scope)
         index = Rigor::Inference::ScopeIndexer.index(@parse.value, default_scope: base)

--- a/lib/rigor/protection/test_suite_oracle.rb
+++ b/lib/rigor/protection/test_suite_oracle.rb
@@ -16,9 +16,9 @@ module Rigor
     # standard mutation-testing hazard the `ensure` cannot cover; callers running this in CI accept that, as
     # `mutant` / Stryker do.)
     class TestSuiteOracle
-      # @param command [Array<String>] the test command (the runner hook)
-      # @param runner [#call, nil] `runner.call(command) -> true iff the suite
-      #   passed`. Defaults to shelling out via `system`.
+      # @rbs command: Array[String] -- The test command (the runner hook)
+      # @rbs runner: untyped --
+      #   `runner.call(command) -> true iff the suite passed`. Defaults to shelling out via `system`.
       def initialize(command:, runner: nil)
         @command = command
         @runner = runner || method(:shell_run)
@@ -31,9 +31,9 @@ module Rigor
       end
 
       # Killed iff the mutant turns the suite red. Restores `original` afterward.
-      # @param path [String] the file to (temporarily) overwrite with the mutant
-      # @param original [String] the clean bytes to restore
-      # @param mutant_source [String] the mutated bytes to test against
+      # @rbs path: String -- The file to (temporarily) overwrite with the mutant
+      # @rbs original: String -- The clean bytes to restore
+      # @rbs mutant_source: String -- The mutated bytes to test against
       def killed?(path:, original:, mutant_source:)
         File.write(path, mutant_source)
         !@runner.call(@command)

--- a/lib/rigor/rbs_extended.rb
+++ b/lib/rigor/rbs_extended.rb
@@ -98,11 +98,9 @@ module Rigor
     # source order; duplicates and unrecognised `rigor:v1:` directives are dropped. Returns an empty array (NEVER
     # `nil`) for a method with no recognised annotations so callers can iterate unconditionally.
     #
-    # @param environment [Rigor::Environment, nil] ADR-13 slice
-    #   3b. When provided, threads the plugin-supplied
-    #   `name_scope:` and the per-run reporter through the
-    #   annotation-parse path. `nil` (default) preserves the
-    #   pre-slice-3b behaviour — no plugin resolvers consulted
+    # @rbs environment: Rigor::Environment? --
+    #   ADR-13 slice 3b. When provided, threads the plugin-supplied `name_scope:` and the per-run reporter through the
+    #   annotation-parse path. `nil` (default) preserves the pre-slice-3b behaviour — no plugin resolvers consulted
     #   and no diagnostics accumulated.
     def read_predicate_effects(method_def, environment: nil)
       return [] if method_def.nil?
@@ -708,10 +706,11 @@ module Rigor
     # `RBS::Extended` conflict channel) rather than silently resolved. Returns `nil` when the list
     # carries neither spelling.
     #
-    # @param annotations [Array<#string>] the node's annotations, in source order.
-    # @param owner_key [String] the method key (`Class#m` / `Class.m`) or class name the bound binds.
-    # @param source [Symbol] {Effects::Envelope::SOURCES} member to stamp when the labelled spelling
-    #   matched; `%a{pure}` always stamps `:pure_annotation`, and a class-level read overrides both.
+    # @rbs annotations: Array[untyped] -- The node's annotations, in source order.
+    # @rbs owner_key: String -- The method key (`Class#m` / `Class.m`) or class name the bound binds.
+    # @rbs source: Symbol --
+    #   {Effects::Envelope::SOURCES} member to stamp when the labelled spelling matched; `%a{pure}` always stamps
+    #   `:pure_annotation`, and a class-level read overrides both.
     def read_effect_envelope(annotations, owner_key:, source: :effect_annotation, registry: nil, reporter: nil)
       return nil if annotations.nil? || annotations.empty?
 

--- a/lib/rigor/rbs_extended/conformance_checker.rb
+++ b/lib/rigor/rbs_extended/conformance_checker.rb
@@ -60,7 +60,7 @@ module Rigor
         results
       end
 
-      # @return [Array] zero or more records for one (class, interface) pair.
+      # @rbs return: Array[untyped] -- Zero or more records for one (class, interface) pair.
       def check_one(rbs_loader, class_name, interface_name, location)
         interface_def = resolve_interface(rbs_loader, class_name, interface_name)
         if interface_def.nil?

--- a/lib/rigor/rbs_extended/envelope_scanner.rb
+++ b/lib/rigor/rbs_extended/envelope_scanner.rb
@@ -50,7 +50,6 @@ module Rigor
       # @param sources [Array<Array(String, String)>] `[buffer name, RBS source]` pairs — the project's
       #   `.rbs` files, plus the virtual entries rbs-inline and plugin `source_rbs` synthesis contribute.
       # @param registry [Rigor::Effects::Registry] the vocabulary an unknown label is judged against.
-      # @return [Result]
       #
       # The `ANNOTATION_HINT` routing test runs here, before any parse: a source with no honoured
       # payload can contribute neither an envelope nor an unresolved report, so a signature tree with
@@ -96,7 +95,6 @@ module Rigor
       # @param loader [Rigor::Environment::RbsLoader] the run's loader; it owns the env walk
       #   ({Rigor::Environment::RbsLoader#each_annotated_method_member}), so the environment itself never
       #   leaves it.
-      # @param registry [Rigor::Effects::Registry]
       # @return [Hash{String => Rigor::Effects::Envelope}] keyed `Class#m` / `Class.m`
       def from_loader(loader:, registry:)
         out = {}

--- a/lib/rigor/rbs_extended/envelope_scanner.rb
+++ b/lib/rigor/rbs_extended/envelope_scanner.rb
@@ -47,9 +47,10 @@ module Rigor
 
       module_function
 
-      # @param sources [Array<Array(String, String)>] `[buffer name, RBS source]` pairs — the project's
-      #   `.rbs` files, plus the virtual entries rbs-inline and plugin `source_rbs` synthesis contribute.
-      # @param registry [Rigor::Effects::Registry] the vocabulary an unknown label is judged against.
+      # @rbs sources: Array[[String, String]] --
+      #   `[buffer name, RBS source]` pairs — the project's `.rbs` files, plus the virtual entries rbs-inline and
+      #   plugin `source_rbs` synthesis contribute.
+      # @rbs registry: Rigor::Effects::Registry -- The vocabulary an unknown label is judged against.
       #
       # The `ANNOTATION_HINT` routing test runs here, before any parse: a source with no honoured
       # payload can contribute neither an envelope nor an unresolved report, so a signature tree with
@@ -92,10 +93,10 @@ module Rigor
       # class discovery knows", which is a project fact; a gem's class-level tag would have to
       # distribute over a definition set this reader does not have.
       #
-      # @param loader [Rigor::Environment::RbsLoader] the run's loader; it owns the env walk
-      #   ({Rigor::Environment::RbsLoader#each_annotated_method_member}), so the environment itself never
-      #   leaves it.
-      # @return [Hash{String => Rigor::Effects::Envelope}] keyed `Class#m` / `Class.m`
+      # @rbs loader: Rigor::Environment::RbsLoader --
+      #   The run's loader; it owns the env walk ({Rigor::Environment::RbsLoader#each_annotated_method_member}), so
+      #   the environment itself never leaves it.
+      # @rbs return: Hash[String, Rigor::Effects::Envelope] -- Keyed `Class#m` / `Class.m`
       def from_loader(loader:, registry:)
         out = {}
         loader.each_annotated_method_member do |class_name, member|

--- a/lib/rigor/rbs_extended/reporter.rb
+++ b/lib/rigor/rbs_extended/reporter.rb
@@ -32,12 +32,12 @@ module Rigor
         @mutex = Mutex.new
       end
 
-      # @return [Array<UnresolvedEntry>] frozen snapshot of the accumulated unresolved-payload events.
+      # @rbs return: Array[UnresolvedEntry] -- Frozen snapshot of the accumulated unresolved-payload events.
       def unresolved_payloads
         @mutex.synchronize { @unresolved_payloads.dup.freeze }
       end
 
-      # @return [Array<LossyProjectionEntry>] frozen snapshot of the accumulated lossy-projection events.
+      # @rbs return: Array[LossyProjectionEntry] -- Frozen snapshot of the accumulated lossy-projection events.
       def lossy_projections
         @mutex.synchronize { @lossy_projections.dup.freeze }
       end

--- a/lib/rigor/reflection.rb
+++ b/lib/rigor/reflection.rb
@@ -89,8 +89,7 @@ module Rigor
       loader.project_declared_class?(class_name)
     end
 
-    # @return [Symbol] one of `:equal`, `:subclass`, `:superclass`,
-    #   `:disjoint`, `:unknown`.
+    # @rbs return: Symbol -- One of `:equal`, `:subclass`, `:superclass`, `:disjoint`, `:unknown`.
     def class_ordering(lhs, rhs, scope: Scope.empty)
       scope.environment.class_ordering(lhs, rhs)
     end
@@ -449,15 +448,15 @@ module Rigor
     end
     private_class_method :rbs_loader_for
 
-    # @return [Boolean] true when the analyzed source contains a class / module declaration
-    #   for the given name. Does NOT consult the RBS loader (use {.class_known?} for the
-    #   union).
+    # @rbs return: bool --
+    #   True when the analyzed source contains a class / module declaration for the given name. Does NOT consult the
+    #   RBS loader (use {.class_known?} for the union).
     def discovered_class?(class_name, scope: Scope.empty)
       scope.discovered_classes.key?(class_name.to_s)
     end
 
-    # @return [Boolean] true when the ScopeIndexer recorded a `def` for the given method on
-    #   the given class with the matching kind.
+    # @rbs return: bool --
+    #   True when the ScopeIndexer recorded a `def` for the given method on the given class with the matching kind.
     #
     # ADR-46 — a MISS records a negative cross-file dependency, so a consumer whose analysis
     # turned on "the project does not define this method" is re-checked once a later edit

--- a/lib/rigor/reflection.rb
+++ b/lib/rigor/reflection.rb
@@ -51,9 +51,6 @@ module Rigor
 
     module_function
 
-    # @param class_name [String, Symbol]
-    # @param scope [Rigor::Scope]
-    # @return [Boolean]
     def class_known?(class_name, scope: Scope.empty)
       return true if scope.discovered_classes.key?(class_name.to_s)
 
@@ -98,21 +95,18 @@ module Rigor
       scope.environment.class_ordering(lhs, rhs)
     end
 
-    # Returns the `Rigor::Type::Nominal` for the class name, or nil when no source knows the
-    # class.
+    # nil when no source knows the class.
     def nominal_for_name(class_name, scope: Scope.empty)
       scope.environment.nominal_for_name(class_name)
     end
 
-    # Returns the `Rigor::Type::Singleton` for the class name's class object, or nil when no
-    # source knows the class.
+    # nil when no source knows the class.
     def singleton_for_name(class_name, scope: Scope.empty)
       scope.environment.singleton_for_name(class_name)
     end
 
-    # Returns the type of the named constant. Joins in-source constants (recorded by
-    # `ScopeIndexer`) and RBS-side constants. In-source wins on collision because the user's
-    # source is the authoritative declaration.
+    # Joins in-source constants (recorded by `ScopeIndexer`) and RBS-side constants.
+    # In-source wins on collision because the user's source is the authoritative declaration.
     #
     # This is the flat lookup keyed on the literal `constant_name`. Callers that need Ruby's
     # lexical constant resolution (walking the enclosing class path, and folding in registry
@@ -401,10 +395,8 @@ module Rigor
     end
     private_class_method :peeled_nesting
 
-    # Returns the RBS `RBS::Definition::Method` for the instance method, or nil when the
-    # class or method is not in RBS. The source-side discovered-method facts are reachable
-    # through {.discovered_method?}; a future slice will unify the two under a
-    # `MethodDefinition` carrier.
+    # nil when the class or method is not in RBS. Source-side facts are {.discovered_method?};
+    # unifying the two is a future slice.
     def instance_method_definition(class_name, method_name, scope: nil, environment: nil)
       loader = rbs_loader_for(scope, environment)
       return nil if loader.nil?
@@ -412,8 +404,6 @@ module Rigor
       loader.instance_method(class_name: class_name.to_s, method_name: method_name.to_sym)
     end
 
-    # Returns the RBS `RBS::Definition::Method` for the singleton (class-side) method, or
-    # nil.
     def singleton_method_definition(class_name, method_name, scope: nil, environment: nil)
       loader = rbs_loader_for(scope, environment)
       return nil if loader.nil?
@@ -421,10 +411,8 @@ module Rigor
       loader.singleton_method(class_name: class_name.to_s, method_name: method_name.to_sym)
     end
 
-    # Returns the full RBS instance-side class definition (`RBS::Definition`), used by
-    # callers that walk the method table or member list. Returns nil when the class is not
-    # in RBS or when the loader cannot build a definition (e.g. constant aliases, malformed
-    # signatures).
+    # nil when the class is not in RBS, or when the loader cannot build a definition
+    # (constant aliases, malformed signatures).
     def instance_definition(class_name, scope: nil, environment: nil)
       loader = rbs_loader_for(scope, environment)
       return nil if loader.nil?
@@ -434,7 +422,6 @@ module Rigor
       nil
     end
 
-    # Returns the full RBS singleton-side class definition.
     def singleton_definition(class_name, scope: nil, environment: nil)
       loader = rbs_loader_for(scope, environment)
       return nil if loader.nil?
@@ -444,9 +431,8 @@ module Rigor
       nil
     end
 
-    # Returns the RBS-declared type parameter names for the class (e.g. `[:A]` for
-    # `Array[A]`), or `[]` when the class is non-generic / not in RBS. Used by the dispatcher
-    # when binding generic method types to a concrete receiver.
+    # `[]` when the class is non-generic or not in RBS. The dispatcher uses this when binding
+    # generic method types to a concrete receiver.
     def class_type_param_names(class_name, scope: nil, environment: nil)
       loader = rbs_loader_for(scope, environment)
       return [] if loader.nil?
@@ -454,9 +440,7 @@ module Rigor
       loader.class_type_param_names(class_name.to_s)
     end
 
-    # Internal helper — resolves the RBS loader from either the `scope:` or the
-    # `environment:` kwarg, defaulting to the empty scope's environment when neither is
-    # given. Public methods document both spellings; the helper centralises the dispatch.
+    # Public methods take `scope:` or `environment:`; this is the one dispatch.
     def rbs_loader_for(scope, environment)
       return environment.rbs_loader if environment
       return scope.environment.rbs_loader if scope
@@ -472,7 +456,6 @@ module Rigor
       scope.discovered_classes.key?(class_name.to_s)
     end
 
-    # @param kind [:instance, :singleton]
     # @return [Boolean] true when the ScopeIndexer recorded a `def` for the given method on
     #   the given class with the matching kind.
     #

--- a/lib/rigor/runtime/jit.rb
+++ b/lib/rigor/runtime/jit.rb
@@ -70,8 +70,8 @@ module Rigor
       # call is what enabled YJIT (so the `?`-suffix predicate convention does
       # not apply; hence the Naming/PredicateMethod exemption).
       #
-      # @return [Boolean] true if this call enabled YJIT; false if it was a
-      #   no-op (unavailable / opted out / already enabled).
+      # @rbs return: bool --
+      #   True if this call enabled YJIT; false if it was a no-op (unavailable / opted out / already enabled).
       def enable_now # rubocop:disable Naming/PredicateMethod
         return false unless available?
         return false if disabled?
@@ -90,8 +90,8 @@ module Rigor
       # up front (unavailable / opted out / already enabled), so callers never
       # pay for a thread that could only no-op.
       #
-      # @param seconds [Numeric] the amortization deadline.
-      # @return [Thread, nil] the deadline thread, or nil when no-op up front.
+      # @rbs seconds: Numeric -- The amortization deadline.
+      # @rbs return: Thread? -- The deadline thread, or nil when no-op up front.
       def enable_after(seconds)
         return nil unless available?
         return nil if disabled?
@@ -143,10 +143,10 @@ module Rigor
       # Re-arming goes through {enable_after}, so the child records the same
       # absolute deadline it inherited and a grandchild fork carries it too.
       #
-      # @return [Thread, nil] the child's deadline thread; nil when YJIT was
-      #   enabled immediately, and nil when the call is a no-op up front
-      #   (unavailable / opted out / already enabled — a child forked after the
-      #   parent enabled inherits the enabled state and has nothing to do).
+      # @rbs return: Thread? --
+      #   The child's deadline thread; nil when YJIT was enabled immediately, and nil when the call is a no-op up
+      #   front (unavailable / opted out / already enabled — a child forked after the parent enabled inherits the
+      #   enabled state and has nothing to do).
       def rearm_after_fork
         return nil unless available?
         return nil if disabled?
@@ -174,12 +174,12 @@ module Rigor
         value && value >= 0 ? value : DEFAULT_DEADLINE_SECONDS
       end
 
-      # @return [Boolean] whether this Ruby exposes `RubyVM::YJIT.enable`.
+      # @rbs return: bool -- Whether this Ruby exposes `RubyVM::YJIT.enable`.
       def available?
         defined?(RubyVM::YJIT.enable) ? true : false
       end
 
-      # @return [Boolean] whether the opt-out env switch is set.
+      # @rbs return: bool -- Whether the opt-out env switch is set.
       def disabled?
         ENV[DISABLE_ENV] == "1"
       end

--- a/lib/rigor/runtime/jit.rb
+++ b/lib/rigor/runtime/jit.rb
@@ -166,8 +166,6 @@ module Rigor
 
       # The resolved {enable_after} deadline: {DEADLINE_ENV} when it parses to a
       # non-negative float, else {DEFAULT_DEADLINE_SECONDS}.
-      #
-      # @return [Numeric]
       def deadline_seconds
         raw = ENV.fetch(DEADLINE_ENV, nil)
         return DEFAULT_DEADLINE_SECONDS if raw.nil? || raw.empty?

--- a/lib/rigor/sig_gen/generator.rb
+++ b/lib/rigor/sig_gen/generator.rb
@@ -43,7 +43,6 @@ module Rigor
       # @return [Array<UnrenderableMethod>] empty on a healthy run; read after {#run}.
       attr_reader :unrenderable, :unresolvable_superclasses
 
-      # @param configuration [Rigor::Configuration]
       # @param paths [Array<String>] files / directories to scan.
       # @param observations [Hash{[String, Symbol] => Array<Array<Rigor::Type>>}]
       #   ADR-14 slice 3 — per-target-method arg-tuple observations
@@ -80,7 +79,6 @@ module Rigor
         map.transform_values { |entries| entries.map { |entry| ObservedCall.from(entry) } }
       end
 
-      # @return [Array<MethodCandidate>]
       def run
         @environment = build_environment
         resolved = resolve_paths(@paths)

--- a/lib/rigor/sig_gen/generator.rb
+++ b/lib/rigor/sig_gen/generator.rb
@@ -40,15 +40,14 @@ module Rigor
       # one is a Rigor rendering DEFECT, not a property of the user's code, so the CLI reports them as such.
       UnrenderableMethod = Data.define(:path, :class_name, :method_name, :rbs, :error)
 
-      # @return [Array<UnrenderableMethod>] empty on a healthy run; read after {#run}.
+      # @rbs return: Array[UnrenderableMethod] -- Empty on a healthy run; read after {#run}.
       attr_reader :unrenderable, :unresolvable_superclasses
 
-      # @param paths [Array<String>] files / directories to scan.
-      # @param observations [Hash{[String, Symbol] => Array<Array<Rigor::Type>>}]
-      #   ADR-14 slice 3 — per-target-method arg-tuple observations
-      #   produced by {ObservationCollector}. An empty Hash (the default)
-      #   means "no observations available; emit `untyped` for every
-      #   parameter position" per ADR-5 clause 2.
+      # @rbs paths: Array[String] -- Files / directories to scan.
+      # @rbs observations: Hash[[String, Symbol], Array[Array[Rigor::Type]]] --
+      #   ADR-14 slice 3 — per-target-method arg-tuple observations produced by {ObservationCollector}. An empty Hash
+      #   (the default) means "no observations available; emit `untyped` for every parameter position" per ADR-5
+      #   clause 2.
       def initialize(configuration:, paths:, observations: {}, include_private: false)
         @configuration = configuration
         @paths = paths

--- a/lib/rigor/sig_gen/layout_index.rb
+++ b/lib/rigor/sig_gen/layout_index.rb
@@ -30,11 +30,10 @@ module Rigor
         @index = nil
       end
 
-      # @param class_name [String] fully-qualified Ruby class
-      #   name (e.g. `"Rigor::Type::Top"`).
-      # @return [Pathname, nil] absolute path of the sig file
-      #   that already declares this class, or `nil` when no
-      #   existing declaration is found.
+      # @rbs class_name: String -- Fully-qualified Ruby class name (e.g. `"Rigor::Type::Top"`).
+      # @rbs return: Pathname? --
+      #   Absolute path of the sig file that already declares this class, or `nil` when no existing declaration is
+      #   found.
       def file_for(class_name)
         index[class_name]
       end

--- a/lib/rigor/sig_gen/layout_index.rb
+++ b/lib/rigor/sig_gen/layout_index.rb
@@ -21,12 +21,10 @@ module Rigor
     # in multiple files for additive member contributions, but the writer only needs one canonical target per
     # class.
     class LayoutIndex
-      # @param signature_paths [Array<String, Pathname>, nil]
       #   the `.rigor.yml`-configured signature directories.
       #   When `nil` or empty, falls back to `<project_root>/sig`
       #   if it exists (matching `Environment.for_project`'s
       #   auto-detection convention).
-      # @param project_root [String, Pathname]
       def initialize(signature_paths:, project_root: Dir.pwd)
         @signature_paths = resolve_paths(signature_paths, project_root)
         @index = nil

--- a/lib/rigor/sig_gen/meta_class_shape.rb
+++ b/lib/rigor/sig_gen/meta_class_shape.rb
@@ -29,11 +29,9 @@ module Rigor
 
       module_function
 
-      # @param kind [:data, :struct]
       # @param members [Array<Symbol>] ordered member names from the ADR-48 layout.
       # @param member_types [Hash{Symbol => String}] erased RBS spellings; a member with no entry renders `untyped`.
       # @param keyword_init [Boolean] the `Struct.new(..., keyword_init: true)` flag; ignored for `:data`.
-      # @return [Shape]
       def of(kind:, members:, member_types: {}, keyword_init: false)
         types = members.to_h { |member| [member, member_types[member] || "untyped"] }
         accessors = kind == :struct ? struct_accessors(members, types) : readers(members, types)

--- a/lib/rigor/sig_gen/meta_class_shape.rb
+++ b/lib/rigor/sig_gen/meta_class_shape.rb
@@ -29,9 +29,9 @@ module Rigor
 
       module_function
 
-      # @param members [Array<Symbol>] ordered member names from the ADR-48 layout.
-      # @param member_types [Hash{Symbol => String}] erased RBS spellings; a member with no entry renders `untyped`.
-      # @param keyword_init [Boolean] the `Struct.new(..., keyword_init: true)` flag; ignored for `:data`.
+      # @rbs members: Array[Symbol] -- Ordered member names from the ADR-48 layout.
+      # @rbs member_types: Hash[Symbol, String] -- Erased RBS spellings; a member with no entry renders `untyped`.
+      # @rbs keyword_init: bool -- The `Struct.new(..., keyword_init: true)` flag; ignored for `:data`.
       def of(kind:, members:, member_types: {}, keyword_init: false)
         types = members.to_h { |member| [member, member_types[member] || "untyped"] }
         accessors = kind == :struct ? struct_accessors(members, types) : readers(members, types)

--- a/lib/rigor/sig_gen/observation_collector.rb
+++ b/lib/rigor/sig_gen/observation_collector.rb
@@ -32,7 +32,6 @@ module Rigor
     #   the collector cannot attribute them to a specific class.
     # - Zero-argument calls give no observation; methods are matched by `(class_name, method_name)` only.
     class ObservationCollector # rubocop:disable Metrics/ClassLength
-      # @param configuration [Rigor::Configuration]
       # @param paths [Array<String>] observe paths (files /
       #   directories).
       # @param source_paths [Array<String>] source-tree paths

--- a/lib/rigor/sig_gen/observation_collector.rb
+++ b/lib/rigor/sig_gen/observation_collector.rb
@@ -18,7 +18,7 @@ module Rigor
     # for every `Prism::CallNode` whose receiver types as a `Type::Nominal`. The {Generator} consumes the
     # resulting map to render `--params=observed` RBS:
     #
-    # @return [Hash{[class_name, method_name] => Array<Array<Rigor::Type>>}]
+    # @rbs return: Hash[[class_name, method_name], Array[Array[Rigor::Type]]]
     #
     # ADR-5 clause 2 compliance: the observed union is the MOST PERMISSIVE parameter contract the existing
     # callers prove sufficient — by construction it accepts every type any caller has already passed. The
@@ -32,15 +32,11 @@ module Rigor
     #   the collector cannot attribute them to a specific class.
     # - Zero-argument calls give no observation; methods are matched by `(class_name, method_name)` only.
     class ObservationCollector # rubocop:disable Metrics/ClassLength
-      # @param paths [Array<String>] observe paths (files /
-      #   directories).
-      # @param source_paths [Array<String>] source-tree paths
-      #   (defaults to `configuration.paths`) pre-walked to
-      #   register every project-defined class so that calls
-      #   like `Foo.new.bar(x)` in the observe tree resolve
-      #   to a `Type::Nominal[Foo]` receiver instead of
-      #   degrading to `Dynamic[top]` for the unknown
-      #   constant.
+      # @rbs paths: Array[String] -- Observe paths (files / directories).
+      # @rbs source_paths: Array[String] --
+      #   Source-tree paths (defaults to `configuration.paths`) pre-walked to register every project-defined class so
+      #   that calls like `Foo.new.bar(x)` in the observe tree resolve to a `Type::Nominal[Foo]` receiver instead of
+      #   degrading to `Dynamic[top]` for the unknown constant.
       def initialize(configuration:, paths:, source_paths: nil)
         @configuration = configuration
         @paths = paths

--- a/lib/rigor/sig_gen/path_mapper.rb
+++ b/lib/rigor/sig_gen/path_mapper.rb
@@ -21,7 +21,6 @@ module Rigor
     # When the source path is not under any configured source root (e.g. files supplied directly on the CLI
     # from outside `lib/`), the full relative path is preserved under the sig root.
     class PathMapper
-      # @param configuration [Rigor::Configuration]
       # @param project_root [String, Pathname] (defaults to `Dir.pwd`)
       # @param layout_index [LayoutIndex, nil] optional class
       #   → existing sig file index; routes the target to the
@@ -32,7 +31,6 @@ module Rigor
         @layout_index = layout_index
       end
 
-      # @param source_path [String]
       # @param class_name [String, nil] fully-qualified Ruby
       #   class name. When supplied and matched by the
       #   `LayoutIndex`, the consolidated sig file's path is

--- a/lib/rigor/sig_gen/path_mapper.rb
+++ b/lib/rigor/sig_gen/path_mapper.rb
@@ -21,22 +21,20 @@ module Rigor
     # When the source path is not under any configured source root (e.g. files supplied directly on the CLI
     # from outside `lib/`), the full relative path is preserved under the sig root.
     class PathMapper
-      # @param project_root [String, Pathname] (defaults to `Dir.pwd`)
-      # @param layout_index [LayoutIndex, nil] optional class
-      #   → existing sig file index; routes the target to the
-      #   consolidated file when the class is already declared.
+      # @rbs project_root: String | Pathname -- (defaults to `Dir.pwd`)
+      # @rbs layout_index: LayoutIndex? --
+      #   Optional class → existing sig file index; routes the target to the consolidated file when the class is
+      #   already declared.
       def initialize(configuration:, project_root: Dir.pwd, layout_index: nil)
         @configuration = configuration
         @project_root = Pathname(project_root)
         @layout_index = layout_index
       end
 
-      # @param class_name [String, nil] fully-qualified Ruby
-      #   class name. When supplied and matched by the
-      #   `LayoutIndex`, the consolidated sig file's path is
-      #   returned instead of the 1:1 mirror.
-      # @return [Pathname] absolute path of the target `.rbs`
-      #   file for the candidate.
+      # @rbs class_name: String? --
+      #   Fully-qualified Ruby class name. When supplied and matched by the `LayoutIndex`, the consolidated sig file's
+      #   path is returned instead of the 1:1 mirror.
+      # @rbs return: Pathname -- Absolute path of the target `.rbs` file for the candidate.
       def target_for(source_path, class_name: nil)
         existing = existing_target_for(class_name)
         return existing if existing

--- a/lib/rigor/sig_gen/rbs_validity.rb
+++ b/lib/rigor/sig_gen/rbs_validity.rb
@@ -23,16 +23,16 @@ module Rigor
 
       module_function
 
-      # @param line [String] a rendered RBS method line, e.g. `def self.parse: (String) -> Integer`.
-      # @return [String, nil] the parse error's first line, or nil when the line is valid.
+      # @rbs line: String -- A rendered RBS method line, e.g. `def self.parse: (String) -> Integer`.
+      # @rbs return: String? -- The parse error's first line, or nil when the line is valid.
       def method_line_error(line)
         return nil if line.nil?
 
         source_error("class #{PROBE_CLASS}\n  #{line}\nend\n")
       end
 
-      # @param source [String] a complete `.rbs` file's text.
-      # @return [String, nil] the parse error's first line, or nil when the file is valid.
+      # @rbs source: String -- A complete `.rbs` file's text.
+      # @rbs return: String? -- The parse error's first line, or nil when the file is valid.
       def source_error(source)
         ::RBS::Parser.parse_signature(::RBS::Buffer.new(name: "(rigor sig-gen)", content: source))
         nil

--- a/lib/rigor/sig_gen/renderer.rb
+++ b/lib/rigor/sig_gen/renderer.rb
@@ -20,8 +20,6 @@ module Rigor
         @out = out
       end
 
-      # @param candidates [Array<MethodCandidate>]
-      # @param mode [:print, :diff]
       # @param format [String] "text" or "json"
       # @param selection [Array<Symbol>] subset of
       #   {Classification} constants to include; an empty

--- a/lib/rigor/sig_gen/renderer.rb
+++ b/lib/rigor/sig_gen/renderer.rb
@@ -20,10 +20,9 @@ module Rigor
         @out = out
       end
 
-      # @param format [String] "text" or "json"
-      # @param selection [Array<Symbol>] subset of
-      #   {Classification} constants to include; an empty
-      #   array means "all emittable classifications".
+      # @rbs format: String -- "text" or "json"
+      # @rbs selection: Array[Symbol] --
+      #   Subset of {Classification} constants to include; an empty array means "all emittable classifications".
       def render(candidates:, mode:, format:, selection:)
         filtered = filter(candidates, selection)
 

--- a/lib/rigor/sig_gen/type_elaborator.rb
+++ b/lib/rigor/sig_gen/type_elaborator.rb
@@ -20,8 +20,6 @@ module Rigor
     # The module is sig-gen-local; the broader question of whether the inference engine itself should always
     # construct generics with explicit type_args is queued as an ADR-14 follow-up.
     module TypeElaborator
-      # @param type [Rigor::Type]
-      # @param environment [Rigor::Environment]
       # @return [Rigor::Type] same shape with bare generic
       #   nominals filled in.
       def self.elaborate(type, environment:)

--- a/lib/rigor/sig_gen/type_elaborator.rb
+++ b/lib/rigor/sig_gen/type_elaborator.rb
@@ -20,8 +20,7 @@ module Rigor
     # The module is sig-gen-local; the broader question of whether the inference engine itself should always
     # construct generics with explicit type_args is queued as an ADR-14 follow-up.
     module TypeElaborator
-      # @return [Rigor::Type] same shape with bare generic
-      #   nominals filled in.
+      # @rbs return: Rigor::Type -- Same shape with bare generic nominals filled in.
       def self.elaborate(type, environment:)
         arity_cache = {}
         walk(type, environment, arity_cache)

--- a/lib/rigor/sig_gen/writer.rb
+++ b/lib/rigor/sig_gen/writer.rb
@@ -50,7 +50,7 @@ module Rigor
       # ADR-14 follow-up: this is the consolidated-layout entry point. The legacy `write(source_path,
       # candidates)` below assumes all candidates share a target and remains for spec convenience.
       #
-      # @return [Array<WriteResult>] one per target sig file.
+      # @rbs return: Array[WriteResult] -- One per target sig file.
       def write_all(candidates)
         emittable = candidates.select { |c| EMITTABLE.include?(c.classification) }
         return [] if emittable.empty?
@@ -61,10 +61,9 @@ module Rigor
                  .map { |target, group| write_target(target, group) }
       end
 
-      # @param candidates [Array<MethodCandidate>] only
-      #   emittable classifications (new-method /
-      #   tighter-return) are honoured; the caller is
-      #   responsible for filtering.
+      # @rbs candidates: Array[MethodCandidate] --
+      #   Only emittable classifications (new-method / tighter-return) are honoured; the caller is responsible for
+      #   filtering.
       def write(source_path, candidates)
         emittable = candidates.select { |c| EMITTABLE.include?(c.classification) }
         return WriteResult.new(source_path: source_path, target_path: nil, action: :noop) if emittable.empty?

--- a/lib/rigor/sig_gen/writer.rb
+++ b/lib/rigor/sig_gen/writer.rb
@@ -50,7 +50,6 @@ module Rigor
       # ADR-14 follow-up: this is the consolidated-layout entry point. The legacy `write(source_path,
       # candidates)` below assumes all candidates share a target and remains for spec convenience.
       #
-      # @param candidates [Array<MethodCandidate>]
       # @return [Array<WriteResult>] one per target sig file.
       def write_all(candidates)
         emittable = candidates.select { |c| EMITTABLE.include?(c.classification) }
@@ -62,12 +61,10 @@ module Rigor
                  .map { |target, group| write_target(target, group) }
       end
 
-      # @param source_path [String]
       # @param candidates [Array<MethodCandidate>] only
       #   emittable classifications (new-method /
       #   tighter-return) are honoured; the caller is
       #   responsible for filtering.
-      # @return [WriteResult]
       def write(source_path, candidates)
         emittable = candidates.select { |c| EMITTABLE.include?(c.classification) }
         return WriteResult.new(source_path: source_path, target_path: nil, action: :noop) if emittable.empty?

--- a/lib/rigor/signature_path_audit.rb
+++ b/lib/rigor/signature_path_audit.rb
@@ -60,17 +60,11 @@ module Rigor
     # `nil` — the unset default, where Rigor auto-detects `<root>/sig` — to get an empty
     # result: an absent auto-detected `sig/` is a normal setup, not a misconfiguration, so it
     # is never audited.
-    #
-    # @param signature_paths [Array<String, Pathname>, nil]
-    # @return [Array<Entry>]
     def self.audit(signature_paths)
       Array(signature_paths).map { |path| classify(path.to_s) }
     end
 
     # The subset of {audit} that resolved to nothing — the entries worth warning about.
-    #
-    # @param signature_paths [Array<String, Pathname>, nil]
-    # @return [Array<Entry>]
     def self.warnings(signature_paths)
       audit(signature_paths).select(&:warning?)
     end

--- a/lib/rigor/source/literals.rb
+++ b/lib/rigor/source/literals.rb
@@ -32,7 +32,6 @@ module Rigor
       # The Symbol a literal `Prism::SymbolNode` / `Prism::StringNode` names, or `nil` for any other node
       # (including `nil`).
       #
-      # @param node [Prism::Node, nil]
       # @return [Symbol, nil]
       def symbol_or_string(node)
         return nil unless node.is_a?(Prism::SymbolNode) || node.is_a?(Prism::StringNode)
@@ -45,7 +44,6 @@ module Rigor
       # raw name rather than the interned Symbol (route helpers, factory names, filter targets).
       # `#unescaped` round-trips an interpolation-free `:foo` / `"foo"` to `"foo"` for both kinds.
       #
-      # @param node [Prism::Node, nil]
       # @return [String, nil]
       def symbol_or_string_name(node)
         return nil unless node.is_a?(Prism::SymbolNode) || node.is_a?(Prism::StringNode)
@@ -57,7 +55,6 @@ module Rigor
       # `Prism::StringNode` and `nil`). Stricter than {.symbol_or_string}: a DSL that accepts only `:draft`
       # and not `"draft"` keeps that distinction by reaching for this rather than the Symbol-or-String form.
       #
-      # @param node [Prism::Node, nil]
       # @return [Symbol, nil]
       def symbol(node)
         return nil unless node.is_a?(Prism::SymbolNode)
@@ -69,7 +66,6 @@ module Rigor
       # `Prism::StringNode` and `nil`). The String-returning sibling of {.symbol} — SymbolNode-only, but the
       # caller wants the raw name rather than the interned Symbol.
       #
-      # @param node [Prism::Node, nil]
       # @return [String, nil]
       def symbol_name(node)
         return nil unless node.is_a?(Prism::SymbolNode)
@@ -79,9 +75,6 @@ module Rigor
 
       # Every literal Symbol/String positional argument of a call, in source order. Non-literal arguments
       # are dropped. Returns `[]` when the call has no argument list.
-      #
-      # @param call_node [Prism::CallNode, nil]
-      # @return [Array<Symbol>]
       def symbol_arguments(call_node)
         args = call_node&.arguments&.arguments
         return [] if args.nil?
@@ -93,10 +86,6 @@ module Rigor
       # {.symbol_name} — for callers that need a predicate rather than an extraction (hash-key matching in
       # keyword or assoc argument positions, e.g. `el.is_a?(AssocNode) && symbol_named?(el.key, "required")`).
       # Uses `#unescaped` (not `#value`) for round-trip consistency.
-      #
-      # @param node [Prism::Node, nil]
-      # @param name [String]
-      # @return [Boolean]
       def symbol_named?(node, name)
         node.is_a?(Prism::SymbolNode) && node.unescaped == name
       end
@@ -104,8 +93,6 @@ module Rigor
       # The literal Symbol/String at positional `index`, or `nil` when the call has no argument list, the
       # index is out of range, or the argument there is not a literal Symbol/String.
       #
-      # @param call_node [Prism::CallNode, nil]
-      # @param index [Integer]
       # @return [Symbol, nil]
       def symbol_arg(call_node, index)
         args = call_node&.arguments&.arguments

--- a/lib/rigor/source/literals.rb
+++ b/lib/rigor/source/literals.rb
@@ -32,7 +32,7 @@ module Rigor
       # The Symbol a literal `Prism::SymbolNode` / `Prism::StringNode` names, or `nil` for any other node
       # (including `nil`).
       #
-      # @return [Symbol, nil]
+      # @rbs return: Symbol?
       def symbol_or_string(node)
         return nil unless node.is_a?(Prism::SymbolNode) || node.is_a?(Prism::StringNode)
 
@@ -44,7 +44,7 @@ module Rigor
       # raw name rather than the interned Symbol (route helpers, factory names, filter targets).
       # `#unescaped` round-trips an interpolation-free `:foo` / `"foo"` to `"foo"` for both kinds.
       #
-      # @return [String, nil]
+      # @rbs return: String?
       def symbol_or_string_name(node)
         return nil unless node.is_a?(Prism::SymbolNode) || node.is_a?(Prism::StringNode)
 
@@ -55,7 +55,7 @@ module Rigor
       # `Prism::StringNode` and `nil`). Stricter than {.symbol_or_string}: a DSL that accepts only `:draft`
       # and not `"draft"` keeps that distinction by reaching for this rather than the Symbol-or-String form.
       #
-      # @return [Symbol, nil]
+      # @rbs return: Symbol?
       def symbol(node)
         return nil unless node.is_a?(Prism::SymbolNode)
 
@@ -66,7 +66,7 @@ module Rigor
       # `Prism::StringNode` and `nil`). The String-returning sibling of {.symbol} — SymbolNode-only, but the
       # caller wants the raw name rather than the interned Symbol.
       #
-      # @return [String, nil]
+      # @rbs return: String?
       def symbol_name(node)
         return nil unless node.is_a?(Prism::SymbolNode)
 
@@ -93,7 +93,7 @@ module Rigor
       # The literal Symbol/String at positional `index`, or `nil` when the call has no argument list, the
       # index is out of range, or the argument there is not a literal Symbol/String.
       #
-      # @return [Symbol, nil]
+      # @rbs return: Symbol?
       def symbol_arg(call_node, index)
         args = call_node&.arguments&.arguments
         return nil if args.nil?

--- a/lib/rigor/source/node_children.rb
+++ b/lib/rigor/source/node_children.rb
@@ -107,7 +107,6 @@ module Rigor
       # would with `compact_child_nodes.each`. Walkers holding a known `Prism::Node` call `#rigor_each_child`
       # directly; this wrapper is the nil-tolerant entry.
       #
-      # @yieldparam child [Prism::Node]
       def each_child(node, &)
         node.rigor_each_child(&) if node.is_a?(Prism::Node)
       end

--- a/lib/rigor/source/node_locator.rb
+++ b/lib/rigor/source/node_locator.rb
@@ -22,8 +22,6 @@ module Rigor
       class OutOfRangeError < StandardError; end
 
       class << self
-        # @param source [String]
-        # @param root [Prism::Node]
         # @param line [Integer] 1-indexed line number
         # @param column [Integer] 1-indexed column number (byte index within the line)
         # @return [Prism::Node, nil]
@@ -31,7 +29,6 @@ module Rigor
           new(source: source, root: root).at_position(line: line, column: column)
         end
 
-        # @param root [Prism::Node]
         # @param offset [Integer] 0-indexed byte offset
         # @return [Prism::Node, nil]
         def at_offset(root:, offset:)
@@ -40,7 +37,6 @@ module Rigor
       end
 
       # @param source [String, nil] used by `#at_position`; may be omitted when only `#at_offset` is needed.
-      # @param root [Prism::Node]
       def initialize(source:, root:)
         @source = source
         @root = root

--- a/lib/rigor/source/node_locator.rb
+++ b/lib/rigor/source/node_locator.rb
@@ -22,21 +22,21 @@ module Rigor
       class OutOfRangeError < StandardError; end
 
       class << self
-        # @param line [Integer] 1-indexed line number
-        # @param column [Integer] 1-indexed column number (byte index within the line)
-        # @return [Prism::Node, nil]
+        # @rbs line: Integer -- 1-indexed line number
+        # @rbs column: Integer -- 1-indexed column number (byte index within the line)
+        # @rbs return: Prism::Node?
         def at_position(source:, root:, line:, column:)
           new(source: source, root: root).at_position(line: line, column: column)
         end
 
-        # @param offset [Integer] 0-indexed byte offset
-        # @return [Prism::Node, nil]
+        # @rbs offset: Integer -- 0-indexed byte offset
+        # @rbs return: Prism::Node?
         def at_offset(root:, offset:)
           new(source: nil, root: root).at_offset(offset)
         end
       end
 
-      # @param source [String, nil] used by `#at_position`; may be omitted when only `#at_offset` is needed.
+      # @rbs source: String? -- Used by `#at_position`; may be omitted when only `#at_offset` is needed.
       def initialize(source:, root:)
         @source = source
         @root = root
@@ -44,7 +44,7 @@ module Rigor
 
       # Resolve a `(line, column)` pair (1-indexed) to the deepest enclosing node.
       #
-      # @raise [OutOfRangeError] if the line or column falls outside the source buffer.
+      # Raises OutOfRangeError if the line or column falls outside the source buffer.
       def at_position(line:, column:)
         offset = position_to_offset(line, column)
         at_offset(offset)

--- a/lib/rigor/source/node_walker.rb
+++ b/lib/rigor/source/node_walker.rb
@@ -25,8 +25,7 @@ module Rigor
     module NodeWalker
       module_function
 
-      # @yieldparam node [Prism::Node]
-      # @return [Enumerator] when no block is given.
+      # @rbs return: Enumerator[untyped] -- When no block is given.
       def each(root, &)
         return to_enum(__method__, root) unless block_given?
 
@@ -48,9 +47,7 @@ module Rigor
       # block invocation MUST copy it (`Plugin::NodeContext` does). Used by the plugin engine to give
       # `node_rule` blocks their enclosing class / method / block context (ADR-37 slice 1d).
       #
-      # @yieldparam node [Prism::Node]
-      # @yieldparam ancestors [Array<Prism::Node>]
-      # @return [Enumerator] when no block is given.
+      # @rbs return: Enumerator[untyped] -- When no block is given.
       def each_with_ancestors(root, &)
         return to_enum(__method__, root) unless block_given?
 

--- a/lib/rigor/triage.rb
+++ b/lib/rigor/triage.rb
@@ -34,11 +34,9 @@ module Rigor
     # `rbs.coverage.missing-gem`) survives; the count-based H5/H6 recognisers guard against info themselves so
     # recognition trace never reads as a bug.
     #
-    # @param diagnostics [Array<Analysis::Diagnostic>]
     # @param top [Integer] hotspot-file cap
     # @param hints [Boolean] run the heuristic catalogue
     # @param include_info [Boolean] route info into the volume views
-    # @return [Report]
     def analyze(diagnostics, top: 10, hints: true, include_info: false)
       routed = include_info ? diagnostics : diagnostics.reject { |d| d.severity == :info }
       Report.new(

--- a/lib/rigor/triage.rb
+++ b/lib/rigor/triage.rb
@@ -34,9 +34,9 @@ module Rigor
     # `rbs.coverage.missing-gem`) survives; the count-based H5/H6 recognisers guard against info themselves so
     # recognition trace never reads as a bug.
     #
-    # @param top [Integer] hotspot-file cap
-    # @param hints [Boolean] run the heuristic catalogue
-    # @param include_info [Boolean] route info into the volume views
+    # @rbs top: Integer -- Hotspot-file cap
+    # @rbs hints: bool -- Run the heuristic catalogue
+    # @rbs include_info: bool -- Route info into the volume views
     def analyze(diagnostics, top: 10, hints: true, include_info: false)
       routed = include_info ? diagnostics : diagnostics.reject { |d| d.severity == :info }
       Report.new(

--- a/lib/rigor/triage/catalogue.rb
+++ b/lib/rigor/triage/catalogue.rb
@@ -91,7 +91,7 @@ module Rigor
       INFO_GUARDED = %i[h5_systemic_cluster h6_genuine_bugs].freeze
       private_constant :INFO_GUARDED
 
-      # @param include_info [Boolean] let H5/H6 see `:info` diagnostics
+      # @rbs include_info: bool -- Let H5/H6 see `:info` diagnostics
       def recognise(diagnostics, include_info: false)
         claimed = {}.compare_by_identity
         recognisers.filter_map do |recogniser|

--- a/lib/rigor/triage/catalogue.rb
+++ b/lib/rigor/triage/catalogue.rb
@@ -91,9 +91,7 @@ module Rigor
       INFO_GUARDED = %i[h5_systemic_cluster h6_genuine_bugs].freeze
       private_constant :INFO_GUARDED
 
-      # @param diagnostics [Array<Analysis::Diagnostic>]
       # @param include_info [Boolean] let H5/H6 see `:info` diagnostics
-      # @return [Array<Hint>]
       def recognise(diagnostics, include_info: false)
         claimed = {}.compare_by_identity
         recognisers.filter_map do |recogniser|
@@ -121,7 +119,6 @@ module Rigor
            h5_systemic_cluster h6_genuine_bugs]
       end
 
-      # --- H1 — likely ActiveSupport core_ext --------------------
       def h1_activesupport(pool)
         matched = pool.select do |d|
           parsed = parse_undefined_method(d)
@@ -139,7 +136,6 @@ module Rigor
         ), matched]
       end
 
-      # --- H2K — known project monkey-patch (engine-proven) ------
       # ADR-17 / WD3 slice 4: the `call.undefined-method` rule sets `project_definition_site` when the project itself
       # defines the called method on the receiver class somewhere in the file set (a reopened core/stdlib/gem class the
       # dispatcher does not apply cross-file). That is direct evidence — not a spread heuristic — so this recogniser is
@@ -161,7 +157,6 @@ module Rigor
         ), matched]
       end
 
-      # --- H2 — likely a project monkey-patch / refinement -------
       def h2_monkey_patch(pool)
         groups = undefined_method_groups(pool).select do |(_method, _recv), diags|
           diags.map(&:path).uniq.size >= MONKEY_PATCH_MIN_FILES
@@ -179,7 +174,6 @@ module Rigor
         ), matched]
       end
 
-      # --- H3 — gem ships no RBS ---------------------------------
       def h3_gem_without_rbs(pool)
         notice = pool.find { |d| d.message.match?(/gem\(s\).*have no RBS available/) }
         return nil unless notice
@@ -194,7 +188,6 @@ module Rigor
         ), [notice]]
       end
 
-      # --- H4 — possible ActiveRecord relation misinference ------
       def h4_ar_relation(pool)
         matched = pool.select do |d|
           parsed = parse_undefined_method(d)
@@ -213,7 +206,6 @@ module Rigor
         ), matched]
       end
 
-      # --- H7 — unresolved toplevel implicit-self calls ----------
       # ADR-34: `call.unresolved-toplevel` fires on a toplevel implicit-self call (no receiver, outside any def / class
       # / module) that resolves against no visible contributor. The canonical opt-out is `pre_eval:` — the file is
       # usually a script relying on methods defined by a monkey-patch or a required helper Rigor did not walk. Grouped,
@@ -234,7 +226,6 @@ module Rigor
         ), matched]
       end
 
-      # --- H5 — systemic single-file cluster ---------------------
       def h5_systemic_cluster(pool)
         bucket = pool.group_by { |d| [d.path, rule_of(d)] }
                      .select { |_key, diags| diags.size >= SYSTEMIC_THRESHOLD }
@@ -251,7 +242,6 @@ module Rigor
         ), matched]
       end
 
-      # --- H6 — low-count scattered rules = likely genuine bugs --
       def h6_genuine_bugs(pool)
         small = pool.group_by { |d| rule_of(d) }
                     .select { |rule, diags| rule && diags.size.between?(1, GENUINE_BUG_MAX_COUNT) }

--- a/lib/rigor/type/accepts_result.rb
+++ b/lib/rigor/type/accepts_result.rb
@@ -26,7 +26,6 @@ module Rigor
 
       attr_reader :trinary, :mode, :reasons
 
-      # @param trinary [Rigor::Trinary]
       # @param mode [Symbol] currently `:gradual` (default) or `:strict`.
       # @param reasons [Array<String>, String, nil] textual reasons; a
       #   single string is wrapped, `nil` becomes an empty array.

--- a/lib/rigor/type/accepts_result.rb
+++ b/lib/rigor/type/accepts_result.rb
@@ -26,9 +26,9 @@ module Rigor
 
       attr_reader :trinary, :mode, :reasons
 
-      # @param mode [Symbol] currently `:gradual` (default) or `:strict`.
-      # @param reasons [Array<String>, String, nil] textual reasons; a
-      #   single string is wrapped, `nil` becomes an empty array.
+      # @rbs mode: Symbol -- Currently `:gradual` (default) or `:strict`.
+      # @rbs reasons: (Array[String] | String)? --
+      #   Textual reasons; a single string is wrapped, `nil` becomes an empty array.
       def initialize(trinary, mode: :gradual, reasons: nil)
         raise ArgumentError, "trinary must be Rigor::Trinary, got #{trinary.class}" unless trinary.is_a?(Trinary)
         raise ArgumentError, "mode must be one of #{MODES.inspect}, got #{mode.inspect}" unless MODES.include?(mode)

--- a/lib/rigor/type/data_class.rb
+++ b/lib/rigor/type/data_class.rb
@@ -24,9 +24,8 @@ module Rigor
     class DataClass
       attr_reader :members, :class_name
 
-      # @param members [Array<Symbol>] ordered member names.
-      # @param class_name [String, nil] the bound class name, or nil for
-      #   the anonymous `Data.define(...)` result.
+      # @rbs members: Array[Symbol] -- Ordered member names.
+      # @rbs class_name: String? -- The bound class name, or nil for the anonymous `Data.define(...)` result.
       def initialize(members, class_name = nil)
         unless members.is_a?(Array) && members.all?(Symbol)
           raise ArgumentError, "members must be an Array of Symbols, got #{members.inspect}"

--- a/lib/rigor/type/data_instance.rb
+++ b/lib/rigor/type/data_instance.rb
@@ -27,10 +27,10 @@ module Rigor
     class DataInstance
       attr_reader :members, :class_name
 
-      # @param members [Hash{Symbol => Rigor::Type}] ordered member -> type
-      #   map. Every declared member is present (Data instances are total).
-      # @param class_name [String, nil] the tagging class name, or nil for
-      #   an instance of an anonymous `Data.define(...)` class.
+      # @rbs members: Hash[Symbol, Rigor::Type] --
+      #   Ordered member -> type map. Every declared member is present (Data instances are total).
+      # @rbs class_name: String? --
+      #   The tagging class name, or nil for an instance of an anonymous `Data.define(...)` class.
       def initialize(members, class_name = nil)
         unless members.is_a?(Hash) && members.each_key.all?(Symbol)
           raise ArgumentError, "members must be a Hash with Symbol keys, got #{members.inspect}"
@@ -44,13 +44,12 @@ module Rigor
         freeze
       end
 
-      # @return [Array<Symbol>] ordered member names.
+      # @rbs return: Array[Symbol] -- Ordered member names.
       def member_names
         members.keys
       end
 
-      # @return [Rigor::Type, nil] the member's value type, or nil when the
-      #   name is not a declared member.
+      # @rbs return: Rigor::Type? -- The member's value type, or nil when the name is not a declared member.
       def member_type(name)
         members[name]
       end

--- a/lib/rigor/type/hash_shape.rb
+++ b/lib/rigor/type/hash_shape.rb
@@ -34,22 +34,16 @@ module Rigor
 
       attr_reader :pairs, :required_keys, :optional_keys, :read_only_keys, :extra_keys
 
-      # @param pairs [Hash{Symbol|String => Rigor::Type}] ordered map of
-      #   keys to declared types. Keys MUST be Symbol or String;
-      #   values MUST be Rigor::Type instances. The hash is duped and
-      #   frozen at construction; callers MUST NOT mutate the input
-      #   afterwards (mutation does not affect the carrier, but the
-      #   carrier is a value object).
-      # @param required_keys [Array<Symbol|String>, nil] keys that MUST
-      #   be present. When omitted, every non-optional key is required.
-      #   When supplied without optional_keys, every remaining known key
-      #   is treated as optional.
-      # @param optional_keys [Array<Symbol|String>, nil] keys that MAY
-      #   be absent. Optional absence is not a stored nil.
-      # @param read_only_keys [Array<Symbol|String>] entries that cannot
-      #   be written through this shape view.
-      # @param extra_keys [Symbol] :closed rejects keys outside pairs;
-      #   :open permits them.
+      # @rbs pairs: Hash[Symbol | String, Rigor::Type] --
+      #   Ordered map of keys to declared types. Keys MUST be Symbol or String; values MUST be Rigor::Type instances.
+      #   The hash is duped and frozen at construction; callers MUST NOT mutate the input afterwards (mutation does
+      #   not affect the carrier, but the carrier is a value object).
+      # @rbs required_keys: Array[Symbol | String]? --
+      #   Keys that MUST be present. When omitted, every non-optional key is required. When supplied without
+      #   optional_keys, every remaining known key is treated as optional.
+      # @rbs optional_keys: Array[Symbol | String]? -- Keys that MAY be absent. Optional absence is not a stored nil.
+      # @rbs read_only_keys: Array[Symbol | String] -- Entries that cannot be written through this shape view.
+      # @rbs extra_keys: Symbol -- :closed rejects keys outside pairs; :open permits them.
       def initialize(pairs = nil, **keywords)
         pairs, policy = split_constructor_args(pairs, keywords)
         validate_pairs!(pairs)

--- a/lib/rigor/type/refined.rb
+++ b/lib/rigor/type/refined.rb
@@ -135,11 +135,10 @@ module Rigor
       NUMERIC_LITERAL_PREFIX = /\A[+-]?\d/
       private_constant :NUMERIC_LITERAL_PREFIX
 
-      # @param value [Object] typically a `Constant#value`
-      # @return [Boolean] true when `value` is a String that is a
-      #   single, complete Ruby numeric literal. Total over
-      #   arbitrary input — never raises (Prism reports malformed
-      #   input through `errors`, it does not throw).
+      # @rbs value: untyped -- Typically a `Constant#value`
+      # @rbs return: bool --
+      #   True when `value` is a String that is a single, complete Ruby numeric literal. Total over arbitrary input —
+      #   never raises (Prism reports malformed input through `errors`, it does not throw).
       def self.ruby_numeric_literal?(value)
         return false unless value.is_a?(String)
         return false if value.empty?
@@ -216,8 +215,8 @@ module Rigor
       }.freeze
       private_constant :COMPLEMENT_PAIRS
 
-      # @return [Symbol, nil] the registered complement predicate
-      #   id, or nil when no pair is registered for this predicate.
+      # @rbs return: Symbol? --
+      #   The registered complement predicate id, or nil when no pair is registered for this predicate.
       def complement_predicate_id
         COMPLEMENT_PAIRS[predicate_id]
       end

--- a/lib/rigor/type/struct_class.rb
+++ b/lib/rigor/type/struct_class.rb
@@ -26,10 +26,9 @@ module Rigor
     class StructClass
       attr_reader :members, :class_name, :keyword_init
 
-      # @param members [Array<Symbol>] ordered member names.
-      # @param class_name [String, nil] the bound class name, or nil for
-      #   the anonymous `Struct.new(...)` result.
-      # @param keyword_init [Boolean] the `keyword_init:` flag.
+      # @rbs members: Array[Symbol] -- Ordered member names.
+      # @rbs class_name: String? -- The bound class name, or nil for the anonymous `Struct.new(...)` result.
+      # @rbs keyword_init: bool -- The `keyword_init:` flag.
       def initialize(members, class_name = nil, keyword_init: false)
         unless members.is_a?(Array) && members.all?(Symbol)
           raise ArgumentError, "members must be an Array of Symbols, got #{members.inspect}"

--- a/lib/rigor/type/struct_instance.rb
+++ b/lib/rigor/type/struct_instance.rb
@@ -29,10 +29,10 @@ module Rigor
     class StructInstance
       attr_reader :members, :class_name
 
-      # @param members [Hash{Symbol => Rigor::Type}] ordered member -> type
-      #   map. Every declared member is present (Struct instances are total).
-      # @param class_name [String, nil] the tagging class name, or nil for
-      #   an instance of an anonymous `Struct.new(...)` class.
+      # @rbs members: Hash[Symbol, Rigor::Type] --
+      #   Ordered member -> type map. Every declared member is present (Struct instances are total).
+      # @rbs class_name: String? --
+      #   The tagging class name, or nil for an instance of an anonymous `Struct.new(...)` class.
       def initialize(members, class_name = nil)
         unless members.is_a?(Hash) && members.each_key.all?(Symbol)
           raise ArgumentError, "members must be a Hash with Symbol keys, got #{members.inspect}"
@@ -46,13 +46,12 @@ module Rigor
         freeze
       end
 
-      # @return [Array<Symbol>] ordered member names.
+      # @rbs return: Array[Symbol] -- Ordered member names.
       def member_names
         members.keys
       end
 
-      # @return [Rigor::Type, nil] the member's value type, or nil when the
-      #   name is not a declared member.
+      # @rbs return: Rigor::Type? -- The member's value type, or nil when the name is not a declared member.
       def member_type(name)
         members[name]
       end

--- a/lib/rigor/type_node/resolver_chain.rb
+++ b/lib/rigor/type_node/resolver_chain.rb
@@ -32,8 +32,8 @@ module Rigor
         freeze
       end
 
-      # @return [Array<Rigor::Plugin::TypeNodeResolver>] ordered
-      #   resolver instances, in plugin-registration order.
+      # @rbs return: Array[Rigor::Plugin::TypeNodeResolver] --
+      #   Ordered resolver instances, in plugin-registration order.
       attr_reader :resolvers
 
       # First non-nil `resolve(node, scope)` answer from the chain;

--- a/plugins/rigor-actioncable/lib/rigor/plugin/actioncable/analyzer.rb
+++ b/plugins/rigor-actioncable/lib/rigor/plugin/actioncable/analyzer.rb
@@ -34,10 +34,6 @@ module Rigor
         # The broadcast violations for a single call node, or `[]` when the node is not a
         # `broadcast_to` / `ActionCable.server.broadcast` call this plugin recognises. ADR-37: the
         # engine owns the walk.
-        #
-        # @param call_node [Prism::Node]
-        # @param channel_index [ChannelIndex]
-        # @return [Array<Violation>]
         def violations_for(call_node:, channel_index:)
           return [] unless call_node.is_a?(Prism::CallNode)
 

--- a/plugins/rigor-actioncable/lib/rigor/plugin/actioncable/channel_discoverer.rb
+++ b/plugins/rigor-actioncable/lib/rigor/plugin/actioncable/channel_discoverer.rb
@@ -43,7 +43,6 @@ module Rigor
           @base_classes = base_classes.to_set { |name| strip_root(name.to_s) }
         end
 
-        # @return [ChannelIndex]
         def discover
           entries = []
           ruby_files_under(@search_paths).each do |path|

--- a/plugins/rigor-actionmailer/lib/rigor/plugin/actionmailer/analyzer.rb
+++ b/plugins/rigor-actionmailer/lib/rigor/plugin/actionmailer/analyzer.rb
@@ -42,10 +42,6 @@ module Rigor
 
         # The mailer-call violations for a single call node (0..2), or `[]` when it is not a
         # `<Mailer>.action(...)` call on a known mailer. ADR-37: the engine owns the walk.
-        #
-        # @param call_node [Prism::Node]
-        # @param mailer_index [MailerIndex]
-        # @return [Array<Violation>]
         def violations_for(call_node:, mailer_index:)
           return [] unless call_node.is_a?(Prism::CallNode) && action_call_candidate?(call_node)
 

--- a/plugins/rigor-actionmailer/lib/rigor/plugin/actionmailer/mailer_discoverer.rb
+++ b/plugins/rigor-actionmailer/lib/rigor/plugin/actionmailer/mailer_discoverer.rb
@@ -38,7 +38,6 @@ module Rigor
         VIEW_FORMATS = %w[html text].freeze
         VIEW_EXTENSIONS = %w[erb haml slim].freeze
 
-        # @param io_boundary [Rigor::Plugin::IoBoundary]
         # @param search_paths [Array<String>] absolute or project-relative paths to scan for mailers.
         # @param base_classes [Array<String>] direct superclasses that mark a class as a mailer.
         # @param views_root [String] absolute or project-relative path to the views directory (typically
@@ -53,7 +52,6 @@ module Rigor
           @views_root = views_root
         end
 
-        # @return [MailerIndex]
         def discover
           # Two-pass: first collect every module's defs (for the include-following step), then build
           # per-class entries that pull in actions from include'd modules. GitLab's `Notify` mailer

--- a/plugins/rigor-actionpack/lib/rigor/plugin/actionpack/analyzer.rb
+++ b/plugins/rigor-actionpack/lib/rigor/plugin/actionpack/analyzer.rb
@@ -81,10 +81,8 @@ module Rigor
         # duplicates on Mastodon and ~119 on Redmine, exactly stacked with the rails-routes diagnostics.
         # Returns `[]` for unknown / arity-mismatch shapes.
         #
-        # @param call_node [Prism::Node]
         # @param helper_table [Hash{String => Hash}] each entry carries `name`, `arity`,
         #   `acceptable_arities`, `path`, `http_method`, `action`.
-        # @return [Array<Violation>]
         def helper_violations_for(call_node:, helper_table:)
           return [] unless implicit_helper_call?(call_node)
 
@@ -108,10 +106,7 @@ module Rigor
         # each filter name reference is validated against it. Calls outside a known controller
         # contribute nothing.
         #
-        # @param call_node [Prism::Node]
         # @param ancestors [Array<Prism::Node>] the lexical ancestor chain
-        # @param controller_index [ControllerIndex]
-        # @return [Array<Violation>]
         def filter_violations_for(call_node:, ancestors:, controller_index:)
           return [] unless filter_call?(call_node)
 
@@ -144,10 +139,6 @@ module Rigor
         # AR model's column list (looked up via the model_index fact published by `rigor-activerecord`).
         # Calls whose `:require` argument is a non-literal Symbol are passed through; namespaced models
         # (`params.require(:admin_user)` → `Admin::User`) are deferred.
-        #
-        # @param call_node [Prism::Node]
-        # @param model_index [Hash{String => Hash}]
-        # @return [Array<Violation>]
         def permit_violations_for(call_node:, model_index:)
           return [] unless permit_chain?(call_node)
 
@@ -179,12 +170,8 @@ module Rigor
         # method that doesn't call `render`) is also skipped — Phase 3 validates explicit renders only,
         # since the implicit path would false-positive on `redirect_to` / `head` / early returns.
         #
-        # @param call_node [Prism::Node]
         # @param ancestors [Array<Prism::Node>] the lexical ancestor chain
         # @param path [String] file being analysed
-        # @param view_search_roots [Array<String>]
-        # @param controller_index [ControllerIndex, nil]
-        # @return [Array<Violation>]
         def render_violations_for(call_node:, ancestors:, path:, view_search_roots:, controller_index: nil)
           return [] unless render_call?(call_node)
 

--- a/plugins/rigor-actionpack/lib/rigor/plugin/actionpack/controller_discoverer.rb
+++ b/plugins/rigor-actionpack/lib/rigor/plugin/actionpack/controller_discoverer.rb
@@ -42,7 +42,6 @@ module Rigor
           @search_paths = search_paths
         end
 
-        # @return [ControllerIndex]
         def discover
           entries = {}
           ruby_files_under(@search_paths).each do |path|

--- a/plugins/rigor-activejob/lib/rigor/plugin/activejob/analyzer.rb
+++ b/plugins/rigor-activejob/lib/rigor/plugin/activejob/analyzer.rb
@@ -25,10 +25,6 @@ module Rigor
 
         # The job-call violations for a single call node (0..2), or `[]` when the node is not a
         # `<Job>.perform_*` entry call on a known job. ADR-37: the engine owns the walk.
-        #
-        # @param call_node [Prism::Node]
-        # @param job_index [JobIndex]
-        # @return [Array<Violation>]
         def violations_for(call_node:, job_index:)
           return [] unless call_node.is_a?(Prism::CallNode) && entry_call?(call_node)
 

--- a/plugins/rigor-activejob/lib/rigor/plugin/activejob/job_discoverer.rb
+++ b/plugins/rigor-activejob/lib/rigor/plugin/activejob/job_discoverer.rb
@@ -32,7 +32,6 @@ module Rigor
           @base_classes = base_classes.to_set { |name| strip_root(name.to_s) }
         end
 
-        # @return [JobIndex]
         def discover
           candidates = []
           ruby_files_under(@search_paths).each do |path|

--- a/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/model_discoverer.rb
+++ b/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/model_discoverer.rb
@@ -77,7 +77,6 @@ module Rigor
       #   `ApplicationRecord`) setting `self.table_name_prefix` for every model under it — both already
       #   guess wrong identically on unpatched code.
       class ModelDiscoverer
-        # @param io_boundary [Rigor::Plugin::IoBoundary]
         # @param search_paths [Array<String>] absolute or project-relative paths.
         # @param base_classes [Array<String>] superclass names that identify a class as an AR model.
         # Declaration macros whose column's runtime value is a rich object, not the SQL scalar. Their column

--- a/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/schema_parser.rb
+++ b/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/schema_parser.rb
@@ -46,7 +46,6 @@ module Rigor
         ].freeze
 
         # @param source [String] contents of `db/schema.rb`
-        # @return [SchemaTable]
         def self.parse(source)
           tree = Prism.parse(source).value
           new.parse(tree)

--- a/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/structure_sql_parser.rb
+++ b/plugins/rigor-activerecord/lib/rigor/plugin/activerecord/structure_sql_parser.rb
@@ -55,7 +55,6 @@ module Rigor
         CONSTRAINT_KEYWORDS = %w[CONSTRAINT PRIMARY UNIQUE CHECK FOREIGN EXCLUDE LIKE PARTITION].freeze
 
         # @param source [String] contents of `db/structure.sql`
-        # @return [SchemaTable]
         def self.parse(source)
           new.parse(source)
         end

--- a/plugins/rigor-factorybot/lib/rigor/plugin/factorybot/analyzer.rb
+++ b/plugins/rigor-factorybot/lib/rigor/plugin/factorybot/analyzer.rb
@@ -28,11 +28,6 @@ module Rigor
         # The violations for a single entry call (`FactoryBot.create(...)` etc.), or `[]` when the node
         # is not an entry call or its first argument is not a literal factory name. ADR-37: the engine
         # owns the walk.
-        #
-        # @param call_node [Prism::Node]
-        # @param factory_index [FactoryIndex]
-        # @param model_index [Hash, nil]
-        # @return [Array<Violation>]
         def violations_for(call_node:, factory_index:, model_index: nil)
           return [] unless entry_call?(call_node)
 

--- a/plugins/rigor-factorybot/lib/rigor/plugin/factorybot/factory_discoverer.rb
+++ b/plugins/rigor-factorybot/lib/rigor/plugin/factorybot/factory_discoverer.rb
@@ -37,7 +37,6 @@ module Rigor
           @search_paths = search_paths
         end
 
-        # @return [FactoryIndex]
         def discover
           entries = {}
           ruby_files_under(@search_paths).each do |path|

--- a/plugins/rigor-minitest/lib/rigor/plugin/minitest/assertion_analyzer.rb
+++ b/plugins/rigor-minitest/lib/rigor/plugin/minitest/assertion_analyzer.rb
@@ -59,8 +59,6 @@ module Rigor
       module AssertionAnalyzer
         module_function
 
-        # @param call_node [Prism::CallNode]
-        # @param environment [Rigor::Environment, nil]
         # @return [Rigor::FlowContribution, nil]
         def contribution_for(call_node, environment:)
           return nil unless call_node.is_a?(Prism::CallNode)

--- a/plugins/rigor-pundit/lib/rigor/plugin/pundit/analyzer.rb
+++ b/plugins/rigor-pundit/lib/rigor/plugin/pundit/analyzer.rb
@@ -33,11 +33,6 @@ module Rigor
         # The policy violations for a single call node (0..2 of them), or `[]` when the node is not a
         # Pundit entry call or its record type is not statically determinable. ADR-37: the engine owns the
         # walk, so this is per-node logic.
-        #
-        # @param call_node [Prism::Node]
-        # @param policy_index [PolicyIndex]
-        # @param scope [Rigor::Scope, nil]
-        # @return [Array<Violation>]
         def violations_for(call_node:, policy_index:, scope:)
           return [] unless call_node.is_a?(Prism::CallNode) && entry_call?(call_node)
 

--- a/plugins/rigor-pundit/lib/rigor/plugin/pundit/policy_discoverer.rb
+++ b/plugins/rigor-pundit/lib/rigor/plugin/pundit/policy_discoverer.rb
@@ -28,7 +28,6 @@ module Rigor
           @base_classes = base_classes.to_set
         end
 
-        # @return [PolicyIndex]
         def discover
           entries = []
           ruby_files_under(@search_paths).each do |path|

--- a/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/analyzer.rb
+++ b/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/analyzer.rb
@@ -91,22 +91,10 @@ module Rigor
           RAILS_SHIPPED_KEY_PREFIXES.any? { |prefix| key_str.start_with?(prefix) }
         end
 
-        # @param path [String]
-        # @param root [Prism::Node]
-        # @param locale_index [LocaleIndex]
-        # @param configured_locales [Array<String>]
-        # @return [Array<Diagnostic>]
         # The translation violations for a single call node, or `[]` when it is not a recognised `t` /
         # `translate` call with a literal key. ADR-37: the engine owns the walk; `action` (the enclosing
         # method, for lazy `t('.key')` expansion) comes from the node-rule `NodeContext`, and
         # `controller_scope` from the file path.
-        #
-        # @param call_node [Prism::Node]
-        # @param locale_index [LocaleIndex]
-        # @param configured_locales [Array<String>]
-        # @param controller_scope [String, nil]
-        # @param action [String, nil]
-        # @return [Array<Violation>]
         def violations_for(call_node:, locale_index:, configured_locales:, controller_scope:, action:)
           return [] unless call_node.is_a?(Prism::CallNode) && translate_call_candidate?(call_node)
 

--- a/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/locale_index.rb
+++ b/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/locale_index.rb
@@ -36,7 +36,6 @@ module Rigor
 
         attr_reader :entries, :locales
 
-        # @param entries [Array<Entry>]
         # @param locales [Array<String>] all locale names that contributed at least one key.
         def initialize(entries, locales:)
           @entries = entries.freeze

--- a/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/locale_loader.rb
+++ b/plugins/rigor-rails-i18n/lib/rigor/plugin/rails_i18n/locale_loader.rb
@@ -35,7 +35,6 @@ module Rigor
           @load_errors = []
         end
 
-        # @return [LocaleIndex]
         def load
           per_key = {} # dotted_key => { locale => Set<String> }
           per_key_kinds = {} # dotted_key => { locale => :string|:array|:hash }

--- a/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/analyzer.rb
+++ b/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/analyzer.rb
@@ -62,19 +62,10 @@ module Rigor
         ].freeze
 
         # @param path [String] file being analysed
-        # @param root [Prism::Node]
-        # @param helper_table [HelperTable]
-        # @return [Array<Diagnostic>]
         # The route-helper violations for a single call node (0..2), or `[]` when the node is not an
         # implicit `*_path` / `*_url` helper call, is shadowed by a same-file binding, or is in a
         # suppressed directory. ADR-37: the engine owns the walk; the same-file `shadowing` set is built
         # once as the node-rule file context.
-        #
-        # @param call_node [Prism::Node]
-        # @param helper_table [HelperTable]
-        # @param shadowing [Set<String>]
-        # @param path [String]
-        # @return [Array<Violation>]
         def violations_for(call_node:, helper_table:, shadowing:, path:)
           return [] unless call_node.is_a?(Prism::CallNode) && implicit_helper_call?(call_node)
 

--- a/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/helper_table.rb
+++ b/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/helper_table.rb
@@ -71,7 +71,6 @@ module Rigor
           @by_name[helper_name.to_s]&.first
         end
 
-        # @return [Boolean]
         def known?(helper_name)
           @by_name.key?(helper_name.to_s)
         end

--- a/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/routes_parser.rb
+++ b/plugins/rigor-rails-routes/lib/rigor/plugin/rails_routes/routes_parser.rb
@@ -58,7 +58,6 @@ module Rigor
         # @param file_reader [Proc, nil] called with `"name.rb"` to load a
         #   draw partial from `config/routes/name.rb`. Returns file contents
         #   or nil when the file is absent.
-        # @return [HelperTable]
         def parse(contents, file_reader: nil, custom_helpers: [], grape_prefixes: [], acronyms: [])
           parse_result = Prism.parse(contents)
           unless parse_result.errors.empty?

--- a/plugins/rigor-rbs-inline/lib/rigor/plugin/rbs_inline.rb
+++ b/plugins/rigor-rbs-inline/lib/rigor/plugin/rbs_inline.rb
@@ -95,6 +95,7 @@ module Rigor
           return nil if parsed.nil?
 
           uses, decls, rbs_decls = parsed
+          drop_unannotated_defs!(decls)
           rendered = reattach_declaration_annotations(::RBS::Inline::Writer.write(uses, decls, rbs_decls))
           return nil if rendered.nil? || rendered.strip.empty?
 
@@ -108,6 +109,51 @@ module Rigor
         end
 
         private
+
+        # ADR-93 WD1, applied inside an annotated file: upstream's writer emits
+        # `def f: (untyped x) -> untyped` for every unannotated sibling of an annotated
+        # method. Those skeletons duplicate a project's `sig/` declarations
+        # (`DuplicatedMethodDefinitionError`) and replace body inference with `untyped`.
+        # Keep members that actually carry an annotation; leave nested declarations in place.
+        def drop_unannotated_defs!(nodes)
+          Array(nodes).each do |node|
+            next unless node.respond_to?(:members) && node.members.respond_to?(:select!)
+
+            node.members.select! { |member| keep_synthesized_member?(member) }
+            drop_unannotated_defs!(node.members)
+          end
+        end
+
+        def keep_synthesized_member?(member)
+          case member
+          when ::RBS::Inline::AST::Members::RubyDef
+            annotated_ruby_def?(member)
+          when ::RBS::Inline::AST::Members::RubyAttr
+            annotated_ruby_attr?(member)
+          else
+            true
+          end
+        end
+
+        def annotated_ruby_def?(member)
+          return true if member.assertion
+          return true if member.annotated_method_types
+          return true if member.return_type
+          return true if member.var_type_hash.any?
+          return true if member.comments&.each_annotation&.any?
+
+          false
+        end
+
+        def annotated_ruby_attr?(member)
+          return true if member.assertion
+          return false unless member.comments
+
+          member.comments.each_annotation.any? do |annotation|
+            annotation.is_a?(::RBS::Inline::AST::Annotations::VarType) ||
+              annotation.is_a?(::RBS::Inline::AST::Annotations::TypeAssertion)
+          end
+        end
 
         # Re-attaches a class- or module-level `%a{…}` that upstream's writer dropped (#452).
         #

--- a/plugins/rigor-rspec-rails/lib/rigor/plugin/rspec_rails/have_http_status_analyzer.rb
+++ b/plugins/rigor-rspec-rails/lib/rigor/plugin/rspec_rails/have_http_status_analyzer.rb
@@ -41,7 +41,6 @@ module Rigor
         # `have_http_status(<int|symbol>)` matcher or its argument is statically valid. ADR-37: the engine
         # owns the walk, so this is per-node logic — no traversal here.
         #
-        # @param call_node [Prism::Node]
         # @return [Violation, nil]
         def violation_for(call_node)
           return nil unless call_to_matcher?(call_node)

--- a/plugins/rigor-rspec/lib/rigor/plugin/rspec/analyzer.rb
+++ b/plugins/rigor-rspec/lib/rigor/plugin/rspec/analyzer.rb
@@ -20,9 +20,6 @@ module Rigor
 
         module_function
 
-        # @param path [String]
-        # @param root [Prism::Node]
-        # @return [Array<Diagnostic>]
         def diagnose(path:, root:)
           diagnostics = []
           ScopeWalker.collect_scopes(root).each do |outer|

--- a/plugins/rigor-rspec/lib/rigor/plugin/rspec/let_scope_index.rb
+++ b/plugins/rigor-rspec/lib/rigor/plugin/rspec/let_scope_index.rb
@@ -45,7 +45,6 @@ module Rigor
         # ADR-52 slice 5a — every `let` / `subject` name declared anywhere in the file, across all describe
         # scopes. Feeds the plugin's `dynamic_return file_methods:` gate: the engine only consults the rule
         # for a call whose name appears here; the precise line-scoped resolution stays in `let_block_at`.
-        # @return [Array<Symbol>]
         def let_names
           @records.flat_map { |rec| rec.lets.keys }.uniq
         end

--- a/plugins/rigor-rspec/lib/rigor/plugin/rspec/let_type_resolver.rb
+++ b/plugins/rigor-rspec/lib/rigor/plugin/rspec/let_type_resolver.rb
@@ -30,11 +30,8 @@ module Rigor
 
         module_function
 
-        # @param block_node [Prism::BlockNode]
-        # @param describe_const [String, nil]
         # @param factory_index [Object, nil] something responding to `find(factory_name)` and returning an
         #   entry that responds to `model_class`.
-        # @param environment [Rigor::Environment, nil]
         # @return [Rigor::Type, nil]
         def resolve(block_node, describe_const:, factory_index:, environment:)
           tail = body_tail(block_node)

--- a/plugins/rigor-shoulda-matchers/lib/rigor/plugin/shoulda_matchers/analyzer.rb
+++ b/plugins/rigor-shoulda-matchers/lib/rigor/plugin/shoulda_matchers/analyzer.rb
@@ -72,23 +72,15 @@ module Rigor
 
         module_function
 
-        # @param path [String]
-        # @param root [Prism::Node]
         # @param model_index [Hash{String => Hash}, nil] the `:model_index` fact value — the flat
         #   `class_name => { table:, columns:, associations:, ... }` Hash `rigor-activerecord` publishes
         #   (ADR-9's "the value is data, not objects" contract; see `Activerecord#index_to_published_hash`).
         #   When nil the analyzer falls silent.
-        # @return [Array<Diagnostic>]
         # The matcher violations for a single call node (0..1), or `[]` when it is not a shoulda matcher,
         # sits outside any `describe <ModelConst>` block, or the model is unknown. ADR-37: the engine owns
         # the walk; the model anchor comes from the node-rule `NodeContext` ancestors (the innermost
         # enclosing `describe`-with-constant — nested const describes override, `describe ".method"`
         # string blocks inherit), exactly as the former recursive anchor propagation did.
-        #
-        # @param matcher_call [Prism::Node]
-        # @param ancestors [Array<Prism::Node>]
-        # @param model_index [Hash{String => Hash}, nil]
-        # @return [Array<Violation>]
         def violations_for(matcher_call:, ancestors:, model_index:)
           return [] if model_index.nil?
           return [] unless matcher_invocation?(matcher_call)

--- a/plugins/rigor-sidekiq/lib/rigor/plugin/sidekiq/analyzer.rb
+++ b/plugins/rigor-sidekiq/lib/rigor/plugin/sidekiq/analyzer.rb
@@ -34,10 +34,6 @@ module Rigor
 
         # The worker-call violations for a single call node (0..2), or `[]` when the node is not a
         # `<Worker>.perform_*` entry call on a known worker. ADR-37: the engine owns the walk.
-        #
-        # @param call_node [Prism::Node]
-        # @param worker_index [WorkerIndex]
-        # @return [Array<Violation>]
         def violations_for(call_node:, worker_index:)
           return [] unless call_node.is_a?(Prism::CallNode) && entry_call?(call_node)
 

--- a/plugins/rigor-sidekiq/lib/rigor/plugin/sidekiq/worker_discoverer.rb
+++ b/plugins/rigor-sidekiq/lib/rigor/plugin/sidekiq/worker_discoverer.rb
@@ -33,7 +33,6 @@ module Rigor
           @marker_modules = marker_modules.to_set { |name| strip_root(name.to_s) }
         end
 
-        # @return [WorkerIndex]
         def discover
           candidates = []
           ruby_files_under(@search_paths).each do |path|

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet.rb
@@ -443,7 +443,6 @@ module Rigor
       private_constant :EMPTY_CATALOG_BUNDLE
 
       # @param root [String] directory or single file.
-      # @param catalog [Catalog]
       # @param sigil_by_path [Hash{String=>Symbol}] accumulator: harvested file → detected sigil level.
       # @param parse_errors_by_path [Hash{String=>Array<Hash>}] accumulator: file → `{kind:,line:,column:}` tuples.
       # @param extensions [Array<String>] file extensions to accept (e.g. `[".rb"]` for project source,

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/absurd_recognizer.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/absurd_recognizer.rb
@@ -37,7 +37,6 @@ module Rigor
       #   run, so the same Prism node object is seen in both the `dynamic_return` rule and
       #   `diagnostics_for_file`.
       module AbsurdRecognizer
-        # @param call_node [Prism::CallNode]
         # @return [Boolean] true when `call_node` is `T.absurd(x)`.
         def self.absurd_call?(call_node)
           return false unless call_node.is_a?(Prism::CallNode)
@@ -50,8 +49,6 @@ module Rigor
           arguments&.size == 1
         end
 
-        # @param call_node [Prism::CallNode]
-        # @param scope [Rigor::Scope, nil]
         # @return [Boolean] true when the discriminant has been narrowed to `bot` (the branch is
         #   unreachable, so `T.absurd` is correct). The caller suppresses the `absurd-reachable` diagnostic
         #   in this case.

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/assertion_recognizer.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/assertion_recognizer.rb
@@ -53,8 +53,6 @@ module Rigor
 
         module_function
 
-        # @param call_node [Prism::CallNode]
-        # @param scope [Rigor::Scope]
         # @param plugin_id [String] used for the contribution's `provenance.source_family`.
         # @return [Rigor::FlowContribution, nil]
         def recognize(call_node:, scope:, plugin_id:)

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/catalog.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/catalog.rb
@@ -23,7 +23,6 @@ module Rigor
           @frozen_after_build = false
         end
 
-        # @param signature [MethodSignature]
         def record(signature)
           raise "Catalog already finalised" if @frozen_after_build
 
@@ -33,7 +32,6 @@ module Rigor
 
         # @param class_name [String] the class / module that carries the mixin (`class Post; include Foo;
         #   end` records under `"Post"`).
-        # @param kind [:include, :extend]
         # @param module_name [String] the textual name of the mixed-in module as it appeared at the
         #   include / extend site (`"Foo"`, `"Foo::Bar"`, `"::Foo"`).
         def record_mixin(class_name:, kind:, module_name:)
@@ -60,7 +58,6 @@ module Rigor
           @entries[key_for(class_name, method_name, kind)]
         end
 
-        # @param class_name [String]
         # @return [Hash{Symbol => Array<String>}] frozen mapping `{ include: [...], extend: [...] }`.
         #   Returns {EMPTY_MIXINS} when no mixins were recorded.
         def mixins_for(class_name)
@@ -77,8 +74,6 @@ module Rigor
         # static assertion vocabulary), and the precise `(class, kind)` lookup stays in the rule block.
         # Computed fresh per call — the plugin memoises the resolved set, and `freeze!` freezes the
         # catalog itself so a lazy memo ivar here would raise.
-        #
-        # @return [Array<Symbol>]
         def method_names
           @entries.keys.map { |key| key[1] }.uniq
         end

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/sig_parser.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/sig_parser.rb
@@ -45,7 +45,6 @@ module Rigor
         module_function
 
         # @param sig_call [Prism::CallNode] the `sig { ... }` / `sig do ... end` call.
-        # @return [ParseResult, ParseError]
         def parse(sig_call)
           return ParseError.new(reason: :no_block, node: sig_call) if sig_call.block.nil?
 

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/sigil_detector.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/sigil_detector.rb
@@ -52,7 +52,6 @@ module Rigor
           DEFAULT_LEVEL
         end
 
-        # @param level [Symbol]
         # @return [Boolean] true when `# typed: ignore`. The harvest pipeline calls this to short-circuit
         #   walking the file's AST.
         def ignored?(level)

--- a/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/type_translator.rb
+++ b/plugins/rigor-sorbet/lib/rigor/plugin/sorbet/type_translator.rb
@@ -52,7 +52,6 @@ module Rigor
 
         module_function
 
-        # @param node [Prism::Node, nil]
         # @return [Rigor::Type] never `nil`; unrecognised forms degrade to `Type::Combinator.untyped`.
         def translate(node)
           return Rigor::Type::Combinator.untyped if node.nil?
@@ -67,7 +66,6 @@ module Rigor
           end
         end
 
-        # @param node [Prism::ConstantReadNode]
         def translate_constant_read(node)
           name = node.name.to_s
           return Rigor::Type::Combinator.untyped if name.empty?
@@ -75,7 +73,6 @@ module Rigor
           Rigor::Type::Combinator.nominal_of(name)
         end
 
-        # @param node [Prism::ConstantPathNode]
         def translate_constant_path(node)
           name = constant_path_name(node)
           return degraded if name.nil?

--- a/spec/integration/plugins/rbs_inline_plugin_spec.rb
+++ b/spec/integration/plugins/rbs_inline_plugin_spec.rb
@@ -187,6 +187,23 @@ RSpec.describe "plugins/rigor-rbs-inline" do
       RUBY
     end
 
+    it "does not emit untyped skeletons for unannotated sibling methods" do
+      rendered = synthesized_for(<<~RUBY)
+        class Mixed
+          # @rbs x: Integer
+          def one(x)
+            x
+          end
+
+          def two(y)
+            y
+          end
+        end
+      RUBY
+      expect(rendered).to include("def one")
+      expect(rendered).not_to include("def two")
+    end
+
     # `class Foo #:nodoc:` is one of the most common comments in Ruby, and upstream's parser reads the RDoc
     # directive as a type assertion of an alias named `nodoc`. Left alone, 61 of mail's files opted into
     # synthesis on that alone — which is why the annotation gate by itself only got mail from 42 to 31

--- a/spec/integration/precision_snapshot_spec.rb
+++ b/spec/integration/precision_snapshot_spec.rb
@@ -29,10 +29,6 @@
 #   # The WHOLE corpus — only after an engine-wide change whose full diff you intend to review.
 #   UPDATE_SNAPSHOTS=1 bundle exec rspec spec/integration/precision_snapshot_spec.rb
 #
-# The verifying run reports and pins the number of snapshots that contain no captured type. This is deliberately a
-# corpus-level count: adding a fixture without a local or an `assert_type` expression must not quietly enlarge the
-# gate's vacuous surface.
-#
 # Whatever the selection, READ the recorded types before committing them: a golden taken from a buggy run pins
 # the bug, in the one artifact whose purpose is to notice it.
 #
@@ -178,8 +174,6 @@ def snapshot_path(fixture_name)
   File.join(SNAPSHOTS_DIR, "#{safe}.yml")
 end
 
-# A snapshot with neither top-level locals nor fixture assertions pins no type. It remains useful as a fixture
-# execution check, but its vacuity is reported and counted so the precision gate cannot silently lose coverage.
 def vacuous_snapshot_warning(names)
   "\n#{names.size} snapshot(s) pinned no type at all: #{names.sort.join(', ')}.\n" \
     "This gate captures top-level locals and fixture-declared `assert_type` expressions, and those fixtures " \

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -487,7 +487,7 @@ RSpec.describe Rigor::CLI do
             def foo; end
 
             def bar
-              foo
+              "x"
             end
 
             def baz
@@ -531,9 +531,10 @@ RSpec.describe Rigor::CLI do
 
           # `a = foo`: foo's synthesized `-> void` recovers to `top` (was `Dynamic[top]` under the plugin-free env).
           expect(JSON.parse(foo_out)["type"]).to eq("top")
-          # `b = bar`: bar is un-annotated, so its synthesized skeleton is `() -> untyped` and it stays Dynamic —
-          # proving the flip at 14 is the annotation's synthesis, not an unrelated change.
-          expect(JSON.parse(bar_out)["type"]).to eq("Dynamic[top]")
+          # `b = bar`: bar is un-annotated. Upstream would emit `() -> untyped` and keep Dynamic;
+          # we drop that skeleton so body inference (`"x"`) stands — proving the flip at 14 is the
+          # annotation, not a file-wide untyped overlay.
+          expect(JSON.parse(bar_out)["type"]).to eq("\"x\"")
         end
       end
 

--- a/spec/rigor/environment/rbs_loader_spec.rb
+++ b/spec/rigor/environment/rbs_loader_spec.rb
@@ -1607,5 +1607,21 @@ RSpec.describe Rigor::Environment::RbsLoader do
       expect(collision_warnings.first).to include(colliding_virtual.first)
       expect(collision_warnings.first).not_to include(clean_virtual.first)
     end
+
+    it "keeps an inline method that sig/ does not declare, and drops the duplicate" do
+      File.write(File.join(tmpdir, "m.rbs"), "class Demo\n  def shared: () -> ::String\nend\n")
+      virtual = [
+        "virtual:rbs-inline:/app/lib/demo.rb",
+        "class Demo\n  def shared: () -> ::Integer\n  def only_inline: () -> ::Integer\nend\n"
+      ]
+      loader = build_loader([virtual])
+      env = loader.send(:env)
+      expect(env).not_to be_nil
+      builder = RBS::DefinitionBuilder.new(env: env)
+      definition = builder.build_instance(RBS::TypeName.parse("::Demo"))
+      expect(definition.methods[:shared].defs.first.type.type.return_type.to_s).to include("String")
+      expect(definition.methods[:only_inline]).not_to be_nil
+      expect(loader.definition_build_failures).to eq([])
+    end
   end
 end


### PR DESCRIPTION
Stricter keep test: a comment stays only if it states a constraint the next lines do not. ADR citations, fail-soft `nil`, false-positive bounds, and declined alternatives stay.

Dropped:

- Copy-paste that restated a nearby contract.
- Bare YARD `@param` / `@return` that only repeated the signature.
- Heuristic banners that restated the method name (`h1_activesupport` does not need `--- H1 — likely ActiveSupport ---`).
- Catalog labels that restated the symbols they sit on (`:hash, :==, :eql?` is already identity hashing).
- `Returns the X` openers on Reflection facades; the nil / collision / dispatcher sentences remain.

Remaining type-bearing comments are rbs-inline (`# @rbs name: T -- prose`). This tree already declares those methods in `sig/`, so `.rigor.dist.yml` keeps the magic-comment gate: lib/ comments are the dialect, `sig/` is the type source. Unannotated siblings no longer get `untyped` skeletons, and a method already in `sig/` keeps the `.rbs` declaration.

The comment rewrite is internal hygiene. The ingestion guards are in `changelog.d/fixed/comment-redundancy.md`.