### PR TITLE
Guard the registry's manifest reads at construction

### DIFF
--- a/changelog.d/fixed/fix-806-registry-manifest-guard.md
+++ b/changelog.d/fixed/fix-806-registry-manifest-guard.md
@@ -1,0 +1,1 @@
+- **[plugins]** A plugin whose manifest cannot be read no longer aborts the run during environment construction: it is reported as a single plugin load error naming the plugin, and analysis continues over the plugins that loaded ([#890](https://github.com/rigortype/rigor/pull/890))

--- a/docs/internal-spec/plugin.md
+++ b/docs/internal-spec/plugin.md
@@ -843,8 +843,10 @@ A subclass overrides one method:
   no-op.
 
 The engine aggregates every loaded plugin's resolvers — in
-**plugin-registration order** (`Registry#type_node_resolvers` flat-maps
-across plugins) — into a single `Rigor::TypeNode::ResolverChain`, which
+**plugin-registration order** (`Registry#type_node_resolvers`, compiled
+at registry construction from the same guarded manifest read its
+`compile_aggregates` siblings use) — into a single
+`Rigor::TypeNode::ResolverChain`, which
 consults them in order and returns the **first non-`nil`** answer. The
 chain is composed once per `Analysis::Runner.run`; when no plugin
 contributes a resolver the engine short-circuits (no `NameScope` is
@@ -881,7 +883,7 @@ and exposed as `Analysis::Runner#plugin_registry`.
 | `#plugins` | Loaded `Rigor::Plugin::Base` instances in deterministic order. |
 | `#ids` | `Array<String>` of manifest ids, parallel to `#plugins`. |
 | `#find(id)` | Lookup by id; `nil` when absent. |
-| `#load_errors` | `Array<Rigor::Plugin::LoadError>` collected during loading. |
+| `#load_errors` | `Array<Rigor::Plugin::LoadError>` collected during loading, followed by any raised by a plugin's manifest read at registry construction. |
 | `#empty?` / `#any_load_errors?` | Predicates. |
 
 `Registry::EMPTY` is the singleton frozen empty registry the
@@ -968,7 +970,20 @@ genuinely mixed installations that anchoring cannot see.
 ## Failure isolation (per ADR-2 § "Plugin Trust and I/O Policy")
 
 Loading runs every plugin entry independently; a failure on one
-entry does not abort the others. Each failure is collected as a
+entry does not abort the others. Registry construction then reads
+each loaded plugin's manifest once, behind the same per-plugin
+isolation: a plugin whose `#manifest` raises contributes nothing to
+the construction-time aggregates (`type_node_resolvers`,
+`open_receivers`, `additional_initializers`) and its raise is
+collected as a further `LoadError` — appended after the loader's own,
+and referring to the plugin CLASS, since `manifest.id` is exactly what
+could not be read. Aggregating there rather than on demand is
+load-bearing: `Environment#build_name_scope` demands
+`Registry#type_node_resolvers` during Environment construction, which
+nothing rescues, so a lazy read would abort the run rather than
+degrade it.
+
+Each failure is collected as a
 `LoadError` on the resulting registry, then surfaced by
 `Analysis::Runner#run` as an `:error` `Diagnostic` with:
 

--- a/lib/rigor/plugin/registry.rb
+++ b/lib/rigor/plugin/registry.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require_relative "blueprint"
+# Issue #806 — {Registry#guarded_manifest} constructs one. `Rigor::Plugin::LoadError` MUST be defined by
+# then: an unresolved bare `LoadError` in this lexical scope silently falls back to Ruby's own ::LoadError.
+require_relative "load_error"
 
 module Rigor
   module Plugin
@@ -229,11 +232,14 @@ module Rigor
       #   {.materialize} carries none (the provenance surface runs only on the coordinator).
       def initialize(plugins: [], load_errors: [], blueprints: [], resolved_gem_paths: {})
         @plugins = plugins.dup.freeze
-        @load_errors = load_errors.dup.freeze
         @blueprints = blueprints.dup.freeze
         @resolved_gem_paths = resolved_gem_paths.dup.freeze
         @contribution_index = ContributionIndex.new(@plugins)
-        compile_aggregates
+        # Issue #806 — every manifest the construction-time aggregates need is read ONCE here, behind a
+        # per-plugin rescue, and a plugin that raises joins `load_errors` instead of taking the run down.
+        manifest_errors = []
+        compile_aggregates(@plugins.map { |plugin| guarded_manifest(plugin, manifest_errors) })
+        @load_errors = (load_errors + manifest_errors).freeze
         # ADR-52 WD4 — the single engine-owned node-rule walk, compiled once per run from the node-rule
         # plugin subset (registry order). The runner reuses it for every file; it builds fresh per-file
         # state internally, so it is safe to freeze and share.
@@ -306,9 +312,14 @@ module Rigor
       # in plugin registration order. `Environment#build_name_scope` builds a `TypeNode::ResolverChain` from
       # this list (environment.rb). The first non-nil `#resolve(node, scope)` return wins per ADR-13 WD3 /
       # WD5 — registration order is the user's lever.
-      def type_node_resolvers
-        plugins.flat_map { |plugin| plugin.manifest.type_node_resolvers }
-      end
+      #
+      # Issue #806 — compiled at construction alongside its `compile_aggregates` siblings, and for a second
+      # reason beyond theirs: `Environment#build_name_scope` demands it during Environment CONSTRUCTION, so
+      # the previous per-call `plugin.manifest` read had no rescue above it anywhere — a plugin raising here
+      # aborted every `Environment.for_project`, i.e. the whole run, before any seam could record it. The
+      # guard has to sit at registry construction because that is the last point at which a failure can still
+      # join `load_errors` (the registry freezes immediately after).
+      attr_reader :type_node_resolvers
 
       # ADR-20 slice 6 — aggregate every loaded plugin's manifest-declared HKT registrations + definitions
       # into a single `Inference::HktRegistry` overlay that `Environment#hkt_registry` merges on top of the
@@ -419,10 +430,14 @@ module Rigor
       # compiled once at construction (the registry is frozen, so the flat_map-on-every-call versions
       # re-derived an invariant). `@contracts_by_path` is a mutable per-path memo inside the frozen registry
       # — safe because the contract set and the glob semantics are fixed for the lifetime of the run.
-      def compile_aggregates
-        @additional_initializers = @plugins.flat_map { |p| safe_manifest(p)&.additional_initializers || [] }.freeze
-        @open_receivers = @plugins.flat_map { |p| (safe_manifest(p)&.open_receivers || []).map(&:to_s) }.uniq.freeze
+      #
+      # @param manifests — one entry per plugin, positionally aligned with `@plugins`;
+      #   nil where {#guarded_manifest} caught a raising manifest read.
+      def compile_aggregates(manifests)
+        @additional_initializers = manifests.flat_map { |m| m&.additional_initializers || [] }.freeze
+        @open_receivers = manifests.flat_map { |m| (m&.open_receivers || []).map(&:to_s) }.uniq.freeze
         @open_receivers_set = @open_receivers.to_set.freeze
+        @type_node_resolvers = manifests.flat_map { |m| m&.type_node_resolvers || [] }.freeze
         @protocol_contracts = @plugins.flat_map { |p| safe_protocol_contracts(p) }.freeze
         @contracts_by_path = {}
         @effect_memo = {}
@@ -463,6 +478,21 @@ module Rigor
       def safe_manifest(plugin)
         plugin.manifest
       rescue StandardError
+        nil
+      end
+
+      # Issue #806 — {#safe_manifest} with a receipt. The construction-time aggregates degraded silently
+      # when a manifest read raised, so a plugin that contributed nothing looked identical to a plugin that
+      # was never asked; the load-error channel is where "a plugin could not be loaded" already lives, and
+      # `Analysis::Runner` turns each entry into one `plugin_loader.load-error` row naming the plugin. The
+      # plugin ref is the CLASS, not `manifest.id`: the manifest is the surface that just failed.
+      def guarded_manifest(plugin, errors)
+        plugin.manifest
+      rescue StandardError => e
+        errors << LoadError.new(
+          "plugin #{plugin.class} raised while reading its manifest: #{e.class}: #{e.message}",
+          plugin_ref: plugin.class.to_s, cause: e
+        )
         nil
       end
 

--- a/spec/rigor/plugin/registry_spec.rb
+++ b/spec/rigor/plugin/registry_spec.rb
@@ -144,6 +144,49 @@ RSpec.describe Rigor::Plugin::Registry do
       registry = described_class.new(plugins: [ts])
       expect(registry.type_node_resolvers).to eq([pick, omit])
     end
+
+    # Issue #806 — the reader is demanded from `Environment#build_name_scope` during Environment
+    # CONSTRUCTION, where nothing rescues; before the guard a raising manifest aborted the whole run.
+    describe "a plugin whose manifest read raises (#806)" do
+      # A `Plugin::Base` subclass that never declared a manifest — `Base.manifest` with no fields raises
+      # `ArgumentError`. This is the shape the loader's own validation is supposed to keep out, which is
+      # why the defect is latent rather than reachable from a `.rigor.yml` today.
+      let(:manifest_less_plugin_class) { Class.new(Rigor::Plugin::Base) }
+
+      let(:registry) do
+        healthy = build_plugin("ts-utilities", [resolver], services)
+        described_class.new(plugins: [manifest_less_plugin_class.new(services: services), healthy])
+      end
+      let(:resolver) { resolver_class.new }
+
+      it "does not raise, and still aggregates the healthy plugins' resolvers" do
+        expect { registry }.not_to raise_error
+        expect(registry.type_node_resolvers).to eq([resolver])
+      end
+
+      it "records the failure on the load-error channel, naming the plugin" do
+        expect(registry).to be_any_load_errors
+        error = registry.load_errors.last
+        expect(error).to be_a(Rigor::Plugin::LoadError)
+        expect(error.plugin_ref.to_s).to eq(manifest_less_plugin_class.to_s)
+        expect(error.message).to include("raised while reading its manifest", "ArgumentError")
+        expect(error.cause_class).to eq(ArgumentError)
+      end
+
+      it "keeps the loader's own errors ahead of the manifest ones" do
+        loader_error = Rigor::Plugin::LoadError.new("boom", plugin_ref: "rigor-earlier")
+        registry = described_class.new(
+          plugins: [manifest_less_plugin_class.new(services: services)], load_errors: [loader_error]
+        )
+
+        expect(registry.load_errors.map(&:plugin_ref).map(&:to_s))
+          .to eq(["rigor-earlier", manifest_less_plugin_class.to_s])
+      end
+
+      it "lets Environment construct over it (the #806 crash site)" do
+        expect { Rigor::Environment.new(plugin_registry: registry) }.not_to raise_error
+      end
+    end
   end
 
   describe "#signature_paths (ADR-25)" do


### PR DESCRIPTION
Fixes #806

`Plugin::Registry#type_node_resolvers` did `plugins.flat_map { |plugin| plugin.manifest.type_node_resolvers }` on every call, and one of its callers is `Environment#build_name_scope` — reached from `Environment#initialize`, where nothing rescues. A plugin whose manifest read raised therefore aborted every `Environment.for_project`, i.e. the whole run, before any seam could record anything. Its siblings in `compile_aggregates` (`open_receivers`, `additional_initializers`) all went through the rescued `safe_manifest`; this reader did not.

## The premise, checked against the code

The issue was AI-filed during triage, so I verified it before fixing. It holds, with one correction worth recording: the raise cannot come from `Manifest#type_node_resolvers` itself (a frozen `attr_reader`), only from `plugin.manifest` — an instance-level `#manifest` override, or a `Plugin::Base` subclass that never declared one, where `Base.manifest` raises `ArgumentError`. The unguarded read is real; the issue's "manifest raises from `type_node_resolvers`" phrasing is one level off.

The IoBoundary / stale-cache angle (#630) does **not** apply here. A plugin manifest is an in-memory `Manifest` object cached on the plugin class at class-definition time, not a file read, so there is no I/O to route through the boundary and no cache dependency to record. Nothing to follow up.

## The fix

Read every plugin's manifest **once** at registry construction, behind a per-plugin rescue, and compile `type_node_resolvers` from that result alongside its `compile_aggregates` siblings. Construction is the last point at which a failure can still join `load_errors` (the registry freezes immediately after), and `load_errors` is the channel that already owns "a plugin could not be loaded" — `Analysis::Runner` turns each entry into one `plugin_loader.load-error` row on `.rigor.yml`. The entry names the plugin **class** rather than `manifest.id`, because the manifest is the surface that just failed. Loader errors keep their position ahead of manifest ones.

That also closes the silent half of the old behaviour: a plugin whose manifest raised contributed nothing to the other aggregates and looked identical to a plugin that was never asked.

## Verification

Four new examples in `spec/rigor/plugin/registry_spec.rb`, over a `Plugin::Base` subclass that never declared a manifest. Mutation-verified by restoring `lib/rigor/plugin/registry.rb` from `HEAD` with the spec left in place: **4/4 fail**, and the last one fails with exactly the reported stack — `registry.rb:310` → `environment.rb:746` (`build_name_scope`) → `environment.rb:102` (`Environment#initialize`).

`docs/internal-spec/plugin.md` is updated in the same commit: the `type_node_resolvers` aggregation paragraph, the `Registry#load_errors` row, and the "Failure isolation" section now state that registry construction reads each manifest under the same per-plugin isolation.

## Residue deliberately left

`Registry#find`, `#ids`, `#source_rbs_synthesizers` and `CLI::PluginsCommand#plugin_matches_entry?` still read `plugin.manifest` unguarded. None of them runs during Environment construction, so none has #806's blast radius, and guarding them is a behaviour question of its own (what should `ids` return for a plugin with no readable id?). Out of scope here.
