### PR TITLE
Add a worktree helper that clones the gem bundle copy-on-write

### DIFF
--- a/.claude/skills/rigor-worktree/SKILL.md
+++ b/.claude/skills/rigor-worktree/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rigor-worktree
 description: |
-  Create a git worktree for isolated or parallel work with its gem bundle in place — `bin/rigor-worktree <branch>` clones `vendor/bundle` copy-on-write from the main clone (APFS clonefile: a few seconds, ~zero disk, isolated and writable) instead of the old `vendor` symlink that let one worktree's `bundle install` mutate everyone's gems. Use when the user asks to "make a worktree", "set up a worktree for a subagent", "give each worker its own checkout", "spin up an isolated tree for a dependency-bump branch", or when a lib-editing agent must not share a working tree with one running `exe/rigor`. Covers the two worktree-only gotchas: `references/` submodules are NOT populated (a reference-reading gate then silently SKIPS) and `.git` is shared (never `git stash`, never deregister a submodule).
+  Create a git worktree for isolated or parallel work with its gem bundle already in place — `bin/rigor-worktree` clones `vendor/bundle` copy-on-write from the main clone (APFS clonefile: seconds, near-zero disk, isolated and writable) instead of a shared `vendor` symlink where one worktree's `bundle install` mutates everyone's gems. Use when asked to "make a worktree", "set up a worktree for a subagent", "give each worker its own checkout", or "spin up an isolated tree for a dependency-bump branch", or when a lib-editing agent needs its own tree apart from one running `exe/rigor`. Also the reference for worktree gotchas — an empty `references/` and the shared `.git`.
 metadata:
   internal: true
 ---

