### PR TITLE
Publish the cache schema marker by rename

### DIFF
--- a/changelog.d/fixed/fix-807-marker-write-race.md
+++ b/changelog.d/fixed/fix-807-marker-write-race.md
@@ -1,0 +1,1 @@
+- **[cache]** Two `rigor check` processes sharing one `.rigor/cache` no longer race each other's schema-version marker, so neither clears the cache root out from under the other or fails with `Errno::ENOENT` ([#891](https://github.com/rigortype/rigor/pull/891)).

--- a/docs/internal-spec/cache.md
+++ b/docs/internal-spec/cache.md
@@ -431,7 +431,12 @@ A read encountering any of the following silently returns a
 cache miss; the producer block reruns and the next write
 overwrites the bad entry:
 
-- Missing entry file.
+- Missing entry file — including one that disappears between
+  the existence check and the open (`Errno::ENOENT`), which is
+  what a concurrent process clearing or compacting the root
+  looks like. Every other `SystemCallError` (permission, I/O)
+  still raises: a broken filesystem must stay visible rather
+  than degrade into an endless recompute.
 - Entry shorter than the minimum envelope (header + trailer).
 - Mismatched magic + format-version header.
 - Mismatched trailing SHA-256.
@@ -462,6 +467,15 @@ with different semantics for a writable vs. a read-only store:
 **Writable store:**
 
 - Marker missing → write the current value, proceed. Disk available.
+- Marker present but EMPTY → treated exactly as missing: write the
+  current value, proceed, keep the entries. Disk available.
+  Emptiness carries no information — it is what a torn in-place
+  write looks like, what a crash between the create and the write
+  leaves behind, and what the clear-then-rewrite below itself passes
+  through — and destroying a cache root is the wrong answer to an
+  ambiguous signal. Declining grants the entries no trust they did
+  not already have, since a missing marker over existing entries is
+  kept and served by the rule above.
 - Marker matches → proceed. Disk available.
 - Marker disagrees → wipe every entry under `<root>` (`unlink` every
   child via `FileUtils.rm_rf`), rewrite the marker, and proceed as if
@@ -529,6 +543,15 @@ a fully committed entry, never a torn write — POSIX guarantees
 a brief window where the destination file exists but is empty
 (between `O_CREAT` and the first successful `rename`) treats it
 as a cache miss per the read fault-tolerance rules above.
+
+`schema_version.txt` is published by steps 3–5 alone — the same
+temp-file-then-rename, without the destination lock. It needs the
+atomicity: its reader is another process's `Store` constructor,
+which takes no lock, and a reader that saw a truncated marker
+would conclude the marker disagreed and clear the root under a
+sibling mid-read. It does not need the lock: every writer of the
+marker writes the same value, so there is no last-writer-wins
+question to settle.
 
 ### File format
 

--- a/lib/rigor/cache/store.rb
+++ b/lib/rigor/cache/store.rb
@@ -394,10 +394,22 @@ module Rigor
 
       # Reads and validates one entry file. Any failure (missing, short, bad magic, bad version, bad
       # checksum, unmarshal-able) returns nil so the caller treats it as a cache miss.
+      #
+      # The `ENOENT` rescue covers the gap between the existence check and the open: a concurrent process
+      # compacting or clearing the root can unlink the file in between, and a file that is gone reads as the
+      # same miss the existence check above already reports for one that was never there (issue #807). It is
+      # deliberately narrow — every other `SystemCallError` (a permission error, an I/O error) still raises,
+      # so a genuinely broken filesystem stays visible instead of degrading into an endless recompute. A
+      # present-but-corrupt file is not touched by this either: it still goes through the envelope and
+      # payload checks below.
       def read_entry(path, deserialize: nil)
         return nil unless File.file?(path)
 
-        bytes = File.binread(path)
+        begin
+          bytes = File.binread(path)
+        rescue Errno::ENOENT
+          return nil
+        end
         return nil unless envelope_valid?(bytes)
 
         body = bytes.byteslice(HEADER.bytesize, bytes.bytesize - HEADER.bytesize - 32)
@@ -486,19 +498,31 @@ module Rigor
       def atomically_replace(path, body)
         File.open(path, File::RDWR | File::CREAT, 0o644) do |lock_fd|
           lock_fd.flock(File::LOCK_EX)
