### PR TITLE
Gate ProjectEnvironment against for_project's discovery keywords

### DIFF
--- a/spec/rigor/project_environment_spec.rb
+++ b/spec/rigor/project_environment_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Rigor::ProjectEnvironment do
+  # Every `Environment.for_project` keyword that is NOT a dependency-discovery axis. The gate below asserts
+  # that whatever remains after subtracting this list is spelled by
+  # {Rigor::ProjectEnvironment.dependency_discovery_options}.
+  #
+  # An allowlist of the non-discovery names, rather than a `bundler_* / rbs_collection_*` name pattern: the
+  # gap being guarded (issue #821) is a keyword that reaches `check` and no other build entry, and a name
+  # pattern can only catch the ones that happen to be named after today's two axes. A third dependency
+  # source — a `gemspec_*`, a `gem_sig_*` — would be exactly the same bug and would pass a pattern silently.
+  # The cost is that a new NON-discovery keyword has to be classified here; the failure message says so, and
+  # that classification is the adjudication the gate exists to force.
+  def non_discovery_keywords
+    %i[
+      root
+      libraries
+      signature_paths
+      cache_store
+      plugin_registry
+      dependency_source_index
+      rbs_extended_reporter
+      boundary_cross_reporter
+      source_rbs_synthesis_reporter
+      synthetic_method_index
+      project_patched_methods
+      source_files
+    ].freeze
+  end
+
+  # A configuration carrying a non-default value for every discovery axis, so a call site that passes a
+  # keyword but hard-codes its value is distinguishable from one that reads the configuration.
+  let(:configuration) do
+    Rigor::Configuration.new(
+      "bundler" => {
+        "bundle_path" => "vendor/spec-bundle",
+        "auto_detect" => true,
+        "lockfile" => "spec/Gemfile.lock"
+      },
+      "rbs_collection" => {
+        "lockfile" => "spec/rbs_collection.lock",
+        "auto_detect" => true
+      }
+    )
+  end
+
+  def for_project_keywords
+    Rigor::Environment.method(:for_project).parameters
+                      .filter_map { |kind, name| name if %i[key keyreq].include?(kind) }
+  end
+
+  # Captures the keywords one block's `Environment.for_project` call is made with, without paying a real
+  # environment build.
+  def capture_for_project_keywords
+    captured = nil
+    allow(Rigor::Environment).to receive(:for_project) do |**kwargs|
+      captured = kwargs
+      Rigor::Environment.new(rbs_loader: nil)
+    end
+    yield
+    captured
+  end
+
+  describe ".dependency_discovery_options" do
+    # Issue #821 was one build entry missing these axes entirely; #864 gated the other producer of the RBS
+    # env against its own build method's keyword list. This is the same shape one level up: the helper is
+    # the single spelling of the discovery axes, so a new axis added to `for_project` and threaded only
+    # through `check` has to fail here rather than ship as a probe/sig-gen divergence.
+    it "spells every dependency-discovery keyword Environment.for_project accepts" do
+      missing = for_project_keywords - non_discovery_keywords - described_class.dependency_discovery_options(
+        configuration
+      ).keys
+
+      expect(missing).to be_empty,
+                         "Environment.for_project accepts #{missing.join(', ')}, which " \
+                         "ProjectEnvironment.dependency_discovery_options does not pass. Every command that " \
+                         "types against the project's real dependencies goes through that helper, so an " \
+                         "axis missing from it reaches `rigor check` alone and the probes / sig-gen build a " \
+                         "different type universe (issue #821). Add it to the helper — or, if it is not a " \
+                         "dependency-discovery axis, to non_discovery_keywords in this spec."
+    end
+
+    # The keyword names double as the configuration's reader names, so each value can be checked against the
+    # configuration it was built from. A hard-coded default in the helper fails here.
+    it "reads each value from the configuration reader of the same name" do
+      options = described_class.dependency_discovery_options(configuration)
+
+      expect(options).to eq(options.keys.to_h { |key| [key, configuration.public_send(key)] })
+      expect(options.values).to include("vendor/spec-bundle", "spec/rbs_collection.lock", true)
+    end
+  end
+
+  describe "the call sites that must use the helper" do
+    let(:discovery_options) { described_class.dependency_discovery_options(configuration) }
+
+    it "is used by .build" do
+      captured = capture_for_project_keywords do
+        described_class.build(configuration: configuration, source_files: [])
+      end
+
+      expect(captured).to include(discovery_options)
+    end
+
+    it "is used by .bare" do
+      captured = capture_for_project_keywords { described_class.bare(configuration) }
+
+      expect(captured).to include(discovery_options)
+    end
+
+    it "is used by PoolCoordinator#build_runner_environment" do
+      coordinator = Rigor::Analysis::Runner::PoolCoordinator.new(
+        configuration: configuration, cache_store: nil, explain: false, workers: 1,
+        collect_stats: false, buffer: nil, environment_override: nil,
+        rbs_extended_reporter: nil, boundary_cross_reporter: nil,
+        source_rbs_synthesis_reporter: nil, snapshots: nil,
+        plugin_registry: -> {}, dependency_source_index: -> {},
+        synthetic_method_index: -> {}, project_patched_methods: -> {},
+        analyze_file: ->(_path, _environment) { [] }
+      )
+
+      captured = capture_for_project_keywords { coordinator.build_runner_environment }
+
+      expect(captured).to include(discovery_options)
+    end
+
+    # The remaining build entries are asserted at source level rather than behaviourally: each is
+    # reachable only through machinery whose construction is the expensive part and unrelated to what is
+    # being checked — `WorkerSession.new` materialises the plugin registry and runs every plugin's
+    # `#prepare` before its `for_project` call is reached, `LanguageServer::ProjectContext#environment`
+    # first drives a whole project pre-pass through a second `Runner`, and `SigGen`'s two collectors build
+    # their environment from inside a full generation run. Driving them here would buy a slower, flakier
+    # restatement of what the file already says unambiguously: the helper is splatted in, and no discovery
+    # keyword is spelled by hand.
+    #
+    # `pool_coordinator.rb` is deliberately absent — it is covered behaviourally above, and its separate
+    # `prewarm_rbs_cache_for_pool` still spells the axes literally, so the no-literal half would not hold.
+    {
+      "Analysis::WorkerSession" => "lib/rigor/analysis/worker_session.rb",
+      "LanguageServer::ProjectContext" => "lib/rigor/language_server/project_context.rb"
+    }.each do |label, path|
+      it "is splatted into #{label}'s environment build" do
+        source = File.read(File.expand_path("../../#{path}", __dir__))
+
+        expect(source).to include("**ProjectEnvironment.dependency_discovery_options(")
+        expect(source).not_to include("rbs_collection_lockfile:")
+      end
+    end
+
+    # SigGen reaches the axes one hop further out: both collectors delegate the whole build to
+    # {ProjectEnvironment.build}, which the behavioural example above already pins to the helper. What is
+    # checked here is only that the delegation is still what they do.
+    {
+      "SigGen::Generator" => "lib/rigor/sig_gen/generator.rb",
+      "SigGen::ObservationCollector" => "lib/rigor/sig_gen/observation_collector.rb"
+    }.each do |label, path|
+      it "is reached by #{label} through ProjectEnvironment.build" do
+        source = File.read(File.expand_path("../../#{path}", __dir__))
+
+        expect(source).to include("ProjectEnvironment.build(configuration:")
+        expect(source).not_to include("rbs_collection_lockfile:")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #864 (issue #849) and #869 (issue #821). Spec-only.