--- a/.claude/skills/rigor-worktree/SKILL.md
+++ b/.claude/skills/rigor-worktree/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: rigor-worktree
+description: |
+  Create a git worktree for isolated or parallel work with its gem bundle in place — `bin/rigor-worktree <branch>` clones `vendor/bundle` copy-on-write from the main clone (APFS clonefile: a few seconds, ~zero disk, isolated and writable) instead of the old `vendor` symlink that let one worktree's `bundle install` mutate everyone's gems. Use when the user asks to "make a worktree", "set up a worktree for a subagent", "give each worker its own checkout", "spin up an isolated tree for a dependency-bump branch", or when a lib-editing agent must not share a working tree with one running `exe/rigor`. Covers the two worktree-only gotchas: `references/` submodules are NOT populated (a reference-reading gate then silently SKIPS) and `.git` is shared (never `git stash`, never deregister a submodule).
+metadata:
+  internal: true
+---
+
+# Create a worktree with its bundle in place
+
+A worktree is the isolation boundary for parallel work: a lib-editing
+agent gets its own tree so the `exe/rigor` another agent invokes is not
+the code being rewritten under it, and a branch with its own
+`Gemfile.lock` can `bundle install` without touching anyone else.
+
+```sh
+bin/rigor-worktree [--with-references] [--with-tools] <branch> [start-point]
+```
+
+- `<branch>` — an existing branch is checked out; a new name is created
+  from `<start-point>` (default `origin/master`).
+- The worktree lands at `$RIGOR_WT_ROOT/<slug>`, default
+  `<main>/../rigor-wt/<slug>` (`~/repo/ruby/rigor-wt/<slug>` in the usual
+  layout). `<slug>` is the branch with a leading `codex/` stripped and
+  `/` → `-`.
+
+The script runs `git worktree add`, then populates the bundle:
+
+- `vendor/bundle` (~126M, ~9800 files) is **copy-on-write cloned** from
+  the main clone — `cp -Rc` / `clonefile(2)` on APFS, a reflink on
+  btrfs/xfs, a plain copy elsewhere. A few seconds, near-zero disk until
+  blocks diverge, and the copy is **writable and isolated**.
+- `.bundle/config` is copied (`BUNDLE_PATH: "vendor/bundle"`, a relative
+  path — it only resolves because the real `vendor/bundle` is now
+  in-tree).
+
+No `.git/info/exclude` entry is needed: the real `vendor/bundle/`
+directory matches the stock `.gitignore` `/vendor/bundle/`, so
+`git status` stays clean. (The old symlink approach needed a `vendor`
+exclude because a symlink named `vendor` does not match that pattern.)
+
+The main clone must have a populated `vendor/bundle` first — the script
+refuses otherwise. Run `make setup` there once if needed.
+
+## The two worktree-only gotchas the script can't hide
+
+**`references/` submodules are NOT populated in a worktree.** A worktree
+shares `.git`, but submodule working trees are per-checkout, so every
+`references/*` directory is empty. A spec that reads a reference checkout
+(`spec/docs/c_effects_raises_gate_spec.rb` is the clear one; the
+builtin-catalog extraction target reads `references/ruby` too) then
+**`skip`s — not fails — silently**, and a worker believes its gate ran
+when only the fixture arm did. Options:
+
+- `--with-references` — CoW-clones every populated `references/*`
+  checkout and re-points each copied `.git` file at the shared module
+  store. Fine because `references/` is **read-only** here.
+- or run `make init-submodules` inside the worktree.
+
+Verify a reference-reading gate actually **executed** (not `pending` /
+`skipped`) before believing it.
+
+**`.git` is shared across all worktrees.** From the fleet rules:
+
+- **Never `git stash`** in a worktree — the stash stack is per-repo, so a
+  `stash`/`pop` can pop another session's WIP into your tree. Take
+  baselines with `git checkout <sha> -- <path>` … `git checkout HEAD --
+  <path>`, and **commit before any baseline swap**.
+- **Never `git submodule deinit` / `git submodule update --init` that
+  removes a registration** — it deregisters the submodule for the *main
+  clone*. Adding a checkout in a worktree is fine; removing a
+  registration is never fine. Repair:
+  `git submodule update --init --filter=blob:none references/<name>`.
+
+## `--with-tools`
+
+Also CoW-clones `tool/steep/vendor` and `tool/sorbet/vendor` (each its
+own bundle under `tool/*/Gemfile`). Only needed for a branch that runs
+`make steep-check` or touches the Sorbet adapter.
+
+## When the branch changes `Gemfile.lock`
+
+Run `bundle install` in the worktree. It re-resolves against the cloned
+bundle and diverges only the blocks it changes — the main clone and
+sibling worktrees are untouched. This is the whole point of cloning
+rather than symlinking.
+
+## Staleness
+
+The clone is pinned to the main clone's `vendor/bundle` at creation time.
+If `master` later bumps a gem, an existing worktree keeps the old gems
+until you `bundle install` in it — which is safer than the symlink
+behaviour, where the branch would silently start running against
+whatever the main clone was last install'd to.
+
+## Running gates in a worktree
+
+Per the fleet rules — foreground, generous timeout, never
+`run_in_background` (a backgrounded `make verify` is the known stall and
+a detached wait cannot always be woken); and **one full-suite / corpus
+job on the machine at a time** — four concurrent `make verify` runs
+OOM-killed the host. Implementation parallel, verification serial.
+
+## Removing a worktree
+
+```sh
+git worktree remove <path>      # --force if the tree is dirty
+git worktree prune
+```
+
+The CoW clone's disk is reclaimed with the directory.
+
+## Quick checklist
+
+- `bin/rigor-worktree <branch>` — bundle cloned, `.bundle/config` copied,
+  `git status` clean.
+- Add `--with-references` if any gate this branch runs reads a
+  `references/` checkout; otherwise expect silent skips.
+- Add `--with-tools` for a Steep / Sorbet branch.
+- In the worktree: no `git stash`, no submodule deregistration, commit
+  before baseline swaps.
+- Gates foreground; one heavy job at a time.
+- `bundle install` in the worktree if the branch moved `Gemfile.lock`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,11 @@ Abbreviated `nix … develop --command` below; commands are otherwise shown in t
 - Target Ruby is `4.0.5`; the gemspec requires `>= 4.0.0`, `< 4.1`.
 - `flake.nix` points Bundler at `vendor/bundle`, keeping gem installs off the machine's global state.
 - First-time setup is `make setup`.
+- Parallel or isolated work gets a worktree via `bin/rigor-worktree <branch>` — it copy-on-write
+  clones `vendor/bundle` from the main clone (APFS clonefile), so every tree has an isolated,
+  writable bundle instead of a shared `vendor` symlink. `references/` submodules are **not**
+  populated in a worktree (pass `--with-references`), and `.git` is shared — never `git stash` or
+  deregister a submodule from one. Full contract: the `rigor-worktree` skill.
 - CI does **not** use Nix: it installs Ruby via `ruby/setup-ruby` and runs `make verify` directly.
 
 ## Common Commands

