### PR TITLE
Ask the scope whether a name is a project class

### DIFF
--- a/changelog.d/fixed/fix-732-known-user-class-unify.md
+++ b/changelog.d/fixed/fix-732-known-user-class-unify.md
@@ -1,0 +1,1 @@
+- **[check]** The Liskov override rules now recognise a parent class whose only project-side content is class methods, so a `sig/`-declared method inherited from such a parent is compared against its override instead of being skipped ([#892](https://github.com/rigortype/rigor/pull/892)).

--- a/lib/rigor/analysis/check_rules.rb
+++ b/lib/rigor/analysis/check_rules.rb
@@ -3191,9 +3191,15 @@ module Rigor
           names
         end
 
+        # Issue #732 — the predicate is asked of the SCOPE, not re-implemented here. This rule kept its own
+        # three-table copy until #723 widened the scope's with `discovered_methods` and left this one behind,
+        # so the two disagreed about exactly one shape (a project class with no instance def, no superclass
+        # and no include — `class Base; def self.build = :built; end`) with nothing observing the fork. #682
+        # made `Scope` the single owner of the candidate ORDER; this makes it the single owner of the
+        # predicate that filters those candidates too.
         def resolve_override_ancestor_name(scope, subclass_qualified, raw_ancestor)
           resolved = scope.ancestor_name_candidates(subclass_qualified, raw_ancestor)
-                          .find { |candidate| known_user_class?(scope, candidate) }
+                          .find { |candidate| scope.known_user_class?(candidate) }
           return resolved if resolved
 
           # ADR-46 slice 3 — the override checker reads the class graph
@@ -3205,12 +3211,6 @@ module Rigor
           # widening picks it up.
           DependencyRecorder.read_missing(:class, raw_ancestor.to_s.split("::").last) if DependencyRecorder.active?
           nil
-        end
-
-        def known_user_class?(scope, name)
-          scope.discovered_superclasses.key?(name) ||
-            scope.discovered_def_nodes.key?(name) ||
-            scope.discovered_includes.key?(name)
         end
 
         def build_override_visibility_diagnostic(path, def_node, parent_class, parent_visibility, override_visibility)

--- a/spec/rigor/analysis/check_rules/override_and_return_type_spec.rb
+++ b/spec/rigor/analysis/check_rules/override_and_return_type_spec.rb
@@ -514,6 +514,33 @@ RSpec.describe "return-type and Liskov override rules", type: :runner do
         RUBY
         expect(vis_diags(result).first&.message).to include("overrides NS::Base#greet")
       end
+
+      # #732 — the resolver asks `Scope#known_user_class?`, it does not re-implement it. The copy this
+      # rule carried read three discovery tables; #723 widened the scope's with a fourth
+      # (`discovered_methods`) and left the copy behind, so a parent whose only project-side content is a
+      # CLASS method resolved to a project class for dispatch and to nothing here — the walk ended before
+      # reaching `Base`, and this reports nothing at all pre-fix.
+      it "resolves a parent whose only project-side content is a class method" do
+        result = analyze(<<~RUBY, sig: { "demo.rbs" => <<~RBS })
+          class Base
+            def self.build = :built
+          end
+
+          class Sub < Base
+            def name = 42
+          end
+        RUBY
+          class Base
+            def self.build: () -> Symbol
+            def name: () -> String
+          end
+
+          class Sub < Base
+            def name: () -> Integer
+          end
+        RBS
+        expect(diags_for(result, "def.override-return-widened").first&.message).to include("overrides Base#name")
+      end
     end
   end
 

--- a/spec/rigor/scope_spec.rb
+++ b/spec/rigor/scope_spec.rb
@@ -584,4 +584,40 @@ RSpec.describe Rigor::Scope do
       expect(described_class.empty.ancestor_name_candidates("Widget", "Base")).to eq(%w[Base])
     end
   end
+
+  # #723 / #732 — the predicate that filters those candidates, and the reason it is owned HERE. Every
+  # ancestor-name resolver asks it: `compute_ancestor_class_name` for dispatch and the constant ladder,
+  # `ExpressionTyper`'s gem-provenance probe, and the override rules' `resolve_override_ancestor_name`,
+  # which carried a copy of this body reading only the first three tables until #732 replaced it with this
+  # call. Each table admits a class on its OWN, so the fork was observable on exactly one shape.
+  describe "#known_user_class?" do
+    def scope_with_discovery(**tables)
+      described_class.empty.with_discovery(Rigor::Scope::DiscoveryIndex::EMPTY.with(**tables))
+    end
+
+    it "admits a class the project declares a superclass for" do
+      scope = scope_with_discovery(discovered_superclasses: { "Base" => "Object" })
+      expect(scope.known_user_class?("Base")).to be(true)
+    end
+
+    it "admits a class the project declares an instance def in" do
+      expect(scope_with_discovery(discovered_def_nodes: { "Base" => {} }).known_user_class?("Base")).to be(true)
+    end
+
+    it "admits a class the project declares an include in" do
+      expect(scope_with_discovery(discovered_includes: { "Base" => %w[Mixin] }).known_user_class?("Base")).to be(true)
+    end
+
+    # The divergent shape. `class Base; def self.build = :built; end` records no instance def node, no
+    # superclass and no include, so this is the only table that says the project defines anything under the
+    # name at all — and a resolver reading the other three ends its walk one hop early.
+    it "admits a class whose only project content is a class method" do
+      scope = scope_with_discovery(discovered_methods: { "Base" => { build: :singleton } })
+      expect(scope.known_user_class?("Base")).to be(true)
+    end
+
+    it "refuses a name no discovery table mentions" do
+      expect(described_class.empty.known_user_class?("String")).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #732.

`known_user_class?` — "does the project declare a class under this name" — existed twice with the same body: `Scope#known_user_class?`, which every ancestor-name resolver asks, and a private copy inside the override rules' `resolve_override_ancestor_name` (`Analysis::CheckRules`). #682 made `Scope` the single owner of the candidate *order* an as-written ancestor name walks, but left the predicate that *filters* those candidates forked; #723 then widened only the scope's copy with a fourth discovery table (`discovered_methods`).

So the two disagreed about exactly one shape — a project class with no instance def, no superclass and no include, i.e. one whose only project-side content is class methods (`class Base; def self.build = :built; end`). Dispatch and the constant ladder saw it as a project class; the override walk did not, and ended one hop early.

## What actually moves

The issue's own "Consequence today" section names a missed `flow.override-visibility-reduced`, and its author's follow-up comment on the issue retracts that — correctly: `nearest_ancestor_visibility` gates on `scope.user_def_for`, the def-node table, which a class-methods-only parent cannot populate, so recognising it changes nothing for that rule. I re-confirmed this against the code: `includes_of` / `superclass_of` read the same two tables the narrow predicate did, so such a class also has no ancestors of its own for the walk to continue into.

The consumer that *does* move is the other one, `nearest_ancestor_method_def`, which gates on an RBS declaration (`Reflection.instance_method_definition`) rather than a def node. A class-methods-only parent carrying a `sig/` instance declaration was invisible to the ADR-35 Liskov signature rules. Pre-fix this is silent; post-fix it reports:

```ruby
# app.rb
class Base
  def self.build = :built
end

class Sub < Base
  def name = 42
end
```

```rbs
# sig/app.rbs
class Base
  def self.build: () -> Symbol
  def name: () -> String
end

class Sub < Base
  def name: () -> Integer
end
```

```
app.rb:6:7: warning: return type of `name' widened from String to Integer (overrides Base#name); breaks substitutability [def.override-return-widened]
```

That is a true positive: the inherited declaration says `String`, the override declares `Integer`. Both sides are explicitly authored RBS, which is what gates the rule.

## False-positive check

`exe/rigor check lib` — zero `warning:` / `error:` lines. `rigor check --fail-on=warning plugins/*/lib examples/*/lib` — clean. The full 29-example override/return-type family and the 602-example set covering `Scope`, all of `spec/rigor/analysis/check_rules/`, the public-API drift snapshot and the rooted-ancestor integration spec are green, as are the ADR-46 incremental / dependency-recorder specs (the fix also stops the resolver recording a spurious negative `read_missing(:class, ...)` edge for a class that does exist).

## Specs

Both entry points, on the divergent shape:

- `spec/rigor/scope_spec.rb` — a new `#known_user_class?` block pinning all four tables as independently sufficient, including the `discovered_methods`-only one. Passes both ways; it is the control that says which reading is the owner's.
- `spec/rigor/analysis/check_rules/override_and_return_type_spec.rb` — the fixture above through the rule. **Fails pre-fix** (`expected nil to include "overrides Base#name"`), verified by restoring the pre-fix `check_rules.rb` under the new specs.

`Scope#known_user_class?` was already public (since #530), so `public_api_drift_spec`'s snapshot does not move — the issue's closing note about that is stale.
