### PR TITLE
Gate the env-cache producer against build_env_for's keyword list

### DIFF
--- a/changelog.d/added/fix-849-env-producer-gate.md
+++ b/changelog.d/added/fix-849-env-producer-gate.md
@@ -1,0 +1,1 @@
+- **[cache]** `rigor type-of`, `type-scan`, `trace` and `annotate` are documented as building their environment fresh — they never read or write the persistent cache, which is why none of them accepts `--no-cache` ([#864](https://github.com/rigortype/rigor/pull/864)).

--- a/docs/manual/02-cli-reference.md
+++ b/docs/manual/02-cli-reference.md
@@ -138,6 +138,17 @@ truncation explicit. `--trace` records fail-soft fallbacks,
 after the rows of a line table in text output. The editor-mode
 `--tmp-file` / `--instead-of` pair is accepted as on `check`.
 
+The four probe commands — `type-of`, `type-scan`, `trace` and
+`annotate` — build their environment fresh on every invocation
+and never read or write the persistent cache. That is why none
+of them takes `--no-cache`: the flag would have nothing to skip.
+A probe therefore types against the environment `rigor check
+--no-cache` analyses with. The environment a cached (default)
+`rigor check` builds is meant to be identical, and Rigor gates
+the two builds against each other — but if you are chasing a
+disagreement between a probe and a `check` run, comparing
+against `rigor check --no-cache` removes that variable.
+
 ## `rigor trace`
 
 Replay HOW the engine typed a file, step by step, as a

--- a/spec/rigor/cache/rbs_environment_spec.rb
+++ b/spec/rigor/cache/rbs_environment_spec.rb
@@ -10,7 +10,31 @@ RSpec.describe Rigor::Cache::RbsEnvironment do
   let(:store) { Rigor::Cache::Store.new(root: cache_root) }
   let(:loader) { Rigor::Environment::RbsLoader.new }
 
+  # A loader carrying a non-default value for every `build_env_for` keyword, so a producer that forwards a
+  # keyword but not the loader's value is distinguishable from one that forwards both.
+  let(:fully_populated_loader) do
+    sig_dir = File.join(tmpdir, "forwarding_sig")
+    FileUtils.mkdir_p(sig_dir)
+    File.write(File.join(sig_dir, "forwarded.rbs"), "class Forwarded[Elem]\nend\n")
+    Rigor::Environment::RbsLoader.new(
+      libraries: ["set"],
+      signature_paths: [sig_dir],
+      deferred_signature_paths: [sig_dir],
+      virtual_rbs: [["forwarded_virtual.rbs", "class ForwardedVirtual\nend\n"]]
+    )
+  end
+
   after { FileUtils.rm_rf(tmpdir) }
+
+  # The keyword parameters of the loader's OWN `build_env_for`. Resolved past `RbsEnvMemo::Interception`,
+  # which the suite prepends onto the same singleton with a mirrored signature: reading the mirror would let
+  # a keyword added to the loader and to neither the memo nor the producer pass unnoticed.
+  def build_env_for_keywords
+    owner = Rigor::Environment::RbsLoader.singleton_class
+    method = owner.instance_method(:build_env_for)
+    method = method.super_method until method.owner == owner
+    method.parameters.filter_map { |kind, name| name if %i[key keyreq].include?(kind) }
+  end
 
   describe ".fetch" do
     it "returns an RBS::Environment with the loaded class declarations" do
@@ -50,6 +74,44 @@ RSpec.describe Rigor::Cache::RbsEnvironment do
 
       expect(Rigor::Environment::RbsLoader).to have_received(:build_env_for)
         .with(hash_including(deferred_signature_paths: deferred_loader.deferred_signature_paths))
+    end
+
+    # Issue #849 — the example above pins ONE input; this pins the SHAPE. `build_env_for` is reached from
+    # two entries (this producer on a cache miss, the loader's own `build_env` under `--no-cache` and every
+    # probe command), and a keyword threaded through the second alone builds a different environment on the
+    # default run. Reading the keyword list off the method itself is what makes the next such keyword fail
+    # here rather than ship: the expectation has nothing to update when one is added, only the producer does.
+    it "forwards every keyword build_env_for accepts" do
+      forwarded = nil
+      allow(Rigor::Environment::RbsLoader).to receive(:build_env_for).and_wrap_original do |original, **kwargs|
+        forwarded = kwargs
+        original.call(**kwargs)
+      end
+
+      described_class.fetch(loader: fully_populated_loader, store: store)
+
+      missing = build_env_for_keywords - forwarded.keys
+      expect(missing).to be_empty,
+                         "Cache::RbsEnvironment.compute does not forward #{missing.join(', ')} to " \
+                         "RbsLoader.build_env_for. Every cached run — the CLI default — builds its " \
+                         "environment through this producer, so an input reaching only the loader's own " \
+                         "build_env runs on no real `rigor check` at all (issue #610)."
+    end
+
+    # The keyword names double as the loader's reader names, so the producer's own value can be checked
+    # against the loader it was handed. A keyword forwarded with a hard-coded default instead of the
+    # loader's value fails here — the 0.3.8 failure mode one step short of omitting the keyword.
+    it "forwards each keyword's value from the loader it is given" do
+      forwarded = nil
+      allow(Rigor::Environment::RbsLoader).to receive(:build_env_for).and_wrap_original do |original, **kwargs|
+        forwarded = kwargs
+        original.call(**kwargs)
+      end
+
+      described_class.fetch(loader: fully_populated_loader, store: store)
+
+      expected = build_env_for_keywords.to_h { |keyword| [keyword, fully_populated_loader.public_send(keyword)] }
+      expect(forwarded).to eq(expected)
     end
 
     it "produces an env that is still usable for instance_method lookups after cache hit" do


### PR DESCRIPTION
Fixes #849.

Two deliverables, split out of #610's reopen (#848).

**A structural gate that the env-cache producer forwards every `build_env_for` input.** `RbsLoader.build_env_for` is reached from two entries: the loader's own `build_env` (taken only with no cache store — `rigor check --no-cache` and every probe command) and `Cache::RbsEnvironment.compute` (taken on every cache miss, i.e. the default run). #770 threaded `deferred_signature_paths:` through the first alone, and 0.3.8 shipped the plugin-signature stand-down running on no real `rigor check` at all, behind a green gate whose loader held no store. #848 forwarded the input but left the shape available to the next change.

The gate reads the keyword parameter list off `build_env_for` itself (`Method#parameters`, resolved past `RbsEnvMemo::Interception`, whose mirrored signature would otherwise answer for the loader's own) and compares it against what the producer actually passes, captured by wrapping the method while `.fetch` runs over a real `Cache::Store`. `Method#parameters` was preferred to an enumerated expectation because it leaves the spec nothing to update when a keyword is added — the producer becomes the only place the new name has to appear, which is exactly the omission being guarded. A second example pins each forwarded value to the loader's reader of the same name, so a keyword forwarded with a hard-coded default fails too.

Verified by mutation: dropping `deferred_signature_paths:` from the producer fails with `Cache::RbsEnvironment.compute does not forward deferred_signature_paths to RbsLoader.build_env_for. …`; adding a keyword to `build_env_for` alone fails the same way naming it.

**A manual line on the probes' cache behaviour.** Verified in the code first: `type-of`, `type-scan`, `trace` and `annotate` all build through `ProbeEnvironment.build`, whose `Environment.for_project` call passes no `cache_store:` — so the claim holds for all four. `docs/manual/02-cli-reference.md` now says they build fresh, never read or write the persistent cache, which is why none of them takes `--no-cache`, and that a probe therefore types against the environment `rigor check --no-cache` analyses with.

Out of scope, per the issue: making the probes read the cache, and adding a no-op `--no-cache` to `type-of`.
