### PR TITLE
Declare rigor-ffi's config_schema for the exceptions/target keys

### DIFF
--- a/changelog.d/fixed/fix-918-ffi-config-schema.md
+++ b/changelog.d/fixed/fix-918-ffi-config-schema.md
@@ -1,0 +1,1 @@
+- **[rigor-ffi]** `.rigor.yml`'s `exceptions:` and `target:` keys for the `rigor-ffi` plugin now validate and take effect, instead of being silently rejected as unknown config. ([#944](https://github.com/rigortype/rigor/pull/944))

--- a/docs/adr/30-rigor-ffi-plugin-shape.md
+++ b/docs/adr/30-rigor-ffi-plugin-shape.md
@@ -195,7 +195,9 @@ The nominal carrier honors the
 - **Return** — return types declared as the nominal alias stay
   strict `Nominal[<alias>]`.
 
-A per-project `.rigor.yml` exception list (`rigor_ffi: { nominal_typedef_exceptions: ["log_target_ptr"] }`)
+A per-project `.rigor.yml` exception list (the plugin's own
+`config_schema`-declared `exceptions:` key, e.g.
+`plugins: [{gem: rigor-ffi, config: {exceptions: ["log_target_ptr"]}}]`)
 lets a project opt a typedef back to transparent if the heuristic
 misfires.
 
@@ -247,10 +249,11 @@ ffx detection cascades through three sources, top-down:
    resolved dependency, the project is considered an ffx target.
    Reuses the bundler-parsing path already present for
    `BundleSigDiscovery` (v0.1.5).
-3. **Explicit configuration.** `.rigor.yml` may set
-   `rigor_ffi: { target: ffx }` to force the detection. Last
-   resort, present for environments where neither `extconf.rb`
-   nor `Gemfile.lock` is authoritative.
+3. **Explicit configuration.** `.rigor.yml` may set the
+   `config_schema`-declared `target:` key
+   (`plugins: [{gem: rigor-ffi, config: {target: ffx}}]`) to force
+   the detection. Last resort, present for environments where
+   neither `extconf.rb` nor `Gemfile.lock` is authoritative.
 
 Detection results are cached at the project-context level (cleared
 when the relevant input file changes, per ADR-6's cache invalidation

--- a/plugins/rigor-ffi/README.md
+++ b/plugins/rigor-ffi/README.md
@@ -27,6 +27,21 @@ plugins/rigor-ffi/
     └── demo.rb
 ```
 
+## Configuration
+
+```yaml
+plugins:
+  - gem: rigor-ffi
+    config:
+      exceptions: ["log_target_ptr"]  # default: []
+      target: ffx                     # default: "auto"
+```
+
+- `exceptions` — typedef alias names the nominal-opaque-pointer heuristic (WD4) should keep as a
+  transparent `:pointer` alias even though they match the `_ptr$` / `_handle$` naming pattern.
+- `target` — `"auto"` (default) runs the `extconf.rb` / `Gemfile.lock` cascade (WD6); `"ffi"` / `"ffx"`
+  pin the target outright.
+
 ## Features
 
 - **AST literal walking**: Recognizes `attach_function`, `callback`, `typedef`, `enum`, `bitmask`, and `layout`.

--- a/plugins/rigor-ffi/lib/rigor/plugin/ffi.rb
+++ b/plugins/rigor-ffi/lib/rigor/plugin/ffi.rb
@@ -13,9 +13,20 @@ module Rigor
     class FFI < Base
       manifest(
         id: "ffi",
-        version: "0.1.0",
+        # Bumped 2026-09-10 (#918) — declares `config_schema` for the two `.rigor.yml` surfaces ADR-30
+        # WD4 (`exceptions`) and WD6 (`target`) already read off `config` but the manifest never
+        # published, so both keys were rejected by `Manifest#validate_config` as unknown.
+        version: "0.2.0",
         description: "Models FFI library bindings, struct layouts, callbacks, carrier types, and ffx target compatibility.",
-        signature_paths: ["sig"]
+        signature_paths: ["sig"],
+        config_schema: {
+          # WD4 — typedef alias names the nominal-opaque-pointer heuristic should treat as a transparent
+          # `:pointer` alias even though they match the `_ptr$` / `_handle$` naming pattern.
+          "exceptions" => { kind: :array, default: [] },
+          # WD6 — forces ffx-target detection instead of the `extconf.rb` / `Gemfile.lock` cascade.
+          # `"auto"` (the default) keeps the cascade; `"ffi"` / `"ffx"` pin the target outright.
+          "target" => { kind: :string, default: "auto" }
+        }
       )
 
       producer :ffi_catalog do

