### PR TITLE
Fix two CLI-surface defects the ADR audit turned up

### DIFF
--- a/changelog.d/fixed/fix-cli-help-verbs.md
+++ b/changelog.d/fixed/fix-cli-help-verbs.md
@@ -1,0 +1,1 @@
+- **[cli]** `rigor help` now lists `baseline` and `unused`, the two dispatchable commands it had been omitting. ([#906](https://github.com/rigortype/rigor/pull/906))

--- a/changelog.d/fixed/fix-cli-playground-argv.md
+++ b/changelog.d/fixed/fix-cli-playground-argv.md
@@ -1,0 +1,1 @@
+- **[cli]** `rigor playground` no longer drops its first argument — `--port=` is honoured again, and a bare `rigor playground` starts instead of raising. ([#906](https://github.com/rigortype/rigor/pull/906))

--- a/lib/rigor/cli.rb
+++ b/lib/rigor/cli.rb
@@ -383,11 +383,13 @@ module Rigor
                      (opt-in; effects update/check/diff/explain)
           explain    Print the description of one or all CheckRules
           diff       Compare current diagnostics to a saved baseline JSON
+          baseline   Manage the baseline file (baseline generate/regenerate/dump/drift/prune)
           sig-gen    Emit RBS skeletons inferred from .rb sources
           lsp        Run the Rigor Language Server (LSP) over stdio
           mcp        Run the Rigor MCP server over stdio
           triage     Summarise diagnostics: distribution, hotspots, hints
           coverage   Report type-precision coverage (precise vs Dynamic ratio)
+          unused     Report unreferenced classes, modules and constants as removal candidates
           plugins    Report activation status of every configured plugin
           plugin     Browse bundled plugin source as worked examples (list/path/print/root)
           playground Start the browser playground (requires rigor-playground gem)

--- a/lib/rigor/cli.rb
+++ b/lib/rigor/cli.rb
@@ -320,7 +320,10 @@ module Rigor
         @err.puts "Install it with: gem install rigor-playground"
         return EXIT_USAGE
       end
-      Rigor::CLI::PlaygroundCommand.new(@argv[1..], @out, @err).run
+      # `run` shifts the verb off `@argv` before dispatching, so the handler receives the arguments
+      # already. Slicing here dropped the first one — `rigor playground --port=4000` served the
+      # default port, and a bare `rigor playground` passed `nil` into a command that iterates it.
+      Rigor::CLI::PlaygroundCommand.new(@argv, @out, @err).run
     end
 
     def run_skill

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe Rigor::CLI do
     expect(out).to include("type-of")
   end
 
+  # `baseline` and `unused` were both dispatchable, documented in the manual, and absent from this
+  # list — nothing compared the two, so `rigor help` answered for 23 of the 25 verbs.
+  it "documents every dispatchable verb in the help text" do
+    _status, out, _err = run_cli("help")
+
+    undocumented = described_class::HANDLERS.keys.reject do |verb|
+      out.lines.any? { |line| line.match?(/\A {2}#{Regexp.escape(verb)}\s/) }
+    end
+
+    expect(undocumented).to be_empty
+  end
+
   it "reports unknown commands as usage errors" do
     status, _out, err = run_cli("nope")
 

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -41,6 +41,40 @@ RSpec.describe Rigor::CLI do
     expect(undocumented).to be_empty
   end
 
+  # `run` shifts the verb off `@argv` before dispatch, so a handler that slices again drops its
+  # first real argument — and, with no arguments at all, hands `nil` to a command that iterates it.
+  describe "playground argument forwarding" do
+    let(:playground_command) do
+      Class.new do
+        class << self
+          attr_accessor :received
+        end
+
+        def initialize(argv, _out, _err)
+          self.class.received = argv
+        end
+
+        def run = 0
+      end
+    end
+
+    def run_playground(*argv)
+      cli = described_class.new(["playground", *argv], out: StringIO.new, err: StringIO.new)
+      allow(cli).to receive(:require).with("rigor/playground").and_return(true)
+      stub_const("Rigor::CLI::PlaygroundCommand", playground_command)
+      cli.run
+      playground_command.received
+    end
+
+    it "forwards every argument" do
+      expect(run_playground("--port=4000", "--no-open")).to eq(["--port=4000", "--no-open"])
+    end
+
+    it "forwards an empty list rather than nil when invoked bare" do
+      expect(run_playground).to eq([])
+    end
+  end
+
   it "reports unknown commands as usage errors" do
     status, _out, err = run_cli("nope")
 


### PR DESCRIPTION
Two defects found by the 2026-09-09 ADR corpus audit ([`docs/notes/20260909-adr-corpus-audit.md`](https://github.com/rigortype/rigor/blob/master/docs/notes/20260909-adr-corpus-audit.md) § 0), each found by checking an ADR's claim against the code and finding the code wrong. They are independent; one commit each.

**`rigor playground` dropped its first argument.** `CLI#run` shifts the verb off `@argv` before dispatching, so every handler reads `@argv` directly — except `run_playground`, which sliced it again. `rigor playground --port=4000` served the default port, and a bare `rigor playground` handed `nil` to a command whose first act is `@argv.each`. Only reachable with the `rigor-playground` gem installed, which is why no spec saw it; the new specs stub the require and the command class, and on the pre-fix tree they report `["--no-open"]` and `nil`.

**`rigor help` answered for 23 of the 25 dispatchable verbs.** `baseline` (ADR-22) and `unused` (ADR-102) are both in `HANDLERS` and both carry a manual chapter, and neither was in the help text. Nothing compared the two lists. The added spec is that comparison — every `HANDLERS` key must have a line in the help body — and it fails on the pre-fix tree naming exactly those two.

`make verify` green; `git diff --check` clean.