-          tmp = "#{path}.tmp.#{Process.pid}.#{SecureRandom.hex(4)}"
-          begin
-            File.open(tmp, "wb") do |f|
-              f.write(body)
-              f.fsync
-            end
-            File.rename(tmp, path)
-          ensure
-            # A failed write/rename must not leak its temp file — rely on the 1-hour `cleanup_stale_temp_files`
-            # sweep only as a backstop for crashes that skip this ensure entirely.
-            unlink_entry(tmp) if File.exist?(tmp)
-          end
+          publish_by_rename(path, body)
           fsync_directory(File.dirname(path))
+        end
+      end
+
+      # The rename-into-place half of {#atomically_replace}, without the destination lock: writes `body` to a
+      # sibling temp file, fsyncs it, and renames it over `path`. POSIX makes the rename atomic within one
+      # filesystem, so an unlocked concurrent reader sees either the previous contents in full or the new
+      # ones in full — never a truncated or half-written file.
+      #
+      # {#repair_writable_marker!} uses this half alone. It needs the atomicity (its reader is another
+      # process's constructor, which does not lock) but not the ordering a lock would buy: every writer of
+      # `schema_version.txt` writes the same value, so there is no last-writer-wins question to settle.
+      def publish_by_rename(path, body)
+        tmp = "#{path}.tmp.#{Process.pid}.#{SecureRandom.hex(4)}"
+        begin
+          File.open(tmp, "wb") do |f|
+            f.write(body)
+            f.fsync
+          end
+          File.rename(tmp, path)
+        ensure
+          # A failed write/rename must not leak its temp file — rely on the 1-hour `cleanup_stale_temp_files`
+          # sweep only as a backstop for crashes that skip this ensure entirely.
+          unlink_entry(tmp) if File.exist?(tmp)
         end
       end
 
@@ -530,23 +554,46 @@ module Rigor
         false
       end
 
+      # The marker is PUBLISHED BY RENAME rather than written in place. Its reader is another process's
+      # constructor, which takes no lock, so an `O_TRUNC`-then-write would expose a window in which the file
+      # exists and is empty; a reader landing there concludes the marker disagrees and clears the whole cache
+      # root — under, among others, a sibling that is between its own `File.file?` and `File.binread`, which
+      # is the `Errno::ENOENT` of issue #807. Two `rigor check` processes over one fresh `.rigor/cache` are
+      # enough to hit it.
+      #
+      # An EMPTY marker is treated as an ABSENT one — rewritten, never cleared on. Emptiness carries no
+      # information: it is what a torn write by an older Rigor looks like, what a crash between the create
+      # and the write leaves, and what this method's own clear-then-rewrite passes through. Answering an
+      # ambiguous signal by destroying a cache root is the wrong trade, and declining grants the entries
+      # below no trust they did not already have — a marker that is simply MISSING over existing entries is
+      # already kept and served (see the spec's writable-store rules), and `clear_cache_root!` removes the
+      # marker before rewriting it, so it produces that state itself.
       def repair_writable_marker!
         FileUtils.mkdir_p(@root)
         marker = File.join(@root, "schema_version.txt")
         current = self.class.schema_marker_value
 
-        if File.file?(marker)
-          on_disk = File.read(marker).strip
-          return true if on_disk == current
+        on_disk = read_marker(marker)
+        return true if on_disk == current
 
-          clear_cache_root!
-        end
+        clear_cache_root! unless on_disk.nil? || on_disk.empty?
 
         FileUtils.mkdir_p(@root)
-        File.write(marker, "#{current}\n")
+        publish_by_rename(marker, "#{current}\n")
+        fsync_directory(@root)
         true
       rescue StandardError
         false
+      end
+
+      # @return the marker's content, or nil when there is none to read — including the case of a concurrent
+      #   {#clear_cache_root!} removing it between the check and the open.
+      def read_marker(path)
+        return nil unless File.file?(path)
+
+        File.read(path).strip
+      rescue Errno::ENOENT
+        nil
       end
 
       def clear_cache_root!

--- a/spec/rigor/cache/store_spec.rb
+++ b/spec/rigor/cache/store_spec.rb
@@ -612,10 +612,17 @@ RSpec.describe Rigor::Cache::Store do
     it "derives the temp filename's random suffix from SecureRandom.hex(4) (16 hex chars)" do
       allow(SecureRandom).to receive(:hex).and_call_original
       store.fetch_or_compute(producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor) { :v }
