### PR TITLE
Generate rigor init's rule-id comment from ALL_RULES

### DIFF
--- a/changelog.d/fixed/fix-920-init-template-rules.md
+++ b/changelog.d/fixed/fix-920-init-template-rules.md
@@ -1,0 +1,1 @@
+- **[cli]** `rigor init`'s generated `.rigor.yml` now lists every shipped rule id in its `disable:` comment instead of a stale 7-of-31 subset, and points at `rigor explain <rule>` for detail. ([#947](https://github.com/rigortype/rigor/pull/947))

--- a/lib/rigor/cli.rb
+++ b/lib/rigor/cli.rb
@@ -12,6 +12,7 @@ require_relative "analysis/result"
 require_relative "cli/options"
 require_relative "cli/diagnostic_formats"
 require_relative "ci_detector"
+require_relative "analysis/check_rules/rule_ids"
 
 module Rigor
   # The CLI class is a dispatcher: each `run_*` method delegates to a command-specific class once the command grows
@@ -169,6 +170,30 @@ module Rigor
       @out.puts "  3. Run `rigor check` to analyse your code."
     end
 
+    # Word-wraps `CheckRules::ALL_RULES` into a comma-separated, `#`-commented block for `init_template`, so the
+    # listed rule ids cannot drift from the catalogue the way a hand-picked subset did (#920) — every rule and only
+    # a rule actually in `ALL_RULES` gets named here.
+    def rule_ids_comment
+      prefix = "#                "
+      max_width = 78 - prefix.length
+      ids = Analysis::CheckRules::ALL_RULES
+      lines = []
+      current = +""
+      ids.each_with_index do |id, index|
+        token = "#{id}#{index == ids.length - 1 ? '.' : ','}"
+        if current.empty?
+          current = token
+        elsif current.length + 1 + token.length <= max_width
+          current << " " << token
+        else
+          lines << current
+          current = token
+        end
+      end
+      lines << current unless current.empty?
+      lines.map { |line| "#{prefix}#{line}" }.join("\n")
+    end
+
     # Renders the starter `.rigor.yml` body. The template serialises `Configuration::DEFAULTS` (so the on-disk file
     # round-trips through `Configuration.load`) and prepends a short header that points the user at the keys they are
     # most likely to want to edit.
@@ -187,11 +212,10 @@ module Rigor
         #                See https://github.com/rigortype/rigor/tree/master/plugins
         #                for production plugins (rigor-activerecord, rigor-sorbet, …).
         # - disable:     list of `rigor check` rule identifiers to
-        #                silence project-wide. The shipped rules are
-        #                call.undefined-method, call.wrong-arity,
-        #                call.argument-type-mismatch,
-        #                call.possible-nil-receiver, dump.type,
-        #                assert.type-mismatch, flow.always-raises.
+        #                silence project-wide. Every rule id Rigor
+        #                ships (run `rigor explain <rule>` for what
+        #                each one catches):
+        #{rule_ids_comment}
         #                A bare family token (`call`, `flow`,
         #                `assert`, `dump`, `def`) wildcards every
         #                rule under that prefix. Legacy unprefixed

--- a/spec/rigor/cli_spec.rb
+++ b/spec/rigor/cli_spec.rb
@@ -2536,4 +2536,35 @@ RSpec.describe Rigor::CLI do
       end
     end
   end
+
+  # #920 — the template once hand-listed 7 of `ALL_RULES`'s 31 entries under "The shipped rules are"; a rule
+  # landing without a template update silently reintroduces that drift. Running `init` for real (not reading the
+  # template constant) is the only way to catch the CLI's actual `rigor explain`-eligible id set going stale.
+  describe "init" do
+    it "lists every ALL_RULES id, and only ALL_RULES ids, as rule identifiers in the written config" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, ".rigor.yml")
+
+        status, = run_cli("init", "--path=#{path}")
+        expect(status).to eq(0)
+
+        written = File.read(path)
+        rule_block = written[/each one catches\):\n(.*?)\n\s*#\s*A bare family token/m, 1]
+        listed_ids = rule_block.scan(/[a-z]+(?:\.[a-z][a-z-]*)+/).uniq
+
+        expect(listed_ids.sort).to eq(Rigor::Analysis::CheckRules::ALL_RULES.sort)
+      end
+    end
+
+    it "still writes YAML that round-trips through Configuration.load" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, ".rigor.yml")
+
+        status, = run_cli("init", "--path=#{path}")
+        expect(status).to eq(0)
+
+        expect { Rigor::Configuration.load(path) }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`rigor init`'s `.rigor.yml` template said "the shipped rules are" and then hand-listed 7 of `ALL_RULES`'s 31 entries. A user reading the generated config concluded Rigor has seven rules.

## Changes

- `lib/rigor/cli.rb`: added a `rule_ids_comment` helper that word-wraps `CheckRules::ALL_RULES` into the template's `# - disable:` comment block, so the listed ids cannot drift from the catalogue. The comment now points at `rigor explain <rule>` instead of describing each rule inline.
- `spec/rigor/cli_spec.rb`: added specs that run `rigor init` through the CLI entry point in a tmpdir and assert every `ALL_RULES` id is listed, no id outside `ALL_RULES` is listed, and the written file still round-trips through `Configuration.load`.

Fixes #920

## Test plan

- [x] `bundle exec rspec spec/rigor/cli_spec.rb` (in the Flake)
- [x] `bundle exec rubocop lib/rigor/cli.rb spec/rigor/cli_spec.rb` (in the Flake)
- [x] `bundle exec exe/rigor check lib/rigor/cli.rb` (in the Flake) — clean, only the pre-existing gem-RBS-coverage info
- [x] Manually ran `rigor init` in a scratch dir and confirmed the written YAML parses and lists all 31 rule ids