--- a/bin/rigor-worktree
+++ b/bin/rigor-worktree
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Create a git worktree whose gem bundle is a copy-on-write clone of the main clone.
+#
+# `vendor/bundle` (~126M, ~9800 files) is populated with APFS clonefile(2): a few
+# seconds, near-zero disk, and the worktree gets an ISOLATED, writable bundle. A
+# `bundle install` for a branch's own `Gemfile.lock` then diverges only the blocks
+# it changes and never touches the main clone or a sibling worktree — unlike a
+# `vendor` symlink, where one worktree's `bundle install` mutates everyone's gems.
+# On a non-APFS host `cp` falls back to a reflink (btrfs/xfs) or a plain copy.
+#
+# Usage:
+#   bin/rigor-worktree [--with-references] [--with-tools] <branch> [start-point]
+#
+#   <branch>            existing branch -> checked out; otherwise created from
+#                       <start-point> (default: origin/master).
+#   --with-references   also CoW-clone the populated references/ submodule
+#                       checkouts (read-only here) so a reference-reading gate
+#                       does not silently SKIP in the worktree.
+#   --with-tools        also CoW-clone the tool/steep and tool/sorbet bundles.
+#
+# The worktree is created at $RIGOR_WT_ROOT/<slug> (default: <main>/../rigor-wt/<slug>),
+# where <slug> is the branch name with a leading `codex/` stripped and `/` -> `-`.
+#
+# Exit code: 0 on success, non-zero on failure.
+
+set -euo pipefail
+
+prog=${0##*/}
+die() { echo "$prog: $*" >&2; exit 1; }
+
+usage() {
+  cat >&2 <<EOF
+usage: $prog [--with-references] [--with-tools] <branch> [start-point]
+
+  <branch>           existing branch is checked out; a new one is created from
+                     <start-point> (default: origin/master)
+  --with-references  also CoW-clone the populated references/ submodule checkouts
+  --with-tools       also CoW-clone the tool/steep and tool/sorbet bundles
+
+The worktree lands at \$RIGOR_WT_ROOT/<slug> (default: <main>/../rigor-wt/<slug>).
+EOF
+  exit "${1:-0}"
+}
+
+with_references=0
+with_tools=0
+args=()
+for a in "$@"; do
+  case "$a" in
+    --with-references) with_references=1 ;;
+    --with-tools)      with_tools=1 ;;
+    -h|--help)         usage 0 ;;
+    -*)               die "unknown option: $a (see --help)" ;;
+    *)                args+=("$a") ;;
+  esac
+done
+
+[ "${#args[@]}" -ge 1 ] || usage 1
+branch=${args[0]}
+start=${args[1]:-origin/master}
+
+main=$(git rev-parse --path-format=absolute --git-common-dir)
+main=${main%/.git}
+[ -d "$main" ] || die "cannot locate the main clone (resolved: $main)"
+[ -d "$main/vendor/bundle" ] || \
+  die "no $main/vendor/bundle — run 'make setup' (or 'bundle install') in the main clone first"
+
+slug=${branch#codex/}
+slug=${slug//\//-}
+wt_root=${RIGOR_WT_ROOT:-$(dirname "$main")/rigor-wt}
+wt=$wt_root/$slug
+if [ -e "$wt" ]; then die "$wt already exists"; fi
+
+# Pick a copy-on-write cp. macOS `cp -Rc` uses clonefile(2) and silently falls
+# back to copyfile(2) across filesystems; GNU cp gets --reflink=auto (CoW on
+# btrfs/xfs, plain copy elsewhere); anything else does a plain recursive copy.
+cow_cp() {
+  local src=$1 dst=$2
+  case "$(uname)" in
+    Darwin) cp -Rc "$src" "$dst" ;;
+    *) if cp --version 2>/dev/null | grep -q coreutils; then
+         cp -a --reflink=auto "$src" "$dst"
+       else
+         cp -R "$src" "$dst"
+       fi ;;
+  esac
+}
+
+clone_into_wt() { # clone_into_wt REL   (REL is relative to the repo root)
+  local rel=$1
+  if [ ! -e "$main/$rel" ]; then echo "  skip $rel (absent in main clone)"; return 0; fi
+  mkdir -p "$wt/$(dirname "$rel")"
+  cow_cp "$main/$rel" "$wt/$rel"
+  echo "  cloned $rel"
+}
+
+if git -C "$main" rev-parse --verify --quiet "refs/heads/$branch" >/dev/null; then
+  echo "==> git worktree add $wt $branch"
+  git -C "$main" worktree add "$wt" "$branch"
+else
+  echo "==> git worktree add $wt -b $branch $start"
+  git -C "$main" worktree add "$wt" -b "$branch" "$start"
+fi
+
+echo "==> cloning the gem bundle (copy-on-write)"
+clone_into_wt vendor/bundle
+mkdir -p "$wt/.bundle"
+if cp "$main/.bundle/config" "$wt/.bundle/config" 2>/dev/null; then
+  echo "  copied .bundle/config"
+else
+  printf 'BUNDLE_PATH: "vendor/bundle"\n' > "$wt/.bundle/config"
+  echo "  wrote a default .bundle/config"
+fi
+
+if [ "$with_tools" -eq 1 ]; then
+  echo "==> cloning the tool bundles"
+  for t in tool/steep tool/sorbet; do
+    clone_into_wt "$t/vendor"
+    if [ -f "$main/$t/.bundle/config" ]; then
+      mkdir -p "$wt/$t/.bundle"
+      cp "$main/$t/.bundle/config" "$wt/$t/.bundle/config"
+    fi
+  done
+fi
+
+if [ "$with_references" -eq 1 ]; then
+  echo "==> cloning references/ submodule checkouts (read-only)"
+  for d in "$main"/references/*/; do
+    name=$(basename "$d")
+    if [ ! -e "${d}.git" ]; then echo "  skip references/$name (not initialized in main)"; continue; fi
+    cow_cp "${d%/}" "$wt/references/$name"
+    # A submodule `.git` file is relative to the main clone; re-point the copy
+    # at the shared module store so read-only git commands resolve.
+    printf 'gitdir: %s/.git/modules/references/%s\n' "$main" "$name" > "$wt/references/$name/.git"
+    if git -C "$wt/references/$name" rev-parse --verify --quiet HEAD >/dev/null; then
+      echo "  cloned references/$name"
+    else
+      echo "  WARNING: references/$name cloned but its git linkage looks wrong" >&2
+    fi
+  done
+fi
+
+echo
+echo "Worktree ready: $wt"
+echo "  branch:  $(git -C "$wt" rev-parse --abbrev-ref HEAD)"
+echo "  bundle:  vendor/bundle — CoW clone of the main clone, isolated and writable"
+if [ "$with_references" -eq 0 ]; then
+  echo "  refs:    references/ is NOT populated — a reference-reading gate will"
+  echo "           silently SKIP here. Re-run with --with-references, or run"
+  echo "           'make init-submodules' in the worktree, if a gate needs one."
+fi
+echo
+echo "Work inside the Flake as usual. If this branch changes Gemfile.lock, run"
+echo "'bundle install' in the worktree: it re-resolves against the clone and"
+echo "diverges only the changed blocks."


### PR DESCRIPTION
Parallel and isolated work needs a worktree, but the gem-bundle wiring for one has been ad hoc: some worktrees symlink `vendor/` to the main clone (so one `bundle install` mutates every tree), others run a full independent `bundle install` (~1 min, 59M each), and the steps lived only in scratch notes.

`bin/rigor-worktree <branch>` standardises it on an **APFS copy-on-write clone** of `vendor/bundle`:

- `cp -Rc` / `clonefile(2)` — ~3s for the 126M / 9800-file tree, near-zero disk until blocks diverge, and the copy is **writable and isolated**. A later `bundle install` for the branch's own `Gemfile.lock` diverges only the blocks it touches; the main clone and sibling worktrees are untouched.
- Falls back to a reflink (btrfs/xfs) or a plain copy off APFS. CI never uses worktrees, so it is unaffected.
- A real `vendor/bundle/` directory matches the stock `.gitignore` `/vendor/bundle/`, so no `.git/info/exclude` entry is needed (the symlink approach needed one).

Flags:

- `--with-references` — CoW-clones the read-only `references/*` submodule checkouts (a worktree leaves them empty, so a reference-reading spec silently skips) and re-points each copied `.git` file at the shared module store.
- `--with-tools` — same for `tool/steep` and `tool/sorbet`.

The `rigor-worktree` skill carries the full contract, including the two worktree-only hazards the script cannot hide: a shared `.git` (never `git stash`, never deregister a submodule) and an unpopulated `references/`.

## Verification

- `make verify` green.
- Manual: created a worktree both plain and `--with-references`, confirmed `git status` clean (no `?? vendor`), `bundle check` + `bundle exec` (native `rbs` extension) work under the Flake, `git -C <wt>/references/rbs rev-parse HEAD` resolves, and the main clone's `git submodule status` is untouched.