-      expect(SecureRandom).to have_received(:hex).with(4)
+      # `at_least`: the marker is published through the same temp-file-then-rename helper, so a single fetch
+      # over a fresh root draws two suffixes. The claim is where the suffix comes from, not how many.
+      expect(SecureRandom).to have_received(:hex).with(4).at_least(:once)
     end
 
     it "leaves no .tmp file behind when the rename itself fails" do
+      # Repair the marker first: it is published by rename too, so an unqualified stub would fail the
+      # constructor's repair and this example would never reach the ENTRY write it is about.
+      store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: { warm: true }, descriptor: descriptor
+      ) { "warm" }
       allow(File).to receive(:rename).and_raise(Errno::ENOSPC)
 
       expect do
@@ -646,6 +653,119 @@ RSpec.describe Rigor::Cache::Store do
         producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
       ) { :should_not_run }
       expect(final).to match(/\Avalue-\d+\z/)
+    end
+  end
+
+  # Issue #807. Constructing a Store repairs `schema_version.txt`, and its reader is another PROCESS's
+  # constructor, which holds no lock. An in-place write let that reader see the file empty, decide the marker
+  # disagreed, and clear the whole cache root — under, among others, a sibling between its own existence
+  # check and its read, which surfaced as `Errno::ENOENT` out of `#read_entry`. Two `rigor check` runs over
+  # one fresh `.rigor/cache` are enough.
+  describe "concurrent marker repair (issue #807)" do
+    # Built once on the main thread and only then handed to the racing threads: `let` memoization is not
+    # thread-safe, so no example may reach `descriptor` from inside one.
+    def reader_over(desc)
+      lambda do |store, n, produce|
+        store.fetch_or_compute(
+          producer_id: "p", generation_cap: :unbounded, params: { n: n }, descriptor: desc
+        ) { "#{produce}-#{n}" }
+      end
+    end
+
+    # Releases `count` threads at once, each constructing its own Store over `root` and then reading every
+    # entry, and collects whatever escaped them.
+    def race_constructors(root, read, entries, count)
+      errors = []
+      mutex = Mutex.new
+      gate = Queue.new
+      threads = Array.new(count) do
+        Thread.new do
+          gate.pop
+          store = described_class.new(root: root)
+          entries.times { |n| read.call(store, n, "recomputed") }
+        rescue StandardError => e
+          mutex.synchronize { errors << e }
+        end
+      end
+      sleep 0.05 # let every thread reach the gate, so the repairs really do coincide
+      count.times { gate << :go }
+      threads.each(&:join)
+      errors
+    end
+
+    it "publishes the marker by rename, so a concurrent reader never sees it empty" do
+      renamed = []
+      allow(File).to receive(:rename).and_wrap_original do |original, from, to|
+        renamed << to
+        original.call(from, to)
+      end
+
+      described_class.new(root: cache_root)
+                     .fetch_or_compute(
+                       producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+                     ) { :v }
+
+      marker = File.join(cache_root, "schema_version.txt")
+      expect(renamed).to include(marker)
+      expect(File.read(marker).strip).to eq(described_class.schema_marker_value)
+      expect(Dir.glob("#{marker}.tmp.*")).to be_empty
+    end
+
+    it "treats an EMPTY marker as a missing one rather than clearing the root" do
+      store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) { :first }
+      key = descriptor.cache_key_for(producer_id: "p", params: {})
+      entry_path = File.join(cache_root, "p", key[0, 2], "#{key[2..]}.entry")
+      File.write(File.join(cache_root, "schema_version.txt"), "")
+
+      result = described_class.new(root: cache_root).fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) { :second }
+
+      expect(File.exist?(entry_path)).to be(true)
+      expect(result).to eq(:first)
+      expect(File.read(File.join(cache_root, "schema_version.txt")).strip)
+        .to eq(described_class.schema_marker_value)
+    end
+
+    it "reads an entry unlinked between the existence check and the open as a miss" do
+      store.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) { :first }
+      fresh = described_class.new(root: cache_root)
+      # What a sibling's `clear_cache_root!` (or an eviction sweep) does to a file this reader has already
+      # stat'd. It must read as the same miss a never-written entry does, not escape as `Errno::ENOENT`.
+      allow(File).to receive(:binread).and_raise(Errno::ENOENT)
+
+      called = 0
+      result = fresh.fetch_or_compute(
+        producer_id: "p", generation_cap: :unbounded, params: {}, descriptor: descriptor
+      ) do
+        called += 1
+        :second
+      end
+
+      expect(called).to eq(1)
+      expect(result).to eq(:second)
+    end
+
+    it "survives many stores constructed over one root left stale by an earlier release" do
+      entries = 250
+      root = File.join(tmpdir, "upgrade-race")
+      read = reader_over(descriptor)
+      seed = described_class.new(root: root)
+      entries.times { |n| read.call(seed, n, "seed") }
+      # Every process starting now finds a stale marker and takes the clear-the-root path, so each one's
+      # clear races the others' reads. Pre-fix this raised `Errno::ENOENT` out of `#read_entry` on 12 of 13
+      # measured runs; the three examples above pin the same fix deterministically.
+      File.write(File.join(root, "schema_version.txt"), "0.0.0.0.0\n")
+
+      errors = race_constructors(root, read, entries, 48)
+
+      expect(errors).to be_empty, "raised: #{errors.map(&:inspect).uniq.first(3).join(', ')}"
+      expect(File.read(File.join(root, "schema_version.txt")).strip)
+        .to eq(described_class.schema_marker_value)
     end
   end
 


