### PR TITLE
Fix Tab indentation and the dark-theme cursor in the playground editors

### DIFF
--- a/apps/rigor-playground/frontend/index.html
+++ b/apps/rigor-playground/frontend/index.html
@@ -250,16 +250,15 @@
     }
 
     /* Tab indents (see the keymap below), so the usual Tab focus move is gone;
-       name the Escape-then-Tab hatch here — CodeMirror requires it when Tab is
-       bound, and it keeps the widget clear of the "no keyboard trap" criterion.
-       It truncates rather than wraps on narrow headers; the full sentence stays
-       in the accessibility tree for the editor's aria-describedby. */
+       keep its Escape-then-Tab hatch visible without crowding header controls. */
     #editor-help {
-      min-width: 0;
-      overflow: hidden;
+      flex-shrink: 0;
+      padding: var(--rigor-sp-1) var(--rigor-sp-4);
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
       white-space: nowrap;
-      text-overflow: ellipsis;
       font-size: 11px;
+      line-height: 1.5;
       color: var(--muted);
     }
     #editor-help kbd {
@@ -585,17 +584,6 @@
 
     /* ─── Responsive: collapse sidebar below 720px ────────────────── */
     @media (max-width: 720px) {
-      /* The header has no room to keep the hint legible here; clip it from
-         sight but leave it in the accessibility tree for aria-describedby. */
-      #editor-help {
-        position: absolute;
-        width: 1px; height: 1px;
-        margin: -1px; padding: 0;
-        overflow: hidden;
-        clip: rect(0 0 0 0);
-        white-space: nowrap;
-        border: 0;
-      }
       main { flex-direction: column; }
       #sidebar {
         width: 100%;
@@ -610,12 +598,12 @@
   <header>
     <span class="brand">Rigor <span class="product">Playground</span></span>
     <span id="status" aria-live="polite">Ready</span>
-    <p id="editor-help"><kbd>Esc</kbd> then <kbd>Tab</kbd> to move focus out of the editor.</p>
     <div class="toolbar">
       <button class="btn" id="theme-btn" title="Cycle theme (Dark / Light / Auto)" aria-label="Toggle theme">Dark</button>
       <button class="btn active" id="type-btn" aria-pressed="true"><i class="fa-solid fa-eye-slash" aria-hidden="true"></i><span>Hide types</span></button>
     </div>
   </header>
+  <p id="editor-help">Press <kbd>Esc</kbd>, then <kbd>Tab</kbd>, to leave the editor.</p>
 
   <main>
     <div id="editor-wrap">

--- a/apps/rigor-playground/frontend/index.html
+++ b/apps/rigor-playground/frontend/index.html
@@ -597,7 +597,8 @@
   <script type="module">
     import { basicSetup, EditorView, EditorState } from "https://esm.sh/@codemirror/basic-setup@0.20"
     import { StateField, StateEffect, Prec }       from "https://esm.sh/@codemirror/state@0.20"
-    import { Decoration, WidgetType, hoverTooltip } from "https://esm.sh/@codemirror/view@0.20"
+    import { Decoration, WidgetType, hoverTooltip, keymap } from "https://esm.sh/@codemirror/view@0.20"
+    import { indentWithTab }                       from "https://esm.sh/@codemirror/commands@0.20"
     import { StreamLanguage, HighlightStyle, syntaxHighlighting } from "https://esm.sh/@codemirror/language@0.20?deps=@lezer/highlight@1.1.6"
     import { ruby }                                from "https://esm.sh/@codemirror/legacy-modes@0.20/mode/ruby"
     import { lintGutter, setDiagnostics }          from "https://esm.sh/@codemirror/lint@0.20"
@@ -782,6 +783,10 @@ AscDesc.new.ascdesc(:bad)
         doc: INITIAL_DOC,
         extensions: [
           basicSetup,
+          // basicSetup leaves Tab unbound, so the browser's default focus move
+          // wins; bind it to indentation instead. Placed after basicSetup so an
+          // open autocomplete's own Tab binding still takes precedence.
+          keymap.of([indentWithTab]),
           StreamLanguage.define(ruby),
           Prec.highest(syntaxHighlighting(rigorHighlight)),
           lintGutter(),

--- a/apps/rigor-playground/frontend/index.html
+++ b/apps/rigor-playground/frontend/index.html
@@ -249,6 +249,30 @@
       min-height: 44px;
     }
 
