### PR TITLE
Stop documenting a `.rigor.yml` key that does not exist

### DIFF
--- a/changelog.d/fixed/fix-isolation-config-docs.md
+++ b/changelog.d/fixed/fix-isolation-config-docs.md
@@ -1,0 +1,1 @@
+- **[docs]** ADR-39, the internal spec and the `rigor-plugin-author` skill no longer document a `.rigor.yml` `plugins_isolation:` key: the plugin-isolation strategy is selected by the `RIGOR_PLUGIN_ISOLATION` environment variable, and the config key was never implemented. ([#913](https://github.com/rigortype/rigor/pull/913))

--- a/docs/adr/39-plugin-target-library-invocation.md
+++ b/docs/adr/39-plugin-target-library-invocation.md
@@ -205,8 +205,8 @@ reopens `String` / `Hash` changes the Ruby that Rigor's own code runs
 under) and **gem-version clashes** (Ruby allows one version of a gem per
 process, so the target's version can collide with Rigor's own). How much
 isolation is worth its cost depends on the deployment, so the isolation
-is a **configurable strategy** (`.rigor.yml` `plugins_isolation:` /
-`RIGOR_PLUGIN_ISOLATION` env), with three backends behind one interface:
+is a **configurable strategy** (the `RIGOR_PLUGIN_ISOLATION` env), with
+three backends behind one interface:
 
 | Strategy | Isolation | Crash containment | Cost | Notes |
 | --- | --- | --- | --- | --- |
@@ -359,8 +359,7 @@ reframed from "unify the approximations" to "use the real library."
 5. **Selectable isolation strategy** (see § "Isolation of target-library
    invocation"). `Plugin::Isolation` selects one of three backends behind
    a common `call(feature:, receiver:, method:, args:)` interface by the
-   `RIGOR_PLUGIN_ISOLATION` env (which `exe/rigor` maps from
-   `.rigor.yml`'s `plugins_isolation:`), with `process` the **default**
+   `RIGOR_PLUGIN_ISOLATION` env, with `process` the **default**
    (falling back to `none` where `fork` is unavailable). **All three
    landed:**
    - `none` — `require` + `public_send` in the main space (default path).

--- a/docs/internal-spec/plugin.md
+++ b/docs/internal-spec/plugin.md
@@ -570,8 +570,8 @@ project's source.
   `rigor-activerecord` / `rigor-actionpack` / `rigor-actionmailer` /
   `rigor-factorybot` use it.
 - `Rigor::Plugin::Isolation` — the **selectable isolation strategy** for
-  the invocation, chosen by `RIGOR_PLUGIN_ISOLATION` (the `exe/rigor`
-  launcher maps `.rigor.yml`'s `plugins_isolation:` onto it). One
+  the invocation, chosen by `RIGOR_PLUGIN_ISOLATION` alone. There is no
+  `.rigor.yml` key for it ([#911](https://github.com/rigortype/rigor/issues/911)). One
   `call(feature:, receiver:, method:, args:)` interface over three
   backends, **`process` the default**:
   - `process` (default) — a single forked **persistent worker** (forked

--- a/lib/rigor/plugin/isolation.rb
+++ b/lib/rigor/plugin/isolation.rb
@@ -7,8 +7,8 @@ module Rigor
     # ADR-39 slice 5 — the selectable isolation strategy for target-library invocation. A plugin invokes a
     # pure method on a trusted target library (e.g. `ActiveSupport::Inflector.pluralize("post")`) through
     # {.call}; how much the invocation is isolated from Rigor's own process is a **configurable strategy**
-    # (`RIGOR_PLUGIN_ISOLATION` env; the `exe/rigor` launcher maps `.rigor.yml`'s `plugins_isolation:` onto it
-    # before re-exec). Three backends behind one interface:
+    # (the `RIGOR_PLUGIN_ISOLATION` env — there is no `.rigor.yml` key for it, see issue #911). Three
+    # backends behind one interface:
     #
     # - `none` — load into the main space and call directly. Lowest cost; no isolation. Used as the fallback
     #   where fork is unavailable; fine because the invoked library is trusted + pure.

--- a/skills/rigor-plugin-author/references/02-walker-and-types.md
+++ b/skills/rigor-plugin-author/references/02-walker-and-types.md
@@ -152,8 +152,8 @@ For your own target library, follow the same harness: a **fixed
 allow-list** of pure methods, inputs derived from source, and **decline
 (return nil / emit nothing) when the library is unavailable — never
 approximate**. How the call is isolated from Rigor (in-process, a forked
-worker, or a `Ruby::Box`) is a configurable strategy the user picks
-(`plugins_isolation:`); you just call the method.
+worker, or a `Ruby::Box`) is a configurable strategy the user picks with
+the `RIGOR_PLUGIN_ISOLATION` environment variable; you just call the method.
 
 For the common "did you mean …?" suggestion, use the shared helper
 rather than hand-rolling Levenshtein:


### PR DESCRIPTION
From the 2026-09-09 ADR corpus audit ([`docs/notes/20260909-adr-corpus-audit.md`](https://github.com/rigortype/rigor/blob/master/docs/notes/20260909-adr-corpus-audit.md) § 0).

ADR-39 (`:208`, `:363`), the **normative** `docs/internal-spec/plugin.md:573`, the shipped `skills/rigor-plugin-author` reference, and `Plugin::Isolation`'s own doc comment all state that the plugin-isolation strategy is chosen by a `.rigor.yml` `plugins_isolation:` key which `exe/rigor` maps onto `RIGOR_PLUGIN_ISOLATION`.

There is no such key:

- `exe/rigor` reads `ENV["RIGOR_PLUGIN_ISOLATION"]` and has never parsed `.rigor.yml` — `git log -S 'rigor.yml' -- exe/rigor` is empty.
- `Plugin::Isolation.strategy` (`lib/rigor/plugin/isolation.rb:104`) reads the variable alone.
- The key is absent from `schemas/rigor-config.schema.json`, which ADR-99 names a source of truth.

The claim arrived with the implementing commit `3a9c99d2`: the mapping is in its message, not in its diff. A user following the binding document writes a key that is silently ignored.

This PR only makes the documents true. [#911](https://github.com/rigortype/rigor/issues/911) is the feature they were describing — reading the strategy from the configuration, with the schema entry ADR-99 requires and the guard that keeps the two in step; `ruby_box` stays environment-only there, since `RUBY_BOX=1` must be set before Ruby boots.

`make verify` and `make docs-check` both green.