--- a/spec/integration/plugins/ffi_plugins_spec.rb
+++ b/spec/integration/plugins/ffi_plugins_spec.rb
@@ -143,4 +143,71 @@ RSpec.describe "FFI plugin family" do
       expect(Rigor::Plugin::FFIRZMQ.manifest.id).to eq("ffi-rzmq")
     end
   end
+
+  # Issue #918 — WD4's `exceptions` and WD6's `target` are read from `config` inside the plugin, but the
+  # manifest declared no `config_schema`, so `Manifest#validate_config` rejected both as unknown before a
+  # single line of the plugin's own logic ever ran. These drive the real `Rigor::Analysis::Runner`
+  # against a `.rigor.yml`-shaped plugin entry (not the bare unit calls above) to prove the config keys
+  # both validate AND change the produced type.
+  describe "configuration (#918)" do
+    include Rigor::IntegrationSupport::PluginHelpers
+
+    let(:plugin_class) { Rigor::Plugin::FFI }
+    let(:typedef_source) do
+      <<~RUBY
+        module MyLib
+          extend FFI::Library
+          typedef :pointer, :my_ptr
+          attach_function :open, [], :my_ptr
+        end
+
+        Rigor.dump_type(MyLib.open)
+      RUBY
+    end
+    let(:pointer_source) do
+      <<~RUBY
+        module MyLib
+          extend FFI::Library
+          attach_function :open, [], :pointer
+        end
+
+        Rigor.dump_type(MyLib.open)
+      RUBY
+    end
+
+    def dumps(result)
+      result.diagnostics.select { |d| d.qualified_rule == "dump.type" }.map(&:message)
+    end
+
+    it "treats a typedef alias as the nominal opaque-pointer type by default (WD4)" do
+      result = run_plugin(source: typedef_source)
+      expect(dumps(result)).to eq(["dump_type: MyLib::MyPtr"])
+    end
+
+    it "widens the nominal exception back to FFI::Pointer once `exceptions` names it (WD4)" do
+      result = run_plugin(
+        source: typedef_source,
+        plugin_entry: { "gem" => "rigor-ffi", "config" => { "exceptions" => ["my_ptr"] } }
+      )
+      expect(dumps(result)).to eq(["dump_type: FFI::Pointer"])
+    end
+
+    it "returns FFI::Pointer for the ffi-gem target by default" do
+      result = run_plugin(source: pointer_source)
+      expect(dumps(result)).to eq(["dump_type: FFI::Pointer"])
+    end
+
+    it "returns Integer instead once `target: ffx` is forced through config (WD6)" do
+      result = run_plugin(
+        source: pointer_source,
+        plugin_entry: { "gem" => "rigor-ffi", "config" => { "target" => "ffx" } }
+      )
+      expect(dumps(result)).to eq(["dump_type: Integer"])
+    end
+
+    it "rejects an unknown config key instead of silently ignoring it" do
+      errors = Rigor::Plugin::FFI.manifest.validate_config({ "bogus" => true })
+      expect(errors).to include(a_string_matching(/unknown config key "bogus"/))
+    end
+  end
 end


### PR DESCRIPTION
## What

Declares `config_schema` in `rigor-ffi`'s manifest for the two `.rigor.yml` surfaces ADR-30 documents (WD4's `exceptions` typedef-exception list, WD6's `target` override) — the plugin code already read both off `config["exceptions"]` / `config["target"]`, but with no `config_schema` declared, `Manifest#validate_config` rejected either key as `unknown config key` before any plugin logic ran.

## Why

ADR-99 makes `config_schema` the source of truth for what a plugin's `.rigor.yml` block accepts. Both keys already toggle real behaviour (`Types.nominal_opaque_pointer?`'s exception check, `TargetDetector.detect`'s explicit-override branch) — this is not new work, just publishing the schema for behaviour that already exists.

## Changes

- `plugins/rigor-ffi/lib/rigor/plugin/ffi.rb` — declares `config_schema: { "exceptions" => {kind: :array, default: []}, "target" => {kind: :string, default: "auto"} }`, bumps the plugin manifest version to `0.2.0`.
- `docs/adr/30-rigor-ffi-plugin-shape.md` — corrects the WD4/WD6 illustrative snippets, which showed a `rigor_ffi: {...}` top-level namespace that was never how plugin config actually works (the real shape is the plugin entry's own `config:` block).
- `plugins/rigor-ffi/README.md` — adds a Configuration section documenting both keys.
- `spec/integration/plugins/ffi_plugins_spec.rb` — adds a `configuration (#918)` block that drives the real `Rigor::Analysis::Runner` against a `.rigor.yml`-shaped plugin entry and asserts the produced type changes (not just that the key validates): the typedef alias resolves to the nominal type by default and to `FFI::Pointer` once excepted, and a `:pointer` return resolves to `FFI::Pointer` by default and `Integer` once `target: ffx` is forced. Also asserts an unknown key is still rejected.

Fixes #918
