### PR TITLE
Bind the editor buffer to the analysed set it stands in for

### DIFF
--- a/changelog.d/fixed/fix-960-incremental-editor-buffer.md
+++ b/changelog.d/fixed/fix-960-incremental-editor-buffer.md
@@ -1,0 +1,1 @@
+- **[incremental]** `rigor check --incremental` in editor mode (`--tmp-file` / `--instead-of`) now analyses the buffer's bytes and their dependents instead of silently serving the answers for the file on disk. ([#966](https://github.com/rigortype/rigor/pull/966))

--- a/docs/internal-spec/cache.md
+++ b/docs/internal-spec/cache.md
@@ -673,6 +673,38 @@ full run, so the snapshot can never wedge or stale an analysis.
    determine the changed set `ΔF`; the affected closure `ΔF ∪ dependents[ΔF]`
    is re-analysed and the rest served from `Payload#cache`.
 
+### Editor mode (`--tmp-file` / `--instead-of`)
+
+An incremental run may carry an `Analysis::BufferBinding`: one project
+path whose bytes are read from the editor's temp file instead of from
+disk. Two rules bind that run, and neither follows from the tier above.
+
+- **The binding is resolved against the analysed set, not by string
+  equality.** `--instead-of` carries whatever spelling the editor hands
+  the CLI (absolute, `./`-prefixed, relative); the analysed set carries
+  the spelling the run's path arguments produce. A binding whose logical
+  path is not a member of that set MUST be re-spelled onto the member
+  with the same real path. Without it the substitution silently applies
+  nowhere: the run reads the file on disk, reports an empty closure, and
+  serves the pre-buffer answers
+  ([#960](https://github.com/rigortype/rigor/issues/960)).
+- **The buffer's own content digest decides change, not the recorded
+  stat tuple.** The substituted path is changed exactly when the
+  editor's bytes hash to something other than the digest the snapshot
+  recorded for it — an edit in the editor never moves the on-disk stat
+  tuple, so the stat tier reads the file as fresh no matter what the
+  user typed. The closure is then `{path} ∪ dependents[path]`; a buffer
+  whose bytes equal the recorded digest leaves the closure empty,
+  because every cached answer was computed under exactly those bytes.
+
+A buffer-bearing session MUST NOT write its snapshot back. Its per-file
+digests and diagnostics describe bytes that exist only in the editor,
+and persisting them would make the next `rigor check --incremental`
+believe the file on disk had already been analysed in a state it was
+never in. A session that cannot reuse an existing snapshot therefore
+declines rather than running a baseline — nothing it computed could warm
+the next keystroke anyway.
+
 ### `Payload` (current `SCHEMA = 13`)
 
 ```

--- a/lib/rigor/analysis/incremental_session.rb
+++ b/lib/rigor/analysis/incremental_session.rb
@@ -407,10 +407,13 @@ module Rigor
       end
 
       # The current project file set (cheap directory expansion, no analysis), used to detect files added /
-      # removed since the last run.
+      # removed since the last run. Also where an editor buffer's binding is re-spelled onto the set, since
+      # this is where the run first learns how it spells its own members.
       def current_files
         runner = build_runner
-        @paths ? runner.analysis_file_set(@paths) : runner.analysis_file_set
+        files = @paths ? runner.analysis_file_set(@paths) : runner.analysis_file_set
+        rebind_buffer(files)
+        files
       end
 
       # Verification engine (the `--verify-incremental` gate): with NO source edit, re-analyze `subset` fresh
@@ -1017,18 +1020,51 @@ module Rigor
         candidates.reject { |path| stat_fresh?(path) }
       end
 
-      # A bound buffer's logical path is never fresh: the bytes to analyse live in the editor's temp file, and
-      # the recorded entry describes the file on disk. Re-analysing it when the two happen to agree costs one
-      # file; trusting the stat tuple would serve the editor its own stale diagnostics.
       def buffer_path?(path)
         !@buffer.nil? && path == @buffer.logical_path
+      end
+
+      # Editor mode (#146) — the bound buffer's logical path is fresh exactly when the EDITOR's bytes still
+      # hash to the digest the snapshot recorded for the file they stand in for. The recorded stat tuple
+      # describes the file on disk, which an edit in the editor never moves, so validating through it serves
+      # the editor its own pre-buffer answers (#960); hashing the buffer makes the substituted file changed
+      # whenever it differs, and keeps an untouched buffer out of the closure. Anything unreadable or
+      # unrecorded reads as changed, the conservative direction the rest of this tier takes.
+      def buffer_fresh?(path)
+        recorded = Cache::FileDigest.content_digest(@digests[path])
+        return false if recorded.nil?
+
+        Cache::FileDigest.hexdigest(@buffer.resolve(path)) == recorded
+      rescue StandardError
+        false
+      end
+
+      # Editor mode (#146 / #960) — `--instead-of` is spelled the way the editor spells it (absolute, or
+      # `./`-prefixed), while the analysed set is spelled the way the run's path arguments produce. A binding
+      # whose logical path matches no member of that set substitutes nothing at all: every reader keeps
+      # reading the file on disk and the run answers as if no buffer had been passed. Re-spell the binding
+      # onto the set's own member, identified by real path, once the set is known.
+      def rebind_buffer(files)
+        return if @buffer.nil? || files.include?(@buffer.logical_path)
+
+        target = real_path(@buffer.logical_path)
+        return if target.nil?
+
+        match = files.find { |path| real_path(path) == target }
+        @buffer = BufferBinding.new(logical_path: match, physical_path: @buffer.physical_path) if match
+      end
+
+      def real_path(path)
+        File.realpath(path)
+      rescue StandardError
+        nil
       end
 
       # True when `path`'s recorded stat entry proves it unchanged since the last analysis. Any stat / parse
       # failure (missing entry, unreadable / vanished file) reads as NOT fresh (→ re-analyse), preserving the
       # prior `digest(path) != recorded` "changed" semantics for a file that cannot be validated.
       def stat_fresh?(path)
-        return false if buffer_path?(path)
+        return buffer_fresh?(path) if buffer_path?(path)
 
         entry = @digests[path]
         return false if entry.nil?

--- a/lib/rigor/cache/file_digest.rb
+++ b/lib/rigor/cache/file_digest.rb
@@ -112,6 +112,14 @@ module Rigor
         hexdigest(path) == digest
       end
 
+      # The content-digest field of a packed `:stat` entry ({.pack_stat}); nil when the entry is absent or not
+      # well-formed. Exposed for the caller that must compare the recorded digest against bytes it hashes
+      # itself rather than against the file on disk — the incremental session's editor-mode freshness check,
+      # whose authority is the editor's buffer.
+      def self.content_digest(packed)
+        parse_stat(packed)&.first
+      end
+
       # The VALIDATION-side stat, served from the per-run table when one is installed — a collecting run
       # validates the effects entry and the diagnostics entry against the same ~thousands-of-files
       # dependency descriptor, and the second pass is pure repetition under the run's own stable-filesystem

--- a/spec/rigor/analysis/incremental_session_spec.rb
+++ b/spec/rigor/analysis/incremental_session_spec.rb
@@ -878,7 +878,30 @@ end
       end
     end
 
-    it "re-analyses the buffer even when its bytes match the file on disk" do
+    # #960 — `--instead-of` carries whatever spelling the editor hands the CLI, while the analysed set carries
+    # the spelling the run's path arguments produce. A binding whose logical path is not character-identical to
+    # a member of that set used to substitute nothing anywhere: the run read the file on disk, reported an
+    # empty closure, and served the pre-buffer answers — a wrong answer that looked like a fast one.
+    it "substitutes the buffer when the logical path is spelled differently from the analysed set's member" do
+      Dir.mktmpdir do |dir|
+        buffer = write_editor_project(dir)
+        config = editor_config(dir)
+        snapshot = Rigor::Cache::IncrementalSnapshot.new(root: File.join(dir, ".cache"))
+        fp = fingerprint(config, analysis_root(dir))
+        warm_snapshot(config, dir, snapshot, fp)
+
+        detour = Rigor::Analysis::BufferBinding.new(
+          logical_path: File.join(dir, "lib", "..", "lib", "widget.rb"),
+          physical_path: buffer.physical_path
+        )
+        result = guarded_run_buffer_recheck(buffer_session(config, dir, detour), snapshot: snapshot, fingerprint: fp)
+
+        expect(result.diagnostics.map(&:message)).to include(a_string_matching(/undefined method `upcase' for 1/))
+        expect(result.affected).to include(File.join(dir, "lib", "widget.rb"), File.join(dir, "lib", "other.rb"))
+      end
+    end
+
+    it "leaves the closure empty when the buffer's bytes match the file on disk" do
       Dir.mktmpdir do |dir|
         write_editor_project(dir)
         config = editor_config(dir)
@@ -894,9 +917,11 @@ end
         result = guarded_run_buffer_recheck(buffer_session(config, dir, binding_to_identical), snapshot: snapshot,
                                                                                                fingerprint: fp)
 
-        # The stat tuple of the temp file says nothing about the logical path, so the buffer is always re-read.
-        expect(result.affected).to include(File.join(dir, "lib", "widget.rb"))
-        expect(project_diagnostics(result.diagnostics)).to be_empty
+        # The buffer's own content digest is the authority (#960), and it equals the one the snapshot recorded
+        # for the file it stands in for — so the cached answers describe these very bytes. The example above
+        # is the must-still-fire counterpart: a buffer that differs still drags its dependents in.
+        expect(result.affected).to be_empty
+        expect(sorted(result.diagnostics)).to eq(sorted(full_run(analysis_root(dir))))
       end
     end
   end


### PR DESCRIPTION
`rigor check --incremental` in editor mode (`--tmp-file BUF --instead-of PATH`) re-analysed 0 files and served the pre-buffer answers.

Two independent causes, both fixed here.

The binding's logical path was compared against the analysed set by string equality. `--instead-of` carries whatever spelling the editor hands the CLI — an absolute path is the natural one — while the analysed set carries the spelling the run's own path arguments produce. A binding that matches no member substitutes nowhere at all: every reader keeps reading the file on disk, the closure comes out empty, and the run answers as if no buffer had been passed. `IncrementalSession` now re-spells the binding onto the set's own member by real path, at the point where it first learns how it spells its members.

The substituted path's freshness read the recorded stat tuple. An edit in the editor never moves the on-disk tuple, so the stat tier reported the file fresh no matter what the user typed. Freshness for that one path is now the buffer's content digest against the digest the snapshot recorded, making the closure `{PATH} ∪ dependents[PATH]` whenever they differ. That retires the blanket "a bound path is never fresh" rule: a buffer whose bytes equal the recorded digest describes exactly the state the cached answers were computed under, so its closure is empty rather than one file wide (pinned, with the differing-buffer example as its must-still-fire counterpart).

The session already declined to write its snapshot back, so a following plain `--incremental` run still answers the disk state; the existing example pins that and it stays green.

Verified through the real CLI in the Flake on a two-file project: cold `--incremental`, then editor mode with both an absolute and a relative `--instead-of` (both now re-analyse 2 files and report the buffer's type), an unchanged buffer (0 files, 2 served), and a following plain run (warm, disk state).

Both rules were undocumented — `docs/internal-spec/cache.md` gains a normative "Editor mode" subsection under `IncrementalSnapshot` in the same commit.

Fixes #960
