### PR TITLE
Extend the typeless doc-tag dialect and its gate to spec/ and tool/

### DIFF
--- a/lib/rigor/language_server/incremental_sync.rb
+++ b/lib/rigor/language_server/incremental_sync.rb
@@ -64,7 +64,7 @@ module Rigor
       # companion to `range` and is accepted-but-ignored: it is redundant with `range`, historically ambiguous
       # about its units, and `range` is the authoritative field.
       #
-      # @raise UnappliableChange —
+      # @raise UnappliableChange
       def apply(text, change)
         raise UnappliableChange, "contentChanges entry must be a Hash, got #{change.class}" unless change.is_a?(Hash)
 

--- a/lib/rigor/protection/analysis_guard.rb
+++ b/lib/rigor/protection/analysis_guard.rb
@@ -46,7 +46,7 @@ module Rigor
       # @param result — one analysis run.
       # @param context — which oracle call produced it, so the raise points at the right seam.
       # @return the run's diagnostics, when the run was healthy.
-      # @raise AnalyzerCrashed —
+      # @raise AnalyzerCrashed
       def checked(result, context:)
         return result.diagnostics unless result.crashed?
 

--- a/spec/docs/spec_analyzer_guard_spec.rb
+++ b/spec/docs/spec_analyzer_guard_spec.rb
@@ -94,7 +94,7 @@ module SpecAnalyzerGuardScan # rubocop:disable Metrics/ModuleLength -- standalon
   Offense = Struct.new(:line, :source)
 
   class << self
-    # @return [Array<Offense>] every unguarded run site, in source order.
+    # @return every unguarded run site, in source order.
     def offenses(source)
       root = Prism.parse(source).value
       analyzer_locals = collect_analyzer_locals(root)

--- a/spec/docs/type_shaped_comments_spec.rb
+++ b/spec/docs/type_shaped_comments_spec.rb
@@ -193,6 +193,11 @@ RSpec.describe "type-shaped comments (Rigor's own tree)" do
         expect(violations_for(:r5_missing_delimiter, source)).to be_empty
       end
 
+      it "accepts a bare name with nothing after it, since there is nothing to delimit" do
+        source = "# @raise AnalyzerCrashed\ndef foo; end\n"
+        expect(violations_for(:r5_missing_delimiter, source)).to be_empty
+      end
+
       it "checks @raise's exception class the same way, and leaves @return alone" do
         source = "# @raise ArgumentError when amount is zero\n# @return the balance\ndef foo; end\n"
         excerpts = violations_for(:r5_missing_delimiter, source).map(&:excerpt)
@@ -212,6 +217,9 @@ RSpec.describe "type-shaped comments (Rigor's own tree)" do
       expect(scanned).not_to be_empty
       expect(scanned.grep(%r{/lib/})).not_to be_empty
       expect(scanned.grep(%r{plugins/.*/lib/})).not_to be_empty
+      expect(scanned.grep(%r{/spec/})).not_to be_empty
+      expect(scanned.grep(%r{/fixtures/})).to be_empty
+      expect(scanned.grep(%r{/vendor/})).to be_empty
     end
 
     # EXPECTED RED on this branch (see file header) — the corpus fix is separate work.

--- a/spec/rigor/cache/incremental_snapshot_engine_source_spec.rb
+++ b/spec/rigor/cache/incremental_snapshot_engine_source_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "incremental snapshot invalidation on an engine-source edit" do
 
   # One simulated `rigor check --incremental` process: a fresh memo (a real process computes the digest
   # once at boot), a fresh fingerprint, a fresh session, and the snapshot read back off disk.
-  # @return [Array(Array<Diagnostic>, Boolean)] the session's diagnostics and its warm verdict.
+  # @return the session's diagnostics and its warm verdict.
   def check(dir, lib, cache_root)
     Rigor::Cache::EngineSource.reset_process_identity!
     Dir.chdir(dir) do

--- a/spec/rigor/effects/annotations_unchecked_lanes_spec.rb
+++ b/spec/rigor/effects/annotations_unchecked_lanes_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe "effect.annotations-unchecked across the two annotation lanes" do
     { "paths" => ["lib"], "plugins" => ["rigor-rbs-inline"] }
   end
 
-  # @param lane [Symbol] `:rbs` or `:inline`
-  # @return [Array<Rigor::Analysis::Diagnostic>] the rule's findings for one run of that lane.
+  # @param lane — `:rbs` or `:inline`
+  # @return the rule's findings for one run of that lane.
   def findings_for(lane, cached: false, **runner_kwargs)
     Dir.mktmpdir("rigor-441-#{lane}-") do |dir|
       data = lane == :rbs ? build_rbs_lane(dir) : build_inline_lane(dir)

