### PR TITLE
Create PRs as Draft in the skill examples

### DIFF
--- a/.claude/skills/rigor-dependency-update/SKILL.md
+++ b/.claude/skills/rigor-dependency-update/SKILL.md
@@ -135,13 +135,16 @@ in `git status` (`vendor/bundle` stays untracked).
 ## Push and open the PR
 
 ```sh
-git push -u origin <branch>
-gh pr create --base master --title "Update dependencies: bundled gems + Nix Flake dev environment" \
+git push origin HEAD:refs/heads/<branch>
+gh pr create --draft --base master --title "Update dependencies: bundled gems + Nix Flake dev environment" \
   --body "<the two commits, per-layer>"
 ```
 
 The PR's `ci.yml` gate re-runs the full suite on a clean checkout (its own
-`bundle install`), which is the authoritative cross-environment check.
+`bundle install`), which is the authoritative cross-environment check. The PR
+is created `--draft` and goes Ready (`gh pr ready <pr>`) only once an APPROVE
+is recorded on GitHub, CI is green, and no stop instruction stands
+(`AGENTS.md` § "Commit and PR Etiquette").
 
 ## Stays untouched (out of scope here)
 

--- a/.claude/skills/rigor-release-prep/SKILL.md
+++ b/.claude/skills/rigor-release-prep/SKILL.md
@@ -459,11 +459,16 @@ version bump, sealed CHANGELOG, and archive reach the mainline only once the
 required gate is green:
 
 ```sh
-gh pr create --base master --head release/x.y.z \
+gh pr create --draft --base master --head release/x.y.z \
   --title "Bump up version to x.y.z" --body "<short release summary>"
 gh pr checks <pr> --watch        # wait for the required ci.yml gate
+gh pr ready <pr>                 # only with an APPROVE on GitHub, CI green, no stop instruction
 gh pr merge <pr> --rebase --delete-branch
 ```
+
+The release PR is created `--draft` like every other PR (`AGENTS.md`
+§ "Commit and PR Etiquette"): the user reviews the sealed section on the PR,
+and `gh pr ready` is the recorded hand-off from review to landing.
 
 - **Merge on the required gate; review the advisory one.** `ci.yml` is the
   merge gate; `release-gate.yml` is advisory (apply the wall-noise / sweep


### PR DESCRIPTION
## What

The two skills in `.claude/skills/` that show a `gh pr create` invocation (`rigor-dependency-update`, `rigor-release-prep`) now create the PR `--draft` and name the Ready step and its conditions (an APPROVE recorded on GitHub, CI green, no stop instruction), matching the rule PR #814 adds to `AGENTS.md`. The dependency-update example also drops its bare `git push -u` for the explicit-refspec form AGENTS.md prescribes.

No other skill in `.claude/skills/` or `skills/` invokes `gh pr create`; the app's `/triage` flow is not in this repository.

Markdown-only; opened as a Draft PR for wording review, per the 2026-09-08 postmortem.