### PR TITLE
Correct the coverage-gate threshold in two summary lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,8 +494,8 @@ jobs:
           echo "rigor self-check found errors — see diagnostic output above"
           exit 1
 
-      # Precision gate: `rigor coverage --threshold 0.57 lib` fails when the
-      # type-inference precision ratio on Rigor's own source drops below 57 %.
+      # Precision gate: `rigor coverage --threshold 0.58 lib` fails when the
+      # type-inference precision ratio on Rigor's own source drops below 58 %.
       # See the Makefile's `coverage` target for how that number is calibrated.
       # The cold variant runs this so the gate exercises the full analysis path
       # without any cached assistance; the warm variant skips it to avoid

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ check-json:
 	bundle exec exe/rigor check --format=json lib
 
 # Report type-precision coverage for `lib/`.
-# Exits non-zero when the precision ratio drops below 57 %.
+# Exits non-zero when the precision ratio drops below 58 %.
 #
 # Recalibrated 2026-08-31. The original 43 % was measured on 2026-05-26 and
 # never moved; by v0.3.6 `lib` read 58.96 %, so the gate carried ~16 points


### PR DESCRIPTION
Found while attributing `Self-check (cold)`'s runtime.

The precision gate has run at `--threshold 0.58` since the 2026-09-01 re-pin for #513 + #523. The Makefile's calibration record describes that re-pin correctly ("The threshold shifts by the same ~0.8 points to keep the calibrated margin unchanged"), but neither one-line summary above it was updated with it:

- `Makefile:191` — "Exits non-zero when the precision ratio drops below 57 %", three lines above `--threshold 0.58`
- `.github/workflows/ci.yml:497-498` — quotes the command as `rigor coverage --threshold 0.57 lib` and the bound as 57 %

Both are the first thing a reader checks, and both disagreed with the command directly beneath them.

Comment-only. `make coverage` exits 0 at 0.58, and the Makefile still parses (`make coverage` and `make docs-check` both ran from it after the edit); `git diff --check` clean.

## Separate observation, not acted on here

The local ratio now reads **61.84 %** against a 58 % gate. The calibration record was written against `master 58.98` and says the margin "leaves ~2 points, about two years of that drift"; at 61.84 the margin is ~3.8 points, so the gate is drifting back toward the slack the 2026-08-31 recalibration existed to remove. That is a deliberate re-baselining decision rather than a drift fix, and the number should be taken from CI Linux rather than a local run, so it is left alone here.

No changelog fragment: comments only, ships nothing to users.
