### PR TITLE
Rename the chains inside each header-nesting bucket, not the bucket

### DIFF
--- a/changelog.d/fixed/fix-compact-rename-header-buckets.md
+++ b/changelog.d/fixed/fix-compact-rename-header-buckets.md
@@ -1,0 +1,1 @@
+- **[engine]** A project with a compact class header (`class Outer::Leaf` inside `module Wrap`) no longer reports an internal analyzer error on every other file that declares a class inside a module; the re-anchoring shipped in this cycle broke the header-nesting table it rewrote. ([#985](https://github.com/rigortype/rigor/pull/985))

--- a/lib/rigor/inference/scope_indexer.rb
+++ b/lib/rigor/inference/scope_indexer.rb
@@ -4525,8 +4525,13 @@ module Rigor
            struct_member_layouts constant_writes].each do |key|
           acc[key] = rekey_class_table(acc[key], renames)
         end
-        acc[:header_nestings] = acc[:header_nestings].transform_values do |chain|
-          chain.map { |entry| rename_compact_name(renames, entry) }
+        # A `header_nestings` value is a BUCKET (`raw header → chain`, plus the unkeyed union), not a
+        # chain: mapping the bucket itself turned every entry into a `[raw, chain]` pair rendered as a
+        # string, and the next per-file merge (`merge_header_nesting_bucket`) and every
+        # `Scope#recorded_header_nesting` lookup then raised on an Array where a Hash was expected — an
+        # internal analyzer error on every file of a project with one compact header (#984).
+        acc[:header_nestings] = acc[:header_nestings].transform_values do |bucket|
+          bucket.transform_values { |chain| chain.map { |entry| rename_compact_name(renames, entry) } }
         end
         acc[:def_nestings].transform_values! do |chain|
           chain&.map { |entry| rename_compact_name(renames, entry) }

--- a/spec/integration/compact_header_leading_segment_spec.rb
+++ b/spec/integration/compact_header_leading_segment_spec.rb
@@ -48,6 +48,36 @@ RSpec.describe "a compact header's leading segment (#722 residue 2)" do
     Dir.mktmpdir("rigor-compact-header-") { |dir| Dir.chdir(dir) { example.run } }
   end
 
+  # #984 — the rename pass rewrote each `header_nestings` BUCKET as if it were a chain, so a project with
+  # one compact header and any other class carrying a header nesting (a `class B < C` inside a module)
+  # crashed every file: the next per-file merge and every `recorded_header_nesting` lookup saw an Array
+  # where a bucket was expected. Mastodon reported it on 1,073 of its files.
+  it "does not crash the run when another file carries a header nesting alongside the compact header" do
+    FileUtils.mkdir_p("lib")
+    File.write(File.join("lib", "base.rb"), "class Base\n  def tag = :base\nend\n")
+    File.write(File.join("lib", "compact.rb"),
+               "class Outer; end\nmodule Wrap\n  class Outer::Leaf\n    def added = :added\n  end\nend\n")
+    File.write(File.join("lib", "nested.rb"), <<~RUBY)
+      module Api
+        class Widget < Base
+          def probe = tag
+        end
+      end
+      Rigor.dump_type(Api::Widget.new.probe)
+      Rigor.dump_type(Outer::Leaf.new.added)
+    RUBY
+    configuration = Rigor::Configuration.new(
+      Rigor::Configuration::DEFAULTS.merge("paths" => %w[lib], "workers" => 0)
+    )
+    diagnostics = guarded_run(
+      Rigor::Analysis::Runner.new(configuration: configuration, cache_store: nil), %w[lib]
+    ).diagnostics
+    internal = diagnostics.select { |d| d.message.start_with?("internal analyzer error") }
+    expect(internal.map(&:message)).to eq([])
+    dumps = diagnostics.select { |d| d.qualified_rule == "dump.type" }.map(&:message)
+    expect(dumps).to contain_exactly("dump_type: :base", "dump_type: :added")
+  end
+
   it "reopens the top-level class when the nesting supplies no such namespace" do
     expect(dumps_for(<<~RUBY)).to eq(["dump_type: :added", "dump_type: :base"])
       class Outer; end


### PR DESCRIPTION
The v0.3.9 release gate reported 1,073 internal analyzer errors on Mastodon, one per file. #961 mapped each `header_nestings` value as a chain, but the value is a bucket (`raw header → chain`), so every bucket became an Array and the next merge / lookup raised. Reproduced on the survey checkout (2 files → 2 errors; 0 with the fix). Regression spec: a compact header plus a nested subclass in another file, asserting no internal-error row and the expected `dump_type` answers.

Fixes #984