### PR TITLE
Let an IntegerRange receiver reach RBS dispatch

### DIFF
--- a/changelog.d/fixed/fix-842-integer-range-dispatch.md
+++ b/changelog.d/fixed/fix-842-integer-range-dispatch.md
@@ -1,0 +1,1 @@
+- **[inference]** A bounded Integer receiver (`n = ARGV.size`) now resolves `digits`, `fdiv`, `to_f` and any other method the fold tiers do not already own, instead of losing precision to `Dynamic[top]` while the same receiver was already reported for calling an undefined method. ([#858](https://github.com/rigortype/rigor/pull/858))

--- a/docs/internal-spec/inference-engine.md
+++ b/docs/internal-spec/inference-engine.md
@@ -190,6 +190,7 @@ The RBS-backed tier MUST resolve receiver types to a `(class_name, kind)` pair w
 - `Type::Constant[v]` resolves to `(v.class.name, :instance)`.
 - `Type::Nominal[name]` resolves to `(name, :instance)`.
 - `Type::Singleton[name]` (Slice 4 phase 2b) resolves to `(name, :singleton)`. The dispatcher MUST consult `RbsLoader#singleton_method` rather than `instance_method` for this kind, so `Foo.bar` correctly looks up the class methods of `Foo`.
+- `Type::FloatRange` (ADR-109 WD4) resolves to `("Float", :instance)`, and `Type::IntegerRange` (issue #842) resolves to `("Integer", :instance)`: a bounded numeric carrier is its unbounded class for every method the fold tiers above this one do not already own.
 - `Type::Dynamic[T]` recurses into `T`'s static facet using the same rules.
 - `Type::Top` and `Type::Bot` produce no descriptor; the dispatcher MUST return `nil`.
 

--- a/lib/rigor/inference/method_dispatcher/rbs_dispatch.rb
+++ b/lib/rigor/inference/method_dispatcher/rbs_dispatch.rb
@@ -246,8 +246,11 @@ module Rigor
               receiver_descriptor(receiver.base)
             when Type::FloatRange
               # ADR-109 WD4 — a bounded Float is a Float for every method the fold tiers do not own.
-              # (`IntegerRange` has no arm here yet: #842.)
               ["Float", :instance, []]
+            when Type::IntegerRange
+              # #842 — a bounded Integer is an Integer for every method the fold tiers
+              # (ConstantFolding, ShapeDispatch#dispatch_integer_range) do not own.
+              ["Integer", :instance, []]
             when Type::Dynamic
               receiver_descriptor(receiver.static_facet)
             end

--- a/spec/integration/fixtures/integer_range_rbs_dispatch.rb
+++ b/spec/integration/fixtures/integer_range_rbs_dispatch.rb
@@ -1,0 +1,20 @@
+require "rigor/testing"
+include Rigor::Testing
+
+# Issue #842 — `RbsDispatch#receiver_descriptor` had no arm for `Type::IntegerRange`, so any method
+# the fold tiers (ConstantFolding, ShapeDispatch#dispatch_integer_range) do not own fell soft to
+# `Dynamic[top]` instead of reaching RBS. `Integer#digits`/`#fdiv`/`#to_f` are exactly that: RBS-only
+# methods over a bounded-integer receiver.
+n = ARGV.size
+assert_type("non-negative-int", n)
+
+# The fold tiers keep winning for the methods they own — unaffected by this change.
+assert_type("positive-int", n + 1)
+assert_type("positive-int", n.succ)
+assert_type("Integer[1..9]", n.clamp(1, 9))
+assert_type("decimal-int-string", n.to_s)
+
+# Newly reached through RBS dispatch instead of falling to Dynamic[top].
+assert_type("Array[Integer]", n.digits)
+assert_type("Float", n.fdiv(2))
+assert_type("Float", n.to_f)

--- a/spec/integration/fixtures/recursive_dynamic_arg.rb
+++ b/spec/integration/fixtures/recursive_dynamic_arg.rb
@@ -6,8 +6,15 @@ include Rigor::Testing
 # constant-folded, so both branches are joined; the in-cycle `of`
 # self-call keys on `(receiver, method)` exactly as before and stays
 # `Dynamic[top]` (WD3 keeps non-`Bot`, non-value-pinned self-call
-# returns dynamic inside a body). The result is the pre-ADR-55
-# `Constant[1] | Dynamic[top]`, byte-identical to today.
+# returns dynamic inside a body).
+#
+# The multiplication itself no longer inherits that dynamism: the
+# `n <= 1` guard narrows the falsy-branch receiver to an IntegerRange
+# (`positive-int`, excluding 0 and 1), and since #842 that carrier
+# reaches RBS dispatch like any other Integer, so `Integer#*` resolves
+# against the Dynamic argument through the ordinary gradual-typing
+# path (ADR-5) instead of declining outright. Pre-#842 the join was
+# `Constant[1] | Dynamic[top]`.
 class Factorial
   def of(n)
     n <= 1 ? 1 : n * of(n - 1)
@@ -16,4 +23,4 @@ end
 
 f = Factorial.new
 x = rand(10)
-assert_type("1 | Dynamic[top]", f.of(x))
+assert_type("1 | Integer", f.of(x))

--- a/spec/integration/snapshots/integer_range_rbs_dispatch.yml
+++ b/spec/integration/snapshots/integer_range_rbs_dispatch.yml
@@ -1,0 +1,12 @@
+---
+locals:
+  "n": non-negative-int
+assertions:
+  '1': non-negative-int
+  '2': positive-int
+  '3': positive-int
+  '4': Integer[1..9]
+  '5': decimal-int-string
+  '6': Array[Integer]
+  '7': Float
+  '8': Float

--- a/spec/integration/snapshots/recursive_dynamic_arg.yml
+++ b/spec/integration/snapshots/recursive_dynamic_arg.yml
@@ -3,4 +3,4 @@ locals:
   f: Dynamic[top]
   x: Integer
 assertions:
-  '1': 1 | Dynamic[top]
+  '1': 1 | Integer

--- a/spec/integration/type_construction_spec.rb
+++ b/spec/integration/type_construction_spec.rb
@@ -1049,6 +1049,15 @@ RSpec.describe "Rigor type construction (integration)" do
     end
   end
 
+  describe "fixtures/integer_range_rbs_dispatch.rb — issue #842 IntegerRange reaches RBS dispatch" do
+    let(:harness) { harness_for("integer_range_rbs_dispatch") }
+
+    it "resolves RBS-only methods on a bounded Integer without disturbing the fold tiers" do
+      mismatches = harness.errors.select { |d| d.message.start_with?("assert_type ") }
+      expect(mismatches).to be_empty
+    end
+  end
+
   describe "fixtures/container_size.rb — Array/String/Hash#size tightened to non_negative_int" do
     let(:harness) { harness_for("container_size") }
 

--- a/spec/rigor/inference/method_dispatcher/rbs_dispatch_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/rbs_dispatch_spec.rb
@@ -198,6 +198,35 @@ RSpec.describe Rigor::Inference::MethodDispatcher::RbsDispatch do
       end
     end
 
+    # Issue #842 — an IntegerRange receiver used to have no arm in `receiver_descriptor`, so anything
+    # the fold tiers did not own fell soft to Dynamic[top] instead of reaching RBS.
+    describe "IntegerRange receiver (issue #842)" do
+      let(:non_negative_int) { Rigor::Type::Combinator.non_negative_int }
+
+      it "resolves #digits to Array[Integer]" do
+        type = dispatch(non_negative_int, :digits)
+        expect(type).to be_a(Rigor::Type::Nominal)
+        expect(type.class_name).to eq("Array")
+        expect(type.type_args).to eq([Rigor::Type::Combinator.nominal_of(Integer)])
+      end
+
+      it "resolves #fdiv(2) to Float" do
+        type = dispatch(non_negative_int, :fdiv, [Rigor::Type::Combinator.constant_of(2)])
+        expect(type).to be_a(Rigor::Type::Nominal)
+        expect(type.class_name).to eq("Float")
+      end
+
+      it "resolves #to_f to Float" do
+        type = dispatch(non_negative_int, :to_f)
+        expect(type).to be_a(Rigor::Type::Nominal)
+        expect(type.class_name).to eq("Float")
+      end
+
+      it "still declines an undefined method" do
+        expect(dispatch(non_negative_int, :frobnicate)).to be_nil
+      end
+    end
+
     # Issue #303 — method-level `[T]` bound from an argument position. The signatures live in a virtual
     # RBS buffer so the shapes under test are stated here rather than borrowed from whatever core RBS
     # happens to spell today.


### PR DESCRIPTION
## What

`RbsDispatch#receiver_descriptor` had no arm for `Type::IntegerRange`, so a bounded-integer receiver (`n = ARGV.size`, `non-negative-int`) never reached the RBS dispatch tier. Any method the fold tiers (`ConstantFolding`, `ShapeDispatch#dispatch_integer_range`) do not own fell soft to `Dynamic[top]` instead of resolving through Integer's RBS contract - `n.digits`, `n.fdiv(2)`, `n.to_f` all lost precision this way, while `n.frobnicate` was already correctly reported as `call.undefined-method` because `CheckRules#concrete_class_name` and `Protection::Mutator#concrete_class_name` already projected `IntegerRange` to `"Integer"`.

Adds `when Type::IntegerRange then ["Integer", :instance, []]` next to the existing `Type::FloatRange` arm (landed in #844, which left the comment marking this exact gap), and updates that comment now that the gap is closed.

## Why

The fold tiers above this one keep winning for the methods they already own, so this only replaces `Dynamic[top]` with the RBS-declared return - no diagnostic that fires today stops firing, and the risk runs the other way (a call chain that was silently `Dynamic` now types precisely, and a downstream rule could in principle report a genuine mismatch on it). No such regression turned up in this repo's own suite.

## Verified

- `spec/rigor/inference/method_dispatcher/rbs_dispatch_spec.rb` - added a describe block: `IntegerRange` receiver dispatches `digits` -> `Array[Integer]`, `fdiv(2)` -> `Float`, `to_f` -> `Float`; `frobnicate` still declines. 42 examples, 0 failures.
- New integration fixture `spec/integration/fixtures/integer_range_rbs_dispatch.rb` pins the same three methods plus the unaffected fold-tier methods (`n + 1`, `n.succ`, `n.clamp(1, 9)`, `n.to_s`), wired into `spec/integration/type_construction_spec.rb`; its precision snapshot is `spec/integration/snapshots/integer_range_rbs_dispatch.yml`.
- `spec/integration/precision_snapshot_spec.rb` over the whole corpus surfaced one other changed row: `spec/integration/fixtures/recursive_dynamic_arg.rb`'s `f.of(x)` moved from `1 | Dynamic[top]` to `1 | Integer`. The ternary's falsy branch narrows `n` to a `positive-int` `IntegerRange`, and `n * of(n - 1)` - previously stuck at `Dynamic[top]` because that receiver had no RBS descriptor - now resolves through `Integer#*` like any other Integer multiplication (the self-call `of` is still unresolved per ADR-55 WD3; only the arithmetic around it sharpened). Updated the fixture's `assert_type` and comment, and regenerated its snapshot. Read both diffs before committing; no other fixture's precision changed (136 examples, 0 failures after the update).
- `spec/rigor/inference/method_dispatcher/`, `spec/integration/type_construction_spec.rb` and `spec/integration/precision_snapshot_spec.rb` together: 1708 examples, 0 failures.
- `make lint`: clean (1210 files, no offenses).
- `make check`: clean (449 files; only the pre-existing informational `rbs.coverage.missing-gem` note).
- `make check-plugins`: clean (175 files; same informational note).
- `make docs-check`: clean (449 examples, 0 failures, 1 pending - `c_effects_raises_gate_spec.rb`, expected: `references/ruby` is an optional submodule not populated in this worktree).
- `git diff --check`: clean.
- `rigor coverage lib`: precise/typed on the pre-change commit (`3b362102`) was 113675/183828 = 61.84%; on this branch it is 113698/183834 = 61.85% (+23 precise, -36 dynamic; measured via `rigor coverage lib` checked out at each commit in this same worktree).
- Documented the new arm in `docs/internal-spec/inference-engine.md`, next to the RBS-backed tier's existing receiver-descriptor contract (`Type::Constant` / `Type::Nominal` / `Type::Singleton` / `Type::Dynamic` / `Type::Top` / `Type::Bot`).

**The full parallel suite (`make verify` / `make test`) was NOT run** - another agent was running its own gates on this machine at the same time, and two parallel full suites risked exhausting memory. The coordinator runs `make verify` before landing.

Closes #842
