### PR TITLE
Lift the four acceptance gates off the self-check matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,14 +494,42 @@ jobs:
           echo "rigor self-check found errors — see diagnostic output above"
           exit 1
 
+  # ── 4b. Acceptance gates over a cold analysis ───────────────────
+  # Four gates that each need a full, uncached analysis and are otherwise
+  # unrelated to one another. They used to be steps on the self-check matrix
+  # guarded by `if: matrix.cache == 'cold'`, on the stated grounds that their
+  # results are deterministic and need no warm/cold cross-check — which is
+  # precisely why they do not belong to that matrix. Parked there they made a
+  # job named "Self-check (cold)" spend 17% of itself on the self-check and
+  # 83% on this, serialised: 27s of check against 23s + 12s + 74s + 22s of
+  # gates, for a 164-196s job while its warm sibling finished in 44s.
+  #
+  # As their own job the four still run once, still against a fresh checkout
+  # with no `.rigor/cache` to restore from (which is all "cold" ever meant
+  # here), and no longer sit behind the self-check. One job rather than four
+  # because ~137s already clears the Tests matrix's ~180s floor; split it
+  # further only if that floor moves.
+  acceptance-gates:
+    name: Acceptance gates (cold analysis)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0"
+          bundler-cache: true
+
       # Precision gate: `rigor coverage --threshold 0.58 lib` fails when the
       # type-inference precision ratio on Rigor's own source drops below 58 %.
       # See the Makefile's `coverage` target for how that number is calibrated.
-      # The cold variant runs this so the gate exercises the full analysis path
-      # without any cached assistance; the warm variant skips it to avoid
-      # double-counting in CI time.
       - name: Run precision coverage gate
-        if: matrix.cache == 'cold'
         run: make coverage
 
       # Plugin-contract gate (ADR-43): the bundled plugin / example LIB
@@ -509,10 +537,8 @@ jobs:
       # resolution makes a plugin's inherited contract calls
       # (`manifest.…`, `io_boundary.…`) resolve against `Plugin::Base`'s
       # RBS, so misuse of the contract surface surfaces here as
-      # `call.undefined-method`. Cold variant only — the result is
-      # deterministic and needs no warm/cold cross-check.
+      # `call.undefined-method`.
       - name: Run plugin-contract check
-        if: matrix.cache == 'cold'
         run: make check-plugins
 
       # Incremental-analysis acceptance gate (ADR-46): the incremental
@@ -520,9 +546,9 @@ jobs:
       # `--verify-incremental` re-analyzes a subset and serves the rest
       # from the per-file cache, then asserts the merge equals a full
       # `--no-cache` analysis — a mismatch would mean a stale, manufactured
-      # diagnostic. Cold variant only; the result is deterministic.
+      # diagnostic. The longest of the four at ~74s: it runs roughly three
+      # analyses per target, over two targets.
       - name: Run incremental-analysis gate
-        if: matrix.cache == 'cold'
         run: make check-incremental
 
       # Mutation-cache acceptance gate (#134 slice 3): the per-file
@@ -532,10 +558,8 @@ jobs:
       # it — the number the cache serves is the number `--threshold` gates
       # a build on. The gate also asserts the warm arm really was served
       # from cache, so it cannot pass vacuously the day the cache disables
-      # itself. Cold variant only, like the gate above: deterministic, and
-      # it warms its own snapshot.
+      # itself. It warms its own snapshot.
       - name: Run mutation-cache gate
-        if: matrix.cache == 'cold'
         run: make check-mutation-cache
 
   # ── 5. Warm-vs-cold diagnostic diff ─────────────────────────────
@@ -617,7 +641,7 @@ jobs:
   # gated without touching protection rules.
   required:
     name: CI required
-    needs: [changes, test, shard-coverage, excluded-specs, rbs-compat, lint, self-check, self-check-diff, self-check-bleeding-edge]
+    needs: [changes, test, shard-coverage, excluded-specs, rbs-compat, lint, self-check, self-check-diff, self-check-bleeding-edge, acceptance-gates]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -632,6 +656,7 @@ jobs:
           SELF_CHECK_RESULT: ${{ needs.self-check.result }}
           SELF_CHECK_DIFF_RESULT: ${{ needs.self-check-diff.result }}
           SELF_CHECK_BLEEDING_EDGE_RESULT: ${{ needs.self-check-bleeding-edge.result }}
+          ACCEPTANCE_GATES_RESULT: ${{ needs.acceptance-gates.result }}
         run: |
           failed=0
           # Change detection must always succeed — it is what decides