#864 closed the "one build entry got the input, the other did not" loop for `RbsLoader.build_env_for`'s two producers. The same shape is open one level up: `Environment.for_project` is reached from `rigor check` (the pool coordinator, the worker session), the LSP project context, the four probes and sig-gen, and since #869 the dependency-discovery axes they all need have a single spelling — `ProjectEnvironment.dependency_discovery_options`. Nothing forced a *new* axis to reach that helper, so an axis added to `for_project` and threaded through `check` alone would rebuild #821 exactly: `sig-gen` unable to see `ActiveRecord::Base`, a probe typing against a universe the real run never had.

This adds `spec/rigor/project_environment_spec.rb`:

- **The keyword-set gate.** Reads `for_project`'s keyword parameters off the method itself (`Method#parameters`) and asserts that every name not on an explicit allowlist of NON-discovery keywords appears in the helper's hash. The failure message names the keyword and both legitimate resolutions.
- **The value gate.** The keyword names double as the configuration's reader names, so the helper's hash is compared against a `Configuration` built with a non-default value for every axis — an axis passed with a hard-coded default fails here.
- **The call-site gate.** `ProjectEnvironment.build`, `.bare` and `PoolCoordinator#build_runner_environment` are checked behaviourally, by wrapping `Environment.for_project` and comparing the captured keywords against the helper. The worker session, the LSP project context and sig-gen's two collectors are checked at source level, because for each of them the expensive part is the construction, not the call — a comment says so per group.

**Allowlist vs. name pattern.** A `bundler_* / rbs_collection_*` pattern needs no maintenance but only catches axes named after the two that exist today; a third dependency source (a `gemspec_*`, a `gem_sig_*`) is the same bug and would pass it silently. The allowlist costs one classification when a non-discovery keyword is added — a guided edit by the author already editing `for_project` — and never fires on unchanged correct code.

Verified by mutation: hard-coding `rbs_collection_auto_detect:` in the helper, adding a `gemspec_probe:` keyword to `for_project` alone, and replacing the splat in `build_runner_environment` with one literal keyword each fail with a message naming the keyword.

No changelog fragment: the diff is spec-only and changes no user-facing behaviour.

Two residues found while auditing `for_project(` across `lib/`, deliberately left alone:

- `PoolCoordinator#prewarm_rbs_cache_for_pool` passes all five discovery axes but spells them literally instead of splatting the helper. Correct today, drift-prone tomorrow — and the reason `pool_coordinator.rb` is excluded from the source-level half of the gate.
- `CLI::UnusedCommand#foreign_predicate` builds `Environment.for_project(libraries:, signature_paths: [], cache_store:)` with no discovery axes at all. Its "is this name already known outside the project?" predicate therefore does not see gem-shipped `sig/` or an installed `rbs collection`, which looks #821-shaped rather than deliberate (the excluded `signature_paths:` is documented; the missing bundle/collection axes are not).
