### PR TITLE
Recover factory-method freshness for struct member reads

### DIFF
--- a/changelog.d/fixed/fix-599-factory-method-freshness.md
+++ b/changelog.d/fixed/fix-599-factory-method-freshness.md
@@ -1,0 +1,1 @@
+- **[inference]** A `Struct` member read through a factory method (`def build = Pair.new(...)` then `build.items`) folds again — the freshness gate now accepts a chained receiver whose callee is cheaply resolvable and provably returns something it just built, while every self-returning shape stays refused. ([#972](https://github.com/rigortype/rigor/pull/972))

--- a/docs/adr/48-data-struct-value-folding.md
+++ b/docs/adr/48-data-struct-value-folding.md
@@ -39,7 +39,9 @@ positional + `keyword_init:`). The mutation-soundness story is resolved by a
 off a *stored* binding degrades to `Dynamic[top]` (a receiver this expression
 just materialised cannot have been mutated since, so no invalidation is
 needed; a stored binding might have, so it is not folded). "Freshly
-materialised" means `.new` / `[]` / `.with`, NOT any chained call —
+materialised" means `.new` / `[]` / `.with`, or a resolvable factory method
+whose body returns one of those ([#599](https://github.com/rigortype/rigor/issues/599)),
+NOT any chained call —
 [#595](https://github.com/rigortype/rigor/issues/595) corrected that on
 2026-09-02, after a self-returning fluent builder was found serving
 construction-time values post-mutation. This touches
@@ -455,20 +457,35 @@ off a receiver the other gate wrongly called fresh
 (`x.dup_self.with(indent: 9).shout`), so the composed shape survived a fix to
 either half alone.
 
-The cost is a genuinely fresh helper return: `def make = Line.new("x")` then
-`make.text` no longer folds, because the whitelist cannot see through `make`.
-Measured, that costs nothing observable on the struct-heaviest real files in
-the named corpus targets — haml's and hamlit's parsers, faraday's
-`Options`/`Request`, mail's `received_parser` — where a before/after run shows
-an identical diagnostic set and an identical `type-scan` coverage (570
-unrecognized, `CallNode` 461/1966). For the loss to bite, the helper's return
-must already infer to a `StructInstance`, and at these sites it does not. The
-richer fix — consult the callee's inferred return and accept it when it is
-provably not a `self` alias — is tracked as
-[#599](https://github.com/rigortype/rigor/issues/599). Three of this repo's own
-regression guards were written on the factory route and had to be moved onto a
-direct materialisation to stay discriminating, which is the concrete evidence
-for prioritising it.
+The whitelist's own cost was the FACTORY-METHOD idiom: `def make = Line.new("x")`
+then `make.text`, where the return really is fresh and the whitelist could not
+see through `make`. Three of this repo's regression guards were written on that
+route and had to be moved onto a direct materialisation to stay discriminating,
+which is what prioritised the recovery
+([#599](https://github.com/rigortype/rigor/issues/599), landed 2026-09-10).
+
+The gate now has a fourth arm: a chained call whose CALLEE is cheaply resolvable
+and whose body provably returns something it just built. Resolution covers the
+two shapes that cost one table read against the frozen discovery index — a
+receiverless send through `Scope#bindable_top_level_def_for` (the
+confidence-gated accessor, so a call under an unmodelled block `self` still
+declines), and `Const.name` through `Scope#singleton_def_through_ancestors`. An
+INSTANCE-side receiver is refused outright: `x.dup_self` is the #595 bug shape,
+and what `x` holds at the call is exactly what the gate cannot know.
+
+Acceptance is decided on the callee's RETURN POSITION rather than on a
+self-alias scan of its body, which is a deliberate departure from #599's
+sketch. "Cannot return `self`" is not the property freshness needs — a
+factory's `self` is a module or `main`, never the struct, while `def get =
+GLOBAL` over a mutated constant hands back a long-lived instance with no `self`
+anywhere in it. So the body's tail must itself be a materialisation of a
+constant with a recorded member layout (or an inline `Struct.new(…)`), and an
+explicit `return` anywhere in the body refuses, since it hands back an
+expression the tail check never saw. That subsumes the self-alias refusal — a
+body returning `self` has a `SelfNode` tail, not a `.new` — and it needs no
+scan of the caller's locals, whose bindings mean nothing inside the callee.
+The bound on the scan is fail-closed in the #591 sense: a body too large for
+the visit budget is not proven, and unproven is not fresh.
 
 **Slice plan (Struct):** slice 1 = the `StructClass` carrier + `Struct.new`
 recognition; slice 2 = the `StructInstance` carrier + fresh-chain member

--- a/lib/rigor/inference/method_dispatcher/struct_materialization.rb
+++ b/lib/rigor/inference/method_dispatcher/struct_materialization.rb
@@ -4,6 +4,8 @@ require "prism"
 
 require_relative "../../type"
 require_relative "../../source/constant_path"
+require_relative "../../source/node_children"
+require_relative "../struct_fold_safety"
 
 module Rigor
   module Inference
@@ -25,6 +27,10 @@ module Rigor
       module StructMaterialization
         module_function
 
+        # Nodes one factory-body scan may visit before it gives up and refuses. A factory is a handful of
+        # nodes; the bound exists so a pathological body cannot turn a per-call-site gate into a walk.
+        FACTORY_BODY_SCAN_BUDGET = 200
+
         # Issue #595 / #525 — the ONE materialisation test. Both places that must answer "was this receiver
         # expression's struct newly built?" go through it: this module's direct member-read gate above, and
         # `ExpressionTyper`'s caller-side `:self`-grant arm. They had forked answers once (the grant arm was
@@ -40,8 +46,85 @@ module Rigor
           case node.name
           when :new, :[] then struct_class_expression?(node.receiver, scope)
           when :with then !hand_written_with?(receiver, scope)
+          else fresh_factory_call?(node, scope)
+          end
+        end
+
+        # Issue #599 — the FACTORY-METHOD idiom, the one shape #595's whitelist knowingly paid for as a
+        # missed error: `def build = Pair.new("hi", [1, 2])` then `build.items`. The whitelist could not see
+        # through `build`, so the chain declined and a typo on it went unreported.
+        #
+        # It is recovered by asking the callee, under two bounds that keep the answer cheap and fail-closed.
+        #
+        # 1. RESOLUTION is one table read on a shape whose target cannot be an arbitrary object: a
+        #    receiverless send resolved through the confidence-gated top-level def table, or `Const.name`
+        #    resolved through the singleton-side ancestor walk. An INSTANCE-side receiver is refused
+        #    outright — `x.dup_self` is the #595 bug shape, and what `x` holds at the call is exactly what
+        #    this gate has no way to know.
+        # 2. ACCEPTANCE is decided on the callee's RETURN POSITION, not on a self-alias scan of its body.
+        #    "Cannot return `self`" is not the property freshness needs: the factory's `self` is the module
+        #    or `main`, never the struct, while `def get = GLOBAL` over a mutated constant returns a
+        #    long-lived instance with no `self` anywhere in it. What the gate needs is that the returned
+        #    object was built BY THIS CALL, so the body's tail must itself be a materialisation
+        #    ({#fresh_materialization_tail?}) and no `return` may hand back anything else. That subsumes the
+        #    self-alias refusal — a body returning `self` has a `SelfNode` tail, not a `.new` — while
+        #    admitting the idiom the issue is about.
+        def fresh_factory_call?(node, scope)
+          return false if scope.nil?
+
+          body = factory_def_body(node, scope)
+          return false unless body.is_a?(Prism::StatementsNode)
+
+          fresh_materialization_tail?(body.body.last, scope) && !early_return?(body)
+        end
+
+        # The two CHEAPLY RESOLVABLE callee shapes, each a single table read against the frozen discovery
+        # index. `bindable_top_level_def_for` is the confidence-gated accessor — the only one the inference
+        # may bind through — so a call inside a block whose `self` is unmodelled declines here as it does
+        # everywhere else. Anything else, an instance-side receiver above all, resolves to nil.
+        def factory_def_body(node, scope)
+          def_node =
+            case node.receiver
+            when nil then scope.bindable_top_level_def_for(node.name)
+            when Prism::ConstantReadNode, Prism::ConstantPathNode
+              owner = Source::ConstantPath.qualified_name_or_nil(node.receiver)
+              owner && scope.singleton_def_through_ancestors(owner, node.name).first
+            end
+          def_node&.body
+        end
+
+        # A materialisation written in the CALLEE's body, judged syntactically. Deliberately narrower than
+        # {#struct_class_expression?}: that predicate's local-variable arm reads the binding off the scope it
+        # is handed, which is the CALLER's — a local of the same name in the callee body is a different
+        # binding entirely, so the arm is dropped rather than answered from the wrong scope.
+        def fresh_materialization_tail?(node, scope)
+          return false unless node.is_a?(Prism::CallNode)
+          return false unless %i[new []].include?(node.name)
+
+          case node.receiver
+          when Prism::ConstantReadNode, Prism::ConstantPathNode
+            name = Source::ConstantPath.qualified_name_or_nil(node.receiver)
+            !name.nil? && !scope.struct_member_layout(name).nil?
+          when Prism::CallNode then inline_struct_factory?(node.receiver)
           else false
           end
+        end
+
+        # An explicit `return` anywhere in the body hands back an expression the tail check never saw, so the
+        # body is refused rather than scanned arm by arm. Nested `def` / `class` / `module` bodies are a
+        # different method's returns; a block's `return` is this method's, so the walk descends into it. The
+        # visit budget is the fail-closed bound: a body too large to scan is not proven, and unproven is not
+        # fresh.
+        def early_return?(node, budget = [FACTORY_BODY_SCAN_BUDGET])
+          return true if node.is_a?(Prism::ReturnNode)
+          return false if Inference::StructFoldSafety.scope_boundary?(node)
+
+          budget[0] -= 1
+          return true if budget[0].negative?
+
+          found = false
+          node.rigor_each_child { |child| found ||= early_return?(child, budget) }
+          found
         end
 
         # `.with` copies the receiver into a new instance — unless the struct wrote its own, which is free to

--- a/spec/rigor/inference/method_dispatcher/struct_folding_spec.rb
+++ b/spec/rigor/inference/method_dispatcher/struct_folding_spec.rb
@@ -852,35 +852,132 @@ RSpec.describe "Struct.new value folding", type: :runner do
       end
     end
 
-    describe "the measured precision trade" do
-      it "declines a genuinely fresh helper return (the accepted cost)" do
-        # `make` really does hand back a new instance, but the whitelist cannot see through it. Accepted:
-        # a before/after run over haml's and hamlit's parsers, faraday's Options/Request and mail's
-        # received_parser showed an identical diagnostic set and identical `type-scan` coverage, because a
-        # helper return at those sites does not infer to a StructInstance in the first place. The richer
-        # fix (consult the callee's return for a self-alias) is issue #599.
-        expect(dumped_types(<<~RUBY)).to eq(["Dynamic[top]"])
+    # Issue #599 — the FACTORY-METHOD idiom #595's whitelist knowingly paid for as a missed error. The gate
+    # now asks the callee, on two cheaply resolvable shapes only (a receiverless send through the top-level
+    # def table, `Const.name` through the singleton ancestor walk) and accepts it only when the body's return
+    # position is itself a materialisation. Instance-side receivers stay refused — that is the #595 bug
+    # shape, and the block above is the pin for it.
+    describe "a factory method whose return was just materialised (issue #599)" do
+      it "folds a read off a top-level factory" do
+        # Was the "accepted cost" pin of #595: `make` really does hand back a new instance, and the callee
+        # is one table read away.
+        expect(dumped_types(<<~RUBY)).to eq(["\"x\""])
           #{builder_def}
           def make = Line.new("x", 1)
           dump_type(make.text)
         RUBY
       end
 
-      it "declines the factory-method route, and the direct one still reports the typo" do
-        # The paired form of the trade, over the shape the #293 guards above used to carry. The factory
-        # return is genuinely fresh, but the whitelist cannot see through `parse`, so the chain declines and
-        # a typo on it goes unreported; written as a direct materialisation the same typo still fires. The
-        # loss direction is a missed error, never a diagnostic on correct code — and closing it needs the
-        # callee's return consulted for a `self` alias — issue #599.
-        factory = <<~RUBY
+      it "recovers the #293 pair through the factory route: silence from widening, fire on the typo" do
+        # Both halves over one factory, which is what makes each discriminating. The empty-literal member
+        # widens, so the correct "construct empty, then fill" program draws nothing; the non-empty member
+        # still folds, so a genuine typo on it is reported. Before #599 the silence half passed for the
+        # wrong reason (the whole chain declined) and the typo half could not fire at all.
+        empty = <<~RUBY
+          Pair = Struct.new(:label, :items)
+          def build_empty = Pair.new("hi", [])
+        RUBY
+        filled = <<~RUBY
           Pair = Struct.new(:label, :items)
           def build = Pair.new("hi", [1, 2])
         RUBY
-        via_factory = analyze("#{factory}build.items.first.zzz_undefined")
-        direct = analyze("#{factory}Pair.new(\"hi\", [1, 2]).items.first.zzz_undefined")
+        silent = analyze("#{empty}build_empty.items.first.zzz_undefined")
+        firing = analyze("#{filled}build.items.first.zzz_undefined")
 
-        expect(via_factory.diagnostics.map(&:message).join("\n")).not_to include("zzz_undefined")
-        expect(direct.diagnostics.map(&:message).join("\n")).to include("zzz_undefined")
+        expect(silent.diagnostics.map(&:message).join("\n")).not_to include("zzz_undefined")
+        expect(firing.diagnostics.map(&:message).join("\n")).to include("zzz_undefined")
+      end
+
+      it "folds a read off a singleton factory reached through the ancestor walk" do
+        expect(dumped_types(<<~RUBY)).to eq(["\"a\""])
+          Pair = Struct.new(:label, :items)
+          class Base
+            def self.build = Pair.new("a", [1])
+          end
+          class Maker < Base
+          end
+          dump_type(Maker.build.label)
+        RUBY
+      end
+
+      it "keeps the slice-5 grant firing off a factory return" do
+        # The grant arm shares the predicate, so a whole body's implicit-self member reads recover too.
+        expect(dumped_types(<<~RUBY)).to eq(["\"X\""])
+          #{builder_def}
+          def make = Line.new("x", 1)
+          dump_type(make.shout)
+        RUBY
+      end
+
+      describe "must stay Dynamic — the callee was not proven to build what it returns" do
+        it "refuses an INSTANCE-side receiver, whatever the callee does" do
+          # The #595 bug shape: what `x` holds at the call is exactly what this gate cannot know, so the
+          # resolution shapes stop at the top-level and singleton tables.
+          expect(dumped_types(<<~RUBY)).to eq(["Dynamic[top]"])
+            #{builder_def}
+            x = Line.new("a", 2)
+            x.text = "z"
+            dump_type(x.dup_self.text)
+          RUBY
+        end
+
+        it "refuses a factory that hands back a long-lived instance" do
+          # The reason acceptance is decided on the return POSITION and not on a self-alias scan: there is
+          # no `self` anywhere in this body, and the object it returns was mutated two statements ago. A
+          # LATENT guard today — the constant read degrades the carrier before the gate is consulted, so the
+          # sibling below is the one that discriminates against a gate accepting any resolvable callee — and
+          # it pins the shape a later constant-folding gain would otherwise turn into a wrong value.
+          expect(dumped_types(<<~RUBY)).to eq(["Dynamic[top]"])
+            Line = Struct.new(:text)
+            GLOBAL = Line.new("a")
+            def get = GLOBAL
+            GLOBAL.text = "z"
+            dump_type(get.text)
+          RUBY
+        end
+
+        it "refuses a factory whose tail is a local it filled first" do
+          expect(dumped_types(<<~RUBY)).to eq(["Dynamic[top]"])
+            Line = Struct.new(:text)
+            def make
+              r = Line.new("a")
+              r.text = "z"
+              r
+            end
+            dump_type(make.text)
+          RUBY
+        end
+
+        it "refuses a factory with an early return the tail check never saw" do
+          # Latent for the same reason as the example above; the pin is on the scan, not on today's carrier.
+          expect(dumped_types(<<~RUBY)).to eq(["Dynamic[top]"])
+            Line = Struct.new(:text)
+            CACHED = Line.new("a")
+            def make(flag)
+              return CACHED if flag
+              Line.new("b")
+            end
+            CACHED.text = "z"
+            dump_type(make(true).text)
+          RUBY
+        end
+
+        it "refuses a sibling reached by implicit self inside a struct body" do
+          # A receiverless send inside a method body must not resolve through the TOP-LEVEL def table onto a
+          # same-named struct method: `dup_self` here is instance-side and returns `self`.
+          expect(dumped_types(<<~RUBY)).to eq(["Dynamic[top]"])
+            Line = Struct.new(:text) do
+              def dup_self
+                self
+              end
+
+              def peek = dup_self.text
+            end
+            x = Line.new("a")
+            x.text = "z"
+            dump_type(x.peek)
+          RUBY
+        end
       end
     end
 


### PR DESCRIPTION
Recovers the FACTORY-METHOD idiom #598 knowingly paid for as a missed error: `def build = Pair.new("hi", [1, 2])` then `build.items` folds again, so a typo reached through it is reported instead of silently swallowed.

The fresh-receiver gate gains a fourth arm. A chained call counts as fresh when its callee is **cheaply resolvable** — a receiverless send through `Scope#bindable_top_level_def_for` (the confidence-gated accessor, so a call under an unmodelled block `self` still declines) or `Const.name` through `Scope#singleton_def_through_ancestors` — and its body **provably returns something it just built**. An INSTANCE-side receiver is refused outright: `x.dup_self` is the #595 bug shape, and what `x` holds at the call is exactly what the gate cannot know.

**Departure from the issue's sketch, deliberate.** Acceptance is decided on the callee's RETURN POSITION rather than on `StructFoldSafety.self_fold_safe_body?`. "Cannot return `self`" is not the property freshness needs — a factory's `self` is a module or `main`, never the struct, while `def get = GLOBAL` over a mutated constant hands back a long-lived instance with no `self` anywhere in it, which that scan clears. So the body's tail must itself materialise a constant with a recorded member layout (or an inline `Struct.new(…)`), and an explicit `return` anywhere in the body refuses because it hands back an expression the tail check never saw. That subsumes the self-alias refusal — a body returning `self` has a `SelfNode` tail, not a `.new` — while admitting the idiom. The tail check is also deliberately narrower than `struct_class_expression?`: that predicate's local-variable arm reads bindings off the CALLER's scope, which mean nothing inside the callee. The visit budget is #591's fail-closed bound: unproven is not fresh.

Both declines #598 pinned explicitly flip to must-folds, with a comment citing this issue; the #293 factory pair recovers both halves on the factory route (silence from the empty-literal widening, a fired diagnostic on the genuine typo). Every #595 must-stay-Dynamic shape — the self-returning `with_text`, `dup_self`, the composed `x.dup_self.with(indent: 9).shout` — is untouched and green, and new declines pin the instance-side refusal, the long-lived-constant return, a tail that is a filled local, an early return, and a sibling reached by implicit `self` inside a struct body (which must not resolve through the top-level def table).

Two scope items from the issue comments are NOT in this PR — the aliased-constant factory local (N5) and the block-form `include` indexing gap — since both sit outside the freshness arm; the ancestor-walk budget fail-open (NIT-B) is likewise untouched, and this arm's own budget exhaustion fails closed.

Verification: `spec/rigor/inference/method_dispatcher/struct_folding_spec.rb`, `struct_fold_safety_spec.rb`, `data_folding_spec.rb`, `expression_typer_spec.rb`, `scope_spec.rb`, `public_api_drift_spec.rb` and `spec/docs` green; RuboCop clean; `rigor check` clean on the changed file; the issue's repro run through `exe/rigor check`. Per the session's testing policy the full gate runs on CI, not locally.

Fixes #599
