### PR TITLE
Fail the sig/ provenance gate on a declaration with no code

### DIFF
--- a/docs/adr/107-checked-types-and-typeless-comments.md
+++ b/docs/adr/107-checked-types-and-typeless-comments.md
@@ -273,7 +273,7 @@ view costs a command and cannot be.
 | --- | --- | --- |
 | **G1** `spec/docs/type_shaped_comments_spec.rb` | no `[Type]` after a doc tag; an em dash after every tag's name token; every `@param` names a real parameter of the `def` below; no stale `Slice N will` forward references | lands with #822 |
 | **G2** [#812](https://github.com/rigortype/rigor/issues/812) — `make check` fails on a warning | `def.return-type-mismatch` is a **warning**, so `make check` exits 0 with a contradicted return type in the tree. Without G2 the declared-and-checked half of the invariant is theatre | `--fail-on=warning` in a sibling PR |
-| **G3** `spec/rigor/sig_gen/provenance_spec.rb` ([#825](https://github.com/rigortype/rigor/issues/825)) | every declaration is generated-equivalent, authored parameter intent, or a recorded gap: a marker on every `tighter-return`, and a per-file pin on the hand-authored residue | lands in #835 |
+| **G3** `spec/rigor/sig_gen/provenance_spec.rb` ([#825](https://github.com/rigortype/rigor/issues/825)) | every declaration is generated-equivalent, authored parameter intent, or a recorded gap: a marker on every `tighter-return`, a per-file pin on the hand-authored residue, and ([#839](https://github.com/rigortype/rigor/issues/839)) a method that exists — proven by a `def`, by Rigor's own synthetic-shape recognition, or by reflection over the loaded tree | in force |
 
 Already in force, and already serving the invariant: the precision gate
 (`rigor coverage --threshold 0.58 lib`) keeps inference the primary source rather than a fallback;

--- a/docs/handbook/11-sig-gen.md
+++ b/docs/handbook/11-sig-gen.md
@@ -187,6 +187,19 @@ generated-equivalent nor marked. Rigor's own gate is
 ([ADR-107](../adr/107-checked-types-and-typeless-comments.md)
 G3).
 
+One case in that list is not a marker case at all. A
+declaration with no `def` behind it may simply describe a
+method Ruby generates — an `attr_*`, a `Data` member, one a
+class macro defines at load — or it may be left over from a
+`def` that was deleted or renamed, which nothing catches,
+because `rigor check` and Steep both ask whether the
+implementation matches `sig/` and never the converse.
+Rigor's gate separates the two by asking its own
+project index and then the loaded tree
+([#839](https://github.com/rigortype/rigor/issues/839)).
+That check requires the code under `sig/`, so it stays a
+repository gate: `sig-gen` in your project is unchanged.
+
 ## What method shapes the generator covers
 
 Slice-by-slice (each shipped via a CHANGELOG entry — this

--- a/docs/notes/20260908-sig-provenance-audit.md
+++ b/docs/notes/20260908-sig-provenance-audit.md
@@ -220,6 +220,13 @@ All nine are deleted by the commit that seeds the gate. `Prism::Node#rigor_each_
 `no_source` that is correct as written: `Rigor::Source::NodeChildren` compiles it per concrete node
 class at load, which is what its file header already says.
 
+> **Superseded 2026-09-09 by [#839](https://github.com/rigortype/rigor/issues/839).** The reflection
+> pass above was a one-off instrument; it is now two tiers inside the classifier, so `no_source`
+> means *stale* and nothing else, and the legitimate rows carry the shape that explains them
+> (`synthetic_source` / `inherited_source` / `runtime_defined`). The full re-classification, and why
+> `Prism::Node#rigor_each_child` is confirmed rather than exempted, is
+> [the follow-up audit](20260909-sig-no-source-audit.md).
+
 ### `declared_divergent` — 110 at the seeding, 108 since #836, 115 since #837
 
 The declared return differs from the inferred one and `sig-gen`'s guards refuse the swap. Two shapes,
@@ -345,6 +352,13 @@ deleted or renamed — is unchecked, and a stale declaration is worse than a mis
 resolves calls through it. The provenance gate now reports these as `no_source`, mixed in with 218
 legitimate ones; a dedicated check that distinguishes them would be sharper. Area:
 `area:self-testing`.
+
+**Fixed 2026-09-09.** The classifier asks two more sources of truth before reporting a declaration
+unattributed — Rigor's own cross-file recognition (`ScopeIndexer.discovered_project_index_for_paths`
+plus `Scope`'s ancestor walk), then reflection over the loaded tree — so the legitimate rows land in
+`synthetic_source` / `inherited_source` / `runtime_defined` and `no_source` is a hard rule at zero.
+The re-classification of all 224 rows, and the ~1.8 s the two tiers cost, are in
+[the follow-up audit](20260909-sig-no-source-audit.md).
 
 ## What this does not measure
 

--- a/docs/notes/20260909-sig-no-source-audit.md
+++ b/docs/notes/20260909-sig-no-source-audit.md
@@ -1,0 +1,146 @@
+# Where the 224 `no_source` declarations in `sig/` come from (2026-09-09)
+
+Status: the follow-up audit for [#839](https://github.com/rigortype/rigor/issues/839), filed as P4 out
+of the [seeding audit](20260908-sig-provenance-audit.md). Measured on `sig-no-source-839` at
+`origin/master`, rbs 4.x, Ruby 4.0.5.
+
+The seeding audit put 227 declarations in `no_source` — "no `def` `sig-gen` can attribute to this
+declaration" — and found that **nine of them described code that does not exist**: seven methods on
+`StatementEvaluator` / `ScopeIndexer` that had been removed or renamed, and the whole of
+`NumericCatalog`, folded onto `MethodCatalog.for_topic("numeric")`. Nothing in the tree noticed.
+`make check` and `make steep-check` both ask whether the implementation matches `sig/`; neither asks
+the converse, and a stale declaration is worse than a missing one, because RBS resolves calls through
+it.
+
+The nine were deleted with the seeding gate. This note answers the question that made them hard to
+see: **of everything left in `no_source`, why did the static scan find no `def`** — and can the
+legitimate cases be told from the stale ones without hand-listing exemptions?
+
+## Command
+
+The audit is the gate's own classifier, so the note and the gate cannot drift:
+
+```sh
+nix --extra-experimental-features 'nix-command flakes' develop --command \
+  bundle exec ruby -Ilib -Ispec/support -rsig_provenance_auditor \
+    -e 'SigProvenanceAuditor.report(root: Dir.pwd)'
+```
+
+Its last two sections are the tables below. `report` runs with `runtime: true`, which opts the two
+new tiers in (`spec/support/sig_source_index.rb`).
+
+## Two more sources of truth
+
+`sig-gen` enumerates `def`s. A method is not always a `def`, so `no_source` was answering a narrower
+question than it appeared to. Two tiers now run behind it, in order, and only a declaration none of
+the three can find is reported as stale.
+
+**Tier 1 — Rigor's own recognition (static).**
+`Inference::ScopeIndexer.discovered_project_index_for_paths` is the cross-file pre-pass
+`Analysis::Runner` builds before every `rigor check`. It already recognises `attr_*`,
+`define_method`, `alias` / `alias_method`, `module_function`, an `extend` fold, and `Data` / `Struct`
+member layouts — the `call.undefined-method` rule would fire on all of them otherwise — and
+`Scope#discovered_method_through_ancestors?` walks the project's own superclasses and mixins. Asking
+it, rather than re-deriving the shapes in the auditor, keeps **one** recognition in the tree: a second
+one would drift, and its drift would surface as a false stale-declaration report, which AGENTS.md
+§ "Implementation Guidelines" ranks above any worst-case reading.
+
+**Tier 2 — the runtime (reflection).** What no static pass can see: `ValueSemantics#value_fields`
+defines `==` / `eql?` / `hash` from a class macro, `Data.define` generates `.new` and `#with` on an
+anonymous parent, and `Source::NodeChildren` compiles `#rigor_each_child` onto every concrete
+`Prism::*Node` class at load. Reflection over a loaded tree confirms each of them, the way
+`spec/rigor/public_api_drift_spec.rb` already reflects over the public surface — and confirming beats
+an exemption list, because an exemption stays true after the code under it is deleted. Loading a tree
+runs its code, so the tier is opt-in and only ever pointed at this repository; a fixture project,
+whose `lib/` is written by the example auditing it, must never be required.
+
+Reflection is deliberately blind to `Object` / `Kernel` / `BasicObject` (and `Class` / `Module` on the
+singleton side). Every object answers `hash`, `==`, `to_s` and `inspect`, and `sig/` declares all four
+on the type carriers that generate them from `value_fields`; an owner that hands the method to every
+object would confirm such a declaration after the `value_fields` call under it was deleted, which is
+the exact miss this audit exists to close.
+
+## What was in `no_source`
+
+224 declarations, every one explained, **none stale**:
+
+| classification | shape | n | what it is |
+| --- | --- | --- | --- |
+| `inherited_source` | project ancestor | 71 | the project declares the method on a superclass or an included module (`Type::Top#accepts`, owner `Type::AcceptanceRouter`; the five `CLI::*Command#initialize`, owner `CLI::Command`) |
+| `synthetic_source` | Data member | 70 | a `Data.define` member reader (`Analysis::FactStore::Target#kind`) |
+| `runtime_defined` | defined on the class itself at load | 56 | `ValueSemantics#value_fields` emitting `==` (×19), `hash` (×19) and `eql?` (×18) on the type carriers |
+| `synthetic_source` | def or alias | 8 | a `def` `sig-gen` declines to emit: a parameterless `initialize` (skipped on purpose — `Generator#non_trivial_initialize?`), or an `alias eql? ==`, which the indexer records against the aliased def node |
+| `synthetic_source` | `attr_*` / `define_method` / `alias_method` | 6 | dominated by singleton-side `attr_reader` (`Trinary.yes` / `.no` / `.maybe` inside `class << self`) |
+| `runtime_defined` | singleton method, from a generated ancestor | 4 | `.new` on the anonymous `Data.define` parent of a `class X < Data.define(…)` |
+| `runtime_defined` | singleton method, from the class itself at load | 4 | `VoidOrigin.new` / `.[]`, `ParamOverride.new`, `ClassFrame.new` |
+| `runtime_defined` | inherited from `Data` | 3 | `ClassFrame#initialize`, `CallContext#with`, `DiscoveryIndex#with` |
+| `runtime_defined` | compiled onto every subclass at load | 1 | `Prism::Node#rigor_each_child` |
+| `runtime_defined` | inherited from `Exception` | 1 | `Plugin::LoadError#cause` |
+| `no_source` | — | **0** | a declaration nothing defines |
+
+Tier 1 resolves **155 of 224 (69%)**; tier 2 resolves the remaining 69. The single documented
+runtime-generated case, `sig/prism_node_children.rbs`, is confirmed by reflection rather than
+exempted: the declaration sits on the abstract `Prism::Node` so every subclass resolves against one
+declaration, and the subclass sweep is what tells that apart from a stale declaration.
+
+## Per file
+
+Only the files with an unattributed declaration; every other `sig/` file has none.
+
+| file | `synthetic_source` | `inherited_source` | `runtime_defined` | `no_source` |
+| --- | --- | --- | --- | --- |
+| `sig/prism_node_children.rbs` | 0 | 0 | 1 | 0 |
+| `sig/rigor.rbs` | 0 | 2 | 0 | 0 |
+| `sig/rigor/analysis/fact_store.rbs` | 10 | 0 | 2 | 0 |
+| `sig/rigor/cli/diff_command.rbs` | 0 | 1 | 0 | 0 |
+| `sig/rigor/cli/explain_command.rbs` | 0 | 1 | 0 | 0 |
+| `sig/rigor/cli/sig_gen_command.rbs` | 0 | 1 | 0 | 0 |
+| `sig/rigor/environment.rbs` | 1 | 0 | 0 | 0 |
+| `sig/rigor/inference.rbs` | 19 | 0 | 3 | 0 |
+| `sig/rigor/inference/void_origin.rbs` | 3 | 0 | 2 | 0 |
+| `sig/rigor/plugin/fact_store.rbs` | 1 | 0 | 0 | 0 |
+| `sig/rigor/plugin/load_error.rbs` | 0 | 0 | 1 | 0 |
+| `sig/rigor/rbs_extended.rbs` | 12 | 0 | 3 | 0 |
+| `sig/rigor/scope.rbs` | 29 | 0 | 1 | 0 |
+| `sig/rigor/trinary.rbs` | 3 | 0 | 0 | 0 |
+| `sig/rigor/type.rbs` | 6 | 66 | 56 | 0 |
+
+`sig/rigor/type.rbs` is 128 of the 224 on its own, and for one reason: the type carriers are a
+polymorphic family, and each declares the whole shared surface. The 66 inherited rows are `accepts`
+(×21, from `Type::AcceptanceRouter`) and the lattice trio `top` / `bot` / `dynamic` (×15 each, from
+`Type::PlainLattice`); the 56 runtime rows are `==` / `hash` / `eql?` from `ValueSemantics`. One
+mixin extraction and one class macro, multiplied by the family.
+
+## What this changes, and what it does not
+
+**The three new states are residue, not earned.** Knowing that a declared method *exists* says nothing
+about where its *type* came from, and the type is what [ADR-107](../adr/107-checked-types-and-typeless-comments.md)
+§ Decision asks about. Splitting `no_source` into `synthetic_source` / `inherited_source` /
+`runtime_defined` therefore leaves every per-file residue pin in
+`spec/rigor/sig_gen/provenance_spec.rb` exactly where it was — 677 today, unchanged by this work.
+
+**`no_source` is now a hard rule**, not a counted bucket. Zero on a correct tree, so a hard rule costs
+nothing; it was nine before the seeding audit deleted them. The failure names each row as
+`sig/path.rbs:line: Class#method — no source`.
+
+**The check is a repository gate.** It reads `sig/` against `lib/` in Rigor's own tree and requires
+that tree; it is not a `sig-gen` CLI feature, and an adopting project's workflow is unchanged.
+
+**Cost.** Measured in one warm process, 12-core M3 Max: `sig-gen` over `lib/` **18.7 s** (the
+pre-existing cost the gate already paid), tier 1's project index **1.4 s**, and tier 2's require plus
+every classification **0.3 s**. The two tiers add **~1.8 s (+9%)** to a pass that was already the
+reason this gate lives in `spec/rigor/sig_gen/` rather than `make docs-check`.
+
+## What this does not measure
+
+- **`plugins/*/sig` and `examples/*/sig`.** The gate walks the repository's own `sig/` only;
+  `make check-plugins` covers a different property there.
+- **Whether a declaration is *correct*.** Existence is not correctness — `make check` (G2) and
+  `make steep-check` answer that, and provenance (G3's other two mechanisms) answers where the type
+  came from.
+- **A method that exists but is unreachable.** `rigor unused` is the reachability surface.
+- **A plugin-contributed member.** The runtime tier loads `lib/` and not `plugins/`, because
+  requiring a plugin registers it into every spec process that shares the one running the gate.
+  Nothing in `sig/` describes such a member today; one would be reported stale, and the fix is to
+  require its plugin in `spec/support/sig_source_index.rb` — the way
+  `spec/rigor/public_api_drift_spec.rb` requires `rigor-ffi` for the same reason — never an exemption.

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -53,6 +53,7 @@ comparison) appears nowhere else in this index.
 | 2026-09-01 | [Corpus-wide opacity attribution — where types do not attach, on 25 targets](20260901-corpus-opacity-attribution.md) |
 | 2026-09-01 | [Post-campaign opacity re-attribution — the sweep probe re-run on merged master](20260901-post-campaign-opacity-recheck.md) |
 | 2026-09-08 | [Provenance of every declaration in `sig/` — the seeding audit for ADR-107 G3](20260908-sig-provenance-audit.md) |
+| 2026-09-09 | [Where the 224 `no_source` declarations in `sig/` come from](20260909-sig-no-source-audit.md) |
 
 ## Regression sweeps & real-project triage
 

--- a/spec/rigor/sig_gen/provenance_spec.rb
+++ b/spec/rigor/sig_gen/provenance_spec.rb
@@ -15,7 +15,7 @@
 #     # sig-gen gap: #825 — sig-gen types the body `untyped`, so the return is hand-written.
 #     def resolve: (String name) -> Type::t
 #
-# == Two mechanisms, and why not one
+# == Three mechanisms, and why not one
 #
 # The seeding audit (`docs/notes/20260908-sig-provenance-audit.md`) found 358 of 1,052 in-scope
 # declarations earned and 679 residue — 671 once the nine stale declarations the audit also turned up
@@ -31,6 +31,11 @@
 # 2. RATCHET on the residue. Per-file unmarked-residue counts are an exact snapshot below. A new
 #    hand-written declaration raises its file's count and goes red; marking it subtracts from the
 #    count. Closing an engine gap lowers a count and the gate says so, so slack cannot accumulate.
+# 3. HARD RULE on existence (#839). Every declaration must describe a method that EXISTS — proven by
+#    `sig-gen`'s `def`, by Rigor's own cross-file recognition, or by reflection over the loaded tree.
+#    Nothing else in the tree asks this direction: `make check` and `make steep-check` both ask
+#    whether the implementation matches `sig/`. Zero on a correct tree, so a hard rule costs nothing;
+#    it was nine before the seeding audit deleted them.
 #
 # == Why this file and not `spec/docs/`
 #
@@ -46,7 +51,10 @@ require "tmpdir"
 SIG_PROVENANCE_ROOT = File.expand_path("../../..", __dir__)
 
 # Computed once (a ~14 s generator pass) and shared read-only across the corpus examples.
-SIG_PROVENANCE_ROWS = SigProvenanceAuditor.audit(root: SIG_PROVENANCE_ROOT)
+# `runtime: true` opts the #839 existence tiers in: the project index over `lib/`, then a require of
+# `lib/` and reflection over it (`spec/support/sig_source_index.rb`). Safe here and nowhere else in
+# this file — the fixture audits below write their own `lib/`, and requiring one would run it.
+SIG_PROVENANCE_ROWS = SigProvenanceAuditor.audit(root: SIG_PROVENANCE_ROOT, runtime: true)
 
 # A corpus failure must stay readable; the total is always stated even when the listing is truncated.
 SIG_PROVENANCE_LISTING_CAP = 200
@@ -230,6 +238,33 @@ RSpec.describe "sig/ provenance (ADR-107 G3)" do
       expect(rows).to eq([SigProvenanceAuditor::NO_SOURCE])
     end
 
+    it "calls a `define_method` declaration `synthetic_source` — sig-gen enumerates defs (#839)" do
+      rows = classifications_for(ruby: "class Widget\n  define_method(:n) { 42 }\nend\n",
+                                 rbs: "class Widget\n  def n: () -> Integer\nend\n", method: "n")
+      expect(rows).to eq([SigProvenanceAuditor::SYNTHETIC])
+    end
+
+    it "calls a `Data.define` member declaration `synthetic_source` (#839)" do
+      rows = classifications_for(ruby: "Point = Data.define(:x, :y)\n",
+                                 rbs: "class Point\n  def x: () -> Integer\nend\n", method: "x")
+      expect(rows).to eq([SigProvenanceAuditor::SYNTHETIC])
+    end
+
+    it "calls a declaration whose def lives on a project superclass `inherited_source` (#839)" do
+      rows = classifications_for(ruby: "class Base\n  def n\n    42\n  end\nend\n\nclass Widget < Base\nend\n",
+                                 rbs: "class Widget\n  def n: () -> Integer\nend\n", method: "n")
+      expect(rows).to eq([SigProvenanceAuditor::INHERITED])
+    end
+
+    it "counts the #839 states as residue — existence says nothing about where the type came from" do
+      row = audit_fixture(ruby: "class Widget\n  define_method(:n) { 42 }\nend\n",
+                          rbs: "class Widget\n  def n: () -> Integer\nend\n")
+            .find { |r| r.declaration.method_name == "n" }
+
+      expect(SigProvenanceAuditor::EARNED).not_to include(row.classification)
+      expect(row).to be_residue
+    end
+
     it "leaves constants and type aliases out of scope as `non_method`" do
       rows = audit_fixture(ruby: "class Widget\n  def n\n    42\n  end\nend\n",
                            rbs: "class Widget\n  SIZE: Integer\n  type key = Symbol\n  def n: () -> 42\nend\n")
@@ -313,6 +348,31 @@ RSpec.describe "sig/ provenance (ADR-107 G3)" do
 
     it "reports the residue as a total, so the number is visible without a failure" do
       expect(SIG_PROVENANCE_ROWS.count(&:residue?)).to eq(SIG_PROVENANCE_RESIDUE.values.sum)
+    end
+
+    it "resolves every declaration to a def, a recognised shape, or a runtime-defined method (#839)" do
+      stale = SIG_PROVENANCE_ROWS.select { |row| row.classification == SigProvenanceAuditor::NO_SOURCE }
+      expect(stale).to be_empty, lambda {
+        listing = stale.map { |row| "#{row.declaration} — no source" }
+        "#{provenance_failure('stale declaration', listing)}\n\n" \
+          "Each names a method nothing defines: not a `def` sig-gen can attribute, not a shape " \
+          "Rigor's own cross-file recognition knows (`attr_*`, `define_method`, `alias`, a " \
+          "`Data` / `Struct` member, an ancestor the project declares), and not a method the " \
+          "loaded tree carries. A declaration is worse than a missing one — RBS resolves calls " \
+          "through it — so delete it, or restore the code it describes.\n" \
+          "Nothing else in the tree asks this direction: `make check` and `make steep-check` both " \
+          "ask whether the implementation matches `sig/`."
+      }
+    end
+
+    it "confirms the documented runtime-generated declaration rather than exempting it (#839)" do
+      # `sig/prism_node_children.rbs` declares `#rigor_each_child` on the abstract `Prism::Node` so
+      # every subclass resolves against one declaration; `Source::NodeChildren` compiles it onto each
+      # CONCRETE node class at load. Reflection is what tells that apart from a stale declaration.
+      row = SIG_PROVENANCE_ROWS.find { |r| r.declaration.method_name == "rigor_each_child" }
+      expect(row.declaration.path).to eq("sig/prism_node_children.rbs")
+      expect(row.classification).to eq(SigProvenanceAuditor::RUNTIME_DEFINED)
+      expect(row.detail).to include("subclass")
     end
   end
 end

--- a/spec/support/sig_provenance_auditor.rb
+++ b/spec/support/sig_provenance_auditor.rb
@@ -35,13 +35,19 @@
 # instance / singleton kinds treated as interchangeable, because `def self?.x` in RBS and
 # `module_function` in Ruby disagree about which kind a module function is. Everything else that
 # separates the two — a method reached through a mixin or a superclass, a member `Data.define`
-# generates, a `def` in a class `sig-gen` cannot name — lands in `:no_source`, which is residue by
-# construction rather than a bug: the point of counting it is that it should shrink. It also holds
-# the declarations whose `def` was deleted or renamed, which nothing in the tree checks and which
-# this classifier cannot separate from the legitimate rows; issue #839 tracks the sharper check.
+# generates, a `def` in a class `sig-gen` cannot name — is residue by construction rather than a bug:
+# the point of counting it is that it should shrink.
+#
+# Issue #839 splits that population by asking a second and a third source of truth ({SigSourceIndex}):
+# Rigor's own cross-file recognition, then reflection over the loaded tree. A declaration neither can
+# find describes code that does not exist, and `:no_source` now means exactly that — the audit found
+# nine such declarations sitting in `sig/`, which nothing in the tree checked, because `make check`
+# and `make steep-check` both ask whether the implementation matches `sig/` and never the converse.
 require "rbs"
 require "rigor"
 require "rigor/sig_gen"
+require_relative "sig_provenance_report"
+require_relative "sig_source_index"
 
 class SigProvenanceAuditor
   # A declaration whose return is what `sig-gen` proves. Earned.
@@ -68,14 +74,27 @@ class SigProvenanceAuditor
   UNRENDERABLE = :unrenderable
   # `sig-gen` found the `def` but the RBS environment did not resolve it to this declaration.
   UNMATCHED = :unmatched_declaration
-  # No `def` `sig-gen` can attribute to this declaration.
+  # No `def`, but Rigor's own recognition finds the method on the declaring class: an `attr_*`, a
+  # `define_method`, an `alias`, a `Data` / `Struct` member, or a `def` `sig-gen` declines to emit.
+  SYNTHETIC = :synthetic_source
+  # No `def` on the class, but the project declares the method on an ancestor it also declares.
+  INHERITED = :inherited_source
+  # Nothing static explains it and reflection over the loaded tree does: a method a class macro or a
+  # generated ancestor defines at load.
+  RUNTIME_DEFINED = :runtime_defined
+  # Nothing finds the method — not `sig-gen`, not the project index, not the runtime. The declaration
+  # describes code that does not exist (#839); ADR-107 G3 fails on one.
   NO_SOURCE = :no_source
   # Constants, type aliases, interfaces, `include`/`alias` members, class and module headers. No
   # return type to generate, so the provenance rule has nothing to say about them.
   NON_METHOD = :non_method
 
   EARNED = [GENERATED, PARAMETER_INTENT, RETURN_INTENT].freeze
-  RESIDUE = [DECLARED_DIVERGENT, UNTRANSLATABLE, UNRENDERABLE, UNMATCHED, NO_SOURCE].freeze
+  # The three #839 states are residue, not earned: knowing that a declared method EXISTS says nothing
+  # about where its type came from, and the type is what ADR-107 § Decision asks about. Splitting them
+  # out of `:no_source` therefore leaves every per-file residue pin exactly where it was.
+  RESIDUE = [DECLARED_DIVERGENT, UNTRANSLATABLE, UNRENDERABLE, UNMATCHED, SYNTHETIC, INHERITED,
+             RUNTIME_DEFINED, NO_SOURCE].freeze
 
   MARKER_PATTERN = /sig-gen gap:\s*#(?<issue>\d+)\b/
 
@@ -104,8 +123,12 @@ class SigProvenanceAuditor
     #   pays the ~14 s generator pass once.
     # @param configuration — overrides the configuration discovered under `root`; a fixture tree
     #   has no `.rigor.yml` and needs `signature_paths` pointed at its own `sig/`.
-    def audit(root:, candidates: nil, configuration: nil)
-      classify(declarations(root: root), candidates || generate(root: root, configuration: configuration))
+    # @param runtime — let the #839 tiers require `root`'s own `lib/` and reflect over it. Off by
+    #   default: requiring a tree runs its code, and a fixture tree's `lib/` is written by the
+    #   example auditing it.
+    def audit(root:, candidates: nil, configuration: nil, runtime: false)
+      classify(declarations(root: root), candidates || generate(root: root, configuration: configuration),
+               sources: SigSourceIndex.build(root: root, runtime: runtime))
     end
 
     # Every member of every `.rbs` under `sig/`, in file then source order.
@@ -125,9 +148,9 @@ class SigProvenanceAuditor
       end
     end
 
-    def classify(declarations, candidates)
+    def classify(declarations, candidates, sources: SigSourceIndex::NONE)
       index = index_candidates(candidates)
-      declarations.map { |decl| classify_one(decl, index) }
+      declarations.map { |decl| classify_one(decl, index, sources) }
     end
 
     # `{ "sig/rigor/type.rbs" => 187 }` — unmarked residue per file, the number ADR-107 G3 keeps
@@ -136,35 +159,14 @@ class SigProvenanceAuditor
       rows.select(&:residue?).each_with_object(Hash.new(0)) { |row, acc| acc[row.declaration.path] += 1 }
     end
 
-    # Prints the audit tables. The entry point `docs/notes/20260908-sig-provenance-audit.md` cites.
-    def report(root: Dir.pwd, out: $stdout)
-      rows = audit(root: root)
-      out.puts("| classification | n |\n| --- | --- |")
-      rows.group_by(&:classification).sort_by { |_, v| -v.size }
-          .each { |k, v| out.puts("| `#{k}` | #{v.size} |") }
-      report_per_file(rows, out)
-      out.puts("\n### tighter-return (a marker is required on every one)\n")
-      rows.select { |r| r.classification == TIGHTER_RETURN }.each { |r| out.puts("- #{r}") }
+    # Prints the audit tables. The entry point `docs/notes/20260908-sig-provenance-audit.md` and
+    # `docs/notes/20260909-sig-no-source-audit.md` cite. `runtime: true` — a report of the repository's
+    # own `sig/` wants the #839 tiers, and the audit is what the two notes are made of.
+    def report(root: Dir.pwd, out: $stdout, runtime: true)
+      SigProvenanceReport.render(audit(root: root, runtime: runtime), out: out)
     end
 
     private
-
-    REPORT_COLUMNS = ([TIGHTER_RETURN] + RESIDUE).freeze
-    private_constant :REPORT_COLUMNS
-
-    def report_per_file(rows, out)
-      out.puts("\n| file | #{REPORT_COLUMNS.map { |r| "`#{r}`" }.join(' | ')} | earned | residue |")
-      out.puts("| --- |#{' --- |' * (REPORT_COLUMNS.size + 2)}")
-      rows.reject { |r| r.classification == NON_METHOD }.group_by { |r| r.declaration.path }.sort
-          .each { |path, file_rows| out.puts(report_row(path, file_rows)) }
-    end
-
-    def report_row(path, rows)
-      by = rows.group_by(&:classification)
-      cells = REPORT_COLUMNS.map { |state| by.fetch(state, []).size }
-      earned = EARNED.sum { |state| by.fetch(state, []).size }
-      "| `#{path}` | #{cells.join(' | ')} | #{earned} | #{rows.count(&:residue?)} |"
-    end
 
     def index_candidates(candidates)
       candidates.each_with_object({}) do |candidate, acc|
@@ -175,11 +177,17 @@ class SigProvenanceAuditor
       end
     end
 
-    def classify_one(decl, index)
+    # `SigSourceIndex`'s vocabulary, mapped onto the audit's. Kept as a table so a new tier there is
+    # one row here rather than a branch.
+    MISSING_SOURCE = { SigSourceIndex::SYNTHETIC => SYNTHETIC, SigSourceIndex::INHERITED => INHERITED,
+                       SigSourceIndex::RUNTIME => RUNTIME_DEFINED }.freeze
+    private_constant :MISSING_SOURCE
+
+    def classify_one(decl, index, sources)
       return Row.new(declaration: decl, classification: NON_METHOD) if decl.kind.nil?
 
       candidate = index[[decl.class_name, decl.method_name]]
-      return Row.new(declaration: decl, classification: NO_SOURCE) if candidate.nil?
+      return classify_unattributed(decl, sources) if candidate.nil?
 
       case candidate.classification
       when Rigor::SigGen::Classification::EQUIVALENT then classify_equivalent(decl, candidate)
@@ -192,6 +200,15 @@ class SigProvenanceAuditor
                 detail: Rigor::SigGen::Classification::SKIP_DIAGNOSTIC_IDS[candidate.skip_reason])
       else classify_new_method(decl, candidate)
       end
+    end
+
+    # Issue #839 — `sig-gen` attributed no `def` to this declaration. Ask the project index, then the
+    # runtime; only a declaration none of the three can find is stale.
+    def classify_unattributed(decl, sources)
+      found, detail = sources.explain(decl.class_name, decl.method_name)
+      return Row.new(declaration: decl, classification: NO_SOURCE) if found.nil?
+
+      Row.new(declaration: decl, classification: MISSING_SOURCE.fetch(found), detail: detail)
     end
 
     # `sig-gen` never compares an `initialize` against an existing declaration: it emits a

--- a/spec/support/sig_provenance_report.rb
+++ b/spec/support/sig_provenance_report.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# The markdown the two `sig/` provenance notes are made of, rendered from {SigProvenanceAuditor}'s
+# rows. Presentation only — it decides nothing, so a table that reads oddly is a rendering bug and
+# never a classification one.
+#
+# Separate from the auditor because the notes cite the report VERBATIM
+# (`docs/notes/20260908-sig-provenance-audit.md`, `docs/notes/20260909-sig-no-source-audit.md`): the
+# tables and the gate must come from one pass or they drift, and keeping the rendering out of the
+# classifier is what stops "make the table nicer" from touching the classification.
+#
+# Deliberately no `require` of the auditor: it is the caller, it hands over the rows, and every
+# constant read below resolves at call time.
+class SigProvenanceReport
+  class << self
+    def render(rows, out: $stdout)
+      out.puts("| classification | n |\n| --- | --- |")
+      rows.group_by(&:classification).sort_by { |_, group| -group.size }
+          .each { |state, group| out.puts("| `#{state}` | #{group.size} |") }
+      per_file(rows, out)
+      out.puts("\n### tighter-return (a marker is required on every one)\n")
+      rows.select { |row| row.classification == SigProvenanceAuditor::TIGHTER_RETURN }
+          .each { |row| out.puts("- #{row}") }
+      unattributed(rows, out)
+    end
+
+    private
+
+    def columns = [SigProvenanceAuditor::TIGHTER_RETURN] + SigProvenanceAuditor::RESIDUE
+
+    # Issue #839's own table: for every declaration `sig-gen` could attribute no `def` to, WHY the
+    # static scan found none. A `no_source` row here is a stale declaration, and is listed in full
+    # because the gate fails on it.
+    def unattributed(rows, out)
+      states = [SigProvenanceAuditor::SYNTHETIC, SigProvenanceAuditor::INHERITED,
+                SigProvenanceAuditor::RUNTIME_DEFINED, SigProvenanceAuditor::NO_SOURCE]
+      found = rows.select { |row| states.include?(row.classification) }
+      out.puts("\n### where a declaration with no attributed `def` comes from (#{found.size})\n")
+      out.puts("| classification | shape | n |\n| --- | --- | --- |")
+      found.group_by { |row| [row.classification, row.detail] }.sort_by { |_, group| -group.size }
+           .each { |(state, shape), group| out.puts("| `#{state}` | #{shape || '—'} | #{group.size} |") }
+      stale = found.select { |row| row.classification == SigProvenanceAuditor::NO_SOURCE }
+      out.puts("\n### stale declarations (#{stale.size})\n")
+      stale.each { |row| out.puts("- #{row.declaration} — no source") }
+    end
+
+    def per_file(rows, out)
+      out.puts("\n| file | #{columns.map { |state| "`#{state}`" }.join(' | ')} | earned | residue |")
+      out.puts("| --- |#{' --- |' * (columns.size + 2)}")
+      rows.reject { |row| row.classification == SigProvenanceAuditor::NON_METHOD }
+          .group_by { |row| row.declaration.path }.sort
+          .each { |path, file_rows| out.puts(file_row(path, file_rows)) }
+    end
+
+    def file_row(path, rows)
+      by = rows.group_by(&:classification)
+      cells = columns.map { |state| by.fetch(state, []).size }
+      earned = SigProvenanceAuditor::EARNED.sum { |state| by.fetch(state, []).size }
+      "| `#{path}` | #{cells.join(' | ')} | #{earned} | #{rows.count(&:residue?)} |"
+    end
+  end
+end

--- a/spec/support/sig_source_index.rb
+++ b/spec/support/sig_source_index.rb
@@ -250,6 +250,13 @@ class SigSourceIndex
   # nothing `sig/` describes. Everything else is required, because `require "rigor"` alone leaves
   # ~110 files unloaded — the whole CLI, LSP and MCP surface — and five `CLI::*Command#initialize`
   # declarations resolve only once their file is loaded.
+  #
+  # `plugins/` is NOT loaded, and that is the one boundary this index has. Nothing under `sig/`
+  # describes a plugin-contributed member today (`rigor-ffi` adds `ffi_*` to `Plugin::Base`, and
+  # `sig/rigor/plugin/base.rbs` declares none of them), and requiring a plugin registers it, which
+  # would put a live plugin into every spec process sharing this one. A declaration of such a member
+  # would be reported stale; the fix is to require its plugin here — the way
+  # `spec/rigor/public_api_drift_spec.rb` requires `rigor-ffi` for the same reason — not to exempt it.
   def load_project
     return if @loaded
 

--- a/spec/support/sig_source_index.rb
+++ b/spec/support/sig_source_index.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+# Issue #839 — "does the method this declaration describes exist at all?", asked of two sources of
+# truth beside `sig-gen`.
+#
+# `sig-gen` enumerates `def`s. `sig/` declares methods, and a method is not always a `def`: an
+# `attr_*`, a `define_method`, an `alias`, a `Data.define` / `Struct.new` member, a method reached
+# through a superclass or a mixin, a method compiled onto a class at load
+# (`Rigor::Source::NodeChildren`). {SigProvenanceAuditor} called every one of those `:no_source`
+# together with the declarations whose `def` had been **deleted or renamed** — and the audit
+# (`docs/notes/20260908-sig-provenance-audit.md`) found nine of the latter sitting in `sig/`, which
+# neither `make check` nor `make steep-check` can see: both ask whether the implementation matches
+# `sig/`, never the converse.
+#
+# This index answers the converse, in two tiers, so `:no_source` can mean **stale** and nothing else.
+#
+# == Tier 1 — Rigor's own recognition (static, always on)
+#
+# `Inference::ScopeIndexer.discovered_project_index_for_paths` is the same cross-file pre-pass
+# `Analysis::Runner` builds before a `rigor check`: it already recognises `attr_*`, `define_method`,
+# `alias` / `alias_method`, `module_function`, an `extend` fold, and `Data` / `Struct` member
+# layouts, because the `call.undefined-method` rule would fire on all of them otherwise. Asking it
+# rather than re-deriving the shapes keeps one recognition in the tree — a second one would drift,
+# and the drift would show up as a false stale-declaration report, which AGENTS.md
+# § "Implementation Guidelines" ranks above any worst-case reading. The ancestor walk
+# (`Scope#discovered_method_through_ancestors?`) comes with it, so a method the project declares on
+# a superclass or an included module resolves without a second traversal.
+#
+# == Tier 2 — the runtime (reflection, opt-in)
+#
+# What no static pass can see: `Rigor::ValueSemantics#value_fields` defines `==` / `eql?` / `hash`
+# from a class macro, `Data.define` generates `.new` and `#with` on an anonymous parent, and
+# `Rigor::Source::NodeChildren` compiles `#rigor_each_child` onto every concrete `Prism::*Node`
+# class at load — the case `sig/prism_node_children.rbs` documents in prose. Reflection over a
+# loaded tree confirms each of them, the way `spec/rigor/public_api_drift_spec.rb` already reflects
+# over the public surface, and confirming beats an exemption list: an exemption stays true after the
+# code under it is deleted.
+#
+# Loading a tree runs its code, so tier 2 is **opt-in** (`runtime: true`) and only ever pointed at
+# this repository. A fixture project must never be required: its `lib/` is written by the example
+# that is auditing it.
+require "rigor"
+
+class SigSourceIndex
+  # A method the project defines on the declaring class by a shape that is not a `def` sig-gen
+  # enumerates — or a `def` sig-gen deliberately declines to emit (a parameterless `initialize`).
+  SYNTHETIC = :synthetic
+  # The project declares the method on an ancestor it also declares (a superclass, or an included
+  # module).
+  INHERITED = :inherited
+  # Only reflection over the loaded tree finds it: generated at load, by a class macro or by a
+  # generated ancestor.
+  RUNTIME = :runtime
+
+  # Explains nothing, so every unmatched declaration reads as stale. The default, because the
+  # alternative default would require a fixture tree's `lib/`.
+  NONE = Object.new
+  def NONE.explain(*) = nil
+  NONE.freeze
+
+  class << self
+    # @param root — the project root.
+    # @param paths — the source directories, as `Configuration#paths` spells them.
+    # @param runtime — require the tree and reflect over it (tier 2). Never true for a fixture.
+    def build(root:, paths: ["lib"], runtime: false)
+      new(root: root, paths: paths, runtime: runtime)
+    end
+  end
+
+  def initialize(root:, paths:, runtime:)
+    @root = root
+    @paths = paths
+    @runtime = runtime
+  end
+
+  # `[SYNTHETIC | INHERITED | RUNTIME, detail]` for a method that exists, nil for one that does not.
+  #
+  # Deliberately kind-blind, matching the join {SigProvenanceAuditor} makes against `sig-gen`'s
+  # candidates: `def self?.x` in RBS and `module_function` in Ruby disagree about which kind a module
+  # function is, and answering "this method does not exist" off that disagreement would be a false
+  # report of a stale declaration.
+  #
+  # @param class_name — the qualified class the declaration is nested in.
+  # @param method_name — the declared method name, `=` suffix included for a writer.
+  def explain(class_name, method_name)
+    synthetic(class_name, method_name) || project_ancestor(class_name, method_name) ||
+      runtime(class_name, method_name)
+  end
+
+  # The tier-1 tables, for a caller reporting on the pass itself.
+  def project_index
+    @project_index ||= Rigor::Inference::ScopeIndexer.discovered_project_index_for_paths(ruby_files)
+  end
+
+  private
+
+  def def_index = project_index.fetch(:def_index)
+
+  def ruby_files
+    @ruby_files ||= @paths.flat_map { |path| Dir.glob(File.join(@root, path, "**/*.rb")) }.sort
+  end
+
+  def synthetic(class_name, method_name)
+    return [SYNTHETIC, "Data member"] if member?(def_index.fetch(:data_member_layouts)[class_name], method_name)
+    return [SYNTHETIC, "Struct member"] if struct_member?(class_name, method_name)
+    return nil unless %i[instance singleton].any? { |kind| scope.discovered_method?(class_name, method_name, kind) }
+
+    [SYNTHETIC, accessor?(class_name, method_name) ? "attr_* / define_method / alias_method" : "def or alias"]
+  end
+
+  # Named for the question, not for the answer: `inherited` is `Class`'s own hook name, and a private
+  # helper that shadows it reads as an override of it.
+  def project_ancestor(class_name, method_name)
+    walked = %i[instance singleton].any? do |kind|
+      scope.discovered_method_through_ancestors?(class_name, method_name, kind)
+    end
+    walked ? [INHERITED, "project ancestor"] : nil
+  end
+
+  def runtime(class_name, method_name)
+    return nil unless @runtime
+
+    load_project
+    owner = runtime_owner(constant(class_name), method_name)
+    owner && [RUNTIME, owner]
+  end
+
+  # `Data.define` members carry no writer (a Data instance is frozen); a `Struct.new` member carries
+  # both, so the writer's `=` is stripped before the layout is consulted.
+  def member?(members, method_name)
+    !members.nil? && members.map(&:to_s).include?(method_name)
+  end
+
+  def struct_member?(class_name, method_name)
+    layout = def_index.fetch(:struct_member_layouts)[class_name]
+    member?(layout && layout[:members], method_name.delete_suffix("="))
+  end
+
+  # True when the name is in the accessor / alias / `define_method` existence table rather than the
+  # def-node table. `finalize_def_index` subtracts def-declared names from the former (a cross-file
+  # suppression contract that has nothing to do with existence), which is why {#existence_table}
+  # merges the two back together and only the shape label reads them apart.
+  def accessor?(class_name, method_name)
+    (def_index.fetch(:methods)[class_name] || {}).key?(method_name.to_sym)
+  end
+
+  # One scope carrying the whole project's discovery tables, so `Scope`'s own ancestor walk answers
+  # the mixin / superclass half rather than a second traversal written here.
+  def scope
+    @scope ||= Rigor::Scope.empty(environment: Rigor::Environment.default).with_discovery(
+      Rigor::Scope::DiscoveryIndex::EMPTY.with(
+        discovered_classes: project_index.fetch(:classes),
+        discovered_methods: existence_table,
+        discovered_def_nodes: def_index.fetch(:def_nodes),
+        discovered_singleton_def_nodes: def_index.fetch(:singleton_def_nodes),
+        discovered_superclasses: def_index.fetch(:superclasses),
+        discovered_header_nestings: def_index.fetch(:header_nestings),
+        discovered_includes: def_index.fetch(:includes),
+        data_member_layouts: def_index.fetch(:data_member_layouts),
+        struct_member_layouts: def_index.fetch(:struct_member_layouts)
+      )
+    )
+  end
+
+  # The union of every shape the pre-pass recognises, keyed the way `Scope#discovered_method?` reads
+  # it. `def_index[:methods]` alone would miss every plain `def` (see {#accessor?}) and so would
+  # report an inherited `def` as a stale declaration.
+  def existence_table
+    @existence_table ||= begin
+      table = {}
+      def_index.fetch(:methods).each { |name, entries| entries.each { |m, kind| record(table, name, m, kind) } }
+      def_index.fetch(:def_nodes).each { |name, entries| entries.each_key { |m| record(table, name, m, :instance) } }
+      def_index.fetch(:singleton_def_nodes).each do |name, entries|
+        entries.each_key { |m| record(table, name, m, :singleton) }
+      end
+      table.each_value(&:freeze).freeze
+    end
+  end
+
+  def record(table, class_name, method_name, kind)
+    entries = (table[class_name] ||= {})
+    recorded = entries[method_name]
+    entries[method_name] = recorded.nil? || recorded == kind ? kind : Rigor::Scope::DiscoveryIndex::METHOD_KIND_BOTH
+  end
+
+  def constant(class_name)
+    Object.const_get(class_name)
+  rescue NameError, TypeError
+    nil
+  end
+
+  # Every object answers `hash`, `==`, `to_s` and `inspect`, and `sig/` declares all four on classes
+  # that generate them from `ValueSemantics#value_fields`. Reflection alone would therefore confirm
+  # such a declaration after the `value_fields` call under it was deleted — the exact miss this index
+  # exists to close. An owner that hands the method to EVERY object explains nothing, so it is read
+  # as no owner at all.
+  UNIVERSAL_INSTANCE_OWNERS = [Object, Kernel, BasicObject].freeze
+  UNIVERSAL_SINGLETON_OWNERS = [Class, Module, Object, Kernel, BasicObject].freeze
+  private_constant :UNIVERSAL_INSTANCE_OWNERS, :UNIVERSAL_SINGLETON_OWNERS
+
+  # Instance side first, then singleton, then the subclasses — mirroring {#explain}'s kind-blindness.
+  # The subclass sweep is what confirms `sig/prism_node_children.rbs`: `#rigor_each_child` is
+  # compiled onto every CONCRETE `Prism::*Node`, and declared on the abstract `Prism::Node` so every
+  # subclass resolves against one declaration.
+  def runtime_owner(klass, method_name)
+    return nil unless klass.is_a?(Module)
+
+    instance_owner(klass, method_name) || singleton_owner(klass, method_name) ||
+      (subclass_defines?(klass, method_name) ? "compiled onto every subclass at load" : nil)
+  end
+
+  def instance_owner(klass, method_name)
+    owner = klass.instance_method(method_name).owner
+    return nil if UNIVERSAL_INSTANCE_OWNERS.include?(owner)
+    return "defined on the class itself at load" if owner == klass
+
+    "inherited from #{owner.name || 'a generated ancestor'}"
+  rescue NameError
+    nil
+  end
+
+  def singleton_owner(klass, method_name)
+    owner = klass.method(method_name).owner
+    return nil if UNIVERSAL_SINGLETON_OWNERS.include?(owner)
+
+    # A singleton class has no name of its own (`#<Class:Foo>`); the class it is attached to is the
+    # legible half, and `attached_object` is the only way back to it.
+    attached = owner.respond_to?(:attached_object) ? owner.attached_object : nil
+    "singleton method, from #{singleton_source(attached, klass)}"
+  rescue NameError
+    nil
+  end
+
+  def singleton_source(attached, klass)
+    return "the class itself at load" if attached.equal?(klass)
+
+    attached.is_a?(Module) && attached.name ? attached.name : "a generated ancestor"
+  end
+
+  def subclass_defines?(klass, method_name)
+    return false unless klass.is_a?(Class)
+
+    ObjectSpace.each_object(Class).any? do |candidate|
+      candidate < klass && candidate.method_defined?(method_name.to_sym, false)
+    end
+  end
+
+  # `lib/rigortype.rb` is excluded on purpose: requiring it is the mistake it exists to warn about
+  # (`require "rigortype"` prints a paragraph telling you Rigor is not a library), and it declares
+  # nothing `sig/` describes. Everything else is required, because `require "rigor"` alone leaves
+  # ~110 files unloaded — the whole CLI, LSP and MCP surface — and five `CLI::*Command#initialize`
+  # declarations resolve only once their file is loaded.
+  def load_project
+    return if @loaded
+
+    @loaded = true
+    ruby_files.each do |file|
+      require file unless File.basename(file) == "rigortype.rb"
+    end
+  end
+end


### PR DESCRIPTION
The `sig/` provenance audit (#825 / #835) found nine declarations describing methods that no longer existed, and nothing had fired: `make check` and Steep ask whether the implementation matches `sig/`, never the converse (#839). This makes the converse a standing gate.

- `spec/support/sig_source_index.rb`: two tiers asked before a declaration is called stale. **Static** — `ScopeIndexer.discovered_project_index_for_paths` (the same cross-file pre-pass `rigor check` builds) plus `Scope#discovered_method_through_ancestors?`, which already recognises `attr_*`, `define_method`, `alias` / `alias_method`, `module_function`, `extend` folds and `Data` / `Struct` layouts — no shape is re-derived. **Runtime** — requires `lib/` and reflects, deliberately blind to `Object` / `Kernel` / `BasicObject` owners so a universal `hash` / `==` / `to_s` cannot confirm a declaration after its `value_fields` was deleted.
- The auditor gains `synthetic_source`, `inherited_source`, `runtime_defined`, all in the residue (existence says nothing about where a *type* came from), so every per-file residue pin is unchanged; `no_source` now means stale and nothing else, and the gate goes red on it with `sig/path.rbs:line: Class#method — no source`. Negative test: an injected phantom declaration turns the gate red; `Prism::Node#rigor_each_child` is confirmed by the subclass sweep, not exempted.
- Of the 224 former `no_source` rows the static tier resolves 155 and the runtime tier 69; stale today: zero. Cost: +1.8 s over the 18.7 s `sig-gen` pass the gate already ran.
- Boundary, documented not papered over: the runtime tier loads `lib/`, not `plugins/`; a `sig/` declaration of a plugin-contributed member would read as stale, and the fix is to require its plugin, never an exemption.
- `docs/notes/20260909-sig-no-source-audit.md` records the classification; ADR-107 G3 row extended; handbook 11 says the existence check is a repository gate.

Fixes #839. Draft until the user's word.
