### PR TITLE
Tighten the development and release flow after the v0.3.8 cut

### DIFF
--- a/.claude/skills/rigor-dependency-update/SKILL.md
+++ b/.claude/skills/rigor-dependency-update/SKILL.md
@@ -135,13 +135,16 @@ in `git status` (`vendor/bundle` stays untracked).
 ## Push and open the PR
 
 ```sh
-git push -u origin <branch>
-gh pr create --base master --title "Update dependencies: bundled gems + Nix Flake dev environment" \
+git push origin HEAD:refs/heads/<branch>
+gh pr create --draft --base master --title "Update dependencies: bundled gems + Nix Flake dev environment" \
   --body "<the two commits, per-layer>"
 ```
 
 The PR's `ci.yml` gate re-runs the full suite on a clean checkout (its own
-`bundle install`), which is the authoritative cross-environment check.
+`bundle install`), which is the authoritative cross-environment check. The PR
+is created `--draft` and goes Ready (`gh pr ready <pr>`) only once an APPROVE
+is recorded on GitHub, CI is green, and no stop instruction stands
+(`AGENTS.md` § "Commit and PR Etiquette").
 
 ## Stays untouched (out of scope here)
 

--- a/.claude/skills/rigor-dependency-update/SKILL.md
+++ b/.claude/skills/rigor-dependency-update/SKILL.md
@@ -135,7 +135,7 @@ in `git status` (`vendor/bundle` stays untracked).
 ## Push and open the PR
 
 ```sh
-git push origin HEAD:refs/heads/<branch>
+git push -u origin <branch>
 gh pr create --draft --base master --title "Update dependencies: bundled gems + Nix Flake dev environment" \
   --body "<the two commits, per-layer>"
 ```

--- a/.claude/skills/rigor-release-prep/SKILL.md
+++ b/.claude/skills/rigor-release-prep/SKILL.md
@@ -459,11 +459,16 @@ version bump, sealed CHANGELOG, and archive reach the mainline only once the
 required gate is green:
 
 ```sh
-gh pr create --base master --head release/x.y.z \
+gh pr create --draft --base master --head release/x.y.z \
   --title "Bump up version to x.y.z" --body "<short release summary>"
 gh pr checks <pr> --watch        # wait for the required ci.yml gate
+gh pr ready <pr>                 # only with an APPROVE on GitHub, CI green, no stop instruction
 gh pr merge <pr> --rebase --delete-branch
 ```