--- a/spec/support/guarded_analysis.rb
+++ b/spec/support/guarded_analysis.rb
@@ -37,13 +37,11 @@
 # `guarded_run_buffer_recheck` close that the same way the two helpers above do: at the call site,
 # before the spec's own comparison runs.
 module GuardedAnalysis
-  # @param runner [Rigor::Analysis::Runner]
-  # @param paths [Array<String>, nil] forwarded to `Runner#run` when given; omitted (so the
+  # @param paths — forwarded to `Runner#run` when given; omitted (so the
   #   configuration's own `paths` apply) when nil, which is the dominant call shape.
-  # @param allow_plugin_crash [Boolean] see {InternalAnalyzerErrorGuard.check!} — only for the examples
+  # @param allow_plugin_crash — see {InternalAnalyzerErrorGuard.check!} — only for the examples
   #   that deliberately crash a plugin to assert the runner's isolation envelope.
-  # @return [Rigor::Analysis::Result]
-  # @raise [InternalAnalyzerErrorGuard::AnalyzerCrashed]
+  # @raise InternalAnalyzerErrorGuard::AnalyzerCrashed
   def guarded_run(runner, paths = nil, allow_plugin_crash: false)
     result = paths.nil? ? runner.run : runner.run(paths)
     InternalAnalyzerErrorGuard.check!(
@@ -51,8 +49,7 @@ module GuardedAnalysis
     )
   end
 
-  # @return [Rigor::Analysis::Result]
-  # @raise [InternalAnalyzerErrorGuard::AnalyzerCrashed]
+  # @raise InternalAnalyzerErrorGuard::AnalyzerCrashed
   def guarded_run_source(runner, source:, path: "(source).rb")
     result = runner.run_source(source: source, path: path)
     InternalAnalyzerErrorGuard.check!(result, context: guarded_analysis_context("guarded_run_source"))
@@ -61,9 +58,7 @@ module GuardedAnalysis
   # `WorkerSession#analyze(path)` — the per-file entry the pool workers drive, which returns
   # `Array<Diagnostic>` rather than a `Result`, so it needs the Array-shaped guard.
   #