+    /* Tab indents (see the keymap below), so the usual Tab focus move is gone;
+       name the Escape-then-Tab hatch here — CodeMirror requires it when Tab is
+       bound, and it keeps the widget clear of the "no keyboard trap" criterion.
+       It truncates rather than wraps on narrow headers; the full sentence stays
+       in the accessibility tree for the editor's aria-describedby. */
+    #editor-help {
+      min-width: 0;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      font-size: 11px;
+      color: var(--muted);
+    }
+    #editor-help kbd {
+      font-family: var(--rigor-font-mono);
+      font-size: 10px;
+      color: var(--text);
+      background: var(--bg);
+      border: 1px solid var(--border-strong);
+      border-bottom-width: 2px;
+      border-radius: 3px;
+      padding: 0 3px;
+    }
+
     .brand {
       display: flex;
       align-items: baseline;
@@ -561,6 +585,17 @@
 
     /* ─── Responsive: collapse sidebar below 720px ────────────────── */
     @media (max-width: 720px) {
+      /* The header has no room to keep the hint legible here; clip it from
+         sight but leave it in the accessibility tree for aria-describedby. */
+      #editor-help {
+        position: absolute;
+        width: 1px; height: 1px;
+        margin: -1px; padding: 0;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+        border: 0;
+      }
       main { flex-direction: column; }
       #sidebar {
         width: 100%;
@@ -575,6 +610,7 @@
   <header>
     <span class="brand">Rigor <span class="product">Playground</span></span>
     <span id="status" aria-live="polite">Ready</span>
+    <p id="editor-help"><kbd>Esc</kbd> then <kbd>Tab</kbd> to move focus out of the editor.</p>
     <div class="toolbar">
       <button class="btn" id="theme-btn" title="Cycle theme (Dark / Light / Auto)" aria-label="Toggle theme">Dark</button>
       <button class="btn active" id="type-btn" aria-pressed="true"><i class="fa-solid fa-eye-slash" aria-hidden="true"></i><span>Hide types</span></button>
@@ -787,6 +823,8 @@ AscDesc.new.ascdesc(:bad)
           // wins; bind it to indentation instead. Placed after basicSetup so an
           // open autocomplete's own Tab binding still takes precedence.
           keymap.of([indentWithTab]),
+          // Point assistive tech at the Escape-then-Tab hint above.
+          EditorView.contentAttributes.of({ "aria-describedby": "editor-help" }),
           StreamLanguage.define(ruby),
           Prec.highest(syntaxHighlighting(rigorHighlight)),
           lintGutter(),

--- a/apps/rigor-playground/wasm/index.html
+++ b/apps/rigor-playground/wasm/index.html
@@ -722,6 +722,9 @@ AscDesc.new.ascdesc(:bad)
           EditorView.theme({
             "&": { backgroundColor: "var(--bg)", color: "var(--text)", height: "100%" },
             ".cm-content": { caretColor: "var(--accent)", fontFamily: MONO, padding: "8px 0" },
+            // CM6's base theme draws the cursor as a black left border, which is
+            // invisible on the dark background; paint it with the theme accent.
+            ".cm-cursor": { borderLeftColor: "var(--accent)", borderLeftWidth: "2px" },
             ".cm-gutters": { backgroundColor: "var(--gutter-bg)", color: "var(--gutter-fg)", border: "none", borderRight: "1px solid var(--border)" },
             ".cm-activeLine": { backgroundColor: "var(--active-line)" },
             ".cm-selectionBackground": { backgroundColor: "var(--selection)" },

--- a/apps/rigor-playground/wasm/index.html
+++ b/apps/rigor-playground/wasm/index.html
@@ -89,6 +89,18 @@
       background: var(--surface); border-bottom: 1px solid var(--border);
       flex-shrink: 0; min-height: 44px;
     }
+    /* Tab indents (see the keymap below), so the usual Tab focus move is gone;
+       name the Escape-then-Tab hatch here — CodeMirror requires it when Tab is
+       bound, and it keeps the widget clear of the "no keyboard trap" criterion.
+       It truncates rather than wraps on narrow headers; the full sentence stays
+       in the accessibility tree for the editor's aria-describedby. */
+    #editor-help { min-width: 0; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; font-size: 11px; color: var(--muted); }
+    #editor-help kbd { font-family: var(--rigor-font-mono); font-size: 10px; color: var(--text); background: var(--bg); border: 1px solid var(--border-strong); border-bottom-width: 2px; border-radius: 3px; padding: 0 3px; }
+    /* The header has no room to keep the hint legible here; clip it from sight
+       but leave it in the accessibility tree for aria-describedby. */
+    @media (max-width: 720px) {
+      #editor-help { position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
+    }
     .brand { font-weight: 700; letter-spacing: -0.01em; color: var(--text); display: flex; align-items: baseline; gap: 8px; }
     .brand::before { content: ""; display: inline-block; width: 10px; height: 10px; background: var(--accent); border-radius: 1px; transform: translateY(1px); }
     .brand .product { font-weight: 500; color: var(--muted); }
@@ -226,6 +238,7 @@
   <header>
     <span class="brand">Rigor <span class="product">Playground</span> <span class="wasm-tag">WASM</span></span>
     <span id="status" aria-live="polite">Loading…</span>
+    <p id="editor-help"><kbd>Esc</kbd> then <kbd>Tab</kbd> to move focus out of the editor.</p>
     <div class="toolbar">
       <button class="btn" id="theme-btn" title="Cycle theme">Dark</button>
       <button class="btn active" id="type-btn" aria-pressed="true"><i class="fa-solid fa-eye-slash" aria-hidden="true"></i><span>Hide types</span></button>
@@ -711,6 +724,8 @@ AscDesc.new.ascdesc(:bad)
           // wins; bind it to indentation instead. Placed after basicSetup so an
           // open autocomplete's own Tab binding still takes precedence.
           keymap.of([indentWithTab]),
+          // Point assistive tech at the Escape-then-Tab hint above.
+          EditorView.contentAttributes.of({ "aria-describedby": "editor-help" }),
           Prec.highest(syntaxHighlighting(rigorHighlight)),
           lintGutter(), annoField, traceHlField,
           // Don't clear the type overlay on each keystroke. The existing

--- a/apps/rigor-playground/wasm/index.html
+++ b/apps/rigor-playground/wasm/index.html
@@ -90,17 +90,9 @@
       flex-shrink: 0; min-height: 44px;
     }
     /* Tab indents (see the keymap below), so the usual Tab focus move is gone;
-       name the Escape-then-Tab hatch here — CodeMirror requires it when Tab is
-       bound, and it keeps the widget clear of the "no keyboard trap" criterion.
-       It truncates rather than wraps on narrow headers; the full sentence stays
-       in the accessibility tree for the editor's aria-describedby. */
-    #editor-help { min-width: 0; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; font-size: 11px; color: var(--muted); }
+       keep its Escape-then-Tab hatch visible without crowding header controls. */
+    #editor-help { flex-shrink: 0; padding: 4px 16px; background: var(--surface); border-bottom: 1px solid var(--border); white-space: nowrap; font-size: 11px; line-height: 1.5; color: var(--muted); }
     #editor-help kbd { font-family: var(--rigor-font-mono); font-size: 10px; color: var(--text); background: var(--bg); border: 1px solid var(--border-strong); border-bottom-width: 2px; border-radius: 3px; padding: 0 3px; }
-    /* The header has no room to keep the hint legible here; clip it from sight
-       but leave it in the accessibility tree for aria-describedby. */
-    @media (max-width: 720px) {
-      #editor-help { position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
-    }
     .brand { font-weight: 700; letter-spacing: -0.01em; color: var(--text); display: flex; align-items: baseline; gap: 8px; }
     .brand::before { content: ""; display: inline-block; width: 10px; height: 10px; background: var(--accent); border-radius: 1px; transform: translateY(1px); }
     .brand .product { font-weight: 500; color: var(--muted); }
@@ -238,13 +230,13 @@
   <header>
     <span class="brand">Rigor <span class="product">Playground</span> <span class="wasm-tag">WASM</span></span>
     <span id="status" aria-live="polite">Loading…</span>
-    <p id="editor-help"><kbd>Esc</kbd> then <kbd>Tab</kbd> to move focus out of the editor.</p>
     <div class="toolbar">
       <button class="btn" id="theme-btn" title="Cycle theme">Dark</button>
       <button class="btn active" id="type-btn" aria-pressed="true"><i class="fa-solid fa-eye-slash" aria-hidden="true"></i><span>Hide types</span></button>
       <button class="btn" id="trace-btn" aria-pressed="false" title="Replay how the engine infers each type"><i class="fa-solid fa-film" aria-hidden="true"></i><span>Trace types</span></button>
     </div>
   </header>
+  <p id="editor-help">Press <kbd>Esc</kbd>, then <kbd>Tab</kbd>, to leave the editor.</p>
 
   <main>
     <div id="editor-wrap"><div id="editor"></div></div>

--- a/apps/rigor-playground/wasm/index.html
+++ b/apps/rigor-playground/wasm/index.html
@@ -279,7 +279,8 @@
   <script type="module">
     import { basicSetup, EditorView, EditorState } from "https://esm.sh/@codemirror/basic-setup@0.20"
     import { StateField, StateEffect, Prec }       from "https://esm.sh/@codemirror/state@0.20"
-    import { Decoration, WidgetType }              from "https://esm.sh/@codemirror/view@0.20"
+    import { Decoration, WidgetType, keymap }      from "https://esm.sh/@codemirror/view@0.20"
+    import { indentWithTab }                       from "https://esm.sh/@codemirror/commands@0.20"
     import { StreamLanguage, HighlightStyle, syntaxHighlighting } from "https://esm.sh/@codemirror/language@0.20?deps=@lezer/highlight@1.1.6"
     import { ruby }                                from "https://esm.sh/@codemirror/legacy-modes@0.20/mode/ruby"
     import { lintGutter, setDiagnostics }          from "https://esm.sh/@codemirror/lint@0.20"
@@ -706,6 +707,10 @@ AscDesc.new.ascdesc(:bad)
         doc: INITIAL_DOC,
         extensions: [
           basicSetup, StreamLanguage.define(ruby),
+          // basicSetup leaves Tab unbound, so the browser's default focus move
+          // wins; bind it to indentation instead. Placed after basicSetup so an
+          // open autocomplete's own Tab binding still takes precedence.
+          keymap.of([indentWithTab]),
           Prec.highest(syntaxHighlighting(rigorHighlight)),
           lintGutter(), annoField, traceHlField,
           // Don't clear the type overlay on each keystroke. The existing

--- a/changelog.d/fixed/fix-playground-editor-ux.md
+++ b/changelog.d/fixed/fix-playground-editor-ux.md
@@ -1,0 +1,1 @@
+- **[playground]** Tab now indents in the editor instead of moving focus, and the WASM page's dark-theme cursor no longer blends into the background. ([#990](https://github.com/rigortype/rigor/pull/990))

--- a/changelog.d/fixed/fix-playground-editor-ux.md
+++ b/changelog.d/fixed/fix-playground-editor-ux.md
@@ -1,1 +1,1 @@
-- **[playground]** Tab now indents in the editor instead of moving focus, and the WASM page's dark-theme cursor no longer blends into the background. ([#990](https://github.com/rigortype/rigor/pull/990))
+- **[playground]** Tab now indents in the editor, which also shows how to move focus back out (Esc then Tab), and the WASM page's dark-theme cursor no longer blends into the background. ([#990](https://github.com/rigortype/rigor/pull/990))


### PR DESCRIPTION
Two editor-input fixes in the browser playground, covering both the Rack page (`frontend/index.html`) and the WASM page (`wasm/index.html`).

- **Tab now indents.** CodeMirror 6's `basicSetup` leaves Tab unbound, so the browser's default focus move won. `keymap.of([indentWithTab])` is added after `basicSetup`, so an open autocomplete keeps its own Tab binding ahead of it.
- **The WASM cursor is visible in dark mode.** The WASM theme never overrode `.cm-cursor`, leaving CM6's base-theme black left border on the `terminal-bg` dark background. It now paints with the theme accent, matching the Rack page — so only `wasm/index.html` changed for this one.

Verification: driven in a real Chrome (headless Chrome Beta via Playwright). Before the Tab fix, pressing Tab moved focus to `BODY`; after, focus stays in `.cm-content` and a 2-space indent is inserted. The WASM dark cursor now renders `rgb(224,140,132)` on `rgb(26,29,35)` (~6.6:1).

Changelog fragment added.
