### PR TITLE
Clear the eleven pre-existing Steep problems

### DIFF
--- a/lib/rigor/cli/fused_protection_report.rb
+++ b/lib/rigor/cli/fused_protection_report.rb
@@ -12,7 +12,13 @@ module Rigor
     # Framing (ADR-63 / ADR-62 Criterion A, extended): the payload is the **attribution** — which protection axis is
     # missing — never raw survival. An unprotected site is "add protection here", never "your code is broken".
     # `harness_errors` (#264) — see {Rigor::CLI::FileEffectiveness}; defaults to 0 for the same reason.
-    FusedFileProtection = Data.define(:path, :type_killed, :test_killed, :unprotected, :ratio, :harness_errors) do
+    # A `class ... < Data.define(...)` body, not the `Data.define(...) do ... end` shorthand: Steep
+    # resolves a `def` inside the shorthand block against the *lexically enclosing* class (here,
+    # `Rigor::CLI`, which declares its own differently-shaped `initialize`) rather than the anonymous
+    # Data subclass being defined — a `sig/` declaration for `FusedFileProtection` cannot fix this,
+    # since the misattribution happens before any signature is consulted. The explicit `class` keyword
+    # is a real namespace boundary Steep's block walker respects; behaviour is identical either way.
+    class FusedFileProtection < Data.define(:path, :type_killed, :test_killed, :unprotected, :ratio, :harness_errors)
       def initialize(path:, type_killed:, test_killed:, unprotected:, ratio:, harness_errors: 0)
         super
       end

--- a/lib/rigor/cli/mutation_protection_report.rb
+++ b/lib/rigor/cli/mutation_protection_report.rb
@@ -14,7 +14,13 @@ module Rigor
     # `harness_errors` (#264) — mutants where the harness itself raised (a rescued failure), distinguished from
     # a parse-invalid mutant. Defaults to 0 so existing call sites keep constructing a `FileEffectiveness`
     # without the new keyword.
-    FileEffectiveness = Data.define(:path, :killed, :survived, :ratio, :harness_errors) do
+    # A `class ... < Data.define(...)` body, not the `Data.define(...) do ... end` shorthand: Steep
+    # resolves a `def` inside the shorthand block against the *lexically enclosing* class (here,
+    # `Rigor::CLI`, which declares its own differently-shaped `initialize`) rather than the anonymous
+    # Data subclass being defined — a `sig/` declaration for `FileEffectiveness` cannot fix this,
+    # since the misattribution happens before any signature is consulted. The explicit `class` keyword
+    # is a real namespace boundary Steep's block walker respects; behaviour is identical either way.
+    class FileEffectiveness < Data.define(:path, :killed, :survived, :ratio, :harness_errors)
       def initialize(path:, killed:, survived:, ratio:, harness_errors: 0)
         super
       end

--- a/sig/rigor/analysis/reachability/scan_cache.rbs
+++ b/sig/rigor/analysis/reachability/scan_cache.rbs
@@ -1,0 +1,12 @@
+module Rigor
+  module Analysis
+    module Reachability
+      class ScanCache
+        def self.open: (untyped, ?target_ruby: untyped) -> Rigor::Analysis::Reachability::ScanCache
+        def self.source_digest: () -> String
+        def initialize: (path: untyped, header: untyped) -> void
+        def save: () -> nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
`make steep-check` has reported eleven problems on `master` for some time, in three files with no `sig/` of their own. They predate this cycle (verified on a detached `origin/master`), and none of the type-provenance work touched them. This clears all eleven.

- `lib/rigor/analysis/reachability/scan_cache.rb` (2): Steep bound `ScanCache.open` to `Kernel#open`'s core signature because nothing declared the class. `sig/rigor/analysis/reachability/scan_cache.rbs` is `rigor sig-gen --write`'s output verbatim (`self.open`, `self.source_digest`, `save` generated; `initialize` is return intent); `serve` stays undeclared because the generator skips it, so no marker is needed. The provenance gate reads the new file with zero residue.
- `lib/rigor/cli/fused_protection_report.rb` (5) and `lib/rigor/cli/mutation_protection_report.rb` (4): not a real signature mismatch. `FusedFileProtection` / `FileEffectiveness` were `Data.define(...) do def initialize(...); super; end end` nested inside `class CLI`, and Steep 2.0.0 does not treat the block passed to `Data.define` as a namespace boundary, so it checked the block's `initialize` against `Rigor::CLI#initialize`. A standalone fixture proved an RBS declaration for the nested class cannot fix it (the mismatch is raised before that declaration is consulted). The idiom `class X < Data.define(...)` gives Steep a real lexical boundary; behaviour is identical (`to_h`, `with`, `deconstruct`, keyword constructor), one anonymous class in the ancestry.

`make steep-check`: 11 → 0. `make check` clean, precision 61.86%, provenance gate green with no pin change. Residual and out of scope: three `Data::_DataClass` FATAL lines in Steep's background log (`rule_walk.rb`, `plugin_roots.rb`, `overload_selector.rb`), present before and after, not counted in the problem tally.

No changelog fragment: internal. Draft until the user's word.
