### PR TITLE
Attribute gem constants when the project has no Gemfile.lock

### DIFF
--- a/changelog.d/fixed/fix-530-missing-gem-index-reach.md
+++ b/changelog.d/fixed/fix-530-missing-gem-index-reach.md
@@ -1,0 +1,1 @@
+- **[coverage]** A project with no `Gemfile.lock` now attributes unresolved constants to the installed gem that declares them, so `coverage --protection` routes its gem boundary to `add_rbs` instead of reporting the whole thing as an engine gap. ([#952](https://github.com/rigortype/rigor/pull/952))

--- a/docs/manual/15-type-protection-coverage.md
+++ b/docs/manual/15-type-protection-coverage.md
@@ -337,6 +337,14 @@ ones a type actually catches.
 > point Rigor at it with `bundler.bundle_path:`. Until you do, these
 > holes keep the generic `engine_gap` cause instead of `add_rbs` —
 > the label is missing, never wrong.
+>
+> A project with **no `Gemfile.lock`** is not left out: Rigor falls
+> back to the gems it can see installed — the project's Bundler
+> install tree if one resolves, otherwise the running Ruby's gems —
+> and attributes constants against those. Ownership is still
+> established by reading the gem's own entry file, so the fallback
+> widens which gems can be claimed and never whether an unowned
+> constant is.
 
 Provenance is precision-additive only: it never changes a type, fires
 no diagnostic, and never affects severity or the protection ratio.

--- a/lib/rigor/environment.rb
+++ b/lib/rigor/environment.rb
@@ -13,6 +13,7 @@ require_relative "environment/constant_type_cache_holder"
 require_relative "environment/missing_gem_constant_index"
 require_relative "environment/bundle_sig_discovery"
 require_relative "environment/lockfile_resolver"
+require_relative "environment/installed_gem_set"
 require_relative "environment/rbs_collection_discovery"
 require_relative "plugin/isolation"
 require_relative "environment/rbs_coverage_report"
@@ -332,7 +333,7 @@ module Rigor
         missing_gems, overlay_paths = missing_gems_and_overlay_paths(
           locked: locked, default_libraries: merged_libraries, bundle_sig_paths: gem_sig_paths,
           rbs_collection_paths: collection_paths, plugin_registry: plugin_registry,
-          signature_paths: resolved_paths
+          signature_paths: resolved_paths, bundle_root: bundle_root
         )
         loader_signature_paths = resolved_paths + plugin_sig_paths + gem_sig_paths +
                                  collection_paths + overlay_paths
@@ -415,18 +416,39 @@ module Rigor
       # and consumed twice: as `[gem_name, version]` pairs for the ADR-82 WD9 constant-ownership index, and
       # as the eligible-gem set for the ADR-72 overlay resolution. Returns `[pairs, overlay_paths]`.
       def missing_gems_and_overlay_paths(locked:, default_libraries:, bundle_sig_paths:,
-                                         rbs_collection_paths:, plugin_registry:, signature_paths: [])
-        return [[], []] if locked.empty?
+                                         rbs_collection_paths:, plugin_registry:, signature_paths: [],
+                                         bundle_root: nil)
+        if locked.empty?
+          return unlocked_missing_gems(default_libraries, bundle_sig_paths, rbs_collection_paths, bundle_root)
+        end
 
-        rows = RbsCoverageReport.classify(
-          locked_gems: locked, default_libraries: default_libraries,
-          bundle_sig_paths: bundle_sig_paths, rbs_collection_paths: rbs_collection_paths
-        ).select { |row| row.source == :missing }
+        rows = missing_rows(locked, default_libraries, bundle_sig_paths, rbs_collection_paths)
         overlays = gem_overlay_paths(
           missing_gem_names: rows.map(&:gem_name), plugin_registry: plugin_registry,
           signature_paths: signature_paths
         )
         [rows.map { |row| [row.gem_name, row.version] }, overlays]
+      end
+
+      # Issue #530 — a project with no `Gemfile.lock` still has gems on disk, and before this it handed the
+      # ADR-82 WD9 index nothing, so every constant reaching into an RBS-less gem kept the generic cause and
+      # the whole boundary reported as `engine_gap` rather than `add_rbs`. The installed set stands in for
+      # the locked one ({InstalledGemSet} says why that stays honest), and only for the provenance index:
+      # the second element is always empty because the ADR-72 overlays change what type-checks and so remain
+      # gated on the project's own declaration.
+      def unlocked_missing_gems(default_libraries, bundle_sig_paths, rbs_collection_paths, bundle_root)
+        installed = InstalledGemSet.gems(bundle_path: bundle_root)
+        return [[], []] if installed.empty?
+
+        rows = missing_rows(installed, default_libraries, bundle_sig_paths, rbs_collection_paths)
+        [rows.map { |row| [row.gem_name, row.version] }, []]
+      end
+
+      def missing_rows(gems, default_libraries, bundle_sig_paths, rbs_collection_paths)
+        RbsCoverageReport.classify(
+          locked_gems: gems, default_libraries: default_libraries,
+          bundle_sig_paths: bundle_sig_paths, rbs_collection_paths: rbs_collection_paths
+        ).select { |row| row.source == :missing }
       end
 
       # ADR-72 — resolve the bundled RBS overlay directories to load for this project. A gem is eligible when

--- a/lib/rigor/environment/installed_gem_set.rb
+++ b/lib/rigor/environment/installed_gem_set.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require_relative "lockfile_resolver"
+
+module Rigor
+  class Environment
+    # Issue #530 — the gem set for a project that has NO `Gemfile.lock`.
+    #
+    # ADR-82 WD9's constant-ownership index is driven by the LOCKED gem set, so a project without a
+    # lockfile (a plain library, a `gemspec`-only gem, an app vendored outside Bundler) handed the index
+    # nothing at all: every constant reaching into a real, installed, RBS-less gem recorded the generic
+    # cause, and the entire gem boundary reported as `engine_gap` — "report this to Rigor" — where the
+    # honest story is `add_rbs`. Measured on slim, whose whole Temple boundary lands that way while haml,
+    # which has a lockfile, attributes the same gem correctly.
+    #
+    # Degrading to the gems that are actually INSTALLED keeps ADR-82's honesty criterion intact. A name
+    # here is a gem that exists on disk; the index still has to READ its entry file before claiming any
+    # constant, and its lack of RBS is established by the same {RbsCoverageReport.classify} pass the
+    # lock-driven path uses. The version is the one on disk rather than a declared one — which is the
+    # version a lockfile-less project would load anyway.
+    #
+    # Only the missing-gem provenance index consumes this. The ADR-72 gem overlays stay Gemfile.lock-gated:
+    # an overlay changes what type-checks, so it needs the project's own declaration, while this
+    # side-channel only changes a label.
+    module InstalledGemSet
+      module_function
+
+      # @param bundle_path — the target's resolved bundler install root, or nil.
+      # @return frozen `gem name => LockfileResolver::LockedGem`, the shape
+      #   {RbsCoverageReport.classify} consumes. Empty when neither resolver sees anything, which leaves
+      #   today's generic cause in place.
+      def gems(bundle_path: nil)
+        found = from_bundle_tree(bundle_path)
+        found = from_installed_specs if found.empty?
+        found.freeze
+      end
+
+      # `<bundle>/ruby/X.Y.Z/gems/<name>-<version>/` — the same pure-filesystem layout
+      # {MissingGemConstantIndex.bundle_gem_dirs} walks, preferred over the host's gems so a project that
+      # vendored its bundle without committing the lockfile is read from its own tree. A platform-tagged
+      # directory (`ffi-1.17.4-aarch64-linux-gnu`) does not split into a name/version pair and is skipped:
+      # those gems ship native code, not the pure-Ruby constants this feeds.
+      def from_bundle_tree(bundle_path)
+        return {} if bundle_path.nil?
+
+        base = Pathname.new(bundle_path)
+        return {} unless base.directory?
+
+        Dir.glob(base.join("ruby", "*", "gems", "*")).each_with_object({}) do |dir, acc|
+          name, version = split_name_version(File.basename(dir))
+          next unless name
+
+          acc[name] ||= locked_gem(name, version)
+        end
+      end
+
+      # The gems the RUNNING Ruby can load. For the shipped `gem install rigortype` distribution that IS a
+      # lockfile-less project's gem environment — the same set its own `require` would reach. Under
+      # `bundle exec` it is the analyzer's own bundle instead (the `Gem.paths`-no-ops-under-Bundler
+      # mechanism ADR-90 documents), which yields fewer names, never wrong ones. Highest version per name,
+      # because `stubs` promises no ordering.
+      def from_installed_specs
+        Gem::Specification.stubs.each_with_object({}) do |stub, acc|
+          previous = acc[stub.name]
+          next if previous && Gem::Version.new(previous.version) >= stub.version
+
+          acc[stub.name] = locked_gem(stub.name, stub.version.to_s)
+        end
+      rescue StandardError
+        {}
+      end
+
+      def locked_gem(name, version)
+        LockfileResolver::LockedGem.new(name: name, version: version, platform: "ruby")
+      end
+
+      # Splits a gem install directory's basename. The version tail is anchored on a leading digit and must
+      # carry no further hyphen, which is what excludes the platform-tagged variants above.
+      def split_name_version(basename)
+        match = /\A(.+)-(\d[^-]*)\z/.match(basename)
+        match ? [match[1], match[2]] : nil
+      end
+    end
+  end
+end

--- a/spec/integration/lockfile_less_gem_provenance_spec.rb
+++ b/spec/integration/lockfile_less_gem_provenance_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# Issue #530 item 3 — a project with no `Gemfile.lock`.
+#
+# ADR-82 WD9's constant-ownership index was driven entirely by the LOCKED gem set, so a lockfile-less
+# project handed it nothing and every constant reaching into an RBS-less gem kept the generic
+# `unsupported_syntax` cause. `coverage --protection` then reported the project's whole gem boundary as
+# `engine_gap` — "report this to Rigor" — where the honest answer is `add_rbs`. Measured on slim, whose
+# entire Temple boundary lands that way while haml, which has a lockfile, attributes the same gem
+# correctly.
+#
+# The provenance is a side-channel, so the second example pins the half that must NOT move: the run's
+# diagnostics are byte-identical with and without the fallback.
+
+require "spec_helper"
+require "fileutils"
+require "prism"
+require "tmpdir"
+
+require "rigor/analysis/runner"
+require "rigor/configuration"
+require "rigor/environment"
+require "rigor/inference/protection_scanner"
+require "rigor/scope"
+
+RSpec.describe "gem provenance without a Gemfile.lock (#530)" do
+  # A bundle tree with one gem that ships no `sig/`, and deliberately NO `Gemfile.lock` beside it — the
+  # shape the fallback exists for. The entry file is real because the index establishes ownership by
+  # reading it.
+  def write_project
+    entry = File.join("vendor", "bundle", "ruby", "4.0.0", "gems", "faraday-2.9.0", "lib", "faraday.rb")
+    FileUtils.mkdir_p(File.dirname(entry))
+    File.write(entry, "module Faraday\n  class Connection\n  end\nend\n")
+    FileUtils.mkdir_p("lib")
+    File.write(File.join("lib", "a.rb"), <<~RUBY)
+      def run
+        Faraday::Connection.new.get("/")
+        "text".no_such_method
+      end
+    RUBY
+  end
+
+  def config
+    Rigor::Configuration.new(
+      Rigor::Configuration::DEFAULTS.merge(
+        "paths" => %w[lib], "workers" => 0,
+        "bundler" => { "bundle_path" => "vendor/bundle", "auto_detect" => false, "lockfile" => nil }
+      )
+    )
+  end
+
+  def origins
+    environment = Rigor::Environment.for_project(
+      root: Dir.pwd, bundler_bundle_path: "vendor/bundle", bundler_auto_detect: false
+    )
+    root = Prism.parse(File.read(File.join("lib", "a.rb"))).value
+    scanner = Rigor::Inference::ProtectionScanner.new(scope: Rigor::Scope.empty(environment: environment))
+    scanner.scan(root).sites.to_h { |site| [site.method_name, site.dynamic_origin] }
+  end
+
+  def diagnostics
+    result = guarded_run(Rigor::Analysis::Runner.new(configuration: config), %w[lib])
+    result.diagnostics.map { |d| "#{File.basename(d.path)}:#{d.line}:#{d.column} #{d.qualified_rule} #{d.message}" }
+  end
+
+  around do |example|
+    Dir.mktmpdir("rigor-lockfile-less-") { |dir| Dir.chdir(dir) { example.run } }
+  end
+
+  it "attributes a constant reaching into an installed RBS-less gem to that gem" do
+    write_project
+    expect(origins).to include("new" => :external_gem_without_rbs, "get" => :external_gem_without_rbs)
+  end
+
+  it "keeps the generic cause for a constant no installed gem declares" do
+    # The must-still-decline arm: the fallback widens WHICH gems can be claimed, never whether an unowned
+    # constant is claimed. Without this a change that labelled every unresolved constant would pass above.
+    write_project
+    File.write(File.join("lib", "a.rb"), "def run\n  Farraday::Connection.new\nend\n")
+    expect(origins.fetch("new")).to eq(:unsupported_syntax)
+  end
+
+  it "leaves the run's diagnostics byte-identical" do
+    # Provenance only: the fallback changes a label on the protection report and nothing a user is told
+    # about their code. The `no_such_method` call keeps both sides non-empty, so this is agreement between
+    # two real answers rather than two silences.
+    write_project
+    live = diagnostics
+    expect(live).not_to be_empty
+
+    # Emptying the fallback restores the pre-#530 behaviour, and the origin assertion proves the two arms
+    # really do differ — without it the comparison below could be between two identical runs.
+    allow(Rigor::Environment::InstalledGemSet).to receive(:gems).and_return({})
+    expect(origins.fetch("get")).to eq(:unsupported_syntax)
+    expect(diagnostics).to eq(live)
+  end
+end

--- a/spec/rigor/environment/installed_gem_set_spec.rb
+++ b/spec/rigor/environment/installed_gem_set_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+
+# Issue #530 item 3 — the stand-in gem set for a project with no `Gemfile.lock`.
+RSpec.describe Rigor::Environment::InstalledGemSet do
+  # `<bundle>/ruby/X.Y.Z/gems/<name>-<version>/` with nothing in it: this resolver reads directory names,
+  # not contents.
+  def write_bundle(root, dirs)
+    dirs.each { |name| FileUtils.mkdir_p(File.join(root, "ruby", "4.0.0", "gems", name)) }
+    root
+  end
+
+  it "reads the target's own bundle tree in preference to the host's installed gems" do
+    Dir.mktmpdir do |root|
+      write_bundle(root, %w[faraday-2.9.0 rubocop-ast-1.30.0])
+      gems = described_class.gems(bundle_path: root)
+
+      expect(gems.keys).to contain_exactly("faraday", "rubocop-ast")
+      expect(gems.fetch("rubocop-ast").version).to eq("1.30.0")
+    end
+  end
+
+  it "skips a platform-tagged directory rather than guessing where the name ends" do
+    # The must-still-resolve counterpart rides along: the pure-Ruby sibling in the same tree is still
+    # claimed, so a change that dropped everything would not pass.
+    Dir.mktmpdir do |root|
+      write_bundle(root, ["ffi-1.17.4-aarch64-linux-gnu", "faraday-2.9.0"])
+      expect(described_class.gems(bundle_path: root).keys).to eq(["faraday"])
+    end
+  end
+
+  it "falls back to the installed specs when no bundle tree resolves" do
+    # Whatever Ruby is running this must at least see itself, so the fallback is non-empty and shaped for
+    # `RbsCoverageReport.classify`.
+    gems = described_class.gems(bundle_path: nil)
+
+    expect(gems).not_to be_empty
+    expect(gems.each_value.first).to be_a(Rigor::Environment::LockfileResolver::LockedGem)
+  end
+
+  it "keeps the highest installed version when a gem is installed more than once" do
+    stubs = [
+      instance_double(Gem::StubSpecification, name: "faraday", version: Gem::Version.new("2.9.0")),
+      instance_double(Gem::StubSpecification, name: "faraday", version: Gem::Version.new("2.10.0")),
+      instance_double(Gem::StubSpecification, name: "faraday", version: Gem::Version.new("2.1.0"))
+    ]
+    allow(Gem::Specification).to receive(:stubs).and_return(stubs)
+
+    expect(described_class.gems(bundle_path: nil).fetch("faraday").version).to eq("2.10.0")
+  end
+
+  it "yields nothing rather than a guess when the bundle root does not exist" do
+    allow(Gem::Specification).to receive(:stubs).and_return([])
+    expect(described_class.gems(bundle_path: "/nonexistent/bundle")).to be_empty
+  end
+end


### PR DESCRIPTION
Item 3 of #530: a project with no `Gemfile.lock`.

ADR-82 WD9's constant-ownership index is driven entirely by the LOCKED gem set, so a lockfile-less project handed it nothing and every constant reaching into a real, installed, RBS-less gem kept the generic `unsupported_syntax` cause. `coverage --protection` then reported the project's whole gem boundary as `engine_gap` — "report this to Rigor" — where the honest answer is `add_rbs`. That is slim's Temple boundary, while haml, which has a lockfile, attributes the same gem correctly.

`Environment::InstalledGemSet` stands in for the locked set when there is none: the target's own bundle install tree if one resolves (a project that vendored its gems without committing the lock), otherwise the running Ruby's installed gems — which, for the shipped `gem install rigortype` distribution, IS a lockfile-less project's gem environment. Ownership is still established by READING each gem's entry file, and the lack of RBS by the same `RbsCoverageReport.classify` pass the lock-driven path uses, so the fallback widens which gems can be claimed and never whether an unowned constant is.

The ADR-72 gem overlays stay Gemfile.lock-gated: an overlay changes what type-checks and so needs the project's own declaration, while this side-channel only changes a label.

Measured on a lockfile-less fixture reading into an RBS-less installed gem, `coverage --protection --format json`: `unsupported_syntax` / `engine_gap` → `external_gem_without_rbs` / `add_rbs` on both sites of the chain.

Items 1 and 2 of the issue are already settled — item 1 landed in #773, item 2 is [a measurement artifact](https://github.com/rigortype/rigor/issues/530#issuecomment-5545681818) — so this closes the issue.

### Specs

- `spec/rigor/environment/installed_gem_set_spec.rb` — the two resolvers, the bundle tree preferred over the host, a platform-tagged directory skipped (with its pure-Ruby sibling still claimed), highest version wins, and nothing rather than a guess when neither resolver sees anything.
- `spec/integration/lockfile_less_gem_provenance_spec.rb` — end to end over a real `Environment.for_project`: the constant is attributed, a constant no installed gem declares still keeps the generic cause, and the run's diagnostics are byte-identical with the fallback emptied (the arms are proven different by an origin assertion, so the comparison is not vacuous).

Fixes #530
