### PR TITLE
Read the bundled-plugin catalogue off loaded classes, not the registry

### DIFF
--- a/changelog.d/fixed/fix-bundled-catalog-registry-independence.md
+++ b/changelog.d/fixed/fix-bundled-catalog-registry-independence.md
@@ -1,0 +1,1 @@
+- **[cli]** `rigor doctor`'s plugin-gap advisory no longer depends on which plugins the process happened to register, so an enabled plugin is never reported as a gap. ([#967](https://github.com/rigortype/rigor/pull/967))

--- a/lib/rigor/plugin/bundled_catalog.rb
+++ b/lib/rigor/plugin/bundled_catalog.rb
@@ -51,15 +51,29 @@ module Rigor
 
         def build_entries
           require_bundled_plugins
-          Plugin.registered.filter_map do |id, plugin_class|
+          loaded_plugin_manifests.filter_map do |manifest|
+            id = manifest.id
             next unless FirstParty.bundled?(id)
-
-            manifest = plugin_class.manifest
             next if manifest.target_gems.empty?
 
             Entry.new(gem_name: "#{FirstParty::GEM_PREFIX}#{id}", plugin_id: id,
                       target_gems: manifest.target_gems)
           end.sort_by(&:gem_name).freeze
+        end
+
+        # The manifests of every plugin class the process has loaded, one per id. Read off the classes
+        # rather than {Rigor::Plugin.registered}: `require` is idempotent, so a plugin required earlier and
+        # then dropped by `Rigor::Plugin.unregister!` (every spec does this) is absent from the registry
+        # while still loaded, and an index built from the registry at that moment silently lacks it — the
+        # advisory then reads the project's own enabled plugin as a gap and fails `rigor doctor`.
+        def loaded_plugin_manifests
+          ObjectSpace.each_object(Class).filter_map do |klass|
+            next unless klass < Plugin::Base
+
+            klass.manifest
+          rescue ArgumentError
+            nil
+          end.uniq(&:id)
         end
 
         # A plugin gem that fails to load is skipped rather than fatal: the catalogue exists to *advise*, and

--- a/spec/rigor/cli/doctor_command_spec.rb
+++ b/spec/rigor/cli/doctor_command_spec.rb
@@ -154,6 +154,20 @@ RSpec.describe Rigor::CLI::DoctorCommand do
   # ADR-96 WD2 — the advisory reads each bundled plugin's `target_gems:`, so it covers every framework
   # Rigor ships a plugin for rather than only Rails.
   describe "plugin gap check" do
+    # These examples enable a real bundled plugin by gem name. `require` is a once-per-process no-op and the
+    # suite pervasively calls `Rigor::Plugin.unregister!`, so whether the Loader can resolve
+    # `rigor-activerecord` depends on which spec ran first — the `plugins` check then reports a load error
+    # and the exit status is 1 on one CI shard and 0 on another. Register the classes the way a fresh
+    # process's require would have, so the examples measure the gap advisory and nothing else.
+    before do
+      Rigor::Plugin::BundledCatalog.entries
+      { "rigor-activerecord" => [Rigor::Plugin::Activerecord, "activerecord"],
+        "rigor-sidekiq" => [Rigor::Plugin::Sidekiq, "sidekiq"] }.each do |gem_name, (klass, id)|
+        Rigor::Plugin.register(klass) unless Rigor::Plugin.registered_for(id)
+        Rigor::Plugin.record_gem_registration(gem_name, [id])
+      end
+    end
+
     it "fails when locked gems have bundled plugins and none of them is enabled" do
       File.write("clean.rb", "x = 1\n")
       File.write(".rigor.yml", "paths:\n  - .\n")

--- a/spec/rigor/plugin/bundled_catalog_spec.rb
+++ b/spec/rigor/plugin/bundled_catalog_spec.rb
@@ -20,4 +20,18 @@ RSpec.describe Rigor::Plugin::BundledCatalog do
       .to include("rigor-railties", "rigor-rails-routes")
     expect(described_class.for_gem("no-such-gem")).to be_empty
   end
+
+  describe "independence from the live registry" do
+    # `require` is idempotent, so a plugin loaded by an earlier spec and then dropped by
+    # `Rigor::Plugin.unregister!` is absent from the registry while still loaded. An index built from the
+    # registry at that moment lacked it, and `rigor doctor` then read the project's own enabled plugin as
+    # a gap and failed — only on the CI shard where the spec order produced that state.
+    it "lists a bundled plugin that is loaded but no longer registered" do
+      described_class.entries
+      Rigor::Plugin.unregister!
+      described_class.reset!
+
+      expect(described_class.for_gem("activerecord").map(&:gem_name)).to include("rigor-activerecord")
+    end
+  end
 end


### PR DESCRIPTION
`rigor doctor`'s plugin-gap advisory (#949) built its gem-to-plugin index from `Rigor::Plugin.registered`. `require` is a once-per-process no-op and the suite pervasively calls `Rigor::Plugin.unregister!`, so a bundled plugin loaded by an earlier spec was absent from the registry while still loaded; the index then lacked it, the advisory read the project's own enabled plugin as a gap, and `rigor doctor` exited 1 on whichever CI shard ordered the specs that way. Master went red at c0248433 (the #958 merge) on exactly that shard composition; the same two examples failed on #965's first run and passed on its rerun.

`BundledCatalog` now enumerates the loaded plugin classes (one manifest per id) rather than the live registry, with a spec that unregisters everything and still finds `rigor-activerecord`. The doctor examples that enable a real plugin by gem name register it the way a fresh process's `require` would have, so the `plugins` load check cannot fail them by spec order either. Reproduced with `rspec spec/integration/plugins/activerecord_plugin_spec.rb spec/rigor/cli/doctor_command_spec.rb` (4 failures before, 0 after).