-  # @param session [Rigor::Analysis::WorkerSession]
-  # @return [Array<Rigor::Analysis::Diagnostic>]
-  # @raise [InternalAnalyzerErrorGuard::AnalyzerCrashed]
+  # @raise InternalAnalyzerErrorGuard::AnalyzerCrashed
   def guarded_session_analyze(session, path, allow_plugin_crash: false)
     InternalAnalyzerErrorGuard.check_diagnostics!(
       session.analyze(path),
@@ -75,9 +70,7 @@ module GuardedAnalysis
   # `WorkerSession`. `#baseline` returns `Array<Diagnostic>` directly (mirrors `WorkerSession#analyze`,
   # hence the Array-shaped guard).
   #
-  # @param session [Rigor::Analysis::IncrementalSession]
-  # @return [Array<Rigor::Analysis::Diagnostic>]
-  # @raise [InternalAnalyzerErrorGuard::AnalyzerCrashed]
+  # @raise InternalAnalyzerErrorGuard::AnalyzerCrashed
   def guarded_baseline(session)
     InternalAnalyzerErrorGuard.check_diagnostics!(
       session.baseline, context: guarded_analysis_context("guarded_baseline")
@@ -88,9 +81,7 @@ module GuardedAnalysis
   # :removed, :affected, :reused)`), not a bare Array, so the guard checks its `#diagnostics` field and
   # hands back the whole struct — every call site reads `changed` / `affected` / `reused` off it too.
   #
-  # @param session [Rigor::Analysis::IncrementalSession]
-  # @return [Rigor::Analysis::IncrementalSession::Recheck]
-  # @raise [InternalAnalyzerErrorGuard::AnalyzerCrashed]
+  # @raise InternalAnalyzerErrorGuard::AnalyzerCrashed
   def guarded_recheck(session)
     result = session.recheck
     InternalAnalyzerErrorGuard.check_diagnostics!(
@@ -102,10 +93,7 @@ module GuardedAnalysis
   # `IncrementalSession#reanalyze_subset` — the verification engine (`--verify-incremental`). Returns
   # `Array<Diagnostic>` directly (the merged diagnostics), so the guard checks the returned array.
   #
-  # @param session [Rigor::Analysis::IncrementalSession]
-  # @param subset [Enumerable<String>]
-  # @return [Array<Rigor::Analysis::Diagnostic>]
-  # @raise [InternalAnalyzerErrorGuard::AnalyzerCrashed]
+  # @raise InternalAnalyzerErrorGuard::AnalyzerCrashed
   def guarded_reanalyze_subset(session, subset)
     InternalAnalyzerErrorGuard.check_diagnostics!(
       session.reanalyze_subset(subset), context: guarded_analysis_context("guarded_reanalyze_subset")
@@ -115,9 +103,7 @@ module GuardedAnalysis
   # `IncrementalSession#run_incremental` — the `--incremental` CLI engine — returns `[diagnostics,
   # warm]`. Guards the diagnostics half and hands back the same tuple.
   #
-  # @param session [Rigor::Analysis::IncrementalSession]
-  # @return [Array(Array<Rigor::Analysis::Diagnostic>, Boolean)]
-  # @raise [InternalAnalyzerErrorGuard::AnalyzerCrashed]
+  # @raise InternalAnalyzerErrorGuard::AnalyzerCrashed
   def guarded_run_incremental(session, snapshot:, fingerprint:, persist: true)
     diagnostics, warm = session.run_incremental(snapshot: snapshot, fingerprint: fingerprint, persist: persist)
     InternalAnalyzerErrorGuard.check_diagnostics!(
@@ -130,9 +116,7 @@ module GuardedAnalysis
   # snapshot could not be reused, a legitimate decline (nothing ran) rather than a crash, so the guard
   # applies only to a non-nil `Recheck`.
   #
-  # @param session [Rigor::Analysis::IncrementalSession]
-  # @return [Rigor::Analysis::IncrementalSession::Recheck, nil]
-  # @raise [InternalAnalyzerErrorGuard::AnalyzerCrashed]
+  # @raise InternalAnalyzerErrorGuard::AnalyzerCrashed
   def guarded_run_buffer_recheck(session, snapshot:, fingerprint:)
     result = session.run_buffer_recheck(snapshot: snapshot, fingerprint: fingerprint)
     return result if result.nil?

--- a/spec/support/internal_analyzer_error_guard.rb
+++ b/spec/support/internal_analyzer_error_guard.rb
@@ -48,16 +48,15 @@ module InternalAnalyzerErrorGuard
   # swallow, or count as a pass, a fire this guard did not intend it to catch.
   class AnalyzerCrashed < StandardError; end
 
-  # @param result [Rigor::Analysis::Result]
-  # @param context [String] the calling helper's name, prefixed onto the raised message so a failure points
+  # @param context — the calling helper's name, prefixed onto the raised message so a failure points
   #   straight at which harness entry point saw the crash.
-  # @param allow_plugin_crash [Boolean] for the handful of examples whose SUBJECT is the runner's own
+  # @param allow_plugin_crash — for the handful of examples whose SUBJECT is the runner's own
   #   plugin-isolation envelope (`runner_spec.rb`'s "isolates plugin exceptions …" / "isolates a #prepare
   #   raise …"): there the `:plugin_loader` / `"runtime-error"` diagnostic is what the example asserts on, so
   #   raising on it would make the behaviour untestable. The CHECK-RULE half stays armed regardless — a rule
   #   crashing in one of those runs would still hide the answer, and no spec has a reason to want that.
-  # @return [Rigor::Analysis::Result] `result`, unchanged, when no diagnostic matches {.crash?}.
-  # @raise [AnalyzerCrashed]
+  # @return `result`, unchanged, when no diagnostic matches {.crash?}.
+  # @raise AnalyzerCrashed
   def self.check!(result, context:, allow_plugin_crash: false)
     check_diagnostics!(result.diagnostics, context: context, allow_plugin_crash: allow_plugin_crash)
     result
@@ -69,9 +68,8 @@ module InternalAnalyzerErrorGuard
   # `worker_session_spec`'s Runner-vs-session equivalence examples stayed vacuous under #674 — a crashed
   # rule makes BOTH sides one identical diagnostic, so `eq` holds (issue #674 review).
   #
-  # @param diagnostics [Array<Rigor::Analysis::Diagnostic>]
-  # @return [Array<Rigor::Analysis::Diagnostic>] `diagnostics`, unchanged, when none matches {.crash?}.
-  # @raise [AnalyzerCrashed]
+  # @return `diagnostics`, unchanged, when none matches {.crash?}.
+  # @raise AnalyzerCrashed
   def self.check_diagnostics!(diagnostics, context:, allow_plugin_crash: false)
     culprit = diagnostics.find { |d| crash?(d, allow_plugin_crash: allow_plugin_crash) }
     return diagnostics if culprit.nil?

--- a/spec/support/rbs_core_type_params.rb
+++ b/spec/support/rbs_core_type_params.rb
@@ -9,13 +9,13 @@
 module RbsCoreTypeParams
   RENAMED_IN = Gem::Version.new("4.1.0")
 
-  # @return [Boolean] true on the rbs line that carries the renamed parameters.
+  # @return true on the rbs line that carries the renamed parameters.
   def self.renamed?
     Gem::Version.new(::RBS::VERSION) >= RENAMED_IN
   end
 
   # `Array`'s single element type parameter.
-  # @return [Symbol] `:E` on rbs >= 4.1, `:Elem` before it.
+  # @return `:E` on rbs >= 4.1, `:Elem` before it.
   def self.array_element
     renamed? ? :E : :Elem
   end

--- a/spec/support/rbs_env_memo.rb
+++ b/spec/support/rbs_env_memo.rb
@@ -49,7 +49,7 @@ module RbsEnvMemo
       !RSpec.current_example&.metadata&.fetch(:fresh_rbs_env, false)
     end
 
-    # @return [::RBS::Environment, nil] the cached environment for `key`, promoting it to most-recent.
+    # @return the cached environment for `key`, promoting it to most-recent.
     def fetch(key)
       value = cache.delete(key)
       cache[key] = value unless value.nil?

--- a/spec/support/runner_helpers.rb
+++ b/spec/support/runner_helpers.rb
@@ -113,29 +113,28 @@ module RunnerHelpers
   # other shape that depends on a unique `Dir.pwd`) automatically
   # fall back to the per-call `Dir.mktmpdir` path.
   #
-  # @param source [String, nil] convenience for single-file
+  # @param source — convenience for single-file
   #   fixtures: written to `<workspace>/code.rb`.
-  # @param files [Hash{String => String}] additional files to
+  # @param files — additional files to
   #   write, keyed by relative path inside the workspace.
-  # @param sig [Hash{String => String}] RBS files. When present,
+  # @param sig — RBS files. When present,
   #   content-keyed materialisation kicks in and the resulting
   #   `signature_paths:` entry is threaded into `Configuration`.
-  # @param config [Hash] extra `.rigor.yml`-style overrides
+  # @param config — extra `.rigor.yml`-style overrides
   #   merged into the `Configuration`. `paths:` is always
   #   set to the workspace unless overridden.
-  # @param explain [Boolean] forwarded to `Runner.new(explain:)`.
-  # @param cache_store [Rigor::Cache::Store, :shared, nil]
+  # @param explain — forwarded to `Runner.new(explain:)`.
+  # @param cache_store —
   #   `:shared` (default) reuses the process-wide cache so
   #   RBS core / stdlib resolution stays hot across examples.
   #   Pass `nil` for the cache-disabled (`--no-cache`-equivalent)
   #   behaviour the cache surface tests assert against; pass
   #   an explicit `Cache::Store` to drive isolated cache
   #   behaviour from a spec.
-  # @yieldparam result [Rigor::Analysis::Result]
-  # @yieldparam dir    [String] the project root.
-  # @return [Rigor::Analysis::Result] for callers that prefer
+  # @yieldparam dir — the project root.
+  # @return for callers that prefer
   #   to assert outside the block.
-  # @raise [InternalAnalyzerErrorGuard::AnalyzerCrashed] via
+  # @raise InternalAnalyzerErrorGuard::AnalyzerCrashed — via
   #   {InternalAnalyzerErrorGuard} if the `Result` carries a
   #   diagnostic from either analyzer-crash rescue site — a check
   #   rule raising into the `"internal analyzer error"` diagnostic,

--- a/spec/support/spec_tmpdir.rb
+++ b/spec/support/spec_tmpdir.rb
@@ -46,8 +46,8 @@ module SpecTmpdir
 
     # A temp directory whose lifetime is the whole spec process. Released by {.release_registered!}.
     #
-    # @param prefix [String] `Dir.mktmpdir` prefix, kept descriptive so a residue report names its owner.
-    # @return [String] the directory path.
+    # @param prefix — `Dir.mktmpdir` prefix, kept descriptive so a residue report names its owner.
+    # @return the directory path.
     def suite_lifetime(prefix)
       dir = Dir.mktmpdir(prefix)
       registry << dir
@@ -62,7 +62,7 @@ module SpecTmpdir
 
     # What is still inside {ROOT}. Empty is the contract; a non-empty answer names the leaking prefixes.
     #
-    # @return [Array<String>] basenames.
+    # @return basenames.
     def residue
       return [] unless File.directory?(ROOT)
 

--- a/spec/support/type_shaped_comment_scanner.rb
+++ b/spec/support/type_shaped_comment_scanner.rb
@@ -24,13 +24,21 @@ module TypeShapedCommentScanner
     end
   end
 
-  # The gated scope (relative to a repo root): Rigor's own product tree. Deliberately excludes
-  # spec/, tool/, bin/, and references/ (vendored upstream, not Rigor code).
+  # The gated scope (relative to a repo root): Rigor's own product tree plus its specs and tools.
+  # Deliberately excludes bin/ and references/ (vendored upstream, not Rigor code), and the paths in
+  # SCAN_EXCLUDES below.
   SCAN_GLOBS = %w[
     lib/**/*.rb
     plugins/*/lib/**/*.rb
     examples/*/lib/**/*.rb
+    spec/**/*.rb
+    tool/**/*.rb
   ].freeze
+
+  # Paths inside the globs that are not Rigor prose: spec fixtures are analyzer INPUTS whose comments
+  # carry `# rigor:` suppression directives and must stay byte-identical, and a vendored tree under
+  # tool/ is upstream code.
+  SCAN_EXCLUDES = %w[/fixtures/ /vendor/].freeze
 
   # YARD tags whose grammar reserves a `[Type]` slot right after the tag (or after the one name
   # token that follows it, for the tags that take a name). Every one of these must be written with
@@ -84,7 +92,7 @@ module TypeShapedCommentScanner
   # description continues on the next line). YARD keeps the name binding either way (the dash lands
   # in the description text), so the delimiter costs nothing a tool reads. `@return` has no name and
   # needs no delimiter. Only the tags that take a name token are checked.
-  DELIMITED_TAG_RE = /\A@(?:param|yieldparam|option|raise)\b[ \t]+\S+[ \t]+—(?:[ \t]|\z)/
+  DELIMITED_TAG_RE = /\A@(?:param|yieldparam|option|raise)\b[ \t]+\S+(?:[ \t]*\z|[ \t]+—(?:[ \t]|\z))/
   NAME_TOKEN_TAG_RE = /\A@(?:param|yieldparam|option|raise)\b[ \t]+\S+/
 
   # R4 (stale forward reference) — narrow on purpose (AGENTS.md: "a check that fires on correct
@@ -96,7 +104,9 @@ module TypeShapedCommentScanner
 
   # Every file in the gated scope under `root`, sorted for stable output.
   def scan_paths(root)
-    SCAN_GLOBS.flat_map { |glob| Dir.glob(File.join(root, glob)) }.sort
+    SCAN_GLOBS.flat_map { |glob| Dir.glob(File.join(root, glob)) }
+              .reject { |path| SCAN_EXCLUDES.any? { |fragment| path.include?(fragment) } }
+              .sort
   end
 
   # Runs all four rules over `source` (a single file's content). `path` is only ever used to label

--- a/tool/mutation/mutate.rb
+++ b/tool/mutation/mutate.rb
@@ -80,7 +80,7 @@ module RigorMutation
       @type_filter = type_filter
     end
 
-    # @return [Result, nil] nil when the file yields no (type-relevant) mutants.
+    # @return nil when the file yields no (type-relevant) mutants.
     def run_file(path, seed:, limit:)
       # Force UTF-8: the Flake shell's default external encoding can be
       # US-ASCII, making byte-splicing a non-ASCII file raise an encoding error.


### PR DESCRIPTION
#822 emptied the `[Type]` slot in every YARD tag under `lib/`, `plugins/*/lib`, `examples/*/lib` and gated the form (ADR-107). This applies the same rewrite to `spec/` and `tool/` and widens the gate so the dialect cannot drift back in the trees the first pass skipped.

- Mechanical rewrite over Prism comment lines only (10 files, +36/−55; non-comment byte streams identical): `[Type]` removed, tags with no description dropped, the name token followed by an em dash. Spec fixtures (`spec/**/fixtures/**`, analyzer inputs carrying `# rigor:` directives) stay byte-identical; vendored trees under `tool/` are excluded.
- A bare `@raise Klass` with no description keeps no dash — there is nothing to delimit. Gate rule R5 accepts that form, and the two lines in `lib/` that #822 had left as `@raise Klass —` follow it.
- `spec/support/type_shaped_comment_scanner.rb`: `SCAN_GLOBS` gains `spec/**/*.rb` and `tool/**/*.rb`; `SCAN_EXCLUDES` drops any path under `fixtures/` or `vendor/`; the globs guard now expects spec files and no fixture or vendor files. R1–R5 are green over the widened scope with no further edits (no `#:` / `# @rbs` comments, no stale `@param` names, no stale forward references in spec/ or tool/).

No changelog fragment: nothing user-facing changes. Draft until the user's word.
