### PR TITLE
Decline reversed int<min, max> bounds instead of crashing the file

### DIFF
--- a/changelog.d/fixed/rbs-extended-reversed-int-bounds.md
+++ b/changelog.d/fixed/rbs-extended-reversed-int-bounds.md
@@ -1,0 +1,1 @@
+- **[rbs-extended]** A `rigor:v1` payload with reversed integer-range bounds such as `int<10, 1>` is now reported as `dynamic.rbs-extended.unresolved` at its annotation instead of aborting analysis of the whole Ruby file with an internal analyzer error. ([#828](https://github.com/rigortype/rigor/pull/828))

--- a/lib/rigor/builtins/imported_refinements.rb
+++ b/lib/rigor/builtins/imported_refinements.rb
@@ -141,11 +141,14 @@ module Rigor
 
       # `name<min, max>` — integer-bound parameterised refinements. Each builder takes an
       # `Array<Integer>` and returns a `Rigor::Type` (or `nil`). Bounds are signed integer
-      # literals; `min` MUST be ≤ `max` for the carrier to construct successfully
-      # (`Type::IntegerRange` enforces the invariant).
+      # literals. A reversed pair (`min` > `max`) is declined as `nil` like every other shape
+      # mismatch, so the caller surfaces `dynamic.rbs-extended.unresolved` at the annotation;
+      # `Type::IntegerRange` raises on it instead, and that `ArgumentError` used to escape as an
+      # `internal analyzer error` that abandoned the whole Ruby file.
       PARAMETERISED_INT_BUILDERS = {
         "int" => lambda { |bounds|
           return nil unless bounds.size == 2
+          return nil if bounds[0] > bounds[1]
 
           Type::Combinator.integer_range(bounds[0], bounds[1])
         }

--- a/spec/rigor/analysis/runner_spec.rb
+++ b/spec/rigor/analysis/runner_spec.rb
@@ -5262,6 +5262,20 @@ RSpec.describe Rigor::Analysis::Runner do
       expect(diag.path).to include("demo.rbs")
     end
 
+    it "declines a reversed `int<max, min>` payload as unresolved instead of crashing the file" do
+      # `Type::IntegerRange` raises on `min > max`; before the builder declined the pair, that
+      # `ArgumentError` surfaced as an `internal analyzer error` row and the file was not analyzed.
+      result = analyze_reporter_demo("ReversedBoundsDemo", "int<10, 1>")
+      diag = result.diagnostics.find { |d| d.rule == "dynamic.rbs-extended.unresolved" }
+
+      expect(diag).not_to be_nil
+      expect(diag.message).to include("int<10, 1>")
+      expect(diag.path).to include("demo.rbs")
+      expect(diag.line).to eq(2)
+      crashes = result.diagnostics.select { |d| d.message.start_with?("internal analyzer error") }
+      expect(crashes).to be_empty
+    end
+
     it "surfaces a shape-projection on a non-shape carrier as `dynamic.shape.lossy-projection`" do
       result = analyze_reporter_demo("LossyDemo", "pick_of[Hash[String, Integer], String]")
       diag = result.diagnostics.find { |d| d.rule == "dynamic.shape.lossy-projection" }

--- a/spec/rigor/builtins/imported_refinements_spec.rb
+++ b/spec/rigor/builtins/imported_refinements_spec.rb
@@ -129,6 +129,15 @@ RSpec.describe Rigor::Builtins::ImportedRefinements do
         .to eq(Rigor::Type::Combinator.integer_range(-3, 7))
     end
 
+    it "declines int<min, max> with reversed bounds instead of raising" do
+      # `Type::IntegerRange` raises on `min > max`; the builder declines first so the payload is
+      # reported as `dynamic.rbs-extended.unresolved` rather than crashing the file's analysis.
+      expect(described_class.parse("int<10, 1>")).to be_nil
+      expect(described_class.parse("int<0, -1>")).to be_nil
+      expect(described_class.parse("int<5, 5>"))
+        .to eq(Rigor::Type::Combinator.integer_range(5, 5))
+    end
+
     it "returns nil for arity mismatches in parameterised forms" do
       expect(described_class.parse("non-empty-array[Integer, String]")).to be_nil
       expect(described_class.parse("non-empty-hash[Symbol]")).to be_nil

--- a/spec/rigor/rbs_extended_spec.rb
+++ b/spec/rigor/rbs_extended_spec.rb
@@ -219,6 +219,10 @@ RSpec.describe Rigor::RbsExtended do
       expect(described_class.parse_return_type_override("rigor:v1:return: non-empty-array[")).to be_nil
       expect(described_class.parse_return_type_override("rigor:v1:return: int<5, 10")).to be_nil
     end
+
+    it "returns nil for int<min, max> with reversed bounds instead of raising" do
+      expect(described_class.parse_return_type_override("rigor:v1:return: int<10, 1>")).to be_nil
+    end
   end
 
   describe ".parse_param_annotation" do


### PR DESCRIPTION
A user-authored `RBS::Extended` payload with reversed integer-range bounds, e.g. `%a{rigor:v1:return: int<10, 1>}`, crashed analysis of the whole Ruby file: `Type::Combinator.integer_range` was called unguarded, `Type::IntegerRange#initialize` raised `ArgumentError` on `min > max`, and the raise escaped as `lib/foo.rb:1:1: error: internal analyzer error: ArgumentError: IntegerRange requires min (10) <= max (1)` with the rest of the file left unanalyzed.

The `int` builder in `ImportedRefinements` now returns `nil` on a reversed pair, the same fail-soft path every other builder takes on a shape mismatch, so the caller reports the existing `dynamic.rbs-extended.unresolved` info diagnostic at the annotation (`sig/foo.rbs:2:3`) and analysis continues. `IntegerRange`'s invariant is untouched; its other producers rely on it.

Specs: the parser spec asserts `int<10, 1>` and `int<0, -1>` parse to `nil` while `int<5, 5>` still constructs; the `RbsExtended.parse_return_type_override` spec covers the directive form; a runner integration example asserts the unresolved diagnostic lands on the `.rbs` annotation line and that no `internal analyzer error` row is produced.

Verified with `make verify` and `git diff --check` inside the Flake, plus the `rigor check` repro from the report before and after the fix.

Not in scope: the exit status `rigor check` reports for an internal analyzer error. The report noted exit 0; the local repro before the fix exited 1 with `--no-cache --no-ci-detect`, so that behaviour deserves its own look.
