### PR TITLE
Fix the plugin loader's meta-gem branch, and activate rigor-rbnacl

### DIFF
--- a/changelog.d/fixed/fix-plugin-loader-meta-gem.md
+++ b/changelog.d/fixed/fix-plugin-loader-meta-gem.md
@@ -1,0 +1,1 @@
+- **[plugins]** A plugin gem that pulls in another plugin — every FFI-family plugin requires `rigor-ffi` — is no longer mistaken for a convenience meta-gem, so `plugins: [rigor-sassc]` (or `rigor-ethon`, `rigor-ffi-rzmq`, `rigor-rbnacl`) loads on its own instead of failing with advice that would activate the wrong plugin. ([#908](https://github.com/rigortype/rigor/pull/908))

--- a/changelog.d/fixed/fix-rbnacl-activation.md
+++ b/changelog.d/fixed/fix-rbnacl-activation.md
@@ -1,0 +1,1 @@
+- **[plugins]** `rigor-rbnacl` now registers itself and contributes its bundled RBS, so `RbNaCl::SecretBox#encrypt` / `#decrypt` type as `String`; the plugin had shipped inert, and its advertised signatures were never loaded. ([#908](https://github.com/rigortype/rigor/pull/908))

--- a/lib/rigor/plugin/loader.rb
+++ b/lib/rigor/plugin/loader.rb
@@ -264,14 +264,35 @@ module Rigor
         when 1
           Plugin.registered_for(newly_registered.first)
         else
-          raise LoadError.new(
-            "plugin gem #{entry[:gem].inspect} bundles #{newly_registered.size} plugins " \
-            "(#{newly_registered.sort.inspect}) and cannot be activated as a single `plugins:` entry — " \
-            "it is a convenience meta-gem. List the individual plugin gems you want in `plugins:` " \
-            "(e.g. `rigor-#{newly_registered.min}`), or select one with an explicit `id:` field.",
-            plugin_ref: entry[:gem]
-          )
+          own = own_id_among(entry[:gem], newly_registered)
+          raise meta_gem_error(entry, newly_registered) unless own
+
+          Plugin.registered_for(own)
         end
+      end
+
+      # A gem that registers more than one plugin is a meta-gem only when NONE of the ids is its own. The
+      # FFI family (`rigor-sassc`, `rigor-ethon`, `rigor-ffi-rzmq`, `rigor-rbnacl`) each `require "rigor-ffi"`
+      # for the shared binding analyzer, so listing one of them ALONE registered two plugins — its own and
+      # `ffi` — and the meta-gem branch rejected the entry, telling the user to list `rigor-ffi` instead,
+      # which activates the wrong plugin. The failure was load-order dependent (listing `rigor-ffi` first
+      # made the nested require a no-op and the entry loaded), so it never showed up in the suite, where
+      # some earlier example has always loaded `rigor-ffi`.
+      #
+      # `rigor-rails` stays a meta-gem under this rule: it registers eight ids and none of them is `rails`.
+      def own_id_among(gem_name, ids)
+        own = gem_name.to_s.delete_prefix(Plugin::FirstParty::GEM_PREFIX)
+        ids.find { |id| id == own }
+      end
+
+      def meta_gem_error(entry, newly_registered)
+        LoadError.new(
+          "plugin gem #{entry[:gem].inspect} bundles #{newly_registered.size} plugins " \
+          "(#{newly_registered.sort.inspect}) and cannot be activated as a single `plugins:` entry — " \
+          "it is a convenience meta-gem. List the individual plugin gems you want in `plugins:` " \
+          "(e.g. `rigor-#{newly_registered.min}`), or select one with an explicit `id:` field.",
+          plugin_ref: entry[:gem]
+        )
       end
 
       def validate_config!(manifest, config)

--- a/plugins/rigor-rbnacl/lib/rigor/plugin/rbnacl.rb
+++ b/plugins/rigor-rbnacl/lib/rigor/plugin/rbnacl.rb
@@ -9,7 +9,16 @@ module Rigor
       manifest(
         id: "rbnacl",
         version: "0.1.0",
-        description: "Rigor type support for RbNaCl libsodium bindings"
+        description: "Rigor type support for RbNaCl libsodium bindings",
+        signature_paths: ["sig"],
+        # ADR-26 — `sig/rbnacl.rbs` declares three methods of a class that has many more (`nonce_bytes`,
+        # `key_bytes`, …). Contributing it without opening the receivers would close those classes and
+        # manufacture `call.undefined-method` on correct code, which is the trade the project refuses.
+        open_receivers: [
+          "RbNaCl::SecretBox",
+          "RbNaCl::Signatures::Ed25519::SigningKey",
+          "RbNaCl::Signatures::Ed25519::VerifyKey"
+        ]
       )
 
       # Issue 2 & 5: use robust positional binding extractor and preserve module context
@@ -28,3 +37,5 @@ module Rigor
     end
   end
 end
+
+Rigor::Plugin.register(Rigor::Plugin::RbNaCl)

--- a/spec/integration/all_plugins_load_spec.rb
+++ b/spec/integration/all_plugins_load_spec.rb
@@ -82,6 +82,26 @@ RSpec.describe "bundled plugins and examples all load (structural guard)" do
       end
 
       unless ALL_PLUGINS_META_GEM_IDS.include?(File.basename(dir).sub(/\Arigor-/, ""))
+        # Lexical on purpose. The example below scans `Rigor::Plugin.constants` so it survives another
+        # spec's `Rigor::Plugin.unregister!` — but that makes it blind to the one thing the loader needs,
+        # a `Rigor::Plugin.register` call in the gem's own body. `rigor-rbnacl` shipped without one and
+        # defined its class anyway, so it passed that example while `plugins: [rigor-rbnacl]` failed with
+        # "plugin did not register or could not be matched to a registered class". A grep over the gem's
+        # sources is order-independent and catches exactly that.
+        it "calls Rigor::Plugin.register in its own sources" do
+          sources = Dir[File.join(dir, "lib", "**", "*.rb")]
+          # Both shipped spellings: the qualified top-level call, and the bare `register(Klass)` a plugin
+          # written inside `module Rigor; module Plugin` uses. Anchored at line start so the sentence
+          # naming the method in a gem-entry comment does not count as a call.
+          registering = sources.select { |file| File.read(file).match?(/^[ \t]*(?:Rigor::Plugin\.)?register\(/) }
+
+          expect(registering).not_to(
+            be_empty,
+            "expected one of #{sources.size} file(s) under #{File.join(dir, 'lib')} to call " \
+            "Rigor::Plugin.register — without it the loader cannot activate this plugin"
+          )
+        end
+
         it "registers a Plugin::Base subclass carrying a valid manifest" do
           require entry_for(dir)
           klass = plugin_class_for(id_for(dir))

--- a/spec/rigor/plugin/loader_spec.rb
+++ b/spec/rigor/plugin/loader_spec.rb
@@ -168,7 +168,16 @@ RSpec.describe Rigor::Plugin::Loader do
       expect(registry.load_errors.first.message).to include("did not register any plugin")
     end
 
+    # A gem that registers its OWN id alongside another's is not ambiguous — see the sibling example below.
+    # The meta-gem case is a gem none of whose registered ids is its own, which is what `rigor-rails` is.
     it "surfaces multi-registration ambiguity as a load error" do
+      plugins = ["rigor-pair"]
+      configuration = Rigor::Configuration.new(Rigor::Configuration::DEFAULTS.merge("plugins" => plugins))
+      services = Rigor::Plugin::Services.new(
+        reflection: Rigor::Reflection,
+        type: Rigor::Type::Combinator,
+        configuration: configuration
+      )
       requirer = lambda { |_name|
         Rigor::Plugin.register(plugin_class_a)
         Rigor::Plugin.register(plugin_class_b)
@@ -184,6 +193,23 @@ RSpec.describe Rigor::Plugin::Loader do
       expect(message).to include("convenience meta-gem")
       expect(message).to match(/list the individual plugin gems/i)
       expect(message).to include("`id:`")
+    end
+
+    # The FFI family (`rigor-sassc`, `rigor-ethon`, `rigor-ffi-rzmq`, `rigor-rbnacl`) each `require
+    # "rigor-ffi"` for the shared binding analyzer, so listing one of them ALONE registered two plugins and
+    # was rejected as a meta-gem — with advice ("list `rigor-ffi`") that activates the wrong plugin. It
+    # only reproduced when nothing had loaded `rigor-ffi` first, which is why the suite never saw it.
+    it "resolves a gem that also registers a dependency's plugin to its own id" do
+      requirer = lambda { |_name|
+        Rigor::Plugin.register(plugin_class_b)
+        Rigor::Plugin.register(plugin_class_a)
+        true
+      }
+
+      registry = described_class.load(configuration: configuration, services: services, requirer: requirer)
+
+      expect(registry.load_errors).to be_empty
+      expect(registry.ids).to eq(["alpha"])
     end
 
     it "resolves an explicit `id:` even when the gem registers multiple plugins" do


### PR DESCRIPTION
Started from one line in the 2026-09-09 ADR corpus audit — "`plugins/rigor-rbnacl` ships `sig/rbnacl.rbs` and its README advertises it, but the manifest declares no `signature_paths:`" — and the reproduction turned up a larger defect underneath it.

**`plugins: [rigor-sassc]` did not work.** Any FFI-family plugin listed *alone* failed to load:

```
[ERR] rigor-sassc
      load error: plugin gem "rigor-sassc" bundles 2 plugins (["ffi", "sassc"]) and cannot be
      activated as a single `plugins:` entry — it is a convenience meta-gem. List the individual
      plugin gems you want in `plugins:` (e.g. `rigor-ffi`) …
```

`rigor-sassc`, `rigor-ethon`, `rigor-ffi-rzmq` and `rigor-rbnacl` each `require "rigor-ffi"` for the shared binding analyzer, so requiring one registers two plugins and the ambiguity branch rejected the entry — advising the user to list `rigor-ffi`, which activates a different plugin. It only reproduces when nothing has loaded `rigor-ffi` first, which is why the suite never saw it: some earlier example always has.

The missing disambiguation is the gem's own name. A gem registering more than one plugin is a meta-gem only when **none** of the ids is its own. `rigor-rails` still is one — eight ids, none of them `rails`.

**`rigor-rbnacl` never registered at all.** No `Rigor::Plugin.register` call, so nothing in the plugin ran. The structural guard passed it because it scans `Rigor::Plugin.constants` for a class with a matching manifest id, which a defined-but-unregistered class satisfies; it now also asserts the gem's sources call `register`, in either shipped spelling. That example fails on the pre-fix tree naming exactly `rigor-rbnacl`.

**`signature_paths:` lands with `open_receivers:`.** The bundled RBS declares three methods of classes that have many more, so contributing it alone closes them — measured on a fixture calling the real `RbNaCl::SecretBox#nonce_bytes`, it manufactured two `call.undefined-method` errors. With the receivers open (the ADR-26 trade rigor-activerecord already makes for `ActiveRecord::Relation`), `encrypt` / `decrypt` type as `String` and the undeclared methods degrade to `Dynamic[top]` silently.

Verified end to end through the CLI on throwaway fixtures for `rigor-sassc`, `rigor-rails` (still correctly refused) and `rigor-rbnacl`. `make verify` green; `git diff --check` clean.