### PR TITLE
Fold a version guard written in the rooted spelling

### DIFF
--- a/changelog.d/fixed/issue-877-rooted-version-guard.md
+++ b/changelog.d/fixed/issue-877-rooted-version-guard.md
@@ -1,0 +1,1 @@
+- **[engine]** A version guard written with the rooted spelling — `::RUBY_VERSION`, `::RUBY_ENGINE`, `Gem::Version.new(::RUBY_VERSION)` — now folds exactly as its bare twin does, so the arm that cannot run on the checking Ruby no longer reports. ([#883](https://github.com/rigortype/rigor/pull/883))

--- a/docs/type-specification/control-flow-analysis.md
+++ b/docs/type-specification/control-flow-analysis.md
@@ -255,6 +255,8 @@ The reference values are read from the Ruby running the analyzer, the same premi
 - `RUBY_ENGINE == / != "…"`. Ordering comparisons on an engine name are not version guards and MUST NOT fold.
 - `X::VERSION`, only for constants belonging to a **default gem of the running Ruby**. A gem whose version the project resolves through its own `Gemfile.lock` MUST NOT be read from the analyzer's runtime, because the two copies can differ.
 
+A **rooted** spelling names the same constant its bare twin does — `::` only makes the top-level lookup explicit — so `::RUBY_VERSION`, `::RUBY_ENGINE` and `::X::VERSION` MUST fold exactly as `RUBY_VERSION`, `RUBY_ENGINE` and `X::VERSION` do. This widens no set: a rooted name outside the sets above is as unfoldable as the bare one.
+
 Everything else keeps both arms live, which is always the safe answer: `<=>` (it yields an ordering, not a verdict), `RUBY_PLATFORM` (every comparison against it is platform-dependent by construction, and the checking machine need not be the running machine), `defined?`-style capability probes, `!` / `&&` / `||` compositions, `case` subjects, and a comparison between two bare String literals (a constant comparison, not a version guard). A guard with an unreadable operand is undecidable and both of its arms MUST stay live.
 
 Rationale and the false-positive argument: [ADR-47](../adr/47-narrowing-driven-clause-reachability.md) § WD5.

--- a/lib/rigor/inference/version_guard.rb
+++ b/lib/rigor/inference/version_guard.rb
@@ -48,6 +48,8 @@ module Rigor
     #   with the running Ruby**, where "the analyzer's Ruby is the target's Ruby" already covers them.
     #   A third-party gem's `VERSION` is not read: its version is the project's `Gemfile.lock`'s to say,
     #   and the lockfile is not visible from the inference layer.
+    # * The ROOTED spelling of any of the above — `::RUBY_VERSION`, `::RUBY_ENGINE`, `::Psych::VERSION` —
+    #   names the same constant as its bare twin and folds identically; see {.read_constant}.
     # * `RUBY_PLATFORM` — **never** folded. Every comparison against it is by construction
     #   platform-dependent, and the machine running `rigor` need not be the machine running the program.
     # * `<=>` — never folded (it yields -1/0/1, not a branch verdict), and neither are `defined?(Ractor)`
@@ -68,7 +70,7 @@ module Rigor
 
       # Predefined constants read from the analyzer's runtime, mapped to the operand kind they produce.
       # `:string` operands accept every comparison; `:engine` operands accept equality only.
-      PREDEFINED = { RUBY_VERSION: :string, RUBY_ENGINE: :engine }.freeze
+      PREDEFINED = { "RUBY_VERSION" => :string, "RUBY_ENGINE" => :engine }.freeze
       private_constant :PREDEFINED
 
       # Operand kinds that carry a plain Ruby String, i.e. the ones `Gem::Version.new` may wrap and the
@@ -112,30 +114,37 @@ module Rigor
       def read_operand(node)
         case node
         when Prism::StringNode then [:literal_string, node.unescaped]
-        when Prism::ConstantReadNode then read_predefined(node)
-        when Prism::ConstantPathNode then read_version_constant(node)
+        when Prism::ConstantReadNode, Prism::ConstantPathNode then read_constant(node)
         when Prism::CallNode then read_gem_version(node)
         end
       end
       private_class_method :read_operand
 
-      def read_predefined(node)
-        kind = PREDEFINED[node.name]
+      # Dispatches on the RESOLVED name rather than on the node class. `::RUBY_VERSION` names the very
+      # constant `RUBY_VERSION` names — the leading `::` only makes the top-level lookup explicit — but
+      # Prism spells it as a `ConstantPathNode` with a nil parent, so a node-class dispatch sent it down
+      # the `X::VERSION` path and declined it for not being a curated qualified name. The same program
+      # then had two diagnostic sets for two spellings of one guard
+      # ([#877](https://github.com/rigortype/rigor/issues/877)).
+      #
+      # The foldable set is unchanged and stays closed: an unqualified name folds only when it is one of
+      # {PREDEFINED}, a qualified one only when it is in {VERSION_CONSTANTS}.
+      def read_constant(node)
+        path = Source::ConstantPath.qualified_name_or_nil(node)
+        return nil unless path
+
+        kind =
+          if path.include?("::")
+            :string if VERSION_CONSTANTS.include?(path)
+          else
+            PREDEFINED[path]
+          end
         return nil unless kind
 
-        value = runtime_value(node.name.to_s)
+        value = runtime_value(path)
         value && [kind, value]
       end
-      private_class_method :read_predefined
-
-      def read_version_constant(node)
-        path = Source::ConstantPath.qualified_name_or_nil(node)
-        return nil unless path && VERSION_CONSTANTS.include?(path)
-
-        value = runtime_value(path)
-        value && [:string, value]
-      end
-      private_class_method :read_version_constant
+      private_class_method :read_constant
 
       # `Gem::Version.new(<readable>)`. The inner operand must be a plain version String — an engine name
       # is not a version, and `Gem::Version.new` raises on anything `Gem::Version.correct?` rejects, so a

--- a/spec/rigor/analysis/check_rules/dead_version_guard_arms_spec.rb
+++ b/spec/rigor/analysis/check_rules/dead_version_guard_arms_spec.rb
@@ -207,5 +207,68 @@ RSpec.describe "dead version-guard arms" do
       expect(verdict_for('Foo::VERSION >= "3.1"')).to be_nil
       expect(verdict_for("defined?(Ractor)")).to be_nil
     end
+
+    # issue #877 — `::` only makes the top-level lookup explicit, so each rooted spelling must answer what
+    # its bare twin answers. Prism spells the root as a path node, which used to route these to the curated
+    # `X::VERSION` tier and decline them.
+    describe "the rooted spelling" do
+      it "decides the rooted twin of every bare case" do
+        expect(verdict_for('::RUBY_VERSION >= "0.0"')).to eq(:truthy)
+        expect(verdict_for('::RUBY_VERSION >= "99.0"')).to eq(:falsey)
+        expect(verdict_for('::RUBY_ENGINE == "jruby"')).to eq(:falsey)
+        expect(verdict_for('::RUBY_ENGINE != "jruby"')).to eq(:truthy)
+        expect(verdict_for('::Psych::VERSION >= "0.0"')).to eq(:truthy)
+      end
+
+      it "reaches the Gem::Version wrapping through a rooted inner operand" do
+        expect(verdict_for('Gem::Version.new(::RUBY_VERSION) < Gem::Version.new("2.7")')).to eq(:falsey)
+        expect(verdict_for('::Gem::Version.new(::RUBY_VERSION) >= ::Gem::Version.new("2.7")')).to eq(:truthy)
+      end
+
+      # must-still-fire: the set stays closed, so a rooted name outside it is as unfoldable as the bare one
+      it "declines a rooted constant outside the foldable set" do
+        expect(verdict_for('::Foo::VERSION >= "3.1"')).to be_nil
+        expect(verdict_for('::RUBY_PLATFORM == "java"')).to be_nil
+        expect(verdict_for('::RUBY_ENGINE > "jruby"')).to be_nil
+      end
+    end
+  end
+
+  # The issue's own repro: the rooted arm reported while its bare twin was silent.
+  describe "the rooted repro (#877)" do
+    def undefined_method_diagnostics(source)
+      diagnostics_for(source).select { |d| d.rule == "call.undefined-method" }
+    end
+
+    it "elides the dead arm of a rooted guard, as it does the bare one" do
+      source = <<~RUBY
+        def bare
+          "abc".frobnicate_bare if RUBY_VERSION < "2.7."
+        end
+
+        def rooted
+          "abc".frobnicate_rooted if ::RUBY_VERSION < "2.7."
+        end
+
+        def rooted_engine
+          "abc".frobnicate_rengine if ::RUBY_ENGINE == "jruby"
+        end
+
+        def rooted_gem_version
+          "abc".frobnicate_gem if Gem::Version.new(::RUBY_VERSION) < Gem::Version.new("2.7")
+        end
+      RUBY
+      expect(undefined_method_diagnostics(source)).to be_empty
+    end
+
+    # discrimination — the same call in a LIVE rooted arm still reports
+    it "still reports the call when the rooted guard is live" do
+      diags = undefined_method_diagnostics(<<~RUBY)
+        def live
+          "abc".frobnicate_live if ::RUBY_VERSION > "2.7."
+        end
+      RUBY
+      expect(diags.map(&:method_name)).to eq(["frobnicate_live"])
+    end
   end
 end


### PR DESCRIPTION
`Inference::VersionGuard` folded `RUBY_VERSION` / `RUBY_ENGINE` comparisons only in the bare spelling. `read_operand` dispatched on the Prism node class, and Prism spells `::RUBY_VERSION` as a `ConstantPathNode` with a nil parent — so the rooted spelling of a predefined constant took the curated `X::VERSION` route and was declined for not being in that set. The same program, two spellings of one constant, two diagnostic sets.

Before (on the issue's repro):

```
7:9  error: undefined method `frobnicate_rooted' for "abc"
15:9 error: undefined method `frobnicate_rengine' for "abc"
19:9 error: undefined method `frobnicate_gem' for "abc"
```

After: `No diagnostics` — each rooted arm is elided exactly as its bare twin already was.

The fix dispatches on the RESOLVED name (`Source::ConstantPath.qualified_name_or_nil`): an unqualified name folds when it is one of `PREDEFINED`, a qualified one when it is in `VERSION_CONSTANTS`. The foldable set is unchanged and stays closed — `::Foo::VERSION` and `::RUBY_PLATFORM` are as unfoldable as their bare twins, which the specs pin as must-still-decline controls. The `Gem::Version.new(::RUBY_VERSION)` wrapping reaches the rooted operand through the recursion `read_gem_version` already used.

`docs/type-specification/control-flow-analysis.md`'s version-guard section gains the normative sentence that the rooted spelling names the same constant and folds identically.

Byte-identity: `rigor check --format json --no-cache --workers 0` over `lib plugins/*/lib examples/*/lib` before/after is identical apart from the `stats` timings — this repo carries no rooted version guard, so the change is inert here and only moves the reported set on code that writes one.

Closes #877