### PR TITLE
Apply the three return tightenings sig-gen is right about

### DIFF
--- a/docs/notes/20260908-sig-provenance-audit.md
+++ b/docs/notes/20260908-sig-provenance-audit.md
@@ -122,7 +122,8 @@ narrow a contract that is deliberately wide.
 
 The seven `void` rows are **no longer proposed** — #836 landed on 2026-09-09 and their markers came
 out of `sig/` with it; they are kept here because the reading is what the fix is built on. Eight
-remain, and each still carries its marker.
+remained after that fix; three of those (below) were applied on 2026-09-09 (#838) and their markers
+are gone too. Five still carry their marker.
 
 | declaration | declared | `sig-gen` proposes | reading |
 | --- | --- | --- | --- |
@@ -138,9 +139,9 @@ remain, and each still carries its marker.
 | `Rigor::Type::Top#describe` | `String` | `"top"` | literal over a shared contract |
 | `Rigor::Type::Bot#describe` | `String` | `"bot"` | literal over a shared contract |
 | `Rigor::Type::BoundMethod#erase_to_rbs` | `String` | `"Method"` | literal over a shared contract |
-| `Rigor::Reflection.class_ordering` | `Symbol` | `:disjoint \| :equal \| :subclass \| :superclass \| :unknown` | applicable |
-| `Rigor::Scope#user_def_through_ancestors` | `[untyped?, String?]` | `[untyped, String] \| [nil, nil]` | applicable |
-| `Rigor::Scope#singleton_def_through_ancestors` | `[untyped?, String?]` | `[untyped, String] \| [nil, nil]` | applicable |
+| `Rigor::Reflection.class_ordering` | `Symbol` | `:disjoint \| :equal \| :subclass \| :superclass \| :unknown` | applicable (applied, #838) |
+| `Rigor::Scope#user_def_through_ancestors` | `[untyped?, String?]` | `[untyped, String] \| [nil, nil]` | applicable (applied, #838) |
+| `Rigor::Scope#singleton_def_through_ancestors` | `[untyped?, String?]` | `[untyped, String] \| [nil, nil]` | applicable (applied, #838) |
 
 **Seven are `void`.** `Inference::RbsTypeTranslator` maps RBS `void` to `Type::Top`, and `Top` accepts
 everything, so `Generator#tighter?` reports every `void`-declared method whose body happens to return
@@ -159,10 +160,14 @@ declares `String`; the same for `Trinary#to_s` and `BoundMethod#erase_to_rbs`.
 last expression is *not* a direct literal — here it is one, so the guard passes. Filed as **P2**,
 [#837](https://github.com/rigortype/rigor/issues/837).
 
-**Three are genuinely applicable** and were still left declared, with a marker, rather than applied:
-changing a declaration is a `sig/` edit that has to clear the precision gate and Steep, and the
-provenance gate landing is not the commit to do it in. Filed as **P3**,
-[#838](https://github.com/rigortype/rigor/issues/838).
+**Three were genuinely applicable**, and were left declared with a marker rather than applied when
+the provenance gate landed — changing a declaration is a `sig/` edit that has to clear the precision
+gate and Steep on its own, and that landing was not the commit to do it in. Filed as **P3**,
+[#838](https://github.com/rigortype/rigor/issues/838), and **applied on 2026-09-09**: each declaration
+now reads exactly what `sig-gen --diff --tighter-returns lib` proposes, the three `# sig-gen gap:
+#838` markers are gone, and the residue pin in `spec/rigor/sig_gen/provenance_spec.rb` is unchanged —
+`tighter_return` sits outside the residue pin (#845), so applying the tightenings moves rows within
+the earned/marked bookkeeping, not the pinned residue counts.
 
 ## Where the residue declarations come from (679 at the seeding, 669 now)
 
@@ -256,8 +261,9 @@ nothing, so the gate does not accept one.
 ## The follow-up issues
 
 Filed from this section, and each marker in `sig/` names the one for its category. Fifteen at the
-seeding: seven pointed at #836, five at #837, three at #838. Eight remain — the seven #836 markers
-came out when the fix landed.
+seeding: seven pointed at #836, five at #837, three at #838. Five remain — the seven #836 markers
+came out when that fix landed, and the three #838 markers came out when those tightenings were
+applied.
 
 **P1 — [#836](https://github.com/rigortype/rigor/issues/836) — `sig-gen` proposes a value tightening
 for a method declared `void`.** `RbsTypeTranslator` maps `void` to `Type::Top`, `Top.accepts` is
@@ -288,6 +294,11 @@ is right about.** `Reflection.class_ordering` →
 `[untyped, String] | [nil, nil]`. Each is a `sig/` edit that has to clear
 `rigor coverage --threshold 0.58 lib` and `make steep-check`, so it is its own change. Area:
 `area:sig-gen`.
+
+**Applied 2026-09-09.** All three declarations now match `rigor sig-gen --diff --tighter-returns lib`
+exactly, and their `# sig-gen gap: #838` markers are gone. `make check --fail-on=warning`, the
+precision gate, `make lint`, and `make steep-check` all stayed clean; the residue pin in
+`spec/rigor/sig_gen/provenance_spec.rb` did not move, since `tighter_return` sits outside it (#845).
 
 **P4 — [#839](https://github.com/rigortype/rigor/issues/839) — nothing checks that a declaration in
 `sig/` describes a method that exists.** Nine did not (above). `make check` and `make steep-check`

--- a/sig/rigor/reflection.rbs
+++ b/sig/rigor/reflection.rbs
@@ -3,10 +3,7 @@ module Rigor
     def self?.class_known?: (String | Symbol class_name, ?scope: Scope) -> bool
     def self?.rbs_class_known?: (String | Symbol class_name, ?scope: Scope) -> bool
     def self?.project_declared_class?: (String | Symbol class_name, ?scope: Scope?, ?environment: Environment?) -> bool
-    # sig-gen gap: #838 — sig-gen is RIGHT here: the return is
-    # `:disjoint | :equal | :subclass | :superclass | :unknown`. Applying it is a sig/ edit that has
-    # to clear the precision gate and Steep, so it is P3 of the 2026-09-08 provenance audit.
-    def self?.class_ordering: (String | Symbol lhs, String | Symbol rhs, ?scope: Scope) -> Symbol
+    def self?.class_ordering: (String | Symbol lhs, String | Symbol rhs, ?scope: Scope) -> (:disjoint | :equal | :subclass | :superclass | :unknown)
     def self?.nominal_for_name: (String | Symbol class_name, ?scope: Scope) -> Type::Nominal?
     def self?.singleton_for_name: (String | Symbol class_name, ?scope: Scope) -> Type::Singleton?
     def self?.constant_type_for: (String | Symbol constant_name, ?scope: Scope) -> Type::t?

--- a/sig/rigor/scope.rbs
+++ b/sig/rigor/scope.rbs
@@ -138,9 +138,7 @@ module Rigor
     def class_cvars_for: (String | Symbol? class_name) -> Hash[Symbol, Type::t]
     def discovered_method?: (String | Symbol class_name, String | Symbol method_name, Symbol kind) -> bool
     def user_def_for: (String | Symbol class_name, String | Symbol method_name) -> untyped?
-    # sig-gen gap: #838 — sig-gen is right that the pair is `[untyped, String] | [nil, nil]` rather
-    # than independently optional. Applying it is P3 of the 2026-09-08 provenance audit.
-    def user_def_through_ancestors: (String | Symbol class_name, String | Symbol method_name, ?name_memo: Hash[untyped, untyped]) -> [untyped?, String?]
+    def user_def_through_ancestors: (String | Symbol class_name, String | Symbol method_name, ?name_memo: Hash[untyped, untyped]) -> ([untyped, String] | [nil, nil])
     def discovered_method_through_ancestors?: (String | Symbol? class_name, String | Symbol method_name, Symbol kind, ?name_memo: Hash[untyped, untyped]) -> bool
     def enqueue_ancestors: (String current, Array[String] queue, Hash[untyped, untyped] name_memo, ?mixins: bool) -> void
     def ancestor_name_candidates: (String | Symbol subclass_qualified, String | Symbol raw_ancestor) -> Array[String]
@@ -148,8 +146,7 @@ module Rigor
     # Issue #530 — public so the external-gem ancestry probe asks the same question the walk does.
     def known_user_class?: (String | Symbol name) -> bool
     def singleton_def_for: (String | Symbol class_name, String | Symbol method_name) -> untyped?
-    # sig-gen gap: #838 — same correlated pair as `user_def_through_ancestors` above. P3.
-    def singleton_def_through_ancestors: (String | Symbol class_name, String | Symbol method_name, ?name_memo: Hash[untyped, untyped]) -> [untyped?, String?]
+    def singleton_def_through_ancestors: (String | Symbol class_name, String | Symbol method_name, ?name_memo: Hash[untyped, untyped]) -> ([untyped, String] | [nil, nil])
     def user_def_site_for: (String | Symbol class_name, String | Symbol method_name) -> String?
     def user_singleton_def_site_for: (String | Symbol class_name, String | Symbol method_name) -> String?
     def top_level_def_for: (String | Symbol method_name) -> untyped?

--- a/spec/rigor/sig_gen/provenance_spec.rb
+++ b/spec/rigor/sig_gen/provenance_spec.rb
@@ -23,8 +23,9 @@
 # § Implementation Guidelines puts above worst-case static reading. So:
 #
 # 1. HARD RULE on `tighter_return`. `sig-gen` proposes a narrower return than the declaration; ADR-14
-#    says apply it or record why not, and there are 8 — the seeding audit's 15 less the seven the
-#    #836 fix stopped proposing — so a marker on each is affordable. A ninth fails on arrival.
+#    says apply it or record why not, and there are 5 — the seeding audit's 15 less the seven the
+#    #836 fix stopped proposing and the three #838 applied — so a marker on each remaining one is
+#    affordable. A sixth fails on arrival.
 # 2. RATCHET on the residue. Per-file unmarked-residue counts are an exact snapshot below. A new
 #    hand-written declaration raises its file's count and goes red; marking it subtracts from the
 #    count. Closing an engine gap lowers a count and the gate says so, so slack cannot accumulate.


### PR DESCRIPTION
The `sig/` provenance audit (#825 / #835) left three `tighter_return` proposals that are genuine, and #845 / #837 account for every other one. This applies the three by hand to `rigor sig-gen`'s own rendering and removes their `# sig-gen gap: #838` markers:

- `Rigor::Reflection.class_ordering`: `-> Symbol` → `-> (:disjoint | :equal | :subclass | :superclass | :unknown)`
- `Rigor::Scope#user_def_through_ancestors` and `#singleton_def_through_ancestors`: `-> [untyped?, String?]` → `-> ([untyped, String] | [nil, nil])` — the correlated pair, which the independent-nilability spelling hid.

`rigor sig-gen --diff --tighter-returns lib` now lists only the five #837 rows. The residue pin in `spec/rigor/sig_gen/provenance_spec.rb` is unchanged (`tighter_return` sits outside it); the marker count in its header goes 8 → 5. `make check` (fails on warnings) clean; precision 61.86%; `make steep-check` still reports exactly the 11 pre-existing problems in three files with no `sig/`.

Fixes #838. Draft until the user's word.