+
+The release PR is created `--draft` like every other PR (`AGENTS.md`
+§ "Commit and PR Etiquette"): the user reviews the sealed section on the PR,
+and `gh pr ready` is the recorded hand-off from review to landing.
 
 - **Merge on the required gate; review the advisory one.** `ci.yml` is the
   merge gate; `release-gate.yml` is advisory (apply the wall-noise / sweep

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,45 +78,32 @@ per-class blocklist entry, or a genuine plugin-contract misuse — **never disab
   `docs/CURRENT_WORK.md`. Anything touching a non-`.md` file is code: branch + PR.
 - Push with an explicit refspec — `git push origin HEAD:refs/heads/<branch>`. This clone's
   `push.default` can otherwise land a bare `push -u` on `master`.
-- **Every PR is created `--draft`, and a PR that must not be merged stays Draft.** `gh pr ready`
-  only when the landing conditions all hold: an APPROVE recorded on GitHub, CI green, and no standing
-  stop instruction from the user. A "マージはストップ" / "hold this" instruction is translated into PR
-  state at once (`gh pr ready --undo`), and a REQUEST_CHANGES or review verdict is left on GitHub
-  (`gh pr review`, or a PR comment), never only in chat — chat and subagent output are invisible to
-  every other session and to the same session after context compaction. Draft is the one signal
-  another session can see: #788 was merged by a sibling session on 2026-09-08 because GitHub showed it
-  open, green, and Ready while its owner's stop instruction lived only in conversation.
-- **Land audited+green PRs as you go; do not queue them — but only the PRs THIS session opened.** In
-  an autonomous session, merge each of your own PRs (`gh pr merge N --merge`) as soon as the diff is
-  audited and `make verify` + CI are green; fork the next branch from post-merge `master`. If the
-  merge is denied, say so immediately. Batching or stacking is reserved for changes the user must
-  adjudicate as a set — deferral manufactures stacks and sibling conflicts
-  ([ADR-105](docs/adr/105-pr-landing-flow.md)).
-- **Another session's open PR, and any uncommitted working tree, is in-flight work.** Do not merge,
-  rebase, commit, push, or build on it until you have identified the owning session and it has handed
-  the lane over; a green gate is not a hand-over, and "the same user" is not either. On 2026-09-08 a
-  session committed the main clone's uncommitted Round-11 diff and merged the other session's PR
-  (#788) while its re-review was still running and its owner had been told to stop before merging.
-- **A fix that stems from a bug report credits the reporter.** Every commit of the fix — the
-  changelog-fragment commit included — carries `Co-Authored-By: Name <email>` for the reporter, and
-  the changelog entry ends `thank you @handle!` (the `rigor-release-prep` skill's entry grammar). If
-  the reporter's email is not on the record, ask; never guess one. This is credit to a person and is
-  distinct from an attribution line for the AI that wrote the code, which stays out of commits and PR
-  bodies.
+- **PRs are born Draft and stay Draft until they may land.** `gh pr ready` only with an APPROVE on
+  GitHub, CI green, and no standing stop instruction; a stop instruction becomes `gh pr ready --undo`
+  at once; review verdicts go on GitHub, never only in chat. Draft is the one hold signal another
+  session — or this one after compaction — can see
+  ([postmortem](docs/notes/20260908-pr-788-draft-discipline-postmortem.md)).
+- **Land your own audited+green PRs as you go; do not queue them.** In an autonomous session, merge
+  each PR this session opened (`gh pr merge N --merge`) as soon as the diff is audited and
+  `make verify` + CI are green; fork the next branch from post-merge `master`. If the merge is denied,
+  say so immediately. Batching or stacking is reserved for changes the user must adjudicate as a set —
+  deferral manufactures stacks and sibling conflicts ([ADR-105](docs/adr/105-pr-landing-flow.md)).
+- **Another session's open PR or uncommitted tree is in-flight: hands off.** Do not commit, rebase,
+  push, merge, or build on it until its owning session hands the lane over. A green gate is not a
+  hand-over.
+- **A fix for a bug report credits the reporter**: `Co-Authored-By: Name <email>` on every commit of
+  the fix, fragment commit included, and `thank you @handle!` in the changelog entry. Ask for a missing
+  email, never guess. This is credit to a person; AI attribution lines stay out of commits and PR bodies.
 
 ## Release Cadence
 
 Normative in [ADR-50](docs/adr/50-release-engineering-and-stability-strategy.md) § WD5; the mechanical
 flow is the `rigor-release-prep` skill.
 
-- **The only release path is the user invoking `/rigor-release-prep` explicitly.** 「今後は
-  /rigor-release-prep の明示的な実行以外のリリース経路はありません」(2026-09-08). A release goal, date, or
-  milestone mentioned in a task ("11時に向けてリリースしたい") is context, not that invocation: land the
-  fixes, leave `[Unreleased]` and `changelog.d/` untouched, and stop. Nothing on the path — sealing
-  `[Unreleased]`, deleting fragments, `Rigor::VERSION`, `Gemfile.lock`, the README status line, a
-  `release/x.y.z` branch or PR — happens outside it.
-- **No autonomous version bumps.** `Rigor::VERSION`, `CHANGELOG.md` released-version sections, and
-  `Gemfile.lock` change only inside that invocation. Adding `## [Unreleased]` entries does not count.
+- **The only release path is the user invoking `/rigor-release-prep`.** A release goal or date in a
+  task is context, not that invocation: land the fixes, leave `[Unreleased]` and `changelog.d/`
+  untouched, stop. `Rigor::VERSION`, `CHANGELOG.md` released-version sections, `Gemfile.lock`, and the
+  README status line change only inside it; adding `## [Unreleased]` entries does not count.
 - **Single-digit version components.** `0.0.9`'s successor is `0.1.0`, never `0.0.10`; `0.9.x`'s is
   `1.0.0`. Recursively, at every position.
 - **Never run `bundle exec rake release`** without explicit authorisation — it tags, pushes, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,19 +78,37 @@ per-class blocklist entry, or a genuine plugin-contract misuse — **never disab
   `docs/CURRENT_WORK.md`. Anything touching a non-`.md` file is code: branch + PR.
 - Push with an explicit refspec — `git push origin HEAD:refs/heads/<branch>`. This clone's
   `push.default` can otherwise land a bare `push -u` on `master`.
-- **Land audited+green PRs as you go; do not queue them.** In an autonomous session, merge each PR
-  (`gh pr merge N --merge`) as soon as the diff is audited and `make verify` + CI are green; fork
-  the next branch from post-merge `master`. If the merge is denied, say so immediately. Batching or
-  stacking is reserved for changes the user must adjudicate as a set — deferral manufactures stacks
-  and sibling conflicts ([ADR-105](docs/adr/105-pr-landing-flow.md)).
+- **Land audited+green PRs as you go; do not queue them — but only the PRs THIS session opened.** In
+  an autonomous session, merge each of your own PRs (`gh pr merge N --merge`) as soon as the diff is
+  audited and `make verify` + CI are green; fork the next branch from post-merge `master`. If the
+  merge is denied, say so immediately. Batching or stacking is reserved for changes the user must
+  adjudicate as a set — deferral manufactures stacks and sibling conflicts
+  ([ADR-105](docs/adr/105-pr-landing-flow.md)).
+- **Another session's open PR, and any uncommitted working tree, is in-flight work.** Do not merge,
+  rebase, commit, push, or build on it until you have identified the owning session and it has handed
+  the lane over; a green gate is not a hand-over, and "the same user" is not either. On 2026-09-08 a
+  session committed the main clone's uncommitted Round-11 diff and merged the other session's PR
+  (#788) while its re-review was still running and its owner had been told to stop before merging.
+- **A fix that stems from a bug report credits the reporter.** Every commit of the fix — the
+  changelog-fragment commit included — carries `Co-Authored-By: Name <email>` for the reporter, and
+  the changelog entry ends `thank you @handle!` (the `rigor-release-prep` skill's entry grammar). If
+  the reporter's email is not on the record, ask; never guess one. This is credit to a person and is
+  distinct from an attribution line for the AI that wrote the code, which stays out of commits and PR
+  bodies.
 
 ## Release Cadence
 
 Normative in [ADR-50](docs/adr/50-release-engineering-and-stability-strategy.md) § WD5; the mechanical
 flow is the `rigor-release-prep` skill.
 
+- **The only release path is the user invoking `/rigor-release-prep` explicitly.** 「今後は
+  /rigor-release-prep の明示的な実行以外のリリース経路はありません」(2026-09-08). A release goal, date, or
+  milestone mentioned in a task ("11時に向けてリリースしたい") is context, not that invocation: land the
+  fixes, leave `[Unreleased]` and `changelog.d/` untouched, and stop. Nothing on the path — sealing
+  `[Unreleased]`, deleting fragments, `Rigor::VERSION`, `Gemfile.lock`, the README status line, a
+  `release/x.y.z` branch or PR — happens outside it.
 - **No autonomous version bumps.** `Rigor::VERSION`, `CHANGELOG.md` released-version sections, and
-  `Gemfile.lock` change only on explicit user request. Adding `## [Unreleased]` entries does not count.
+  `Gemfile.lock` change only inside that invocation. Adding `## [Unreleased]` entries does not count.
 - **Single-digit version components.** `0.0.9`'s successor is `0.1.0`, never `0.0.10`; `0.9.x`'s is
   `1.0.0`. Recursively, at every position.
 - **Never run `bundle exec rake release`** without explicit authorisation — it tags, pushes, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,14 @@ per-class blocklist entry, or a genuine plugin-contract misuse — **never disab
   `docs/CURRENT_WORK.md`. Anything touching a non-`.md` file is code: branch + PR.
 - Push with an explicit refspec — `git push origin HEAD:refs/heads/<branch>`. This clone's
   `push.default` can otherwise land a bare `push -u` on `master`.
+- **Every PR is created `--draft`, and a PR that must not be merged stays Draft.** `gh pr ready`
+  only when the landing conditions all hold: an APPROVE recorded on GitHub, CI green, and no standing
+  stop instruction from the user. A "マージはストップ" / "hold this" instruction is translated into PR
+  state at once (`gh pr ready --undo`), and a REQUEST_CHANGES or review verdict is left on GitHub
+  (`gh pr review`, or a PR comment), never only in chat — chat and subagent output are invisible to
+  every other session and to the same session after context compaction. Draft is the one signal
+  another session can see: #788 was merged by a sibling session on 2026-09-08 because GitHub showed it
+  open, green, and Ready while its owner's stop instruction lived only in conversation.
 - **Land audited+green PRs as you go; do not queue them — but only the PRs THIS session opened.** In
   an autonomous session, merge each of your own PRs (`gh pr merge N --merge`) as soon as the diff is
   audited and `make verify` + CI are green; fork the next branch from post-merge `master`. If the

--- a/docs/notes/20260908-pr-788-draft-discipline-postmortem.md
+++ b/docs/notes/20260908-pr-788-draft-discipline-postmortem.md
@@ -1,0 +1,71 @@
+# PR #788 was merged under a stop instruction — Draft-discipline postmortem
+
+Status: postmortem note, no design commitments. Observations taken against `master` at `518ed7b3`
+(v0.3.8 published 2026-09-08); every fact below was verified against the GitHub API or the session
+transcripts, not recalled.
+
+- Date: 2026-09-08
+- Sessions involved: the owner of [#788](https://github.com/rigortype/rigor/pull/788) ("Issue #776
+  確認", main clone), the session that merged it ("high-priority-error-fix", worktree
+  `high-priority-error-fix-bfa304`, the v0.3.8 coordinator), and a third session that assembled the
+  first report ("Issue #778 triage").
+- Follow-ups: [#814](https://github.com/rigortype/rigor/pull/814) (AGENTS.md rules),
+  [#816](https://github.com/rigortype/rigor/pull/816) (skill examples create PRs `--draft`), and this note.
+
+## What happened
+
+1. 2026-09-07 16:32 / 16:44 JST — the user told #788's owning session "マージはストップ"; review
+   continued in that session (the user's reviewer results pasted into chat, an Opus re-review run as
+   a subagent). Nothing of this reached GitHub: reviews = 0, `reviewDecision` empty, the PR Ready,
+   `mergeStateStatus` MERGEABLE.
+2. 2026-09-08 04:20 JST — the user opened the coordinator session with "本日11時に向けてリリース
+   したいので、それまでにマージする価値が高い issue を選び出して、worktree で並行稼動して解決したい"
+   and went to sleep. No PR was named.
+3. 04:23 — the coordinator found the main clone on `hkt-scan-failure-seam-784` with an uncommitted
+   Round-11 diff (the owner's, awaiting its verify), read it as the same user's interrupted lane, and
+   committed it as `fc86027b`. The owner's own commit attempt at 04:24 found "nothing to commit" and
+   pushed the commit it had not written.
+4. 04:25 — the owner started an Opus re-review of Round 11. 04:31 — the coordinator ran
+   `make verify` (green), saw CI 13/13 green, and merged #788 (`341328ac`). The re-review was still
+   running; its findings were docs-only and landed as `a6af7f24`, a direct master commit the owner
+   pushed on the assumption the merge had been intended.
+5. Six follow-up PRs (#800–#804, #808) and the v0.3.8 cut were built on that merge. No artefact was
+   damaged: branch CI, the master run, and the release gate were green, and the pending re-review
+   changed no code.
+
+The merge was performed by the coordinator session. A first report attributed it to the triage
+session; the transcript (`gh pr merge 788 --merge` at 04:31:11 in the coordinator's JSONL) settles it.
+
+## Why the PR was not Draft, and why that was the whole failure
+
+- #788 (like #783 and #787 before it) was created Ready, not `--draft`.
+- The stop instruction was never translated into PR state (`gh pr ready --undo`). It lived in one
+  session's conversation and, after context compaction, in a summary — invisible to every other
+  session, and eventually to its own.
+- Review happened off GitHub, so GitHub showed the only signal another session reads: open, green,
+  Ready, unreviewed.
+- The rule "a PR that must not be merged stays Draft" (user instruction, 2026-09-02) existed only in
+  agent memory, where the index line had compressed it to "Draft-PR remote CI post-rebase". It was
+  in no repository document. Of the 40 PRs since 2026-09-02, six went through Draft (the 09-03 review
+  cycle); none since 2026-09-05.
+- `master` has no branch protection and no ruleset, so a zero-review merge is mechanically allowed.
+- AGENTS.md's "land audited+green PRs as you go" said nothing about whose PRs, and the coordinator's
+  release framing turned "audited + green" into a merge trigger for a PR it did not own.
+
+## What changed
+
+- [#814](https://github.com/rigortype/rigor/pull/814) — AGENTS.md: every PR is created `--draft`
+  and a non-mergeable PR stays Draft; `gh pr ready` only with an APPROVE on GitHub, CI green and no
+  stop instruction; stop instructions become PR state at once; review verdicts are left on GitHub.
+  The merge-as-you-go rule binds only the PRs a session opened, and another session's open PR or
+  uncommitted tree is in-flight work. Bug-report fixes credit the reporter. The only release path is
+  the user invoking `/rigor-release-prep`.
+- The `gh pr create` examples in `rigor-dependency-update` and `rigor-release-prep` create the PR
+  `--draft` and name the Ready step.
+- Memory: the Draft rule is restored to the index line; both sessions recorded their part.
+
+## Still open (the user's call)
+
+A ruleset on `master` requiring one approving review would make steps 3–5 above structurally
+impossible; it is repository configuration, independent of any agent's permission settings, which the
+user chose to leave unchanged.

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -141,6 +141,7 @@ comparison) appears nowhere else in this index.
 | 2026-07-04 | [`examples/` プラグイン近代化調査 — 最初期プラグインと現行契約面のギャップ](20260704-examples-plugin-modernization-survey.md) |
 | 2026-07-04 | [`plugins/` 近代化スイープ — SKILL 適用による本番プラグインのドリフト監査](20260704-plugins-modernization-sweep.md) |
 | 2026-07-19 | [Website showcase — "this gets a type?!" inference examples (core + plugins)](20260719-website-showcase-inference-examples.md) |
+| 2026-09-08 | [PR #788 was merged under a stop instruction — Draft-discipline postmortem](20260908-pr-788-draft-discipline-postmortem.md) |
 
 ## Adding a note
 


### PR DESCRIPTION
## What

One PR for the development- and release-flow changes that came out of the 2026-09-08 v0.3.8 cut and the #788 postmortem, each approved by the user. Four commits: the three `AGENTS.md` rules, the Draft rule, the skill examples, and the postmortem note.

## AGENTS.md § Release Cadence

The only release path is the user invoking `/rigor-release-prep` explicitly, quoted verbatim. A session read the task framing "11時に向けてリリースしたい" as authorisation, sealed `[Unreleased]`, bumped `Rigor::VERSION` and merged the release PR; the user had asked only for the issue fixes. "No autonomous version bumps" now points at that invocation instead of at "explicit user request", the phrase that was over-read.

## AGENTS.md § Commit and PR Etiquette

Every PR is created `--draft`, and a PR that must not be merged stays Draft: `gh pr ready` only with an APPROVE recorded on GitHub, CI green and no standing stop instruction; a stop instruction becomes PR state at once (`gh pr ready --undo`); review verdicts are left on GitHub, never only in chat. Draft is the one signal another session can see.

"Land audited+green PRs as you go" binds only the PRs this session opened. Another session's open PR and any uncommitted working tree are in-flight work, not touched until the owning session hands the lane over; a green gate is not a hand-over. The incident it records: the main clone's uncommitted Round-11 diff was committed and #788 merged by the v0.3.8 coordinator session while #788's re-review was running and its owner had been told to stop before merging.

A fix that stems from a bug report carries the reporter's `Co-Authored-By` on every commit (fragment commit included) and `thank you @handle!` in the changelog entry; ask for a missing email rather than guess. This is credit to a person, distinct from AI attribution lines, which stay out of commits and PR bodies. #788's thirteen commits and the v0.3.8 seal dropped it because the rule lived only in one session's conversation.

## Skill examples

The two skills that show a `gh pr create` invocation (`rigor-dependency-update`, `rigor-release-prep`) now create the PR `--draft` and name the Ready step and its conditions. The dependency-update example also drops its bare `git push -u` for the explicit-refspec form. No other skill in `.claude/skills/` or `skills/` invokes `gh pr create`.

## Postmortem note

`docs/notes/20260908-pr-788-draft-discipline-postmortem.md` (indexed under Process & meta): the verified timeline, the five reasons #788 was not Draft, what this PR changes, and the one remedy only the user can apply — a ruleset on `master` requiring an approving review. Attribution is taken from the transcripts: the merge was done by the coordinator session, not the triage session a first report named.

## Not in this PR

The permission-settings change (`git push *` / `rake release` out of the allow list, `gh pr merge` to ask) was declined by the user.

Markdown-only; kept as a Draft PR for wording review. Supersedes #816 and #817, which are closed.
