### PR TITLE
Stop attributing detached ivar writes to the enclosing class

### DIFF
--- a/changelog.d/fixed/fix-909-ivar-write-facet.md
+++ b/changelog.d/fixed/fix-909-ivar-write-facet.md
@@ -1,0 +1,1 @@
+- **[rules]** `def.ivar-write-mismatch` no longer fires on correct Ruby when a `class << self` def, or a def inside a `Class.new do … end` block, writes an instance variable the enclosing class also writes — those are different variables, and the `class << self` spelling now agrees with `def self.x`. ([#945](https://github.com/rigortype/rigor/pull/945))

--- a/lib/rigor/analysis/check_rules/ivar_write_collector.rb
+++ b/lib/rigor/analysis/check_rules/ivar_write_collector.rb
@@ -2,6 +2,7 @@
 
 require "prism"
 
+require_relative "rule_walk"
 require_relative "../../source/constant_path"
 require_relative "../../source/node_children"
 
@@ -17,7 +18,11 @@ module Rigor
       #
       # Skipped on purpose:
       #
-      # - Singleton-method bodies (`def self.foo`). Their ivars live on the class object, not on instances.
+      # - Singleton-method bodies, in either spelling: `def self.foo`, and (issue #909) any `def` lexically
+      #   inside a `class << self` body. Their ivars live on the class object, not on instances.
+      # - Bodies of an anonymous-class factory block (`Class.new do … end`, `Module.new`, `Struct.new`,
+      #   `Data.define`). The class they define is not the enclosing one, so its ivars are a third store
+      #   again (issue #909).
       # - Class-body ivar writes outside any def — the `Module#@var` surface is a separate slice the engine
       #   doesn't yet model.
       # - Nested classes / modules / defs inside a method body are barriers, mirroring the indexer's
@@ -33,7 +38,7 @@ module Rigor
         # shared full DFS that prune becomes the `:inside_def` gate; the enclosing class / module name stack
         # the legacy walk threaded as `qualified_prefix` is now `context.qualified_prefix`.
         NODE_CLASSES = [Prism::DefNode].freeze
-        RULE_WALK_GATES = [:inside_def].freeze
+        RULE_WALK_GATES = %i[inside_def detached_ivar_facet].freeze
 
         # Returns `Hash[class_name (String) => Hash[ivar_name (Symbol) => Array<{node:, type:}>]]`. Empty
         # when the tree has no qualifying writes.
@@ -66,6 +71,9 @@ module Rigor
 
         def walk(node, qualified_prefix)
           return unless node.is_a?(Prism::Node)
+          # The legacy walk's mirror of {RuleWalk}'s `detached_ivar_facet` context (issue #909); the two
+          # walks share the predicate so the permanent equivalence spec keeps holding.
+          return if RuleWalk.detached_ivar_facet?(node)
 
           case node
           when Prism::ClassNode, Prism::ModuleNode

--- a/lib/rigor/analysis/check_rules/rule_walk.rb
+++ b/lib/rigor/analysis/check_rules/rule_walk.rb
@@ -40,11 +40,26 @@ module Rigor
 
         CLASS_OR_MODULE_NODE_CLASSES = [Prism::ClassNode, Prism::ModuleNode].freeze
 
+        # Issue #909 — the receivers whose block form opens a class body that is NOT the lexically enclosing
+        # class: `Class.new do … end`, `Module.new`, `Struct.new`, `Data.define`. A `def` in such a block
+        # belongs to the anonymous class the call returns, so its ivar writes are a different store from the
+        # enclosing class's.
+        DETACHED_CLASS_FACTORIES = {
+          Class: %i[new],
+          Module: %i[new],
+          Struct: %i[new],
+          Data: %i[define]
+        }.freeze
+        private_constant :DETACHED_CLASS_FACTORIES
+
+        EMPTY_METHODS = [].freeze
+        private_constant :EMPTY_METHODS
+
         # The immutable per-node descent context. Recomputed for each child from its parent's context as the
         # walk descends; collectors read only the fields they declared a need for.
-        Context = Data.define(:in_loop_or_block, :qualified_prefix, :inside_def) do
+        Context = Data.define(:in_loop_or_block, :qualified_prefix, :inside_def, :detached_ivar_facet) do
           def self.root
-            new(in_loop_or_block: false, qualified_prefix: [], inside_def: false)
+            new(in_loop_or_block: false, qualified_prefix: [], inside_def: false, detached_ivar_facet: false)
           end
         end
 
@@ -58,9 +73,13 @@ module Rigor
         # - `:inside_def` (`inside_def`) — lexically inside a `DefNode`; IvarWrite collects only at a `def`
         #   that sits directly in a class / module body (its legacy walk `return`s at the first `def` it
         #   meets, so a nested def is never reached).
+        # - `:detached_ivar_facet` (`detached_ivar_facet`) — under a `class << self` body or an
+        #   anonymous-class factory block, where the enclosing class name does not name the ivar store the
+        #   body writes to.
         GATE_CONTEXT_PREDICATES = {
           loop_or_block: :in_loop_or_block,
-          inside_def: :inside_def
+          inside_def: :inside_def,
+          detached_ivar_facet: :detached_ivar_facet
         }.freeze
 
         # A per-node driver over a fixed collector set: holds the compiled `node_class => [[collector,
@@ -124,12 +143,28 @@ module Rigor
                                LOOP_OR_BLOCK_NODE_CLASSES.any? { |klass| node.is_a?(klass) }
             inside_def = context.inside_def || node.is_a?(Prism::DefNode)
             qualified_prefix = extend_prefix(node, context.qualified_prefix)
+            detached_ivar_facet = context.detached_ivar_facet || detached_ivar_facet?(node)
 
             Context.new(
               in_loop_or_block: in_loop_or_block,
               qualified_prefix: qualified_prefix,
-              inside_def: inside_def
+              inside_def: inside_def,
+              detached_ivar_facet: detached_ivar_facet
             )
+          end
+
+          # True for a node whose descendants write ivars to a store the enclosing class name does not name:
+          # a `class << self` body (the class object's own ivars) or a call that builds an anonymous class
+          # from a block. Every singleton-class body counts, `class << Konstant` included: whichever object's
+          # singleton it opens, it is not the instance facet the enclosing prefix names.
+          def detached_ivar_facet?(node)
+            return true if node.is_a?(Prism::SingletonClassNode)
+            return false unless node.is_a?(Prism::CallNode) && node.block.is_a?(Prism::BlockNode)
+
+            receiver = node.receiver
+            return false unless receiver.is_a?(Prism::ConstantReadNode)
+
+            DETACHED_CLASS_FACTORIES.fetch(receiver.name, EMPTY_METHODS).include?(node.name)
           end
 
           private

--- a/lib/rigor/analysis/rule_catalog.rb
+++ b/lib/rigor/analysis/rule_catalog.rb
@@ -642,7 +642,10 @@ module Rigor
             "Later write is `nil` — the `@cache = nil` clear-idiom is allowlisted.",
             "Either side is Union / Dynamic / IntegerRange / a shape-varied carrier.",
             "Writes live in different classes that happen to share an ivar name.",
-            "Writes are in `def self.foo` (singleton) bodies — those track separately."
+            "Writes are in a singleton body — `def self.foo` or a `class << self` def — those track " \
+            "separately.",
+            "Writes are in a `def` inside an anonymous-class factory block (`Class.new do … end`, " \
+            "`Module.new`, `Struct.new`, `Data.define`): that body defines another class."
           ],
           suppression: "`# rigor:disable ivar-write-mismatch` on the offending write.",
           severity_authored: :error,

--- a/spec/rigor/analysis/check_rules/rule_walk_equivalence_spec.rb
+++ b/spec/rigor/analysis/check_rules/rule_walk_equivalence_spec.rb
@@ -156,6 +156,25 @@ module RuleWalkEquivalenceCases # rubocop:disable Metrics/ModuleLength -- curate
         end
       end
     RUBY
+    "ivar writes skipped under a singleton class and an anonymous-class factory block" => <<~RUBY,
+      class Detached
+        def instance_write
+          @d = 1
+        end
+
+        class << self
+          def singleton_write
+            @d = "two"
+          end
+        end
+
+        Inner = Class.new do
+          def initialize
+            @d = :three
+          end
+        end
+      end
+    RUBY
     "ivar writes inside a nested def are not double-collected" => <<~RUBY,
       class Holder
         def outer

--- a/spec/rigor/analysis/runner_check_rules_spec.rb
+++ b/spec/rigor/analysis/runner_check_rules_spec.rb
@@ -3342,6 +3342,98 @@ RSpec.describe Rigor::Analysis::Runner do
         expect(diag.message).to include("String")
       end
 
+      # Issue #909 — the class object's ivars and an instance's are different stores, and both spellings of a
+      # singleton def must say so.
+      it "does not flag a `class << self` write that diverges from the instance facet" do
+        result = analyze(<<~RUBY)
+          class SingletonMix
+            def initialize
+              @state = "idle"
+            end
+
+            class << self
+              def configure
+                @state = 42
+              end
+            end
+          end
+        RUBY
+        expect(ivar_diags(result)).to be_empty
+      end
+
+      it "does not flag the `def self.x` spelling of the same divergence" do
+        result = analyze(<<~RUBY)
+          class SingletonMix
+            def initialize
+              @state = "idle"
+            end
+
+            def self.configure
+              @state = 42
+            end
+          end
+        RUBY
+        expect(ivar_diags(result)).to be_empty
+      end
+
+      it "still flags a genuine instance-side divergence inside a class that also opens `class << self`" do
+        result = analyze(<<~RUBY)
+          class SingletonMix
+            def initialize
+              @state = "idle"
+            end
+
+            def reset
+              @state = 42
+            end
+
+            class << self
+              def configure
+                @state = :configured
+              end
+            end
+          end
+        RUBY
+        expect(ivar_diags(result).size).to eq(1)
+        expect(ivar_diags(result).first.message).to include("Integer")
+      end
+
+      # Issue #909 — `Class.new do … end` defines a class of its own; its ivars are not the enclosing
+      # class's.
+      it "does not flag a write inside an anonymous-class factory block" do
+        result = analyze(<<~RUBY)
+          class Outer
+            def initialize
+              @own = "outer"
+            end
+
+            Inner = Class.new do
+              def initialize
+                @own = 42
+              end
+            end
+          end
+        RUBY
+        expect(ivar_diags(result)).to be_empty
+      end
+
+      it "still flags a divergence inside a plain (non-class-building) block" do
+        result = analyze(<<~RUBY)
+          class Outer
+            def initialize
+              @own = "outer"
+            end
+
+            def each_thing
+              [1].each do |n|
+                @own = n
+              end
+            end
+          end
+        RUBY
+        expect(ivar_diags(result).size).to eq(1)
+      end
+
       it "is suppressible via `# rigor:disable ivar-write-mismatch`" do
         result = analyze(<<~RUBY)
           class Foo


### PR DESCRIPTION
A `def` inside a `class << self` body carries no receiver, so `IvarWriteCollector` — which excluded singleton bodies by testing the def's own receiver — recorded its `@x = ...` writes against the enclosing class's **instance** facet and compared them with the instance writes. The class object's `@state` and an instance's `@state` are different variables, so `def.ivar-write-mismatch` fired on correct Ruby, and the `def self.x` spelling (which does not fire) disagreed with the `class << self` one.

A `def` inside a `Class.new do … end` block had the mirror problem: that body defines another class, and the walk carried the enclosing prefix into it.

Both are one predicate — a node under which ivar writes land in a store the enclosing prefix does not name: a singleton-class body, or a block given to `Class.new` / `Module.new` / `Struct.new` / `Data.define`. It rides the shared `RuleWalk` context as `detached_ivar_facet` and gates the collector there; the legacy oracle walk shares the same predicate, so the permanent equivalence spec keeps holding (a fixture for the new shapes is added to its corpus).

Deliberately not taken: splitting the `ScopeIndexer` census table by facet. That is a separate engine change with its own false-positive budget (#693); this issue asked only for the wrong answer to go away.

Both repros from the issue now report nothing; a genuine instance-side divergence still fires, including inside a class that also opens `class << self`, and a divergence inside a plain (non-class-building) block still fires.

Fixes #909
