### PR TITLE
Size the three census-walk gaps in #693 and decline all three

### DIFF
--- a/docs/notes/20260909-census-walk-gap-movable-sites.md
+++ b/docs/notes/20260909-census-walk-gap-movable-sites.md
@@ -1,0 +1,224 @@
+# Census-walk gaps — sizing three shapes before fixing any of them (#693)
+
+Status: measurement note. [#693](https://github.com/rigortype/rigor/issues/693) asks
+for the shapes to be sized before they are implemented, and this is that sizing. The
+conclusion is a **decline**; the only design commitment below is the one recorded
+under "Decision".
+
+- Date: 2026-09-09
+- Tree: `master` at `5ad2f450`, Ruby 4.0.5 through the Flake
+- Instrument: [`tool/probe-693/`](../../tool/probe-693/README.md), raw rows in
+  `tool/probe-693/results-20260909.json`
+
+## The three shapes, reproduced
+
+`ScopeIndexer` runs pre-passes that record where each ivar / cvar is written so a
+read elsewhere in the class can be seeded. Three write positions never reach a read.
+All three answer `Dynamic[top]` on master, against controls that answer precisely:
+
+```ruby
+class Control                              # controls
+  @@def_klass = nil
+  def store = (@@def_klass = Post)
+  def read_def_cvar = dump_type(@@def_klass)   # singleton(Post)
+  def initialize = (@post = Post.new)
+  def read_post = dump_type(@post)             # Post
+end
+
+class Census                               # A — class-body cvar
+  @@body_klass = Post
+  def read = dump_type(@@body_klass)           # Dynamic[top]
+end
+
+class Compact                              # B — `class << self`
+  class << self
+    def configure = (@cfg = Post.new)
+    def read_cfg = dump_type(@cfg)             # Dynamic[top]
+  end
+end
+
+class SelfDef                              # B — `def self.x`, the same mechanism
+  def self.configure = (@cfg2 = Post.new)
+  def self.read_cfg2 = dump_type(@cfg2)        # Dynamic[top]
+end
+
+Widget = Class.new do                      # C — anonymous class body
+  def initialize = (@thing = Post.new)
+  def thing = dump_type(@thing)                # Dynamic[top]
+end
+```
+
+The issue names two shapes; the probe treats `def self.x` as part of shape B because
+it is the same mechanism and the same non-answer. **A** is a walk that stops too
+early — `walk_class_cvars` returns at a `DefNode` and never calls `gather_cvar_writes`
+on a class body. **B** is not a walk gap at all: the write *is* collected, and
+`StatementEvaluator#seed_instance_ivars` then declines to seed it because the body is
+a singleton one (`return body_scope if singleton`). **C** is a prefix gap: at the top
+level `collect_def_ivar_writes` returns on `qualified_prefix.empty?`.
+
+## Why a movable-site probe rather than a diagnostic diff
+
+Same reason as [#692](https://github.com/rigortype/rigor/pull/692): a `Dynamic`
+receiver dispatches gradually, so none of these can fire `call.undefined-method` and
+a before/after diagnostic diff over a corpus reads zero whether the shapes are
+everywhere or absent. The probe is Prism-only, with Rigor deliberately out of the
+loop, so the counts do not depend on the analyzer being sized.
+
+The column that decides is **movable**: the rvalue is recoverable (a constant, a
+`Const.new`, or a literal — an opaque rvalue records `Dynamic` after a fix too) **and**
+at least one read of that name is the receiver of a call **in a different method from
+the write**. The cross-method clause is what separates a real gap from the dominant
+idiom, and it removes two thirds of the raw population:
+
+```ruby
+def producer(id, ...)
+  @producers ||= {}          # the write the probe sees
+  @producers[id.to_sym] = …  # the read — same body, flow already types it
+end
+```
+
+That is `lib/rigor/plugin/base.rb:113`, and it is what most of shape B's 605 sites
+look like. A census seed buys nothing there.
+
+## Results
+
+14 targets, 17,706 parsed files. `sites` is exact; `with_read` is a **floor** (a class
+reopened in a file outside the run contributes no reads); `movable` is a **ceiling**
+(it does not check that the recovered type reaches a diagnostic).
+
+### A — class-body `@@x = …` never censused
+
+| target | files | sites | recoverable | with_read | movable | collides |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| rigor `lib`,`plugins` | 674 | 0 | 0 | 0 | 0 | 0 |
+| mastodon | 1,325 | 0 | 0 | 0 | 0 | 0 |
+| gitlab | 11,344 | 11 | 11 | 11 | 11 | 0 |
+| redmine | 346 | 15 | 12 | 10 | 7 | 0 |
+| rails | 2,829 | 18 | 9 | 11 | 5 | 0 |
+| mail | 111 | 5 | 4 | 4 | 3 | 0 |
+| liquid | 63 | 2 | 2 | 2 | 1 | 0 |
+| kramdown | 55 | 1 | 1 | 1 | 1 | 0 |
+| dependabot-core, concurrent-ruby, haml, faraday, parser, rubocop-ast | 959 | 0 | 0 | 0 | 0 | 0 |
+| **total** | **17,706** | **52** | **39** | **39** | **28** | **0** |
+
+### B — ivar writes in `class << self` / `def self.x` not seeded
+
+| target | files | sites | recoverable | with_read | movable | collides |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| gitlab | 11,344 | 321 | 81 | 77 | 8 | 1 |
+| rails | 2,829 | 152 | 58 | 52 | 4 | 2 |
+| redmine | 346 | 36 | 17 | 26 | 5 | 0 |
+| rigor `lib`,`plugins` | 674 | 29 | 12 | 8 | 2 | 0 |
+| mastodon | 1,325 | 22 | 14 | 4 | 0 | 0 |
+| faraday | 33 | 12 | 5 | 0 | 0 | 0 |
+| dependabot-core | 540 | 8 | 3 | 6 | 3 | 0 |
+| parser | 56 | 8 | 8 | 0 | 0 | 0 |
+| concurrent-ruby | 178 | 6 | 4 | 4 | 2 | 0 |
+| liquid | 63 | 5 | 1 | 4 | 1 | 0 |
+| kramdown | 55 | 4 | 0 | 2 | 0 | 0 |
+| haml, rubocop-ast | 152 | 2 | 1 | 1 | 0 | 0 |
+| **total** | **17,706** | **605** | **204** | **184** | **25** | **3** |
+
+### C — ivar writes in `Class.new do … end`
+
+| target | files | sites | recoverable | with_read | movable | collides |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| rails | 2,829 | 22 | 15 | 5 | 2 | 2 |
+| dependabot-core | 540 | 9 | 2 | 9 | 0 | 0 |
+| gitlab | 11,344 | 4 | 2 | 2 | 1 | 0 |
+| everything else | 2,993 | 0 | 0 | 0 | 0 | 0 |
+| **total** | **17,706** | **35** | **19** | **16** | **3** | **2** |
+
+## Adjudication
+
+**The movable sites are real, and they are all the same site.** Every one of shape A's
+28 is a registry table on a plugin manager — `Redmine::Activity.@@available_event_types`,
+`Redmine::WikiFormatting.@@formatters`, `Mail.@@delivery_interceptors`,
+`Kramdown::Parser::Kramdown.@@parsers`, gitlab's five `Gitlab::Testing::*` middlewares.
+Verified on the real tree rather than inferred:
+
+```
+$ rigor type-of lib/redmine/activity.rb:42:9   # `@@available_event_types << event_type`
+type:    Dynamic[top]
+```
+
+Shape B's 25 are the same idiom one facet up (`@permissions`, `@registered_plugins`,
+`@scms`, `@stubs`), and shape C's 3 are two RSpec-adjacent `Class.new` blocks in
+`rails/…/test/` plus one gitlab config walker.
+
+**And the recovered type stops one hop in.** The rvalue mix says so: across all three
+shapes the recoverable rvalues are `[]`, `{}`, `Mutex.new`, `Hash.new { … }` — a
+collection whose *element* type is untyped. Recovering it turns
+`@@available_event_types` from `Dynamic[top]` into `Array[untyped]`, which resolves
+`<<`, `delete` and `include?` and then hands `untyped` to whatever reads an element.
+So the gain is not a type that flows; it is teeth against a mistyped collection method
+on 28 + 25 + 3 receivers corpus-wide — about one site per 300 files, on code that is
+correct today and therefore reports nothing before or after.
+
+**One correction to the issue's premise, in the FP direction.** #693 says "neither
+produces a wrong answer". For shapes B and C that is not true: the write is not lost,
+it is recorded against the *enclosing class's instance facet*, because
+`collect_def_ivar_writes` keys the census table per class with no facet split and a
+`class << self` def carries no receiver to mark it singleton. Both of these are correct
+Ruby and both fire on master:
+
+```ruby
+class SingletonMix
+  def initialize = (@state = Post.new)
+  class << self
+    def configure = (@state = Comment.new)   # warning: def.ivar-write-mismatch
+  end
+end
+
+class Outer
+  def initialize = (@own = Post.new)
+  Inner = Class.new do
+    def initialize = (@own = Comment.new)    # warning: def.ivar-write-mismatch
+  end
+end
+```
+
+`def self.x` does not fire — the write-mismatch collector recognises that spelling as
+singleton and `class << self` is not, which is the same two-spellings-one-meaning
+asymmetry [#681](https://github.com/rigortype/rigor/issues/681) was about. The probe
+counts this population as `collides` (the gap-shape write shares a census slot with an
+ordinary `def`'s write of the same name): **5 sites corpus-wide**, at
+`activesupport/lib/active_support/key_generator.rb:18,25`,
+`lib/gitlab/database/connection_timer.rb:22`, and two rails test files. **None fires
+today** — each pairs one known type against one opaque one, and the mismatch check
+declines. Both files were run to confirm that rather than argued from the shape.
+
+## Decision — not worth doing
+
+**The shapes are rare and the recovered types move nothing, so this is not worth
+doing.** Concretely, per shape:
+
+- **A** is the strongest of the three and still does not clear the bar: 28 movable
+  sites in 6 of 14 targets, each recovering a bare collection. Against that, a
+  class-body `@@x = nil` (3 sites: rails' `@@app`, `@@parallel_worker_id`, redmine's
+  `@@listeners`) would union `nil` into every read of that cvar in the class, which is
+  exactly the widening ADR-58 WD1's declaration-sourced mark and the C2 dead-write
+  elimination were built to keep out of the ivar path. Paying that guarding cost for
+  28 collection receivers is the wrong trade under the FP-first rule.
+- **B** is not a walk fix. `seed_instance_ivars` declines singleton bodies *because*
+  the census table has no facet split, so closing it means splitting the table — a real
+  engine change with its own FP budget — for 25 sites, 2 of which are in Rigor's own
+  `lib/`.
+- **C** is 3 movable sites, two of them under `test/`. What it actually needs is the
+  opposite of seeding: the anonymous class's writes should stop being attributed to the
+  enclosing class.
+
+The by-product is the part worth keeping open. The facet conflation under B and C is a
+**wrong type**, not a precision gap, and it is one distinct-nominals-on-both-facets away
+from a false `def.ivar-write-mismatch`. It is also much cheaper than seeding: marking a
+`class << self` def as singleton for the write-mismatch collector is a spelling fix, not
+a table split. That half should be its own issue, sized by the `collides` column
+(5 sites, 0 firing) rather than by the movable one.
+
+## What this note does not do
+
+- It does not check that a movable site's *receiver* would be RBS-known. It does not
+  have to: every recovered type here is a core collection, so the ceiling is already
+  the optimistic reading and the conclusion is a decline anyway.
+- It does not size the same three shapes for `Struct.new do … end` or
+  `class << SomeConstant`, both of which the probe skips deliberately.

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -83,6 +83,7 @@ comparison) appears nowhere else in this index.
 | 2026-08-23 | [`super` effect edge — corpus measurement (issue #446)](20260823-effect-super-edge-corpus.md) |
 | 2026-08-23 | [Effect labels — ten user stories, adjudicated against the corpus (redmine + mastodon)](20260823-effect-user-stories-corpus.md) |
 | 2026-09-05 | [Top-level `def` cref — sizing the peel before retracting it (issue #716)](20260905-toplevel-def-cref-movable-sites.md) |
+| 2026-09-09 | [Census-walk gaps — sizing three shapes before fixing any of them (issue #693)](20260909-census-walk-gap-movable-sites.md) |
 
 ## Analyzer self-testing (teeth / false-negatives)
 

--- a/tool/probe-693/README.md
+++ b/tool/probe-693/README.md
@@ -1,0 +1,76 @@
+# Census-walk gap probe (issue #693)
+
+The movable-site instrument behind
+[`docs/notes/20260909-census-walk-gap-movable-sites.md`](../../docs/notes/20260909-census-walk-gap-movable-sites.md).
+Kept because the note's conclusion is a *decline*, and a decline that cannot be
+re-derived has to be re-measured the next time the shapes come up.
+
+It lives under `tool/` rather than `tmp/` only because `/tmp/` is in `.gitignore`.
+
+## What it counts
+
+Three shapes that `ScopeIndexer`'s census walks do not record the way an ordinary
+`def` body is recorded:
+
+| shape | what it is |
+| --- | --- |
+| `a_class_body_cvar` | `@@x = …` written directly in a class body. `walk_class_cvars` descends `DefNode`s only, so the write is never censused. |
+| `b_singleton_ivar` | an ivar written in a `class << self` def or a `def self.x`. `StatementEvaluator#seed_instance_ivars` returns early for a singleton body, so the read is never seeded. |
+| `c_anonymous_class_ivar` | an ivar written inside a `Class.new do … end` / `Module.new do … end` body. |
+
+Prism only — Rigor is deliberately not in the loop, so the counts are independent
+of the analyzer whose behaviour is being sized.
+
+## Columns, and what each is a bound on
+
+- **sites** — writes in the gap position. Exact for the three shapes above.
+- **recoverable** — the rvalue is a constant, a `Const.new`, or a literal, so a
+  fixed walk would record something better than `Dynamic`. An opaque rvalue
+  (a call on a non-constant, a parameter) records `Dynamic` either way.
+- **with_read** — the same variable name is read somewhere in the same census
+  scope. A **floor**: a class reopened in another file contributes its reads only
+  when both files are in the run.
+- **consuming** — at least one of those reads is the RECEIVER of a call, which is
+  where a recovered type reaches a dispatch decision. A read that is discarded or
+  handed to an untyped sink moves nothing.
+- **cross_method / MOVABLE** — the consuming read is in a *different* method from
+  the write. This is the column that matters: the dominant idiom in every corpus
+  is `@x ||= {}` immediately followed by `@x[k] = …` in the same body, where flow
+  already supplies the type and the census seed buys nothing. MOVABLE is a
+  **ceiling** — it does not check that the recovered type reaches a diagnostic.
+- **COLLIDES** — the gap-shape write lands in the same census slot as an ordinary
+  `def`'s write of the same ivar name, so the two types union. This is where the
+  gap stops being precision-only: it can fire `def.ivar-write-mismatch` on correct
+  Ruby. `def self.x` is excluded — the write-mismatch collector already recognises
+  that spelling as singleton; `class << self` does not.
+
+## Running it
+
+Inside the Flake shell, from the repo root:
+
+```sh
+nix --extra-experimental-features 'nix-command flakes' develop --command \
+  bundle exec ruby tool/probe-693/census_gap_sites.rb <root> [subdir ...]
+```
+
+`PROBE693_FORMAT=json` emits per-site rows instead of the summary table.
+
+The whole corpus at once (`SURVEY_ROOT` defaults to `~/repo/ruby/rigor-survey`):
+
+```sh
+nix --extra-experimental-features 'nix-command flakes' develop --command \
+  bundle exec ./tool/probe-693/run-corpus.sh
+```
+
+## What it reported on 2026-09-09
+
+`results-20260909.json` holds the per-target summaries plus every movable and
+colliding row. Across 14 targets / 17,706 parsed files:
+
+| shape | sites | movable | collides |
+| --- | ---: | ---: | ---: |
+| `a_class_body_cvar` | 52 | 28 | 0 |
+| `b_singleton_ivar` | 605 | 25 | 3 |
+| `c_anonymous_class_ivar` | 35 | 3 | 2 |
+
+None of the 5 colliding sites fires today. The reading is in the note.

--- a/tool/probe-693/census_gap_sites.rb
+++ b/tool/probe-693/census_gap_sites.rb
@@ -1,0 +1,352 @@
+# frozen_string_literal: true
+
+# Movable-site probe for https://github.com/rigortype/rigor/issues/693.
+#
+# Prism only -- Rigor is deliberately not in the loop, so the counts are
+# independent of the analyzer whose behaviour is being sized. What each column
+# means, and what it is a floor or a ceiling for, is in tool/probe-693/README.md.
+
+require "prism"
+require "json"
+require "set"
+
+module Probe693
+  CVAR_WRITES = [
+    Prism::ClassVariableWriteNode, Prism::ClassVariableOrWriteNode,
+    Prism::ClassVariableAndWriteNode, Prism::ClassVariableOperatorWriteNode
+  ].freeze
+
+  IVAR_WRITES = [
+    Prism::InstanceVariableWriteNode, Prism::InstanceVariableOrWriteNode,
+    Prism::InstanceVariableAndWriteNode, Prism::InstanceVariableOperatorWriteNode
+  ].freeze
+
+  # An rvalue whose type the census could actually recover. Anything outside this
+  # set records `Dynamic` even after the walk is fixed, so a site holding one
+  # cannot move however the gap is closed.
+  module Rvalue
+    LITERALS = [
+      Prism::StringNode, Prism::SymbolNode, Prism::IntegerNode, Prism::FloatNode,
+      Prism::ArrayNode, Prism::HashNode, Prism::TrueNode, Prism::FalseNode,
+      Prism::RegularExpressionNode, Prism::RationalNode, Prism::ImaginaryNode,
+      Prism::InterpolatedStringNode, Prism::InterpolatedSymbolNode, Prism::LambdaNode
+    ].freeze
+
+    RECOVERABLE = %i[constant instantiation literal].freeze
+
+    module_function
+
+    # => :constant | :instantiation | :literal | :nil | :opaque
+    def classify(node)
+      case node
+      when nil then :opaque
+      when Prism::NilNode then :nil
+      when Prism::ConstantReadNode, Prism::ConstantPathNode then :constant
+      when Prism::CallNode then classify_call(node)
+      when Prism::OrNode then merge(classify(node.left), classify(node.right))
+      when Prism::AndNode then classify(node.right)
+      else LITERALS.any? { |k| node.is_a?(k) } ? :literal : :opaque
+      end
+    end
+
+    def classify_call(node)
+      return :instantiation if node.name == :new && constant?(node.receiver)
+      return classify(node.receiver) if %i[freeze dup -@].include?(node.name) && !constant?(node.receiver)
+
+      :opaque
+    end
+
+    def constant?(node)
+      node.is_a?(Prism::ConstantReadNode) || node.is_a?(Prism::ConstantPathNode)
+    end
+
+    def merge(left, right)
+      return left if left == right
+      return right if left == :nil
+      return left if right == :nil
+      return :literal if RECOVERABLE.include?(left) && RECOVERABLE.include?(right)
+
+      :opaque
+    end
+
+    def recoverable?(kind) = RECOVERABLE.include?(kind)
+  end
+
+  # Reads of a variable, split by whether a recovered type would reach a dispatch
+  # decision. A read that is the RECEIVER of a call is where precision buys
+  # something (`call.undefined-method`, a fold, a narrowing); a read that is
+  # discarded or handed to an untyped sink moves nothing.
+  class Reads
+    def initialize
+      @any = Hash.new(0)
+      @consuming = Hash.new(0)
+      # name => Set of method keys holding a CONSUMING read. A read in the same method
+      # body as the write is already typed by flow, so only a foreign method key means
+      # the census seed would buy something.
+      @consuming_methods = Hash.new { |h, k| h[k] = Set.new }
+    end
+
+    attr_reader :any, :consuming, :consuming_methods
+
+    def absorb(other)
+      other.any.each { |n, c| @any[n] += c }
+      other.consuming.each { |n, c| @consuming[n] += c }
+      other.consuming_methods.each { |n, m| @consuming_methods[n].merge(m) }
+      self
+    end
+
+    def record_tree(node, method_key = nil)
+      return unless node.is_a?(Prism::Node)
+
+      key = node.is_a?(Prism::DefNode) ? "#{node.name}@#{node.location.start_line}" : method_key
+      case node
+      when Prism::ClassVariableReadNode, Prism::InstanceVariableReadNode
+        @any[node.name] += 1
+      when Prism::CallNode
+        r = node.receiver
+        if r.is_a?(Prism::ClassVariableReadNode) || r.is_a?(Prism::InstanceVariableReadNode)
+          @consuming[r.name] += 1
+          @consuming_methods[r.name] << key
+        end
+      end
+      node.compact_child_nodes.each { |c| record_tree(c, key) }
+    end
+  end
+
+  Site = Struct.new(:shape, :file, :line, :owner, :name, :rvalue, :enclosing, :spelling, :method_key,
+                    keyword_init: true)
+
+  module Path
+    module_function
+
+    def flatten(node)
+      case node
+      when Prism::ConstantReadNode then [node.name.to_s]
+      when Prism::ConstantPathNode
+        return [node.name.to_s] if node.parent.nil?
+
+        parent = flatten(node.parent)
+        parent && (parent + [node.name.to_s])
+      end
+    end
+
+    def child_prefix(current, constant_path)
+      case constant_path
+      when Prism::ConstantReadNode then current + [constant_path.name.to_s]
+      when Prism::ConstantPathNode
+        parts = flatten(constant_path)
+        parts && (constant_path.parent.nil? ? parts : current + parts)
+      end
+    end
+  end
+
+  # One file. Mirrors ScopeIndexer#walk_class_cvars / #walk_class_ivars: a
+  # declaration opens a new prefix, a plain `def` is where today's census
+  # actually happens, and everything else is descended generically.
+  class Walker
+    def initialize(file)
+      @file = file
+      @sites = []
+      @cvar_reads = Hash.new { |h, k| h[k] = Reads.new }   # class name  => Reads
+      @singleton_reads = Hash.new { |h, k| h[k] = Reads.new } # class name  => Reads
+      @block_reads = Hash.new { |h, k| h[k] = Reads.new }  # file:line   => Reads
+      # Ivar names an ORDINARY `def` of each class writes. A gap-shape write of the
+      # same name lands in the same census slot, which is where the contamination is.
+      @instance_writes = Hash.new { |h, k| h[k] = Set.new }
+    end
+
+    attr_reader :sites, :cvar_reads, :singleton_reads, :block_reads, :instance_writes
+
+    def run(root)
+      walk(root, [])
+      self
+    end
+
+    private
+
+    def walk(node, prefix)
+      return unless node.is_a?(Prism::Node)
+
+      case node
+      when Prism::ClassNode, Prism::ModuleNode
+        child = Path.child_prefix(prefix, node.constant_path)
+        if child
+          if node.body
+            # Cvar READS live in `def` bodies, which the site walk stops at, so the
+            # whole declaration is indexed here in one sweep.
+            @cvar_reads[child.join("::")].record_tree(node.body)
+            walk(node.body, child)
+          end
+          return
+        end
+      when Prism::SingletonClassNode
+        if node.expression.is_a?(Prism::SelfNode) && node.body && !prefix.empty?
+          collect_singleton(node.body, prefix.join("::"))
+        end
+        return
+      when Prism::DefNode
+        if node.receiver.is_a?(Prism::SelfNode)
+          collect_singleton(node, prefix.join("::")) unless prefix.empty?
+        elsif !prefix.empty?
+          # A plain `def` is censused today; its ivar names are what a gap-shape
+          # write of the same name would collide with.
+          each_node(node) do |n|
+            @instance_writes[prefix.join("::")] << n.name if IVAR_WRITES.any? { |k| n.is_a?(k) }
+          end
+        end
+        return
+      when Prism::CallNode
+        if anonymous_class_block?(node)
+          collect_anonymous_class(node, prefix)
+          return
+        end
+      end
+
+      # Shape A: a cvar write reached WITHOUT passing through a `def`.
+      if CVAR_WRITES.any? { |k| node.is_a?(k) } && !prefix.empty?
+        @sites << Site.new(shape: :a_class_body_cvar, file: @file, line: node.location.start_line,
+                           owner: prefix.join("::"), name: node.name, rvalue: Rvalue.classify(rvalue_of(node)))
+      end
+
+      node.compact_child_nodes.each { |c| walk(c, prefix) }
+    end
+
+    def rvalue_of(node) = node.respond_to?(:value) ? node.value : nil
+
+    def anonymous_class_block?(node)
+      node.name == :new && node.block.is_a?(Prism::BlockNode) &&
+        node.receiver.is_a?(Prism::ConstantReadNode) &&
+        %i[Class Module].include?(node.receiver.name)
+    end
+
+    # Shape B: `class << self` and `def self.x`. The class-ivar census table is
+    # keyed per class with no facet split, and StatementEvaluator#seed_instance_ivars
+    # returns early for a singleton body, so neither half of the pair is seeded.
+    def collect_singleton(node, owner)
+      @singleton_reads[owner].record_tree(node)
+      # `class << self` carries no receiver on its defs, so collect_def_ivar_writes
+      # types it as an INSTANCE ivar of the enclosing class; `def self.x` is at least
+      # recognised as singleton by the write-mismatch collector.
+      spelling = node.is_a?(Prism::DefNode) ? :self_def : :singleton_class
+      record_ivar_writes(node, :b_singleton_ivar, owner, enclosing: owner, spelling: spelling)
+    end
+
+    # Shape C: `Klass = Class.new do … end`. At the top level the enclosing
+    # prefix is empty, so collect_def_ivar_writes returns before recording.
+    def collect_anonymous_class(call, prefix)
+      owner = "#{@file}:#{call.location.start_line}"
+      @block_reads[owner].record_tree(call.block)
+      # An anonymous class nested inside a declaration is walked with the ENCLOSING
+      # prefix, so its ivar writes are recorded against the enclosing class.
+      record_ivar_writes(call.block, :c_anonymous_class_ivar, owner, enclosing: prefix.join("::"))
+    end
+
+    def record_ivar_writes(node, shape, owner, enclosing: nil, spelling: nil, method_key: nil)
+      key = node.is_a?(Prism::DefNode) ? "#{node.name}@#{node.location.start_line}" : method_key
+      each_node(node) do |n|
+        if n.is_a?(Prism::DefNode) && !n.equal?(node)
+          record_ivar_writes(n, shape, owner, enclosing: enclosing, spelling: spelling,
+                                             method_key: "#{n.name}@#{n.location.start_line}")
+          next :skip
+        end
+        next unless IVAR_WRITES.any? { |k| n.is_a?(k) }
+
+        @sites << Site.new(shape: shape, file: @file, line: n.location.start_line,
+                           owner: owner, name: n.name, rvalue: Rvalue.classify(rvalue_of(n)),
+                           enclosing: enclosing, spelling: spelling, method_key: key)
+      end
+    end
+
+    def each_node(node, &block)
+      return unless node.is_a?(Prism::Node)
+
+      return if block.call(node) == :skip
+
+      node.compact_child_nodes.each { |c| each_node(c, &block) }
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+
+target = ARGV[0] or abort("usage: census_gap_sites.rb <root> [subdir ...]")
+subdirs = ARGV[1..]
+subdirs = [""] if subdirs.nil? || subdirs.empty?
+
+files = subdirs.flat_map do |sub|
+  Dir.glob(File.join(sub.empty? ? target : File.join(target, sub), "**", "*.rb"))
+end.uniq.sort
+
+sites = []
+cvar_reads = Hash.new { |h, k| h[k] = Probe693::Reads.new }
+singleton_reads = Hash.new { |h, k| h[k] = Probe693::Reads.new }
+block_reads = Hash.new { |h, k| h[k] = Probe693::Reads.new }
+instance_writes = Hash.new { |h, k| h[k] = Set.new }
+parsed = 0
+
+files.each do |path|
+  begin
+    src = File.read(path, encoding: "UTF-8")
+    result = Prism.parse(src)
+  rescue ArgumentError, Encoding::UndefinedConversionError, Errno::ENOENT
+    next
+  end
+  next unless result.success?
+
+  parsed += 1
+  walker = Probe693::Walker.new(path.delete_prefix(target).delete_prefix("/")).run(result.value)
+  sites.concat(walker.sites)
+  walker.cvar_reads.each { |k, v| cvar_reads[k].absorb(v) }
+  walker.singleton_reads.each { |k, v| singleton_reads[k].absorb(v) }
+  walker.block_reads.each { |k, v| block_reads[k].absorb(v) }
+  walker.instance_writes.each { |k, v| instance_writes[k].merge(v) }
+end
+
+reads_for = lambda do |site|
+  case site.shape
+  when :a_class_body_cvar then cvar_reads[site.owner]
+  when :b_singleton_ivar then singleton_reads[site.owner]
+  else block_reads[site.owner]
+  end
+end
+
+rows = sites.map do |s|
+  r = reads_for.call(s)
+  recoverable = Probe693::Rvalue.recoverable?(s.rvalue)
+  consuming = r.consuming[s.name]
+  # A collision is where the gap stops being precision-only: the gap-shape write is
+  # recorded in the SAME census slot as the enclosing class's own instance ivar of
+  # that name, so the two types union and `def.ivar-write-mismatch` can fire on
+  # correct Ruby. `def self.x` is exempt -- the write-mismatch collector already
+  # recognises that spelling as singleton.
+  collides = !s.enclosing.nil? && s.spelling != :self_def && instance_writes[s.enclosing].include?(s.name)
+  foreign = (r.consuming_methods[s.name] - [s.method_key]).size
+  { shape: s.shape, file: s.file, line: s.line, owner: s.owner, name: s.name, rvalue: s.rvalue,
+    spelling: s.spelling, enclosing: s.enclosing,
+    reads: r.any[s.name], consuming_reads: consuming, foreign_consuming_methods: foreign,
+    recoverable: recoverable, movable: recoverable && foreign.positive?, collides: collides }
+end
+
+summary = Hash.new { |h, k| h[k] = Hash.new(0) }
+rows.each do |row|
+  s = summary[row[:shape]]
+  s[:sites] += 1
+  s[:recoverable] += 1 if row[:recoverable]
+  s[:with_read] += 1 if row[:reads].positive?
+  s[:with_consuming_read] += 1 if row[:consuming_reads].positive?
+  s[:cross_method] += 1 if row[:foreign_consuming_methods].positive?
+  s[:movable] += 1 if row[:movable]
+  s[:collides] += 1 if row[:collides]
+end
+
+if ENV["PROBE693_FORMAT"] == "json"
+  puts JSON.pretty_generate(target: target, subdirs: subdirs, files: parsed, summary: summary, rows: rows)
+else
+  puts "target: #{target} [#{subdirs.join(" ")}]  files parsed: #{parsed}"
+  %i[a_class_body_cvar b_singleton_ivar c_anonymous_class_ivar].each do |shape|
+    s = summary[shape]
+    puts format("  %-24s sites=%-6d recoverable=%-6d with_read=%-6d consuming=%-6d cross_method=%-6d MOVABLE=%-5d COLLIDES=%d",
+                shape, s[:sites], s[:recoverable], s[:with_read], s[:with_consuming_read],
+                s[:cross_method], s[:movable], s[:collides])
+  end
+end

--- a/tool/probe-693/results-20260909.json
+++ b/tool/probe-693/results-20260909.json
@@ -1,0 +1,1307 @@
+{
+  "date": "2026-09-09",
+  "targets": {
+    "concurrent-ruby": {
+      "files": 178,
+      "subdirs": [
+        "lib"
+      ],
+      "summary": {
+        "b_singleton_ivar": {
+          "sites": 6,
+          "with_read": 4,
+          "with_consuming_read": 4,
+          "cross_method": 4,
+          "recoverable": 4,
+          "movable": 2
+        }
+      },
+      "movable_rows": [
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/concurrent-ruby/concurrent/synchronization/object.rb",
+          "line": 85,
+          "owner": "Concurrent::Synchronization::Object",
+          "name": "@__atomic_fields__",
+          "rvalue": "literal",
+          "spelling": "self_def",
+          "enclosing": "Concurrent::Synchronization::Object",
+          "reads": 2,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/concurrent-ruby/concurrent/synchronization/object.rb",
+          "line": 120,
+          "owner": "Concurrent::Synchronization::Object",
+          "name": "@__atomic_fields__",
+          "rvalue": "literal",
+          "spelling": "self_def",
+          "enclosing": "Concurrent::Synchronization::Object",
+          "reads": 2,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        }
+      ],
+      "colliding_rows": []
+    },
+    "dependabot-core": {
+      "files": 540,
+      "subdirs": [
+        "common",
+        "bundler",
+        "npm_and_yarn",
+        "python",
+        "go_modules"
+      ],
+      "summary": {
+        "c_anonymous_class_ivar": {
+          "sites": 9,
+          "with_read": 9,
+          "with_consuming_read": 4,
+          "cross_method": 3,
+          "recoverable": 2
+        },
+        "b_singleton_ivar": {
+          "sites": 8,
+          "with_read": 6,
+          "with_consuming_read": 6,
+          "recoverable": 3,
+          "cross_method": 5,
+          "movable": 3
+        }
+      },
+      "movable_rows": [
+        {
+          "shape": "b_singleton_ivar",
+          "file": "common/lib/dependabot/experiments.rb",
+          "line": 14,
+          "owner": "Dependabot::Experiments",
+          "name": "@experiments",
+          "rvalue": "literal",
+          "spelling": "self_def",
+          "enclosing": "Dependabot::Experiments",
+          "reads": 2,
+          "consuming_reads": 2,
+          "foreign_consuming_methods": 2,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "common/lib/dependabot/registry_client.rb",
+          "line": 66,
+          "owner": "Dependabot::RegistryClient",
+          "name": "@cached_errors",
+          "rvalue": "literal",
+          "spelling": "self_def",
+          "enclosing": "Dependabot::RegistryClient",
+          "reads": 2,
+          "consuming_reads": 2,
+          "foreign_consuming_methods": 2,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "common/lib/dependabot/workspace.rb",
+          "line": 34,
+          "owner": "Dependabot::Workspace",
+          "name": "@active_workspace",
+          "rvalue": "instantiation",
+          "spelling": "self_def",
+          "enclosing": "Dependabot::Workspace",
+          "reads": 4,
+          "consuming_reads": 2,
+          "foreign_consuming_methods": 2,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        }
+      ],
+      "colliding_rows": []
+    },
+    "faraday": {
+      "files": 33,
+      "subdirs": [
+        "lib"
+      ],
+      "summary": {
+        "b_singleton_ivar": {
+          "sites": 12,
+          "recoverable": 5
+        }
+      },
+      "movable_rows": [],
+      "colliding_rows": []
+    },
+    "gitlab": {
+      "files": 11344,
+      "subdirs": [
+        "app",
+        "lib"
+      ],
+      "summary": {
+        "b_singleton_ivar": {
+          "sites": 321,
+          "recoverable": 81,
+          "with_read": 77,
+          "with_consuming_read": 38,
+          "cross_method": 16,
+          "movable": 8,
+          "collides": 1
+        },
+        "c_anonymous_class_ivar": {
+          "sites": 4,
+          "recoverable": 2,
+          "with_read": 2,
+          "with_consuming_read": 2,
+          "cross_method": 1,
+          "movable": 1
+        },
+        "a_class_body_cvar": {
+          "sites": 11,
+          "recoverable": 11,
+          "with_read": 11,
+          "with_consuming_read": 11,
+          "cross_method": 11,
+          "movable": 11
+        }
+      },
+      "movable_rows": [
+        {
+          "shape": "b_singleton_ivar",
+          "file": "app/graphql/resolvers/base_resolver.rb",
+          "line": 12,
+          "owner": "Resolvers::BaseResolver",
+          "name": "@requires_argument",
+          "rvalue": "literal",
+          "spelling": "self_def",
+          "enclosing": "Resolvers::BaseResolver",
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "app/graphql/resolvers/base_resolver.rb",
+          "line": 20,
+          "owner": "Resolvers::BaseResolver",
+          "name": "@calls_gitaly",
+          "rvalue": "literal",
+          "spelling": "self_def",
+          "enclosing": "Resolvers::BaseResolver",
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/api/base.rb",
+          "line": 30,
+          "owner": "API::Base",
+          "name": "@skip_global_organization_setup",
+          "rvalue": "literal",
+          "spelling": "singleton_class",
+          "enclosing": "API::Base",
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "c_anonymous_class_ivar",
+          "file": "lib/gitlab/ci/config/interpolation/config.rb",
+          "line": 44,
+          "owner": "lib/gitlab/ci/config/interpolation/config.rb:42",
+          "name": "@visited",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": "Gitlab::Ci::Config::Interpolation::Config",
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/gitlab/gitaly_client.rb",
+          "line": 276,
+          "owner": "Gitlab::GitalyClient",
+          "name": "@channels",
+          "rvalue": "literal",
+          "spelling": "self_def",
+          "enclosing": "Gitlab::GitalyClient",
+          "reads": 2,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/gitlab/memory/reports/heap_dump.rb",
+          "line": 9,
+          "owner": "Gitlab::Memory::Reports::HeapDump",
+          "name": "@write_heap_dump",
+          "rvalue": "literal",
+          "spelling": "singleton_class",
+          "enclosing": "Gitlab::Memory::Reports::HeapDump",
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/gitlab/metrics/methods.rb",
+          "line": 11,
+          "owner": "Gitlab::Metrics::Methods",
+          "name": "@@_metric_provider_mutex",
+          "rvalue": "instantiation",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/gitlab/metrics/methods.rb",
+          "line": 12,
+          "owner": "Gitlab::Metrics::Methods",
+          "name": "@@_metrics_provider_cache",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 4,
+          "consuming_reads": 3,
+          "foreign_consuming_methods": 3,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/gitlab/query_limiting.rb",
+          "line": 24,
+          "owner": "Gitlab::QueryLimiting",
+          "name": "@suppressed",
+          "rvalue": "literal",
+          "spelling": "self_def",
+          "enclosing": "Gitlab::QueryLimiting",
+          "reads": 2,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/gitlab/sidekiq_middleware/pause_control/workers_map.rb",
+          "line": 13,
+          "owner": "Gitlab::SidekiqMiddleware::PauseControl::WorkersMap",
+          "name": "@workers",
+          "rvalue": "instantiation",
+          "spelling": "singleton_class",
+          "enclosing": "Gitlab::SidekiqMiddleware::PauseControl::WorkersMap",
+          "reads": 3,
+          "consuming_reads": 2,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/gitlab/testing/action_cable_blocker.rb",
+          "line": 10,
+          "owner": "Gitlab::Testing::ActionCableBlocker",
+          "name": "@@num_active_requests",
+          "rvalue": "instantiation",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 3,
+          "consuming_reads": 3,
+          "foreign_consuming_methods": 2,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/gitlab/testing/action_cable_blocker.rb",
+          "line": 11,
+          "owner": "Gitlab::Testing::ActionCableBlocker",
+          "name": "@@block_requests",
+          "rvalue": "instantiation",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 3,
+          "consuming_reads": 3,
+          "foreign_consuming_methods": 3,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/gitlab/testing/request_blocker_middleware.rb",
+          "line": 10,
+          "owner": "Gitlab::Testing::RequestBlockerMiddleware",
+          "name": "@@num_active_requests",
+          "rvalue": "instantiation",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 3,
+          "consuming_reads": 3,
+          "foreign_consuming_methods": 3,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/gitlab/testing/request_blocker_middleware.rb",
+          "line": 11,
+          "owner": "Gitlab::Testing::RequestBlockerMiddleware",
+          "name": "@@block_requests",
+          "rvalue": "instantiation",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 3,
+          "consuming_reads": 3,
+          "foreign_consuming_methods": 3,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/gitlab/testing/request_blocker_middleware.rb",
+          "line": 12,
+          "owner": "Gitlab::Testing::RequestBlockerMiddleware",
+          "name": "@@slow_requests",
+          "rvalue": "instantiation",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 3,
+          "consuming_reads": 3,
+          "foreign_consuming_methods": 3,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/gitlab/testing/request_inspector_middleware.rb",
+          "line": 8,
+          "owner": "Gitlab::Testing::RequestInspectorMiddleware",
+          "name": "@@log_requests",
+          "rvalue": "instantiation",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 3,
+          "consuming_reads": 3,
+          "foreign_consuming_methods": 3,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/gitlab/testing/request_inspector_middleware.rb",
+          "line": 9,
+          "owner": "Gitlab::Testing::RequestInspectorMiddleware",
+          "name": "@@logged_requests",
+          "rvalue": "instantiation",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 3,
+          "consuming_reads": 2,
+          "foreign_consuming_methods": 2,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/gitlab/testing/request_inspector_middleware.rb",
+          "line": 10,
+          "owner": "Gitlab::Testing::RequestInspectorMiddleware",
+          "name": "@@inject_headers",
+          "rvalue": "instantiation",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 3,
+          "consuming_reads": 2,
+          "foreign_consuming_methods": 2,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/gitlab/testing/robots_blocker_middleware.rb",
+          "line": 7,
+          "owner": "Gitlab::Testing::RobotsBlockerMiddleware",
+          "name": "@@block_requests",
+          "rvalue": "instantiation",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 3,
+          "consuming_reads": 3,
+          "foreign_consuming_methods": 3,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/release_highlights/validator.rb",
+          "line": 25,
+          "owner": "ReleaseHighlights::Validator",
+          "name": "@all_errors",
+          "rvalue": "literal",
+          "spelling": "self_def",
+          "enclosing": "ReleaseHighlights::Validator",
+          "reads": 3,
+          "consuming_reads": 3,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        }
+      ],
+      "colliding_rows": [
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/gitlab/database/connection_timer.rb",
+          "line": 22,
+          "owner": "Gitlab::Database::ConnectionTimer",
+          "name": "@interval",
+          "rvalue": "constant",
+          "spelling": "singleton_class",
+          "enclosing": "Gitlab::Database::ConnectionTimer",
+          "reads": 0,
+          "consuming_reads": 0,
+          "foreign_consuming_methods": 0,
+          "recoverable": true,
+          "movable": false,
+          "collides": true
+        }
+      ]
+    },
+    "haml": {
+      "files": 51,
+      "subdirs": [
+        "lib"
+      ],
+      "summary": {
+        "b_singleton_ivar": {
+          "sites": 1,
+          "recoverable": 1
+        }
+      },
+      "movable_rows": [],
+      "colliding_rows": []
+    },
+    "kramdown": {
+      "files": 55,
+      "subdirs": [
+        "lib"
+      ],
+      "summary": {
+        "b_singleton_ivar": {
+          "sites": 4,
+          "with_read": 2
+        },
+        "a_class_body_cvar": {
+          "sites": 1,
+          "recoverable": 1,
+          "with_read": 1,
+          "with_consuming_read": 1,
+          "cross_method": 1,
+          "movable": 1
+        }
+      },
+      "movable_rows": [
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/kramdown/parser/kramdown.rb",
+          "line": 315,
+          "owner": "Kramdown::Parser::Kramdown",
+          "name": "@@parsers",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 4,
+          "consuming_reads": 4,
+          "foreign_consuming_methods": 3,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        }
+      ],
+      "colliding_rows": []
+    },
+    "liquid": {
+      "files": 63,
+      "subdirs": [
+        "lib"
+      ],
+      "summary": {
+        "a_class_body_cvar": {
+          "sites": 2,
+          "recoverable": 2,
+          "with_read": 2,
+          "with_consuming_read": 1,
+          "cross_method": 1,
+          "movable": 1
+        },
+        "b_singleton_ivar": {
+          "sites": 5,
+          "with_read": 4,
+          "recoverable": 1,
+          "with_consuming_read": 1,
+          "cross_method": 1,
+          "movable": 1
+        }
+      },
+      "movable_rows": [
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/liquid/condition.rb",
+          "line": 42,
+          "owner": "Liquid::Condition",
+          "name": "@@method_literals",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/liquid/strainer_template.rb",
+          "line": 46,
+          "owner": "Liquid::StrainerTemplate",
+          "name": "@filter_methods",
+          "rvalue": "instantiation",
+          "spelling": "singleton_class",
+          "enclosing": "Liquid::StrainerTemplate",
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        }
+      ],
+      "colliding_rows": []
+    },
+    "mail": {
+      "files": 111,
+      "subdirs": [
+        "lib"
+      ],
+      "summary": {
+        "a_class_body_cvar": {
+          "sites": 5,
+          "recoverable": 4,
+          "with_read": 4,
+          "with_consuming_read": 3,
+          "cross_method": 3,
+          "movable": 3
+        }
+      },
+      "movable_rows": [
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/mail.rb",
+          "line": 22,
+          "owner": "Mail",
+          "name": "@@autoloads",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 2,
+          "consuming_reads": 2,
+          "foreign_consuming_methods": 2,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/mail/mail.rb",
+          "line": 188,
+          "owner": "Mail",
+          "name": "@@delivery_notification_observers",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 4,
+          "consuming_reads": 4,
+          "foreign_consuming_methods": 3,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/mail/mail.rb",
+          "line": 189,
+          "owner": "Mail",
+          "name": "@@delivery_interceptors",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 5,
+          "consuming_reads": 4,
+          "foreign_consuming_methods": 3,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        }
+      ],
+      "colliding_rows": []
+    },
+    "mastodon": {
+      "files": 1325,
+      "subdirs": [
+        "app",
+        "lib"
+      ],
+      "summary": {
+        "b_singleton_ivar": {
+          "sites": 22,
+          "with_read": 4,
+          "with_consuming_read": 3,
+          "recoverable": 14,
+          "cross_method": 1
+        }
+      },
+      "movable_rows": [],
+      "colliding_rows": []
+    },
+    "parser": {
+      "files": 56,
+      "subdirs": [
+        "lib"
+      ],
+      "summary": {
+        "b_singleton_ivar": {
+          "sites": 8,
+          "recoverable": 8
+        }
+      },
+      "movable_rows": [],
+      "colliding_rows": []
+    },
+    "rails": {
+      "files": 2829,
+      "subdirs": [
+        "activerecord",
+        "activesupport",
+        "actionpack",
+        "actionview",
+        "activejob",
+        "activemodel",
+        "activestorage",
+        "actionmailer",
+        "actioncable"
+      ],
+      "summary": {
+        "b_singleton_ivar": {
+          "sites": 152,
+          "recoverable": 58,
+          "with_read": 52,
+          "with_consuming_read": 26,
+          "cross_method": 18,
+          "movable": 4,
+          "collides": 2
+        },
+        "c_anonymous_class_ivar": {
+          "sites": 22,
+          "with_read": 5,
+          "with_consuming_read": 5,
+          "cross_method": 4,
+          "collides": 2,
+          "recoverable": 15,
+          "movable": 2
+        },
+        "a_class_body_cvar": {
+          "sites": 18,
+          "with_read": 11,
+          "recoverable": 9,
+          "with_consuming_read": 5,
+          "cross_method": 5,
+          "movable": 5
+        }
+      },
+      "movable_rows": [
+        {
+          "shape": "c_anonymous_class_ivar",
+          "file": "actionpack/test/dispatch/routing_assertions_test.rb",
+          "line": 360,
+          "owner": "actionpack/test/dispatch/routing_assertions_test.rb:357",
+          "name": "@config",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": "WithRoutingResetTest",
+          "reads": 2,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "actionview/lib/action_view/digestor.rb",
+          "line": 7,
+          "owner": "ActionView::Digestor",
+          "name": "@@digest_mutex",
+          "rvalue": "instantiation",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "activerecord/lib/active_record/filter_attribute_handler.rb",
+          "line": 7,
+          "owner": "ActiveRecord::FilterAttributeHandler",
+          "name": "@sensitive_attribute_declaration_listeners",
+          "rvalue": "instantiation",
+          "spelling": "singleton_class",
+          "enclosing": "ActiveRecord::FilterAttributeHandler",
+          "reads": 2,
+          "consuming_reads": 2,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "activerecord/lib/active_record/fixtures.rb",
+          "line": 541,
+          "owner": "ActiveRecord::FixtureSet",
+          "name": "@@all_cached_fixtures",
+          "rvalue": "instantiation",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 2,
+          "consuming_reads": 2,
+          "foreign_consuming_methods": 2,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "activerecord/test/models/post.rb",
+          "line": 219,
+          "owner": "Post",
+          "name": "@log",
+          "rvalue": "literal",
+          "spelling": "self_def",
+          "enclosing": "Post",
+          "reads": 2,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "activesupport/lib/active_support/editor.rb",
+          "line": 44,
+          "owner": "ActiveSupport::Editor",
+          "name": "@current",
+          "rvalue": "literal",
+          "spelling": "singleton_class",
+          "enclosing": "ActiveSupport::Editor",
+          "reads": 2,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "activesupport/lib/active_support/execution_context.rb",
+          "line": 48,
+          "owner": "ActiveSupport::ExecutionContext",
+          "name": "@after_change_callbacks",
+          "rvalue": "literal",
+          "spelling": "singleton_class",
+          "enclosing": "ActiveSupport::ExecutionContext",
+          "reads": 4,
+          "consuming_reads": 3,
+          "foreign_consuming_methods": 2,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "activesupport/lib/active_support/testing/parallelization.rb",
+          "line": 14,
+          "owner": "ActiveSupport::Testing::Parallelization",
+          "name": "@@before_fork_hooks",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "activesupport/lib/active_support/testing/parallelization.rb",
+          "line": 22,
+          "owner": "ActiveSupport::Testing::Parallelization",
+          "name": "@@after_fork_hooks",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "activesupport/lib/active_support/testing/parallelization.rb",
+          "line": 30,
+          "owner": "ActiveSupport::Testing::Parallelization",
+          "name": "@@run_cleanup_hooks",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "c_anonymous_class_ivar",
+          "file": "activesupport/test/json/encoding_test.rb",
+          "line": 284,
+          "owner": "activesupport/test/json/encoding_test.rb:281",
+          "name": "@people",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": "TestJSONEncoding",
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        }
+      ],
+      "colliding_rows": [
+        {
+          "shape": "c_anonymous_class_ivar",
+          "file": "actioncable/test/server/base_test.rb",
+          "line": 46,
+          "owner": "actioncable/test/server/base_test.rb:44",
+          "name": "@server",
+          "rvalue": "opaque",
+          "spelling": null,
+          "enclosing": "BaseTest",
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": false,
+          "movable": false,
+          "collides": true
+        },
+        {
+          "shape": "c_anonymous_class_ivar",
+          "file": "actionpack/test/dispatch/server_timing_test.rb",
+          "line": 104,
+          "owner": "actionpack/test/dispatch/server_timing_test.rb:102",
+          "name": "@app",
+          "rvalue": "opaque",
+          "spelling": null,
+          "enclosing": "ServerTimingTest",
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": false,
+          "movable": false,
+          "collides": true
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "activesupport/lib/active_support/key_generator.rb",
+          "line": 18,
+          "owner": "ActiveSupport::KeyGenerator",
+          "name": "@hash_digest_class",
+          "rvalue": "opaque",
+          "spelling": "singleton_class",
+          "enclosing": "ActiveSupport::KeyGenerator",
+          "reads": 0,
+          "consuming_reads": 0,
+          "foreign_consuming_methods": 0,
+          "recoverable": false,
+          "movable": false,
+          "collides": true
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "activesupport/lib/active_support/key_generator.rb",
+          "line": 25,
+          "owner": "ActiveSupport::KeyGenerator",
+          "name": "@hash_digest_class",
+          "rvalue": "constant",
+          "spelling": "singleton_class",
+          "enclosing": "ActiveSupport::KeyGenerator",
+          "reads": 0,
+          "consuming_reads": 0,
+          "foreign_consuming_methods": 0,
+          "recoverable": true,
+          "movable": false,
+          "collides": true
+        }
+      ]
+    },
+    "redmine": {
+      "files": 346,
+      "subdirs": [
+        "app",
+        "lib"
+      ],
+      "summary": {
+        "a_class_body_cvar": {
+          "sites": 15,
+          "recoverable": 12,
+          "with_read": 10,
+          "with_consuming_read": 8,
+          "cross_method": 7,
+          "movable": 7
+        },
+        "b_singleton_ivar": {
+          "sites": 36,
+          "with_read": 26,
+          "with_consuming_read": 17,
+          "cross_method": 10,
+          "recoverable": 17,
+          "movable": 5
+        }
+      },
+      "movable_rows": [
+        {
+          "shape": "b_singleton_ivar",
+          "file": "app/models/webhook_payload.rb",
+          "line": 38,
+          "owner": "WebhookPayload",
+          "name": "@events",
+          "rvalue": "literal",
+          "spelling": "self_def",
+          "enclosing": "WebhookPayload",
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/redmine/access_control.rb",
+          "line": 26,
+          "owner": "Redmine::AccessControl",
+          "name": "@permissions",
+          "rvalue": "literal",
+          "spelling": "singleton_class",
+          "enclosing": "Redmine::AccessControl",
+          "reads": 6,
+          "consuming_reads": 5,
+          "foreign_consuming_methods": 5,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/redmine/activity.rb",
+          "line": 24,
+          "owner": "Redmine::Activity",
+          "name": "@@available_event_types",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 3,
+          "consuming_reads": 3,
+          "foreign_consuming_methods": 2,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/redmine/activity.rb",
+          "line": 25,
+          "owner": "Redmine::Activity",
+          "name": "@@default_event_types",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 2,
+          "consuming_reads": 2,
+          "foreign_consuming_methods": 2,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/redmine/activity.rb",
+          "line": 26,
+          "owner": "Redmine::Activity",
+          "name": "@@plugins_event_classes",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 2,
+          "consuming_reads": 2,
+          "foreign_consuming_methods": 2,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/redmine/activity.rb",
+          "line": 27,
+          "owner": "Redmine::Activity",
+          "name": "@@providers",
+          "rvalue": "instantiation",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 2,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/redmine/hook.rb",
+          "line": 22,
+          "owner": "Redmine::Hook",
+          "name": "@@listener_classes",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 2,
+          "consuming_reads": 2,
+          "foreign_consuming_methods": 2,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/redmine/menu_manager.rb",
+          "line": 255,
+          "owner": "Redmine::MenuManager",
+          "name": "@items",
+          "rvalue": "literal",
+          "spelling": "singleton_class",
+          "enclosing": "Redmine::MenuManager",
+          "reads": 2,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/redmine/plugin.rb",
+          "line": 155,
+          "owner": "Redmine::Plugin",
+          "name": "@registered_plugins",
+          "rvalue": "literal",
+          "spelling": "self_def",
+          "enclosing": "Redmine::Plugin",
+          "reads": 1,
+          "consuming_reads": 1,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/redmine/scm/base.rb",
+          "line": 30,
+          "owner": "Redmine::Scm::Base",
+          "name": "@scms",
+          "rvalue": "literal",
+          "spelling": "singleton_class",
+          "enclosing": "Redmine::Scm::Base",
+          "reads": 4,
+          "consuming_reads": 3,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/redmine/search.rb",
+          "line": 23,
+          "owner": "Redmine::Search",
+          "name": "@@available_search_types",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 2,
+          "consuming_reads": 2,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "a_class_body_cvar",
+          "file": "lib/redmine/wiki_formatting.rb",
+          "line": 26,
+          "owner": "Redmine::WikiFormatting",
+          "name": "@@formatters",
+          "rvalue": "literal",
+          "spelling": null,
+          "enclosing": null,
+          "reads": 8,
+          "consuming_reads": 8,
+          "foreign_consuming_methods": 6,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        }
+      ],
+      "colliding_rows": []
+    },
+    "rigor": {
+      "files": 674,
+      "subdirs": [
+        "lib",
+        "plugins"
+      ],
+      "summary": {
+        "b_singleton_ivar": {
+          "sites": 29,
+          "recoverable": 12,
+          "with_read": 8,
+          "with_consuming_read": 6,
+          "cross_method": 2,
+          "movable": 2
+        }
+      },
+      "movable_rows": [
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/rigor/effects/entry_points.rb",
+          "line": 132,
+          "owner": "Rigor::Effects::EntryPoints",
+          "name": "@presets",
+          "rvalue": "literal",
+          "spelling": "singleton_class",
+          "enclosing": "Rigor::Effects::EntryPoints",
+          "reads": 6,
+          "consuming_reads": 6,
+          "foreign_consuming_methods": 5,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        },
+        {
+          "shape": "b_singleton_ivar",
+          "file": "lib/rigor/plugin/first_party.rb",
+          "line": 52,
+          "owner": "Rigor::Plugin::FirstParty",
+          "name": "@memo",
+          "rvalue": "literal",
+          "spelling": "singleton_class",
+          "enclosing": "Rigor::Plugin::FirstParty",
+          "reads": 3,
+          "consuming_reads": 3,
+          "foreign_consuming_methods": 1,
+          "recoverable": true,
+          "movable": true,
+          "collides": false
+        }
+      ],
+      "colliding_rows": []
+    },
+    "rubocop-ast": {
+      "files": 101,
+      "subdirs": [
+        "lib"
+      ],
+      "summary": {
+        "b_singleton_ivar": {
+          "sites": 1,
+          "with_read": 1,
+          "with_consuming_read": 1,
+          "cross_method": 1
+        }
+      },
+      "movable_rows": [],
+      "colliding_rows": []
+    }
+  }
+}

--- a/tool/probe-693/run-corpus.sh
+++ b/tool/probe-693/run-corpus.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Runs census_gap_sites.rb over the survey corpus. Must run inside the Flake
+# shell (see tool/probe-693/README.md). $1 = output directory for the JSON rows.
+set -uo pipefail
+OUT="${1:-tool/probe-693/out}"
+SURVEY="${SURVEY_ROOT:-/Users/megurine/repo/ruby/rigor-survey}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+mkdir -p "$OUT"
+
+run() { # name root subdir...
+  local name="$1" root="$2"; shift 2
+  echo "== $name"
+  PROBE693_FORMAT=json ruby "$HERE/tool/probe-693/census_gap_sites.rb" "$root" "$@" > "$OUT/$name.json" || return
+  ruby "$HERE/tool/probe-693/census_gap_sites.rb" "$root" "$@"
+}
+
+run rigor            "$HERE"                        lib plugins
+run mastodon         "$SURVEY/mastodon"             app lib
+run gitlab           "$SURVEY/gitlab"               app lib
+run redmine          "$SURVEY/redmine"              app lib
+run rails            "$SURVEY/rails"                activerecord activesupport actionpack actionview activejob activemodel activestorage actionmailer actioncable
+run dependabot-core  "$SURVEY/dependabot-core"      common bundler npm_and_yarn python go_modules
+run concurrent-ruby  "$SURVEY/concurrent-ruby"      lib
+run mail             "$SURVEY/mail"                 lib
+run haml             "$SURVEY/haml"                 lib
+run faraday          "$SURVEY/faraday"              lib
+run liquid           "$SURVEY/liquid"               lib
+run parser           "$SURVEY/parser"               lib
+run rubocop-ast      "$SURVEY/rubocop-ast"          lib
+run kramdown         "$SURVEY/kramdown"             lib


### PR DESCRIPTION
Sizes the three shapes [#693](https://github.com/rigortype/rigor/issues/693) asks to be sized before any of them is implemented, with the movable-site probe [#692](https://github.com/rigortype/rigor/pull/692) established. **The conclusion is a decline**, so this lands the measurement and the instrument, not a fix — `Refs #693`, not `Fixes`.

## Why a probe rather than a diagnostic diff

All three shapes answer `Dynamic[top]`, and a `Dynamic` receiver dispatches gradually, so a before/after corpus diagnostic diff reads zero whether the shapes are everywhere or absent. The probe is Prism-only with Rigor deliberately out of the loop, so the counts do not depend on the analyzer being sized.

The column that decides is **movable**: a recoverable rvalue (a constant, a `Const.new`, or a literal — an opaque one records `Dynamic` after a fix too) **and** at least one read of that name is the receiver of a call **in a different method from the write**. That last clause removes two thirds of the raw population, because the dominant idiom is `@x ||= {}` immediately followed by `@x[k] = …` in the same body, where flow already supplies the type and a census seed buys nothing. `lib/rigor/plugin/base.rb:113` is that shape.

## Results — 14 targets, 17,706 parsed files

| shape | sites | recoverable | with_read | movable | collides |
| --- | ---: | ---: | ---: | ---: | ---: |
| A — class-body `@@x = …` never censused | 52 | 39 | 39 | **28** | 0 |
| B — ivar in `class << self` / `def self.x` not seeded | 605 | 204 | 184 | **25** | 3 |
| C — ivar in `Class.new do … end` | 35 | 19 | 16 | **3** | 2 |

Per-target tables and the adjudication are in the note; the raw movable and colliding rows are in `tool/probe-693/results-20260909.json`.

## The reading

The movable sites are real and they are all the same site: a registry table on a plugin manager (`Redmine::Activity.@@available_event_types`, `Redmine::WikiFormatting.@@formatters`, `Mail.@@delivery_interceptors`, `Kramdown::Parser::Kramdown.@@parsers`, five `Gitlab::Testing::*` middlewares). Confirmed on the real tree rather than inferred — `rigor type-of lib/redmine/activity.rb:42:9` answers `Dynamic[top]`.

And every recoverable rvalue across all three shapes is a bare collection (`[]`, `{}`, `Mutex.new`, `Hash.new { … }`), so the recovered type resolves one dispatch hop — `<<`, `delete`, `include?` — and hands `untyped` to whatever reads an element. The gain is teeth against a mistyped collection method on about one site per 300 files, on code that is correct today and so reports nothing before or after.

Against that: shape A's fix would union `nil` into every read of a cvar the class body writes `= nil` (3 corpus sites), which is the widening ADR-58 WD1's declaration-sourced mark and the C2 dead-write elimination were built to keep out of the ivar path. Shape B is not a walk fix at all — `StatementEvaluator#seed_instance_ivars` declines singleton bodies *because* the census table has no facet split, so closing it means splitting the table. Shape C is 3 sites, two under `test/`.

## One correction to the issue's premise, in the FP direction

#693 says "neither produces a wrong answer". For B and C that is not true. The write is not lost — it is recorded against the enclosing class's **instance** facet, because `collect_def_ivar_writes` keys the census table per class with no facet split and a `class << self` def carries no receiver to mark it singleton. Both of these are correct Ruby and both fire `def.ivar-write-mismatch` on master:

```ruby
class SingletonMix
  def initialize = (@state = Post.new)
  class << self
    def configure = (@state = Comment.new)   # warning: def.ivar-write-mismatch
  end
end

class Outer
  def initialize = (@own = Post.new)
  Inner = Class.new do
    def initialize = (@own = Comment.new)    # warning: def.ivar-write-mismatch
  end
end
```

`def self.x` does not fire — the write-mismatch collector recognises that spelling as singleton and `class << self` does not, which is the same two-spellings-one-meaning asymmetry #681 was about. Corpus-wide that population is **5 sites, none firing today** (each pairs one known type against one opaque one); both candidate files were run to confirm that rather than argued from the shape. It is cheaper than seeding and belongs in its own issue.

## Preserving the instrument

`tool/probe-693/` holds the probe, the corpus runner, a README saying how to run it and what each column bounds, and the results. It is under `tool/` rather than `tmp/` only because `/tmp/` is in `.gitignore`; `tool/` is already where `mutation/`, `steep/` and `oss_sweep_compare.rb` live, and it is RuboCop-excluded.

Docs-only + tooling change, so no changelog fragment. `make docs-check` green (448 examples, 0 failures).

Refs #693
