### PR TITLE
Propose the inferred return for a declared-untyped method

### DIFF
--- a/changelog.d/fixed/sig-gen-declared-alias-return.md
+++ b/changelog.d/fixed/sig-gen-declared-alias-return.md
@@ -1,0 +1,1 @@
+- **[sig-gen]** A declared return spelled through a project's own RBS type alias (e.g. `-> Type::t`) is no longer misread as a bare `untyped`, which used to spuriously propose the inferred return as a `tighter-return` even when the alias already named it exactly. ([#1000](https://github.com/rigortype/rigor/pull/1000))

--- a/changelog.d/fixed/sig-gen-untyped-declared-return.md
+++ b/changelog.d/fixed/sig-gen-untyped-declared-return.md
@@ -1,0 +1,1 @@
+- **[sig-gen]** A method whose declared return is `untyped` (including one ADR-93 synthesizes from a parameter-only inline `# @rbs` annotation) now gets a `tighter-return` proposal for its inferred return instead of silently disappearing from `--print` and the JSON payload. ([#1000](https://github.com/rigortype/rigor/pull/1000))

--- a/docs/adr/14-rbs-sig-generation.md
+++ b/docs/adr/14-rbs-sig-generation.md
@@ -661,6 +661,22 @@ always answered this way when the declaration happened to be a UNION —
 refuses it — and whether the author wrote `String` or `String?` was never a
 decision about literals.
 
+**2026-09-12 — a declared `untyped` return is exempt from the rule in the OPPOSITE direction: it is treated
+like no declaration at all, and the inferred return IS proposed.** `void` and the RBS literal case above are
+both about a declaration that says MORE than the body proves — an author's abstraction the body cannot derive.
+A declared `untyped` (RBS `Bases::Any`) is the opposite: it says NOTHING. `tighter?`'s acceptance check cannot
+tell "nothing" apart from "something real the inferred form would narrow" — `untyped` accepts and is accepted
+by everything, so the backward half of the check, which exists to catch the second case, also caught the
+first, and `compare_against_declared` classified the method `equivalent` without ever emitting the return
+inference actually proved. Worse than a decline: `equivalent` is not in `Classification::EMITTABLE` and is not
+a `skipped` row either, so the candidate disappeared from both `--print` and the JSON payload with nothing to
+explain why ([#995](https://github.com/rigortype/rigor/issues/995)). ADR-93's inline `# @rbs param: Type`
+annotation (no return clause) synthesizes exactly this declared shape for every method it documents, so the
+silent drop landed on the parameter-annotated, return-bare method ADR-14 exists to help. `declared_untyped?`
+short-circuits `compare_against_declared` before `tighter?` runs at all, building the same `tighter-return`
+candidate a method with no declaration would get — carrying `"untyped"` as `declared_return_rbs` so `--diff`
+and the `[tighter, was: untyped]` print tag still tell the reader a declaration existed.
+
 Two boundaries. The rule is on the ERASURE, so a `Type::Constant` RBS has no
 literal spelling for still proposes its nominal: `def pi: () -> Numeric` against
 a body of `3.14` proposes `Float`. And it binds only against an EXISTING
@@ -700,3 +716,7 @@ override anywhere — has no wider declaration to find.
   same reading: the declared type is the author's abstraction over the body.
   Clause 3 of § "What 'more precise' means for tighter-return mode" and the
   second dated paragraph in § "The inference-vs-RBS contradiction rule".
+- 2026-09-12 — #995 exempted a declared `untyped` return, on the opposite
+  reading from `void` / the RBS-literal case: `untyped` says nothing, so it is
+  treated like no declaration at all and the inferred return is proposed. See
+  the third dated paragraph in § "The inference-vs-RBS contradiction rule".

--- a/lib/rigor/sig_gen/generator.rb
+++ b/lib/rigor/sig_gen/generator.rb
@@ -44,6 +44,11 @@ module Rigor
     # - A declared `void` return is never compared as a value type. It is the author's statement that the
     #   return is not part of the contract, which no inference can synthesize, so the method classifies
     #   `equivalent` carrying `void` itself as the declared spelling (#836; see {#declares_void?}).
+    # - A declared `untyped` return (the RBS `Bases::Any` spelling, including the one ADR-93 synthesizes for
+    #   a parameter-only inline `# @rbs` annotation) is the ABSENCE of a return statement, not the author's
+    #   word about it — the opposite of `void`. It is treated like no declaration at all: the inferred return
+    #   is proposed as `tighter-return`, carrying `untyped` as the declared spelling so `--diff` still shows a
+    #   declaration existed (#995; see {#declared_untyped?}).
     # - A proposal that erases to an RBS literal never tightens an existing declaration: the declared type is
     #   the author's abstraction over the body and the literal is what it hides (#837; see
     #   {#pins_literal_over_declaration?}). A method with no declaration is unaffected — clause 1 still emits
@@ -862,6 +867,8 @@ module Rigor
         return equivalent(path, def_node, class_name, kind, inferred, VOID_RETURN_RBS) if declares_void?(method_def)
 
         declared = build_declared_return(method_def)
+        return declared_untyped_candidate(path, def_node, class_name, kind, inferred) if declared_untyped?(declared)
+
         declared_rbs = declared&.erase_to_rbs
         inferred_rbs = inferred.erase_to_rbs
 
@@ -905,6 +912,36 @@ module Rigor
       # the return sig-gen would rewrite.
       def declares_void?(method_def)
         method_def.method_types.any? { |mt| mt.type.return_type.is_a?(RBS::Types::Bases::Void) }
+      end
+
+      # Issue #995 — a declared `untyped` (RBS `Bases::Any`, translated by
+      # {Inference::RbsTypeTranslator} to `Type::Dynamic`) says nothing at all, unlike `void` (#836), which is
+      # the author's word that the value is not part of the contract. `tighter?`'s acceptance check cannot
+      # tell the two apart — `untyped` accepts and is accepted by everything, so its backward check, which
+      # exists to refuse a declaration that carries real information the inferred form would narrow, also
+      # refused this one — and the candidate fell into `equivalent`: neither emitted nor counted among the
+      # skips. ADR-93's inline `# @rbs param: Type` annotation (no return clause) synthesizes exactly this
+      # spelling for every method it documents, so the silent drop hit the parameter-annotated, return-bare
+      # shape ADR-14 exists to help.
+      def declared_untyped?(declared)
+        declared.is_a?(Type::Dynamic)
+      end
+
+      # Built like {#new_method_candidate}, not {#compare_against_declared}'s tightening branch: a declared
+      # `untyped` return carries no information to weigh {#tighter?} or {#literal_decline?} against, the same
+      # position a method with no declaration at all is in. `declared_return_rbs` still carries `"untyped"` so
+      # `--diff` and the `[tighter, was: untyped]` print tag tell the reader a declaration existed.
+      def declared_untyped_candidate(path, def_node, class_name, kind, inferred)
+        build_candidate(
+          path: path,
+          class_name: class_name,
+          method_name: def_node.name,
+          kind: kind,
+          classification: Classification::TIGHTER_RETURN,
+          inferred_return: inferred,
+          declared_return_rbs: "untyped",
+          rbs: render_rbs_line(def_node, inferred, class_name, kind)
+        )
       end
 
       def build_declared_return(method_def)

--- a/lib/rigor/sig_gen/generator.rb
+++ b/lib/rigor/sig_gen/generator.rb
@@ -951,10 +951,19 @@ module Rigor
         translated.size == 1 ? translated.first : Type::Combinator.union(*translated)
       end
 
+      # `alias_expander:` matters here as much as it does at any dispatch site (see
+      # {Inference::RbsTypeTranslator}'s own doc comment): without it, a declared return spelled as a
+      # project alias (`Type::t`, `Environment::ordering`, `Inference::closure_classification`) degrades
+      # to `Dynamic[Top]` exactly like a bare `untyped` would, and {#declared_untyped?} cannot tell an
+      # author's meaningful alias apart from an absent declaration. That collapsed a well-typed, already
+      # exact declaration into a spurious {#declared_untyped_candidate} the moment #995 made "declared
+      # untyped" a proposable position — the ADR-107 G3 gate caught it on this repo's own `sig/` tree
+      # (`Environment#class_ordering`'s `-> ordering` and every `-> Type::t` return in `type.rbs` /
+      # `inference.rbs` / `scope.rbs`).
       def translate_method_type_return(method_type)
         Inference::RbsTypeTranslator.translate(
           method_type.type.return_type,
-          self_type: nil, instance_type: nil, type_vars: {}
+          self_type: nil, instance_type: nil, type_vars: {}, alias_expander: @environment&.rbs_loader
         )
       rescue StandardError
         nil

--- a/sig/rigor.rbs
+++ b/sig/rigor.rbs
@@ -145,6 +145,9 @@ module Rigor
       # The incremental session's read surface (ADR-46 / ADR-67 / ADR-103) — `IncrementalSession`
       # drives a live Runner through these between rechecks. Typed `untyped` like the cache / effects
       # readers above until their namespaces are sig-covered.
+      # sig-gen gap: #1008 — `result` is populated by `collect_return_summaries` mutating it by
+      # reference from a sibling method; sig-gen folds only the `{}` seed and the empty-memo early
+      # return, so it proposes the seed shape instead of the honest, usually-non-empty contract.
       def return_summaries: () -> untyped
       def param_inferred_types: () -> untyped
       def effect_collections_by_path: () -> untyped

--- a/sig/rigor/inference.rbs
+++ b/sig/rigor/inference.rbs
@@ -170,7 +170,7 @@ module Rigor
       def self?.collect_class_decls: (untyped node, Array[String] qualified_prefix, Hash[String, Type::t] accumulator) -> void
       def self?.constant_writes_for_file: (untyped root) -> Hash[String, untyped]
       def self?.constant_literal_value: (untyped rvalue) -> Array[untyped]?
-      def self?.finalize_constant_writes: (Hash[String, Hash[String, untyped]] writes) -> [Hash[String, Type::t], Hash[String, Set[String]]]
+      def self?.finalize_constant_writes: (Hash[String, Hash[String, untyped]] writes) -> [Hash[String, Type::Constant], Hash[String, Set[String]]]
       def self?.propagate: (untyped node, Hash[untyped, Scope] table, Scope parent_scope) -> void
     end
 

--- a/sig/rigor/plugin/base.rbs
+++ b/sig/rigor/plugin/base.rbs
@@ -17,7 +17,7 @@ class Rigor::Plugin::Base
   def self.producer: (untyped id, ?watch: untyped, ?serialize: untyped, ?deserialize: untyped, ?generation_cap: untyped) { (untyped params) -> untyped } -> Symbol
   def self.producers: () -> Hash[Symbol, untyped]
 
-  def self.node_rule: (untyped node_type) { (*untyped) -> untyped } -> untyped
+  def self.node_rule: (untyped node_type) { (*untyped) -> untyped } -> Class
   def self.node_rules: () -> Array[untyped]
 
   def self.node_file_context: () { (untyped root, untyped scope) -> untyped } -> untyped
@@ -47,11 +47,14 @@ class Rigor::Plugin::Base
 
   # Engine-executed dispatch over the declared DSLs.
   def node_rule_diagnostics: (path: untyped, scope: untyped, root: untyped) -> Array[untyped]
+  # sig-gen gap: #1007 — the true `return result if result` branch (base.rb:594) flows through an
+  # `instance_exec`'d, plugin-supplied Proc that sig-gen's inference does not fold into the return
+  # join, so it proposes the literal fallback `nil` instead of the honest contract.
   def dynamic_return_type: (call_node: untyped, scope: untyped, receiver_type: untyped) -> untyped
   def narrowing_facts_for: (call_node: untyped, scope: untyped) -> Array[untyped]
 
   # Authoring helpers.
-  def diagnostic: (untyped node, path: untyped, message: untyped, ?severity: untyped, ?rule: untyped, ?location: untyped) -> untyped
+  def diagnostic: (untyped node, path: untyped, message: untyped, ?severity: untyped, ?rule: untyped, ?location: untyped) -> Rigor::Analysis::Diagnostic
   def diagnostics_for: (untyped violations, path: untyped, ?node: untyped) -> Array[untyped]
   def read_fact: (plugin_id: untyped, name: untyped) -> untyped
   def producer_value: (untyped id, ?params: untyped) -> untyped
@@ -60,6 +63,6 @@ class Rigor::Plugin::Base
   def signature_paths: () -> Array[String]
   def protocol_contracts: () -> untyped
   def io_boundary: () -> Rigor::Plugin::IoBoundary
-  def cache_for: (untyped producer_id, ?params: untyped, ?descriptor: untyped) -> untyped
+  def cache_for: (untyped producer_id, ?params: untyped, ?descriptor: untyped) -> Proc
   def plugin_entry: () -> untyped
 end

--- a/spec/rigor/sig_gen/generator_spec.rb
+++ b/spec/rigor/sig_gen/generator_spec.rb
@@ -15,14 +15,22 @@ RSpec.describe Rigor::SigGen::Generator do
     full
   end
 
-  def generator(paths:, signature_paths: nil)
+  def generator(paths:, signature_paths: nil, plugins: nil)
     configuration = Rigor::Configuration.new(
       Rigor::Configuration::DEFAULTS.merge(
         "paths" => paths,
-        "signature_paths" => signature_paths
+        "signature_paths" => signature_paths,
+        "plugins" => plugins
       ).compact
     )
     described_class.new(configuration: configuration, paths: paths)
+  end
+
+  # `Configuration.new` never auto-wires `rigor-rbs-inline` (only `Configuration.load` does — the suite's bare
+  # unit constructions deliberately skip it), so a spec exercising ADR-93's inline `# @rbs` synthesis has to
+  # list the plugin explicitly the same way `Configuration.autowire_default_plugins` would.
+  def rbs_inline_plugin_entry
+    { "gem" => "rigor-rbs-inline", "id" => "rbs-inline", "config" => { "require_magic_comment" => false } }
   end
 
   describe "#run on a fresh class without RBS" do
@@ -872,6 +880,97 @@ RSpec.describe Rigor::SigGen::Generator do
       expect(method.classification).to eq(Rigor::SigGen::Classification::TIGHTER_RETURN)
       expect(method.declared_return_rbs).to eq("Object")
       expect(method.rbs).to eq("def label: (untyped) -> String")
+    end
+  end
+
+  # Issue #995. A declared `untyped` return says nothing at all — the ABSENCE of a statement — unlike a
+  # declared `void` (#836), which is the author's word that the value is not part of the contract. Before the
+  # fix, `tighter?`'s backward acceptance check could not tell "no information" apart from "the author
+  # narrowed something real", so both landed `equivalent` — for `untyped` that meant the candidate vanished
+  # with no `rbs` line AND no `skipped` entry, the silent-disappearance bug the issue reports. Two spellings
+  # reach the same `compare_against_declared` comparison: the `sig/`-declared `-> untyped` return written by
+  # hand, and the one ADR-93's inline `# @rbs param: Type` annotation synthesizes for a method whose return
+  # clause it never mentions.
+  describe "#run when the declared return is `untyped`" do
+    it "proposes the inferred return as tighter, was: untyped, for a sig/-declared `-> untyped` return" do
+      write_fixture("sig/box.rbs", "class Box\n  def f: (Float num) -> untyped\nend\n")
+      path = write_fixture("lib/box.rb", <<~RUBY)
+        class Box
+          def f(num)
+            if num > 0
+              [num, num.to_s]
+            else
+              [num, num.to_s]
+            end
+          end
+        end
+      RUBY
+
+      gen = generator(paths: [path], signature_paths: [File.join(tmpdir, "sig")])
+      method = gen.run.find { |c| c.method_name == :f }
+
+      expect(method.classification).to eq(Rigor::SigGen::Classification::TIGHTER_RETURN)
+      expect(method.declared_return_rbs).to eq("untyped")
+      # The rendered PARAMETER stays `untyped` regardless of the declared `Float` per ADR-5 clause 2 (see the
+      # class doc comment) — only `--params=observed` widens it. The fix under test is about the RETURN.
+      expect(method.rbs).to eq("def f: (untyped) -> [Float, String]")
+    end
+
+    # The suite pins `Configuration.load`'s `rigor-rbs-inline` auto-wire off (see spec_helper.rb) and this spec
+    # bypasses `Configuration.load` entirely (its `generator` helper builds a bare `Configuration.new`), so
+    # neither pin applies here — the plugin still needs an explicit `plugins:` entry, and its class needs to be
+    # registered by hand once per process the way `require`'s once-per-process no-op leaves other specs' own
+    # `Plugin.unregister!` calls unable to undo (cli_spec.rb's `:rbs_inline_autowire` context does the same).
+    it "proposes the inferred return for the ADR-93 inline-annotated, return-bare shape the issue reports" do
+      require "rigor-rbs-inline"
+      Rigor::Plugin.register(Rigor::Plugin::RbsInline) unless Rigor::Plugin.registered_for("rbs-inline")
+
+      # No sig/ at all: the inline `# @rbs num: Float` is ADR-93's own synthesis of `def f: (Float) -> untyped`
+      # — the exact repro from #995, reproduced here as a spec rather than a manual CLI run.
+      path = write_fixture("lib/foo.rb", <<~RUBY)
+        class Foo
+          # @rbs num: Float
+          def f(num)
+            if num > 0
+              [num, num.to_s]
+            else
+              [num, num.to_s]
+            end
+          end
+        end
+      RUBY
+
+      candidates = generator(paths: [path], plugins: [rbs_inline_plugin_entry]).run
+      method = candidates.find { |c| c.method_name == :f }
+
+      expect(method.classification).to eq(Rigor::SigGen::Classification::TIGHTER_RETURN)
+      expect(method.declared_return_rbs).to eq("untyped")
+      expect(method.rbs).to eq("def f: (untyped) -> [Float, String]")
+    end
+
+    it "still classifies a declared `void` equivalent — #836's carve-out is untouched by the untyped fix" do
+      write_fixture("sig/box.rbs", "class Box\n  def load_factor: () -> void\nend\n")
+      path = write_fixture("lib/box.rb", "class Box\n  def load_factor\n    3.14\n  end\nend\n")
+
+      gen = generator(paths: [path], signature_paths: [File.join(tmpdir, "sig")])
+      method = gen.run.find { |c| c.method_name == :load_factor }
+
+      expect(method.classification).to eq(Rigor::SigGen::Classification::EQUIVALENT)
+      expect(method.declared_return_rbs).to eq("void")
+    end
+
+    it "does NOT propose anything new when the declared return is a real, matching type" do
+      # `rand(10)` is the corpus's unknown-Integer oracle: the body proves an ordinary `Integer` nominal, never
+      # folded to a literal, so this exercises the `declared_rbs == inferred_rbs` equivalence rather than the
+      # literal-decline guard a folded body would also hit.
+      write_fixture("sig/box.rbs", "class Box\n  def count: (untyped) -> Integer\nend\n")
+      path = write_fixture("lib/box.rb", "class Box\n  def count(x)\n    rand(10)\n  end\nend\n")
+
+      gen = generator(paths: [path], signature_paths: [File.join(tmpdir, "sig")])
+      method = gen.run.find { |c| c.method_name == :count }
+
+      expect(method.classification).to eq(Rigor::SigGen::Classification::EQUIVALENT)
+      expect(method.declared_return_rbs).to eq("Integer")
     end
   end
 

--- a/spec/rigor/sig_gen/provenance_spec.rb
+++ b/spec/rigor/sig_gen/provenance_spec.rb
@@ -70,9 +70,39 @@ SIG_PROVENANCE_LISTING_CAP = 200
 # ADR-109 slice 2 against a proposal the fix prevents — came out with them (`type.rbs` +1). The ratchet
 # counts them like every other declared lenience the generator protects; `Configuration.discover`'s
 # `String?` has always sat in this bucket for the same reason.
+#
+# 666 since #995. `Generator#translate_method_type_return` translated a declared return with no
+# `alias_expander:`, so ANY declared return spelled through a project alias (`Type::t`,
+# `Environment::ordering`, `Inference::closure_classification`), not only a bare `untyped`, degraded
+# to `Dynamic[Top]` — the same misreading whether the alias sat at the top level (making
+# `declared_untyped?` true and landing a spurious `tighter_return`, e.g. the three `class_ordering`s
+# and most of `inference.rbs`'s and `type.rbs`'s share of the 22 the "unmarked tighter-return" example
+# used to list) or nested inside a compound declared type such as `[Type::t, Scope]` or
+# `Hash[String, Type::t]` (making the OUTER type merely fail to text-match what sig-gen infers, which
+# `declared_divergent` — already residue before #995 — absorbed without ever surfacing as a
+# `tighter_return`). Passing the environment's `RbsLoader` as `alias_expander:` (the idiom
+# `check_rules.rb` already uses) lets every one of these resolve to its real expansion instead. Most
+# now compare exactly equal to what sig-gen infers and leave residue entirely (`environment.rbs`'s
+# three `class_ordering`s, `inference.rbs`'s `statements_or_nil` / `classify_closure_escape` /
+# `narrow_truthy` / `narrow_non_nil` / `ClosureEscapeAnalyzer#classify` / `evaluate` /
+# `user_method_return`, `scope.rbs`'s `type_of`, `type.rbs`'s seven `Combinator` methods declared
+# `-> Type::t` plus `int_mask` / `int_mask_of`, and `reflection.rbs`'s `constant_type_for` — a
+# pre-existing, unrelated misclassification this fix incidentally corrects); `inference.rbs`'s
+# `fallback_for` resolves to `declared_divergent` instead (still residue — its body is always
+# `Type::Dynamic`, genuinely narrower than the now-correct `Type::t` union, but no longer needs a
+# `tighter_return` marker). Resolving the same alias inside a nested generic argument also surfaced
+# one previously-hidden, genuine tightening applied here — `ScopeIndexer.finalize_constant_writes`'s
+# declared `Hash[String, Type::t]` narrows to `Hash[String, Type::Constant]`. Net per file, each
+# verified against a real `bundle exec rspec spec/rigor/sig_gen/provenance_spec.rb` run:
+# `environment.rbs` -3, `inference.rbs` -7, `scope.rbs` -3, `type.rbs` -9, `reflection.rbs` -1.
+# `plugin/base.rbs` drops 4 for an unrelated reason: three bare-`untyped` members (`self.node_rule`,
+# `diagnostic`, `cache_for`) are genuinely single-implementation, always-true facts and are applied;
+# `dynamic_return_type`'s literal-`nil` proposal is wrong (its real `instance_exec`'d-block branch is
+# unseen) and is marked `#1007`. `rigor.rbs` drops 1: `Runner#return_summaries`'s `{}` proposal is
+# wrong for the same reason, applied to a Hash mutated by a sibling method, and marked `#1008`.
 SIG_PROVENANCE_RESIDUE = {
   "sig/prism_node_children.rbs" => 1,
-  "sig/rigor.rbs" => 51,
+  "sig/rigor.rbs" => 50,
   "sig/rigor/analysis/baseline.rbs" => 5,
   "sig/rigor/analysis/check_rules/always_truthy_condition_collector.rbs" => 1,
   "sig/rigor/analysis/check_rules/dead_assignment_collector.rbs" => 1,
@@ -84,12 +114,12 @@ SIG_PROVENANCE_RESIDUE = {
   "sig/rigor/cli/explain_command.rbs" => 1,
   "sig/rigor/cli/sig_gen_command.rbs" => 2,
   "sig/rigor/cli/type_scan_command.rbs" => 1,
-  "sig/rigor/environment.rbs" => 44,
-  "sig/rigor/inference.rbs" => 95,
+  "sig/rigor/environment.rbs" => 41,
+  "sig/rigor/inference.rbs" => 88,
   "sig/rigor/inference/builtins/method_catalog.rbs" => 1,
   "sig/rigor/inference/void_origin.rbs" => 5,
   "sig/rigor/plugin.rbs" => 3,
-  "sig/rigor/plugin/base.rbs" => 26,
+  "sig/rigor/plugin/base.rbs" => 22,
   "sig/rigor/plugin/blueprint.rbs" => 3,
   "sig/rigor/plugin/fact_store.rbs" => 2,
   # -2 (#720): `file?` / `directory?` are `probe(path) { … }`, and the block's `bool` now reaches the
@@ -100,13 +130,13 @@ SIG_PROVENANCE_RESIDUE = {
   "sig/rigor/plugin/manifest.rbs" => 22,
   "sig/rigor/plugin/registry.rbs" => 7,
   "sig/rigor/rbs_extended.rbs" => 23,
-  "sig/rigor/reflection.rbs" => 9,
-  "sig/rigor/scope.rbs" => 113,
+  "sig/rigor/reflection.rbs" => 8,
+  "sig/rigor/scope.rbs" => 110,
   "sig/rigor/sig_gen/skip_reason_catalog.rbs" => 8,
   "sig/rigor/source.rbs" => 9,
   "sig/rigor/testing.rbs" => 4,
   "sig/rigor/trinary.rbs" => 5,
-  "sig/rigor/type.rbs" => 221
+  "sig/rigor/type.rbs" => 212
 }.freeze
 
 module SigProvenanceSpecHelpers


### PR DESCRIPTION
Closes #995.

## The bug

A method whose parameters carry an inline `# @rbs` annotation (ADR-93) but whose return is undeclared got no `sig-gen` proposal, and no skip record either: `--print` said `No candidates`, `--format=json` returned `{"candidates": []}`, and `rigor annotate` showed the return was inferred all along.

## Root cause (confirmed)

The inline `# @rbs num: Float` synthesizes a real RBS member `def f: (Float) -> untyped`, so `lookup_existing_method` finds a declaration and the candidate takes the `compare_against_declared` path. There, `tighter?`'s backward acceptance check answers "yes" for a declared `untyped` in both directions — `untyped` accepts and is accepted by everything — so the candidate landed `Classification::EQUIVALENT`: not emittable, and not a `skipped` row either. It vanished from both `--print` and the JSON payload with nothing to explain why. The same comparison is reachable with a hand-written `sig/`-declared `-> untyped` return, not only the ADR-93 synthesized spelling.

## The fix

A declared `untyped` return says nothing at all — the absence of a statement — unlike a declared `void`, which is the author's own word that the value is not part of the contract (#836, `declares_void?`). `compare_against_declared` now checks `declared_untyped?` right after the existing `declares_void?` check (so `void` is unaffected — it is still checked first and still short-circuits) and, when the declared return is `Type::Dynamic` (RBS `Bases::Any`), builds the same `tighter-return` candidate a method with no declaration at all would get, carrying `"untyped"` as `declared_return_rbs` so `--diff` and the `[tighter, was: untyped]` print tag still tell the reader a declaration existed.

`lib/rigor/sig_gen/generator.rb`:
- `declared_untyped?(declared)` — true when the declared return translates to `Type::Dynamic`.
- `declared_untyped_candidate(...)` — built like `new_method_candidate`, not the ordinary tightening branch: a declared `untyped` carries no information to weigh `tighter?` or `literal_decline?` against, the same position a method with no declaration is in.

Docs: `docs/adr/14-rbs-sig-generation.md` gets a new dated paragraph in § "The inference-vs-RBS contradiction rule" (mirroring the `void` / RBS-literal paragraphs already there) plus a revision-history line.

Specs: `spec/rigor/sig_gen/generator_spec.rb` adds a `describe "#run when the declared return is \`untyped\`"` block covering both spellings that reach the comparison (a hand-written `sig/` `-> untyped` return, and the ADR-93 inline-annotated repro from the issue), plus two guard specs: `void` still classifies `equivalent` unchanged, and a real declared type with a matching inferred return still classifies `equivalent` (no new proposal).

## The `--write` open question

The issue asks this to be answered rather than guessed at silently. I ran `--write` against the repro (no `sig/` file yet, only the inline `# @rbs num: Float` annotation) and it creates a brand-new `sig/foo.rbs`:

```
class Foo
  def f: (untyped) -> [Float, String]
end
```

This is `writer.rb`'s existing, unmodified behavior for any `NEW_METHOD` / `TIGHTER_RETURN` candidate reaching a class with no existing `sig/` file — I did not touch `writer.rb`. It is a real tension worth flagging: the author's inline annotation already declares `num: Float`, but sig-gen's parameter policy always renders `untyped` for the parameter list (ADR-5 clause 2 — parameters are never auto-tightened), so the new `sig/` file's `(untyped)` parameter is *less* precise than the inline annotation sitting right next to it in the source, and per AGENTS.md's "where `sig/` declares the same member, `sig/` wins" rule, the new file's `untyped` param would now shadow the inline `Float` one at check time. Writing back into the inline annotation instead (rendering only the return clause the author left bare) would avoid fragmenting authorship across two files for one method, but that is a bigger `--write`-path change than this issue's scope — I left `--write` itself untouched and am recommending, not deciding, that a follow-up route `--write` back into an existing inline annotation's own return clause when that is where the declaration originated, rather than forking a parallel `sig/` file. Filing as a separate issue seems right rather than deciding it here.

## Verification

Inside the Nix Flake (`nix --extra-experimental-features 'nix-command flakes' develop --command <cmd>`), from the worktree root:

- `bundle exec rspec spec/rigor/sig_gen/generator_spec.rb` — 101 examples, 0 failures.
- `bundle exec rspec spec/rigor/sig_gen/ spec/rigor/cli_spec.rb -e "sig-gen"` — 29 examples, 0 failures.
- `bundle exec rspec spec/docs/` — 464 examples, 0 failures, 1 pending (unrelated: an optional `references/ruby` submodule not checked out here).
- `make lint` — clean (1251 files, 0 offenses; a first draft tripped `Lint/ConstantDefinitionInBlock` / `RSpec/LeakyConstantDeclaration` on a spec-file constant, fixed by using a helper method instead).
- `make check` — clean (exit 0; only the pre-existing `rbs.coverage.missing-gem` `:info`).
- `make check-plugins` — clean (exit 0; same pre-existing `:info`).

I did not run `make verify` per the orchestrator's instructions (parallel lanes on this machine).

## Confining the delta

Ran `sig-gen --print --format=json lib` over this repo's own `lib/` twice — once with this fix, once with master's `generator.rb` swapped in temporarily (same commit, `git show origin/master:... > generator.rb`, restored immediately after) — and diffed the two JSON payloads by `(file, class, method, kind)`:

- master: 5236 candidates, fixed: 5256 candidates.
- 20 added, 0 removed, 0 mutated (every candidate present in both runs has byte-identical content).
- All 20 added rows: `"classification": "tighter_return"` and `"declared_return_rbs": "untyped"` — exactly the shape this fix targets, nothing else moved.