### PR DESCRIPTION
Fixes #807

`Store#repair_writable_marker!` runs in the constructor and wrote `schema_version.txt` in place. Its reader is another process's constructor, which takes no lock, so `O_TRUNC`-then-write exposed a window in which the marker exists and is empty. A reader landing there concludes the marker disagrees and calls `clear_cache_root!` — under, among others, a sibling that is between its own `File.file?` and its `File.binread`, which is the `Errno::ENOENT` out of `#read_entry` the issue reports. Two `rigor check` processes over one fresh `.rigor/cache` are enough for it.

## What changed

- **The marker is published by rename.** The temp-file-then-rename half of `#atomically_replace` is extracted as `#publish_by_rename` so there is one implementation, not two. The marker uses that half alone: it needs the atomicity, but not the ordering a destination lock buys, since every writer of the marker writes the same value.
- **An EMPTY marker is treated as an ABSENT one** — rewritten, never cleared on. Emptiness carries no information: it is what a torn in-place write by an older Rigor looks like, what a crash between the create and the write leaves behind, and what `clear_cache_root!` itself passes through on its way to rewriting the marker. Destroying a whole cache root is the wrong answer to an ambiguous signal, and declining grants the entries below no trust they did not already have — the writable-store rules already keep and serve entries under a marker that is simply missing.
- **`#read_entry` tolerates an `ENOENT` between the existence check and the open**, as defence in depth, reading it as the same miss the existence check already reports for a file that was never there. The rescue is deliberately narrow: every other `SystemCallError` still raises, so a permission or I/O error stays visible instead of degrading into an endless recompute, and a present-but-corrupt file is untouched — that still goes through the envelope and payload checks.
- `docs/internal-spec/cache.md` records all three (the writable-store marker rules, the read fault-tolerance list, and the atomicity section).

## Pre-fix repro

Measured, not assumed.

| Probe | Pre-fix | Post-fix |
| --- | --- | --- |
| 12 processes constructing a Store over one FRESH root, 40 rounds (spurious `clear_cache_root!` calls) | 6 clears, in 4/40 rounds | 0 clears, 0/40 rounds |
| New example "survives many stores constructed over one root left stale by an earlier release" | red on 12 of 13 runs, `Errno::ENOENT … .entry` | green 10/10 |
| The three deterministic new examples (rename publication, empty marker, vanished entry) | red every run | green |

The reported CI failure was `Errno::ENOENT` inside `File.binread`; the concurrency example reproduces exactly that signature and backtrace frame.

## Not weakened

`spec/rigor/cache/store_spec.rb`'s existing "does not collide across concurrent writers targeting the same entry" is untouched — still 16 threads, each constructing its own `Store`. Two neighbouring examples were adjusted for the new write path rather than the assertion they make: the `SecureRandom.hex(4)` example now says `at_least(:once)` (one fetch over a fresh root draws two suffixes now that the marker uses the same helper), and the failing-rename example warms the marker before stubbing `File.rename` so the stub still lands on the ENTRY write it names.

`make verify` green; 1218 files inspected, no offenses; no `warning:` in the `check` output.