@@ -642,7 +667,7 @@ jobs:
           fi
           # A gated job that was skipped (Markdown-only PR) is acceptable;
           # only an outright failure or cancellation blocks the merge.
-          for job_result in "$TEST_RESULT" "$SHARD_COVERAGE_RESULT" "$EXCLUDED_SPECS_RESULT" "$RBS_COMPAT_RESULT" "$LINT_RESULT" "$SELF_CHECK_RESULT" "$SELF_CHECK_DIFF_RESULT" "$SELF_CHECK_BLEEDING_EDGE_RESULT"; do
+          for job_result in "$TEST_RESULT" "$SHARD_COVERAGE_RESULT" "$EXCLUDED_SPECS_RESULT" "$RBS_COMPAT_RESULT" "$LINT_RESULT" "$SELF_CHECK_RESULT" "$SELF_CHECK_DIFF_RESULT" "$SELF_CHECK_BLEEDING_EDGE_RESULT" "$ACCEPTANCE_GATES_RESULT"; do
             if [[ "$job_result" != "success" && "$job_result" != "skipped" ]]; then
               echo "A required job did not succeed (result: $job_result)"
               failed=1


### PR DESCRIPTION
Third in the line that started with [#863](https://github.com/rigortype/rigor/pull/863), and the same shape as it: work parked on one arm of a matrix it has nothing to do with.

## The measurement

Attributing `Self-check (cold)`'s runtime by step, over four runs:

| step | median | share |
| --- | --- | --- |
| setup (job + checkout + Ruby) | 7s | 4% |
| **Run rigor self-check** | 27–31s | **17%** |
| upload artifact | 1s | — |
| Run precision coverage gate (`make coverage`) | 23–26s | 15% |
| Run plugin-contract check (`make check-plugins`) | 12s | 7% |
| **Run incremental-analysis gate** (`make check-incremental`) | **70–78s** | **43%** |
| Run mutation-cache gate (`make check-mutation-cache`) | 22–24s | 14% |

A job named "Self-check (cold)" spent 17% of itself on the self-check. The other four steps carried `if: matrix.cache == 'cold'` with the rationale written next to them — *"the result is deterministic and needs no warm/cold cross-check"* — which is precisely the reason they are not part of that matrix. Parked there they ran serialised behind the check, making the job 164–196s against its warm sibling's 44s, and co-critical with the Tests matrix.

## What changes

The four move to `acceptance-gates`, a peer job. They still run exactly once, and still against a fresh checkout with no `.rigor/cache` to restore from — which is all "cold" ever meant for them, since only the self-check arm has a cache step at all. Nothing about what any gate asserts changes.

Expected: `Self-check (cold)` → ~35s, `acceptance-gates` → ~137s, and the workflow's critical path returns to the Tests matrix at ~180s.

One job rather than four, because ~137s already clears that ~180s floor. Splitting `check-incremental` out on its own is the obvious next cut if the floor ever moves, and it is the only one big enough to be worth it — it runs roughly three analyses per target over two targets, which is its designed cost rather than waste.

## Measured result — and a correction

CI on this branch ([run 34320953163](https://github.com/rigortype/rigor/actions/runs/34320953163), green):

| job | before | after |
| --- | --- | --- |
| Self-check (cold) | 164–196s | **40s** |
| Acceptance gates | — | 121s |
| Self-check (warm) | 44s | 55s |
| Tests shard 1 (critical path) | 176–182s | 180s |
| workflow wall | 220s | 227s |

The job split does what it claimed — `Self-check (cold)` drops 76% and the four gates land at 121s, both well under the Tests matrix.

**The ~20s of wall time this PR predicted did not materialise, and would not have.** That estimate came from the runs where `Self-check (cold)` measured 184–196s. On the run I actually sized the workflow against it was 164s — already below Tests' 182s — so the wall was Tests-bound before this change and is Tests-bound after it. 220s → 227s is noise in both directions. Anyone reading this later should take the wall-clock number as unchanged.

What is real is the structural part: a 164s serial chain that had accumulated five unrelated steps is gone, `Self-check (cold)` means what its name says, and the three largest non-Tests jobs (154s, 121s, 76s) are now positioned to fall with the Tests floor instead of one chain being pinned above it.

## Verification

`make docs-check` green and `git diff --check` clean, exit codes read unpiped; the workflow parses and the job graph was checked (`required.needs` and the fan-in's result loop both carry `acceptance-gates`). Full `make verify` skipped deliberately: the change is workflow-only and moves four unmodified `make` targets between jobs, which this PR's own CI exercises directly.

No changelog fragment: CI-internal, ships nothing to users.

